### PR TITLE
new instant eraser, wysiwyg tool adjust. improvement and tools reset

### DIFF
--- a/src/interface/mainwindow2.cpp
+++ b/src/interface/mainwindow2.cpp
@@ -231,6 +231,8 @@ void MainWindow2::createMenus()
     connect(ui->actionEyedropper, SIGNAL(triggered()), m_toolSet, SLOT(eyedropperOn()));
     connect(ui->actionEraser, SIGNAL(triggered()), m_toolSet, SLOT(eraserOn()));
 
+    connect(ui->actionResetToolsDefault, SIGNAL(triggered()), this, SLOT(resetToolsSettings()));
+
     /// --- Help Menu ---
     connect(ui->actionHelp, SIGNAL(triggered()), this, SLOT(helpBox()));
     connect(ui->actionAbout, SIGNAL(triggered()), this, SLOT(aboutPencil()));
@@ -504,6 +506,16 @@ bool MainWindow2::openObject(QString filePath)
   
     progress.setValue(100);
     return ok;
+}
+
+// Added here (mainWindow2) to be easily located
+// TODO: Find a better place for this function
+void MainWindow2::resetToolsSettings()
+{
+    m_pScribbleArea->resetTools();
+    writeSettings();
+    editor->setTool(m_pScribbleArea->currentToolType());
+    qDebug("tools restored to default settings");
 }
 
 // TODO: need to move to other place

--- a/src/interface/mainwindow2.h
+++ b/src/interface/mainwindow2.h
@@ -68,6 +68,7 @@ public slots:
     bool maybeSave();
     void showPreferences();
     bool openObject(QString strFilename);
+    void resetToolsSettings();
 
 private slots:
     void exportFile();

--- a/src/interface/mainwindow2.ui
+++ b/src/interface/mainwindow2.ui
@@ -20,7 +20,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>22</height>
+     <height>18</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -150,6 +150,8 @@
     <addaction name="actionBucket"/>
     <addaction name="actionEyedropper"/>
     <addaction name="actionEraser"/>
+    <addaction name="separator"/>
+    <addaction name="actionResetToolsDefault"/>
    </widget>
    <widget class="QMenu" name="menuLayer">
     <property name="title">
@@ -680,6 +682,14 @@
   <action name="actionAbout">
    <property name="text">
     <string>About</string>
+   </property>
+  </action>
+  <action name="actionResetToolsDefault">
+   <property name="text">
+    <string>Reset to default</string>
+   </property>
+   <property name="toolTip">
+    <string>Reset to default</string>
    </property>
   </action>
  </widget>

--- a/src/interface/scribblearea.h
+++ b/src/interface/scribblearea.h
@@ -46,6 +46,8 @@ public:
     void setColour(const QColor);
     void resetColours();
 
+    void resetTools();
+
     void deleteSelection();
     void setSelection(QRectF rect, bool);
     void displaySelectionProperties();
@@ -231,10 +233,15 @@ private:
     QList<VertexRef> closestVertices;
     QPointF offset;
 
-    bool resizingTool; //whether or not resizing
-    enum myResizingToolMode {rtmWIDTH, rtmFEATHER}; //interactive brush resizing modes
-    myResizingToolMode resizingToolMode ;
-    qreal brushOrgSize; //start resizing from previous width or feather
+    //WYWIWYG tool adjustments
+    bool adjustingTool; //whether or not resizing
+    enum myWysiToolAdjustment {wtaWIDTH, wtaFEATHER, wtaTRANSPARENCY, wtaERASER};
+    myWysiToolAdjustment wysiToolAdjustment;
+    qreal toolOrgValue; //start resizing from previous width or feather
+
+    //instant tool (temporal eg. eraser)
+    bool instantTool; //whether or not using temporal tool
+    ToolType recoverToolType; //to recover current tool
 
     VectorSelection vectorSelection;
     //bool selectionChanged;

--- a/src/util/pencilsettings.cpp
+++ b/src/util/pencilsettings.cpp
@@ -21,7 +21,7 @@ QSettings* pencilSettings()
     return g_pSettings;
 }
 
-void restoreToDefaultSetting()
+void restoreToDefaultSetting() // TODO: finish reset list
 {
     QSettings* s = g_pSettings;
 
@@ -29,11 +29,14 @@ void restoreToDefaultSetting()
     s->setValue("pencilWidth", 1.0);
     s->setValue("eraserWidth", 10.0);
     s->setValue("brushWidth", 15.0);
+    s->setValue("brushFeather", 15.0);
 
     s->setValue("autosaveNumber", 15);
     s->setValue("toolCursors", true);
 
     s->sync();
+    qDebug("restored default tools");
+
 }
 
 


### PR DESCRIPTION
1. Now, CTRL+SHIFT applies brush size to the eraser and temporarily
   selects it.
2. "wysiwyg" tool adjustment is now more precise.
3. tool reset added to menu/tools. Prevents from persistent crashes
   caused by corrupted settings file .
