### PR TITLE
Event conflicts prevention (for fixed shortcuts including temporary tools)

### DIFF
--- a/src/interface/scribblearea.h
+++ b/src/interface/scribblearea.h
@@ -253,6 +253,7 @@ public:
 protected:
     //Buffer buffer; // used to pre-draw bitmap modifications, such as lines, brushes, etc.
 
+    bool keyboardInUse;
     bool mouseInUse;
     QPointF lastPixel, currentPixel;
     QPointF lastPoint, currentPoint;


### PR DESCRIPTION
1. prevent fixed shortcuts to be executed while drawing
2. temporary tool will not return to previous state until both mouse and
   shortcut keys are released
3. temp. eraser improved
