### PR TITLE
Bitmap layer: Rotation with selector tool (first usable version)

### DIFF
--- a/src/graphics/bitmap/bitmapimage.cpp
+++ b/src/graphics/bitmap/bitmapimage.cpp
@@ -301,8 +301,8 @@ void BitmapImage::moveTopLeft(QPoint point)
 
 void BitmapImage::transform(QRect newBoundaries, bool smoothTransform)
 {
-    if (boundaries != newBoundaries)
-    {
+    //if (boundaries != newBoundaries)
+    //{
         boundaries = newBoundaries;
         newBoundaries.moveTopLeft( QPoint(0,0) );
         QImage* newImage = new QImage( boundaries.size(), QImage::Format_ARGB32_Premultiplied);
@@ -316,7 +316,7 @@ void BitmapImage::transform(QRect newBoundaries, bool smoothTransform)
         painter.end();
         //if (image != NULL) delete image;
         image = newImage;
-    }
+    //}
 }
 
 BitmapImage BitmapImage::transformed(QRect newBoundaries, bool smoothTransform)

--- a/src/interface/scribblearea.h
+++ b/src/interface/scribblearea.h
@@ -56,6 +56,7 @@ public:
     bool somethingSelected;
     bool readCanvasFromCache;
     QRectF mySelection, myTransformedSelection, myTempTransformedSelection;
+    qreal myRotatedAngle;
 
     bool isModified() const { return modified; }
     bool areLayersSane() const;
@@ -70,7 +71,7 @@ public:
     bool usePressure() const { return m_usePressure; }
     bool makeInvisible() const { return m_makeInvisible; }
 
-    enum MoveMode { MIDDLE, TOPLEFT, TOPRIGHT, BOTTOMLEFT, BOTTOMRIGHT };
+    enum MoveMode { MIDDLE, TOPLEFT, TOPRIGHT, BOTTOMLEFT, BOTTOMRIGHT, ROTATION};
     MoveMode getMoveMode() const { return m_moveMode; }
     void setMoveMode(MoveMode moveMode) { m_moveMode = moveMode; }
 

--- a/src/tool/movetool.cpp
+++ b/src/tool/movetool.cpp
@@ -69,8 +69,13 @@ void MoveTool::mousePressEvent(QMouseEvent *event)
                         m_pScribbleArea->paintTransformedSelection();
                         m_pScribbleArea->deselectAll();
                     }
+                    else if (event->modifiers() == Qt::ControlModifier ) // --- rotation
+                    {
+                        m_pScribbleArea->setMoveMode(ScribbleArea::ROTATION );
+                        //qDebug() << "ROTATION";
+                    }
                 }
-                if (layer->type == Layer::VECTOR)
+                else if (layer->type == Layer::VECTOR)
                 {
                     VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(m_pEditor->m_nCurrentFrameIndex, 0);
                     if (m_pScribbleArea->closestCurves.size() > 0)     // the user clicks near a curve
@@ -185,6 +190,12 @@ void MoveTool::mouseMoveEvent(QMouseEvent *event)
                     case ScribbleArea::BOTTOMRIGHT:
                         m_pScribbleArea->myTempTransformedSelection =
                                 m_pScribbleArea->myTransformedSelection.adjusted(0, 0, m_pScribbleArea->offset.x(), m_pScribbleArea->offset.y());
+                        break;
+                    case ScribbleArea::ROTATION:
+                        m_pScribbleArea->myTempTransformedSelection =
+                                m_pScribbleArea->myTransformedSelection; // @ necessary?
+                        m_pScribbleArea->myRotatedAngle = getCurrentPixel().x() - getLastPressPixel().x();
+                        //qDebug() << "rotation" << m_pScribbleArea->myRotatedAngle;
                         break;
                     }
 

--- a/src/tool/selecttool.cpp
+++ b/src/tool/selecttool.cpp
@@ -31,6 +31,8 @@ void SelectTool::mousePressEvent(QMouseEvent *event)
     Layer *layer = m_pEditor->getCurrentLayer();
     if (layer == NULL) { return; }
 
+    m_pScribbleArea->myRotatedAngle = 0;
+
     if (event->button() == Qt::LeftButton)
     {
         if (layer->type == Layer::BITMAP || layer->type == Layer::VECTOR)

--- a/src/tool/smudgetool.cpp
+++ b/src/tool/smudgetool.cpp
@@ -214,7 +214,7 @@ void SmudgeTool::drawStroke()
     QPointF a = lastBrushPoint;
     QPointF b = getCurrentPoint();
 
-    qreal distance = 8 * QLineF(b, a).length();
+    qreal distance = 4 * QLineF(b, a).length();
     int steps = qRound(distance) / brushStep;
 
     for (int i = 0; i < steps; i++)


### PR DESCRIPTION
1. [CTRL]+DRAG from the middle of the selector rotates its content.
2. the box keeps its shape while not rescaled
3. rescaling is non-destructive (its applied exclusively to original)
