### PR TITLE
Smudge 2nd mode = hard ( by pressing [alt] ).

### DIFF
--- a/src/interface/scribblearea.h
+++ b/src/interface/scribblearea.h
@@ -215,7 +215,8 @@ public:
     void drawLine( QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm);
     void drawPath(QPainterPath path, QPen pen, QBrush brush, QPainter::CompositionMode cm);
     void drawBrush(QPointF thePoint, qreal brushWidth, qreal offset, QColor fillColour, qreal opacity);
-    void drawTexturedBrush(BitmapImage *argImg, QPointF srcPoint, QPointF thePoint, qreal brushWidth, qreal offset, qreal opacity);
+    void drawTexturedBrush( BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal offset_, qreal opacity_ );
+    void slideTexturedBrush( BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal offset_, qreal opacity_ );
     void floodFill(VectorImage *vectorImage, QPoint point, QRgb targetColour, QRgb replacementColour, int tolerance);
 
     void paintBitmapBuffer();

--- a/src/tool/smudgetool.h
+++ b/src/tool/smudgetool.h
@@ -9,6 +9,7 @@ class SmudgeTool : public StrokeTool
 public:
     explicit SmudgeTool(QObject *parent = 0);
     ToolType type();
+    uint toolMode;  // 0=normal/smooth 1=smudge - todo: move to basetool? could be useful
     void loadSettings();
     QCursor cursor();
 


### PR DESCRIPTION
Useful for painting & photo-retouch.
Smudging while pressing [alt] produces a hard (non smoothed) pixel
displacement. Normal smudge can be combined to smooth the result.
