### PR TITLE
2 file formats: old simple and new zipped

### DIFF
--- a/pencil.pro
+++ b/pencil.pro
@@ -10,6 +10,7 @@ OBJECTS_DIR = .obj
 DEPENDPATH += . src
 INCLUDEPATH += . src \
             src/external/flash \
+            src/external/quazip \
             src/graphics \
             src/graphics/bitmap \
             src/graphics/vector \
@@ -89,7 +90,18 @@ HEADERS +=  src/interfaces.h \
     src/structure/camera.h \
     src/interface/recentfilemenu.h \
     src/util/util.h \
-    src/interface/colormanager.h
+    src/interface/colormanager.h \
+    src/external/quazip/crypt.h \
+    src/external/quazip/JlCompress.h \
+    src/external/quazip/ioapi.h \
+    src/external/quazip/quazip.h \
+    src/external/quazip/quazip_global.h \
+    src/external/quazip/quazipfile.h \
+    src/external/quazip/quazipfileinfo.h \
+    src/external/quazip/quazipnewinfo.h \
+    src/external/quazip/unzip.h \
+    src/external/quazip/zip.h \
+    src/util/fileformat.h
 
 SOURCES +=  src/graphics/bitmap/blur.cpp \
             src/graphics/bitmap/bitmapimage.cpp \
@@ -151,7 +163,17 @@ SOURCES +=  src/graphics/bitmap/blur.cpp \
     src/structure/camera.cpp \
     src/interface/recentfilemenu.cpp \
     src/util/util.cpp \
-    src/interface/colormanager.cpp
+    src/interface/colormanager.cpp \
+    src/external/quazip/JlCompress.cpp \
+    src/external/quazip/qioapi.cpp \
+    src/external/quazip/quazip.cpp \
+    src/external/quazip/quazipfile.cpp \
+    src/external/quazip/quazipfileinfo.cpp \
+    src/external/quazip/quazipnewinfo.cpp \
+    src/external/quazip/unzip.c \
+    src/external/quazip/zip.c \
+    src/util/fileformat.cpp
+
 
 
 # Track dependencies for all includes
@@ -177,7 +199,7 @@ linux-* {
     INCLUDEPATH += . liblinux
     INCLUDEPATH += src/external/linux
     SOURCES += src/external/linux/linux.cpp
-    LIBS += -Lliblinux -lming -lpng
+    LIBS += -Lliblinux -lming -lpng -lz
 }
 RESOURCES += pencil.qrc
 

--- a/src/external/quazip/JlCompress.cpp
+++ b/src/external/quazip/JlCompress.cpp
@@ -1,0 +1,474 @@
+#include "JlCompress.h"
+#include <QDebug>
+
+static bool copyData(QIODevice &inFile, QIODevice &outFile)
+{
+    while (!inFile.atEnd()) {
+        char buf[4096];
+        qint64 readLen = inFile.read(buf, 4096);
+        if (readLen <= 0)
+            return false;
+        if (outFile.write(buf, readLen) != readLen)
+            return false;
+    }
+    return true;
+}
+
+/**OK
+ * Comprime il file fileName, nell'oggetto zip, con il nome fileDest.
+ *
+ * La funzione fallisce se:
+ * * zip==NULL;
+ * * l'oggetto zip e stato aperto in una modalita non compatibile con l'aggiunta di file;
+ * * non e possibile aprire il file d'origine;
+ * * non e possibile creare il file all'interno dell'oggetto zip;
+ * * si e rilevato un errore nella copia dei dati;
+ * * non e stato possibile chiudere il file all'interno dell'oggetto zip;
+ */
+bool JlCompress::compressFile(QuaZip* zip, QString fileName, QString fileDest) {
+    // zip: oggetto dove aggiungere il file
+    // fileName: nome del file reale
+    // fileDest: nome del file all'interno del file compresso
+
+    // Controllo l'apertura dello zip
+    if (!zip) return false;
+    if (zip->getMode()!=QuaZip::mdCreate &&
+        zip->getMode()!=QuaZip::mdAppend &&
+        zip->getMode()!=QuaZip::mdAdd) return false;
+
+    // Apro il file originale
+    QFile inFile;
+    inFile.setFileName(fileName);
+    if(!inFile.open(QIODevice::ReadOnly)) return false;
+
+    // Apro il file risulato
+    QuaZipFile outFile(zip);
+    if(!outFile.open(QIODevice::WriteOnly, QuaZipNewInfo(fileDest, inFile.fileName()))) return false;
+
+    // Copio i dati
+    if (!copyData(inFile, outFile) || outFile.getZipError()!=UNZ_OK) {
+        return false;
+    }
+
+    // Chiudo i file
+    outFile.close();
+    if (outFile.getZipError()!=UNZ_OK) return false;
+    inFile.close();
+
+    return true;
+}
+
+/**OK
+ * Comprime la cartella dir nel file fileCompressed, se recursive e true allora
+ * comprime anche le sotto cartelle. I nomi dei file preceduti dal path creato
+ * togliendo il pat della cartella origDir al path della cartella dir.
+ * Se la funzione fallisce restituisce false e cancella il file che si e tentato
+ * di creare.
+ *
+ * La funzione fallisce se:
+ * * zip==NULL;
+ * * l'oggetto zip e stato aperto in una modalita non compatibile con l'aggiunta di file;
+ * * la cartella dir non esiste;
+ * * la compressione di una sotto cartella fallisce (1);
+ * * la compressione di un file fallisce;
+ * (1) La funzione si richiama in maniera ricorsiva per comprimere le sotto cartelle
+ * dunque gli errori di compressione di una sotto cartella sono gli stessi di questa
+ * funzione.
+ */
+bool JlCompress::compressSubDir(QuaZip* zip, QString dir, QString origDir, bool recursive) {
+    // zip: oggetto dove aggiungere il file
+    // dir: cartella reale corrente
+    // origDir: cartella reale originale
+    // (path(dir)-path(origDir)) = path interno all'oggetto zip
+
+    // Controllo l'apertura dello zip
+    if (!zip) return false;
+    if (zip->getMode()!=QuaZip::mdCreate &&
+        zip->getMode()!=QuaZip::mdAppend &&
+        zip->getMode()!=QuaZip::mdAdd) return false;
+
+    // Controllo la cartella
+    QDir directory(dir);
+    if (!directory.exists()) return false;
+
+    // Se comprimo anche le sotto cartelle
+    if (recursive) {
+        // Per ogni sotto cartella
+        QFileInfoList files = directory.entryInfoList(QDir::AllDirs|QDir::NoDotAndDotDot);
+        Q_FOREACH (QFileInfo file, files) {
+            // Comprimo la sotto cartella
+            if(!compressSubDir(zip,file.absoluteFilePath(),origDir,recursive)) return false;
+        }
+    }
+
+    // Per ogni file nella cartella
+    QFileInfoList files = directory.entryInfoList(QDir::Files);
+    QDir origDirectory(origDir);
+    Q_FOREACH (QFileInfo file, files) {
+        // Se non e un file o e il file compresso che sto creando
+        if(!file.isFile()||file.absoluteFilePath()==zip->getZipName()) continue;
+
+        // Creo il nome relativo da usare all'interno del file compresso
+        QString filename = origDirectory.relativeFilePath(file.absoluteFilePath());
+
+        // Comprimo il file
+        if (!compressFile(zip,file.absoluteFilePath(),filename)) return false;
+    }
+
+    return true;
+}
+
+/**OK
+ * Estrae il file fileName, contenuto nell'oggetto zip, con il nome fileDest.
+ * Se la funzione fallisce restituisce false e cancella il file che si e tentato di estrarre.
+ *
+ * La funzione fallisce se:
+ * * zip==NULL;
+ * * l'oggetto zip e stato aperto in una modalita non compatibile con l'estrazione di file;
+ * * non e possibile aprire il file all'interno dell'oggetto zip;
+ * * non e possibile creare il file estratto;
+ * * si e rilevato un errore nella copia dei dati (1);
+ * * non e stato possibile chiudere il file all'interno dell'oggetto zip (1);
+ *
+ * (1): prima di uscire dalla funzione cancella il file estratto.
+ */
+bool JlCompress::extractFile(QuaZip* zip, QString fileName, QString fileDest) {
+    // zip: oggetto dove aggiungere il file
+    // filename: nome del file reale
+    // fileincompress: nome del file all'interno del file compresso
+
+    // Controllo l'apertura dello zip
+    if (!zip) return false;
+    if (zip->getMode()!=QuaZip::mdUnzip) return false;
+
+    // Apro il file compresso
+    if (!fileName.isEmpty())
+        zip->setCurrentFile(fileName);
+    QuaZipFile inFile(zip);
+    if(!inFile.open(QIODevice::ReadOnly) || inFile.getZipError()!=UNZ_OK) return false;
+
+    // Controllo esistenza cartella file risultato
+    QDir curDir;
+    if (!curDir.mkpath(QFileInfo(fileDest).absolutePath())) {
+        return false;
+    }
+
+    QuaZipFileInfo info;
+    if (!zip->getCurrentFileInfo(&info))
+        return false;
+
+    if (fileDest.endsWith('/') && QFileInfo(fileDest).isDir()) {
+        return QFile(fileDest).setPermissions(info.getPermissions());
+    }
+
+    // Apro il file risultato
+    QFile outFile;
+    outFile.setFileName(fileDest);
+    if(!outFile.open(QIODevice::WriteOnly)) return false;
+
+    // Copio i dati
+    if (!copyData(inFile, outFile) || inFile.getZipError()!=UNZ_OK) {
+        outFile.close();
+        removeFile(QStringList(fileDest));
+        return false;
+    }
+    outFile.close();
+
+    // Chiudo i file
+    inFile.close();
+    if (inFile.getZipError()!=UNZ_OK) {
+        removeFile(QStringList(fileDest));
+        return false;
+    }
+
+    return outFile.setPermissions(info.getPermissions());
+}
+
+/**
+ * Rimuove i file il cui nome e specificato all'interno di listFile.
+ * Restituisce true se tutti i file sono stati cancellati correttamente, attenzione
+ * perche puo restituire false anche se alcuni file non esistevano e si e tentato
+ * di cancellarli.
+ */
+bool JlCompress::removeFile(QStringList listFile) {
+    bool ret = true;
+    // Per ogni file
+    for (int i=0; i<listFile.count(); i++) {
+        // Lo elimino
+        ret = ret && QFile::remove(listFile.at(i));
+    }
+    return ret;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+/**OK
+ * Comprime il file fileName nel file fileCompressed.
+ * Se la funzione fallisce restituisce false e cancella il file che si e tentato
+ * di creare.
+ *
+ * La funzione fallisce se:
+ * * non si riesce ad aprire l'oggetto zip;
+ * * la compressione del file fallisce;
+ * * non si riesce a chiudere l'oggetto zip;
+ */
+bool JlCompress::compressFile(QString fileCompressed, QString file) {
+    // Creo lo zip
+    QuaZip zip(fileCompressed);
+    QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
+    if(!zip.open(QuaZip::mdCreate)) {
+        QFile::remove(fileCompressed);
+        return false;
+    }
+
+    // Aggiungo il file
+    if (!compressFile(&zip,file,QFileInfo(file).fileName())) {
+        QFile::remove(fileCompressed);
+        return false;
+    }
+
+    // Chiudo il file zip
+    zip.close();
+    if(zip.getZipError()!=0) {
+        QFile::remove(fileCompressed);
+        return false;
+    }
+
+    return true;
+}
+
+/**OK
+ * Comprime i file specificati in files nel file fileCompressed.
+ * Se la funzione fallisce restituisce false e cancella il file che si e tentato
+ * di creare.
+ *
+ * La funzione fallisce se:
+ * * non si riesce ad aprire l'oggetto zip;
+ * * la compressione di un file fallisce;
+ * * non si riesce a chiudere l'oggetto zip;
+ */
+bool JlCompress::compressFiles(QString fileCompressed, QStringList files) {
+    // Creo lo zip
+    QuaZip zip(fileCompressed);
+    QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
+    if(!zip.open(QuaZip::mdCreate)) {
+        QFile::remove(fileCompressed);
+        return false;
+    }
+
+    // Comprimo i file
+    QFileInfo info;
+    Q_FOREACH (QString file, files) {
+        info.setFile(file);
+        if (!info.exists() || !compressFile(&zip,file,info.fileName())) {
+            QFile::remove(fileCompressed);
+            return false;
+        }
+    }
+
+    // Chiudo il file zip
+    zip.close();
+    if(zip.getZipError()!=0) {
+        QFile::remove(fileCompressed);
+        return false;
+    }
+
+    return true;
+}
+
+/**OK
+ * Comprime la cartella dir nel file fileCompressed, se recursive e true allora
+ * comprime anche le sotto cartelle.
+ * Se la funzione fallisce restituisce false e cancella il file che si e tentato
+ * di creare.
+ *
+ * La funzione fallisce se:
+ * * non si riesce ad aprire l'oggetto zip;
+ * * la compressione di un file fallisce;
+ * * non si riesce a chiudere l'oggetto zip;
+ */
+bool JlCompress::compressDir(QString fileCompressed, QString dir, bool recursive) {
+    // Creo lo zip
+    QuaZip zip(fileCompressed);
+    QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
+    if(!zip.open(QuaZip::mdCreate)) {
+        QFile::remove(fileCompressed);
+        return false;
+    }
+
+    // Aggiungo i file e le sotto cartelle
+    if (!compressSubDir(&zip,dir,dir,recursive)) {
+        QFile::remove(fileCompressed);
+        return false;
+    }
+
+    // Chiudo il file zip
+    zip.close();
+    if(zip.getZipError()!=0) {
+        QFile::remove(fileCompressed);
+        return false;
+    }
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+/**OK
+ * Estrae il file fileName, contenuto nel file fileCompressed, con il nome fileDest.
+ * Se fileDest = "" allora il file viene estratto con lo stesso nome con cui e
+ * stato compresso.
+ * Se la funzione fallisce cancella il file che si e tentato di estrarre.
+ * Restituisce il nome assoluto del file estratto.
+ *
+ * La funzione fallisce se:
+ * * non si riesce ad aprire l'oggetto zip;
+ * * l'estrazione del file fallisce;
+ * * non si riesce a chiudere l'oggetto zip;
+ */
+QString JlCompress::extractFile(QString fileCompressed, QString fileName, QString fileDest) {
+    // Apro lo zip
+    QuaZip zip(fileCompressed);
+    if(!zip.open(QuaZip::mdUnzip)) {
+        return QString();
+    }
+
+    // Estraggo il file
+    if (fileDest.isEmpty()) 
+        fileDest = fileName;
+    if (!extractFile(&zip,fileName,fileDest)) {
+        return QString();
+    }
+
+    // Chiudo il file zip
+    zip.close();
+    if(zip.getZipError()!=0) {
+        removeFile(QStringList(fileDest));
+        return QString();
+    }
+    return QFileInfo(fileDest).absoluteFilePath();
+}
+
+/**OK
+ * Estrae i file specificati in files, contenuti nel file fileCompressed, nella
+ * cartella dir. La struttura a cartelle del file compresso viene rispettata.
+ * Se dir = "" allora il file viene estratto nella cartella corrente.
+ * Se la funzione fallisce cancella i file che si e tentato di estrarre.
+ * Restituisce i nomi assoluti dei file estratti.
+ *
+ * La funzione fallisce se:
+ * * non si riesce ad aprire l'oggetto zip;
+ * * l'estrazione di un file fallisce;
+ * * non si riesce a chiudere l'oggetto zip;
+ */
+QStringList JlCompress::extractFiles(QString fileCompressed, QStringList files, QString dir) {
+    // Creo lo zip
+    QuaZip zip(fileCompressed);
+    if(!zip.open(QuaZip::mdUnzip)) {
+        return QStringList();
+    }
+
+    // Estraggo i file
+    QStringList extracted;
+    for (int i=0; i<files.count(); i++) {
+        QString absPath = QDir(dir).absoluteFilePath(files.at(i));
+        if (!extractFile(&zip, files.at(i), absPath)) {
+            removeFile(extracted);
+            return QStringList();
+        }
+        extracted.append(absPath);
+    }
+
+    // Chiudo il file zip
+    zip.close();
+    if(zip.getZipError()!=0) {
+        removeFile(extracted);
+        return QStringList();
+    }
+
+    return extracted;
+}
+
+/**OK
+ * Estrae il file fileCompressed nella cartella dir.
+ * Se dir = "" allora il file viene estratto nella cartella corrente.
+ * Se la funzione fallisce cancella i file che si e tentato di estrarre.
+ * Restituisce i nomi assoluti dei file estratti.
+ *
+ * La funzione fallisce se:
+ * * non si riesce ad aprire l'oggetto zip;
+ * * la compressione di un file fallisce;
+ * * non si riesce a chiudere l'oggetto zip;
+ */
+QStringList JlCompress::extractDir(QString fileCompressed, QString dir) {
+    // Apro lo zip
+    QuaZip zip(fileCompressed);
+    if(!zip.open(QuaZip::mdUnzip)) {
+        return QStringList();
+    }
+
+    QDir directory(dir);
+    QStringList extracted;
+    if (!zip.goToFirstFile()) {
+        return QStringList();
+    }
+    do {
+        QString name = zip.getCurrentFileName();
+        QString absFilePath = directory.absoluteFilePath(name);
+        if (!extractFile(&zip, "", absFilePath)) {
+            removeFile(extracted);
+            return QStringList();
+        }
+        extracted.append(absFilePath);
+    } while (zip.goToNextFile());
+
+    // Chiudo il file zip
+    zip.close();
+    if(zip.getZipError()!=0) {
+        removeFile(extracted);
+        return QStringList();
+    }
+
+    return extracted;
+}
+
+/**OK
+ * Restituisce la lista dei file resenti nel file compresso fileCompressed.
+ * Se la funzione fallisce, restituisce un elenco vuoto.
+ *
+ * La funzione fallisce se:
+ * * non si riesce ad aprire l'oggetto zip;
+ * * la richiesta di informazioni di un file fallisce;
+ * * non si riesce a chiudere l'oggetto zip;
+ */
+QStringList JlCompress::getFileList(QString fileCompressed) {
+    // Apro lo zip
+    QuaZip* zip = new QuaZip(QFileInfo(fileCompressed).absoluteFilePath());
+    if(!zip->open(QuaZip::mdUnzip)) {
+        delete zip;
+        return QStringList();
+    }
+
+    // Estraggo i nomi dei file
+    QStringList lst;
+    QuaZipFileInfo info;
+    for(bool more=zip->goToFirstFile(); more; more=zip->goToNextFile()) {
+      if(!zip->getCurrentFileInfo(&info)) {
+          delete zip;
+          return QStringList();
+      }
+      lst << info.name;
+      //info.name.toLocal8Bit().constData()
+    }
+
+    // Chiudo il file zip
+    zip->close();
+    if(zip->getZipError()!=0) {
+        delete zip;
+        return QStringList();
+    }
+    delete zip;
+
+    return lst;
+}
+

--- a/src/external/quazip/JlCompress.h
+++ b/src/external/quazip/JlCompress.h
@@ -1,0 +1,114 @@
+#ifndef JLCOMPRESSFOLDER_H_
+#define JLCOMPRESSFOLDER_H_
+
+#include "quazip.h"
+#include "quazipfile.h"
+#include "quazipfileinfo.h"
+#include <QString>
+#include <QDir>
+#include <QFileInfo>
+#include <QFile>
+
+/// Utility class for typical operations.
+/**
+  This class contains a number of useful static functions to perform
+  simple operations, such as mass ZIP packing or extraction.
+  */
+class QUAZIP_EXPORT JlCompress {
+private:
+    /// Compress a single file.
+    /**
+      \param zip Opened zip to compress the file to.
+      \param fileName The full path to the source file.
+      \param fileDest The full name of the file inside the archive.
+      \return true if success, false otherwise.
+      */
+    static bool compressFile(QuaZip* zip, QString fileName, QString fileDest);
+    /// Compress a subdirectory.
+    /**
+      \param parentZip Opened zip containing the parent directory.
+      \param dir The full path to the directory to pack.
+      \param parentDir The full path to the directory corresponding to
+      the root of the ZIP.
+      \param recursive Whether to pack sub-directories as well or only
+      files.
+      \return true if success, false otherwise.
+      */
+    static bool compressSubDir(QuaZip* parentZip, QString dir, QString parentDir, bool recursive = true);
+    /// Extract a single file.
+    /**
+      \param zip The opened zip archive to extract from.
+      \param fileName The full name of the file to extract.
+      \param fileDest The full path to the destination file.
+      \return true if success, false otherwise.
+      */
+    static bool extractFile(QuaZip* zip, QString fileName, QString fileDest);
+    /// Remove some files.
+    /**
+      \param listFile The list of files to remove.
+      \return true if success, false otherwise.
+      */
+    static bool removeFile(QStringList listFile);
+
+public:
+    /// Compress a single file.
+    /**
+      \param fileCompressed The name of the archive.
+      \param file The file to compress.
+      \return true if success, false otherwise.
+      */
+    static bool compressFile(QString fileCompressed, QString file);
+    /// Compress a list of files.
+    /**
+      \param fileCompressed The name of the archive.
+      \param files The file list to compress.
+      \return true if success, false otherwise.
+      */
+    static bool compressFiles(QString fileCompressed, QStringList files);
+    /// Compress a whole directory.
+    /**
+      \param fileCompressed The name of the archive.
+      \param dir The directory to compress.
+      \param recursive Whether to pack the subdirectories as well, or
+      just regular files.
+      \return true if success, false otherwise.
+      */
+    static bool compressDir(QString fileCompressed, QString dir = QString(), bool recursive = true);
+
+public:
+    /// Extract a single file.
+    /**
+      \param fileCompressed The name of the archive.
+      \param fileName The file to extract.
+      \param fileDest The destination file, assumed to be identical to
+      \a file if left empty.
+      \return The list of the full paths of the files extracted, empty on failure.
+      */
+    static QString extractFile(QString fileCompressed, QString fileName, QString fileDest = QString());
+    /// Extract a list of files.
+    /**
+      \param fileCompressed The name of the archive.
+      \param files The file list to extract.
+      \param dir The directory to put the files to, the current
+      directory if left empty.
+      \return The list of the full paths of the files extracted, empty on failure.
+      */
+    static QStringList extractFiles(QString fileCompressed, QStringList files, QString dir = QString());
+    /// Extract a whole archive.
+    /**
+      \param fileCompressed The name of the archive.
+      \param dir The directory to extract to, the current directory if
+      left empty.
+      \return The list of the full paths of the files extracted, empty on failure.
+      */
+    static QStringList extractDir(QString fileCompressed, QString dir = QString());
+    /// Get the file list.
+    /**
+      \return The list of the files in the archive, or, more precisely, the
+      list of the entries, including both files and directories if they
+      are present separately.
+      */
+    static QStringList getFileList(QString fileCompressed);
+};
+
+#endif /* JLCOMPRESSFOLDER_H_ */

--- a/src/external/quazip/crypt.h
+++ b/src/external/quazip/crypt.h
@@ -1,0 +1,135 @@
+/* crypt.h -- base code for crypt/uncrypt ZIPfile
+
+
+   Version 1.01e, February 12th, 2005
+
+   Copyright (C) 1998-2005 Gilles Vollant
+
+   This code is a modified version of crypting code in Infozip distribution
+
+   The encryption/decryption parts of this source code (as opposed to the
+   non-echoing password parts) were originally written in Europe.  The
+   whole source package can be freely distributed, including from the USA.
+   (Prior to January 2000, re-export from the US was a violation of US law.)
+
+   This encryption code is a direct transcription of the algorithm from
+   Roger Schlafly, described by Phil Katz in the file appnote.txt.  This
+   file (appnote.txt) is distributed with the PKZIP program (even in the
+   version without encryption capabilities).
+
+   If you don't need crypting in your application, just define symbols
+   NOCRYPT and NOUNCRYPT.
+
+   This code support the "Traditional PKWARE Encryption".
+
+   The new AES encryption added on Zip format by Winzip (see the page
+   http://www.winzip.com/aes_info.htm ) and PKWare PKZip 5.x Strong
+   Encryption is not supported.
+*/
+
+#include "quazip_global.h"
+
+#define CRC32(c, b) ((*(pcrc_32_tab+(((int)(c) ^ (b)) & 0xff))) ^ ((c) >> 8))
+
+/***********************************************************************
+ * Return the next byte in the pseudo-random sequence
+ */
+static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab UNUSED)
+{
+    //(void) pcrc_32_tab; /* avoid "unused parameter" warning */
+    unsigned temp;  /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
+                     * unpredictable manner on 16-bit systems; not a problem
+                     * with any known compiler so far, though */
+
+    temp = ((unsigned)(*(pkeys+2)) & 0xffff) | 2;
+    return (int)(((temp * (temp ^ 1)) >> 8) & 0xff);
+}
+
+/***********************************************************************
+ * Update the encryption keys with the next byte of plain text
+ */
+static int update_keys(unsigned long* pkeys,const unsigned long* pcrc_32_tab,int c)
+{
+    (*(pkeys+0)) = CRC32((*(pkeys+0)), c);
+    (*(pkeys+1)) += (*(pkeys+0)) & 0xff;
+    (*(pkeys+1)) = (*(pkeys+1)) * 134775813L + 1;
+    {
+      register int keyshift = (int)((*(pkeys+1)) >> 24);
+      (*(pkeys+2)) = CRC32((*(pkeys+2)), keyshift);
+    }
+    return c;
+}
+
+
+/***********************************************************************
+ * Initialize the encryption keys and the random header according to
+ * the given password.
+ */
+static void init_keys(const char* passwd,unsigned long* pkeys,const unsigned long* pcrc_32_tab)
+{
+    *(pkeys+0) = 305419896L;
+    *(pkeys+1) = 591751049L;
+    *(pkeys+2) = 878082192L;
+    while (*passwd != '\0') {
+        update_keys(pkeys,pcrc_32_tab,(int)*passwd);
+        passwd++;
+    }
+}
+
+#define zdecode(pkeys,pcrc_32_tab,c) \
+    (update_keys(pkeys,pcrc_32_tab,c ^= decrypt_byte(pkeys,pcrc_32_tab)))
+
+#define zencode(pkeys,pcrc_32_tab,c,t) \
+    (t=decrypt_byte(pkeys,pcrc_32_tab), update_keys(pkeys,pcrc_32_tab,c), t^(c))
+
+#ifdef INCLUDECRYPTINGCODE_IFCRYPTALLOWED
+
+#define RAND_HEAD_LEN  12
+   /* "last resort" source for second part of crypt seed pattern */
+#  ifndef ZCR_SEED2
+#    define ZCR_SEED2 3141592654UL     /* use PI as default pattern */
+#  endif
+
+static int crypthead(passwd, buf, bufSize, pkeys, pcrc_32_tab, crcForCrypting)
+    const char *passwd;         /* password string */
+    unsigned char *buf;         /* where to write header */
+    int bufSize;
+    unsigned long* pkeys;
+    const unsigned long* pcrc_32_tab;
+    unsigned long crcForCrypting;
+{
+    int n;                       /* index in random header */
+    int t;                       /* temporary */
+    int c;                       /* random byte */
+    unsigned char header[RAND_HEAD_LEN-2]; /* random header */
+    static unsigned calls = 0;   /* ensure different random header each time */
+
+    if (bufSize<RAND_HEAD_LEN)
+      return 0;
+
+    /* First generate RAND_HEAD_LEN-2 random bytes. We encrypt the
+     * output of rand() to get less predictability, since rand() is
+     * often poorly implemented.
+     */
+    if (++calls == 1)
+    {
+        srand((unsigned)(time(NULL) ^ ZCR_SEED2));
+    }
+    init_keys(passwd, pkeys, pcrc_32_tab);
+    for (n = 0; n < RAND_HEAD_LEN-2; n++)
+    {
+        c = (rand() >> 7) & 0xff;
+        header[n] = (unsigned char)zencode(pkeys, pcrc_32_tab, c, t);
+    }
+    /* Encrypt random header (last two bytes is high word of crc) */
+    init_keys(passwd, pkeys, pcrc_32_tab);
+    for (n = 0; n < RAND_HEAD_LEN-2; n++)
+    {
+        buf[n] = (unsigned char)zencode(pkeys, pcrc_32_tab, header[n], t);
+    }
+    buf[n++] = zencode(pkeys, pcrc_32_tab, (int)(crcForCrypting >> 16) & 0xff, t);
+    buf[n++] = zencode(pkeys, pcrc_32_tab, (int)(crcForCrypting >> 24) & 0xff, t);
+    return n;
+}
+
+#endif

--- a/src/external/quazip/ioapi.h
+++ b/src/external/quazip/ioapi.h
@@ -1,0 +1,77 @@
+/* ioapi.h -- IO base function header for compress/uncompress .zip
+   files using zlib + zip or unzip API
+
+   Version 1.01e, February 12th, 2005
+
+   Copyright (C) 1998-2005 Gilles Vollant
+
+   Modified by Sergey A. Tachenov to integrate with Qt.
+*/
+
+#ifndef _ZLIBIOAPI_H
+#define _ZLIBIOAPI_H
+
+
+#define ZLIB_FILEFUNC_SEEK_CUR (1)
+#define ZLIB_FILEFUNC_SEEK_END (2)
+#define ZLIB_FILEFUNC_SEEK_SET (0)
+
+#define ZLIB_FILEFUNC_MODE_READ      (1)
+#define ZLIB_FILEFUNC_MODE_WRITE     (2)
+#define ZLIB_FILEFUNC_MODE_READWRITEFILTER (3)
+
+#define ZLIB_FILEFUNC_MODE_EXISTING (4)
+#define ZLIB_FILEFUNC_MODE_CREATE   (8)
+
+
+#ifndef ZCALLBACK
+
+#if (defined(WIN32) || defined (WINDOWS) || defined (_WINDOWS)) && defined(CALLBACK) && defined (USEWINDOWS_CALLBACK)
+#define ZCALLBACK CALLBACK
+#else
+#define ZCALLBACK
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef voidpf (ZCALLBACK *open_file_func) OF((voidpf opaque, voidpf file, int mode));
+typedef uLong  (ZCALLBACK *read_file_func) OF((voidpf opaque, voidpf stream, void* buf, uLong size));
+typedef uLong  (ZCALLBACK *write_file_func) OF((voidpf opaque, voidpf stream, const void* buf, uLong size));
+typedef uLong   (ZCALLBACK *tell_file_func) OF((voidpf opaque, voidpf stream));
+typedef int   (ZCALLBACK *seek_file_func) OF((voidpf opaque, voidpf stream, uLong offset, int origin));
+typedef int    (ZCALLBACK *close_file_func) OF((voidpf opaque, voidpf stream));
+typedef int    (ZCALLBACK *testerror_file_func) OF((voidpf opaque, voidpf stream));
+
+typedef struct zlib_filefunc_def_s
+{
+    open_file_func      zopen_file;
+    read_file_func      zread_file;
+    write_file_func     zwrite_file;
+    tell_file_func      ztell_file;
+    seek_file_func      zseek_file;
+    close_file_func     zclose_file;
+    testerror_file_func zerror_file;
+    voidpf              opaque;
+} zlib_filefunc_def;
+
+
+
+void fill_qiodevice_filefunc OF((zlib_filefunc_def* pzlib_filefunc_def));
+
+#define ZREAD(filefunc,filestream,buf,size) ((*((filefunc).zread_file))((filefunc).opaque,filestream,buf,size))
+#define ZWRITE(filefunc,filestream,buf,size) ((*((filefunc).zwrite_file))((filefunc).opaque,filestream,buf,size))
+#define ZTELL(filefunc,filestream) ((*((filefunc).ztell_file))((filefunc).opaque,filestream))
+#define ZSEEK(filefunc,filestream,pos,mode) ((*((filefunc).zseek_file))((filefunc).opaque,filestream,pos,mode))
+#define ZCLOSE(filefunc,filestream) ((*((filefunc).zclose_file))((filefunc).opaque,filestream))
+#define ZERROR(filefunc,filestream) ((*((filefunc).zerror_file))((filefunc).opaque,filestream))
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/src/external/quazip/qioapi.cpp
+++ b/src/external/quazip/qioapi.cpp
@@ -1,0 +1,146 @@
+/* ioapi.c -- IO base function header for compress/uncompress .zip
+   files using zlib + zip or unzip API
+
+   Version 1.01e, February 12th, 2005
+
+   Copyright (C) 1998-2005 Gilles Vollant
+
+   Modified by Sergey A. Tachenov to integrate with Qt.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "zlib.h"
+#include "ioapi.h"
+#include "quazip_global.h"
+#include <QIODevice>
+
+
+/* I've found an old Unix (a SunOS 4.1.3_U1) without all SEEK_* defined.... */
+
+#ifndef SEEK_CUR
+#define SEEK_CUR    1
+#endif
+
+#ifndef SEEK_END
+#define SEEK_END    2
+#endif
+
+#ifndef SEEK_SET
+#define SEEK_SET    0
+#endif
+
+voidpf ZCALLBACK qiodevice_open_file_func (
+   voidpf /*opaque UNUSED*/,
+   voidpf file,
+   int mode)
+{
+    QIODevice *iodevice = reinterpret_cast<QIODevice*>(file);
+    if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
+        iodevice->open(QIODevice::ReadOnly);
+    else
+    if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
+        iodevice->open(QIODevice::ReadWrite);
+    else
+    if (mode & ZLIB_FILEFUNC_MODE_CREATE)
+        iodevice->open(QIODevice::WriteOnly);
+
+    if (iodevice->isOpen()) {
+        if (iodevice->isSequential()) {
+            iodevice->close();
+            return NULL;
+        } else {
+            return iodevice;
+        }
+    } else
+        return NULL;
+}
+
+
+uLong ZCALLBACK qiodevice_read_file_func (
+   voidpf /*opaque UNUSED*/,
+   voidpf stream,
+   void* buf,
+   uLong size)
+{
+    uLong ret;
+    ret = (uLong)((QIODevice*)stream)->read((char*)buf,size);
+    return ret;
+}
+
+
+uLong ZCALLBACK qiodevice_write_file_func (
+   voidpf /*opaque UNUSED*/,
+   voidpf stream,
+   const void* buf,
+   uLong size)
+{
+    uLong ret;
+    ret = (uLong)((QIODevice*)stream)->write((char*)buf,size);
+    return ret;
+}
+
+uLong ZCALLBACK qiodevice_tell_file_func (
+   voidpf /*opaque UNUSED*/,
+   voidpf stream)
+{
+    uLong ret;
+    ret = ((QIODevice*)stream)->pos();
+    return ret;
+}
+
+int ZCALLBACK qiodevice_seek_file_func (
+   voidpf /*opaque UNUSED*/,
+   voidpf stream,
+   uLong offset,
+   int origin)
+{
+    uLong qiodevice_seek_result=0;
+    int ret;
+    switch (origin)
+    {
+    case ZLIB_FILEFUNC_SEEK_CUR :
+        qiodevice_seek_result = ((QIODevice*)stream)->pos() + offset;
+        break;
+    case ZLIB_FILEFUNC_SEEK_END :
+        qiodevice_seek_result = ((QIODevice*)stream)->size() - offset;
+        break;
+    case ZLIB_FILEFUNC_SEEK_SET :
+        qiodevice_seek_result = offset;
+        break;
+    default: return -1;
+    }
+    ret = !((QIODevice*)stream)->seek(qiodevice_seek_result);
+    return ret;
+}
+
+int ZCALLBACK qiodevice_close_file_func (
+   voidpf /*opaque UNUSED*/,
+   voidpf stream)
+{
+    ((QIODevice*)stream)->close();
+    return 0;
+}
+
+int ZCALLBACK qiodevice_error_file_func (
+   voidpf /*opaque UNUSED*/,
+   voidpf /*stream UNUSED*/)
+{
+    // can't check for error due to the QIODevice API limitation
+    return 0;
+}
+
+void fill_qiodevice_filefunc (
+  zlib_filefunc_def* pzlib_filefunc_def)
+{
+    pzlib_filefunc_def->zopen_file = qiodevice_open_file_func;
+    pzlib_filefunc_def->zread_file = qiodevice_read_file_func;
+    pzlib_filefunc_def->zwrite_file = qiodevice_write_file_func;
+    pzlib_filefunc_def->ztell_file = qiodevice_tell_file_func;
+    pzlib_filefunc_def->zseek_file = qiodevice_seek_file_func;
+    pzlib_filefunc_def->zclose_file = qiodevice_close_file_func;
+    pzlib_filefunc_def->zerror_file = qiodevice_error_file_func;
+    pzlib_filefunc_def->opaque = NULL;
+}

--- a/src/external/quazip/quazip.cpp
+++ b/src/external/quazip/quazip.cpp
@@ -1,0 +1,554 @@
+/*
+Copyright (C) 2005-2011 Sergey A. Tachenov
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2 of the License, or (at
+your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+See COPYING file for the full LGPL text.
+
+Original ZIP package is copyrighted by Gilles Vollant, see
+quazip/(un)zip.h files for details, basically it's zlib license.
+ **/
+
+#include <QFile>
+#include <QFlags>
+
+#include "quazip.h"
+
+/// All the internal stuff for the QuaZip class.
+/**
+  \internal
+
+  This class keeps all the private stuff for the QuaZip class so it can
+  be changed without breaking binary compatibility, according to the
+  Pimpl idiom.
+  */
+class QuaZipPrivate {
+  friend class QuaZip;
+  private:
+    /// The pointer to the corresponding QuaZip instance.
+    QuaZip *q;
+    /// The codec for file names.
+    QTextCodec *fileNameCodec;
+    /// The codec for comments.
+    QTextCodec *commentCodec;
+    /// The archive file name.
+    QString zipName;
+    /// The device to access the archive.
+    QIODevice *ioDevice;
+    /// The global comment.
+    QString comment;
+    /// The open mode.
+    QuaZip::Mode mode;
+    union {
+      /// The internal handle for UNZIP modes.
+      unzFile unzFile_f;
+      /// The internal handle for ZIP modes.
+      zipFile zipFile_f;
+    };
+    /// Whether a current file is set.
+    bool hasCurrentFile_f;
+    /// The last error.
+    int zipError;
+    /// Whether \ref QuaZip::setDataDescriptorWritingEnabled() "the data descriptor writing mode" is enabled.
+    bool dataDescriptorWritingEnabled;
+    /// The constructor for the corresponding QuaZip constructor.
+    inline QuaZipPrivate(QuaZip *q):
+        q(q),
+      fileNameCodec(QTextCodec::codecForLocale()),
+      commentCodec(QTextCodec::codecForLocale()),
+      ioDevice(NULL),
+      mode(QuaZip::mdNotOpen),
+      hasCurrentFile_f(false),
+      zipError(UNZ_OK),
+      dataDescriptorWritingEnabled(true) {}
+    /// The constructor for the corresponding QuaZip constructor.
+    inline QuaZipPrivate(QuaZip *q, const QString &zipName):
+        q(q),
+      fileNameCodec(QTextCodec::codecForLocale()),
+      commentCodec(QTextCodec::codecForLocale()),
+      zipName(zipName),
+      ioDevice(NULL),
+      mode(QuaZip::mdNotOpen),
+      hasCurrentFile_f(false),
+      zipError(UNZ_OK),
+      dataDescriptorWritingEnabled(true) {}
+    /// The constructor for the corresponding QuaZip constructor.
+    inline QuaZipPrivate(QuaZip *q, QIODevice *ioDevice):
+        q(q),
+      fileNameCodec(QTextCodec::codecForLocale()),
+      commentCodec(QTextCodec::codecForLocale()),
+      ioDevice(ioDevice),
+      mode(QuaZip::mdNotOpen),
+      hasCurrentFile_f(false),
+      zipError(UNZ_OK),
+      dataDescriptorWritingEnabled(true) {}
+    /// Returns either a list of file names or a list of QuaZipFileInfo.
+    template<typename TFileInfo>
+        bool getFileInfoList(QList<TFileInfo> *result) const;
+};
+
+QuaZip::QuaZip():
+  p(new QuaZipPrivate(this))
+{
+}
+
+QuaZip::QuaZip(const QString& zipName):
+  p(new QuaZipPrivate(this, zipName))
+{
+}
+
+QuaZip::QuaZip(QIODevice *ioDevice):
+  p(new QuaZipPrivate(this, ioDevice))
+{
+}
+
+QuaZip::~QuaZip()
+{
+  if(isOpen())
+    close();
+  delete p;
+}
+
+bool QuaZip::open(Mode mode, zlib_filefunc_def* ioApi)
+{
+  p->zipError=UNZ_OK;
+  if(isOpen()) {
+    qWarning("QuaZip::open(): ZIP already opened");
+    return false;
+  }
+  QIODevice *ioDevice = p->ioDevice;
+  if (ioDevice == NULL) {
+    if (p->zipName.isEmpty()) {
+      qWarning("QuaZip::open(): set either ZIP file name or IO device first");
+      return false;
+    } else {
+      ioDevice = new QFile(p->zipName);
+    }
+  }
+  switch(mode) {
+    case mdUnzip:
+      p->unzFile_f=unzOpen2(ioDevice, ioApi);
+      if(p->unzFile_f!=NULL) {
+        p->mode=mode;
+        p->ioDevice = ioDevice;
+        return true;
+      } else {
+        p->zipError=UNZ_OPENERROR;
+        if (!p->zipName.isEmpty())
+          delete ioDevice;
+        return false;
+      }
+    case mdCreate:
+    case mdAppend:
+    case mdAdd:
+      p->zipFile_f=zipOpen2(ioDevice,
+          mode==mdCreate?APPEND_STATUS_CREATE:
+          mode==mdAppend?APPEND_STATUS_CREATEAFTER:
+          APPEND_STATUS_ADDINZIP,
+          NULL,
+          ioApi);
+      if(p->zipFile_f!=NULL) {
+        p->mode=mode;
+        p->ioDevice = ioDevice;
+        return true;
+      } else {
+        p->zipError=UNZ_OPENERROR;
+        if (!p->zipName.isEmpty())
+          delete ioDevice;
+        return false;
+      }
+    default:
+      qWarning("QuaZip::open(): unknown mode: %d", (int)mode);
+      if (!p->zipName.isEmpty())
+        delete ioDevice;
+      return false;
+      break;
+  }
+}
+
+void QuaZip::close()
+{
+  p->zipError=UNZ_OK;
+  switch(p->mode) {
+    case mdNotOpen:
+      qWarning("QuaZip::close(): ZIP is not open");
+      return;
+    case mdUnzip:
+      p->zipError=unzClose(p->unzFile_f);
+      break;
+    case mdCreate:
+    case mdAppend:
+    case mdAdd:
+      p->zipError=zipClose(p->zipFile_f, 
+          p->comment.isNull() ? NULL
+          : p->commentCodec->fromUnicode(p->comment).constData());
+      break;
+    default:
+      qWarning("QuaZip::close(): unknown mode: %d", (int)p->mode);
+      return;
+  }
+  // opened by name, need to delete the internal IO device
+  if (!p->zipName.isEmpty()) {
+      delete p->ioDevice;
+      p->ioDevice = NULL;
+  }
+  if(p->zipError==UNZ_OK)
+    p->mode=mdNotOpen;
+}
+
+void QuaZip::setZipName(const QString& zipName)
+{
+  if(isOpen()) {
+    qWarning("QuaZip::setZipName(): ZIP is already open!");
+    return;
+  }
+  p->zipName=zipName;
+  p->ioDevice = NULL;
+}
+
+void QuaZip::setIoDevice(QIODevice *ioDevice)
+{
+  if(isOpen()) {
+    qWarning("QuaZip::setIoDevice(): ZIP is already open!");
+    return;
+  }
+  p->ioDevice = ioDevice;
+  p->zipName = QString();
+}
+
+int QuaZip::getEntriesCount()const
+{
+  QuaZip *fakeThis=(QuaZip*)this; // non-const
+  fakeThis->p->zipError=UNZ_OK;
+  if(p->mode!=mdUnzip) {
+    qWarning("QuaZip::getEntriesCount(): ZIP is not open in mdUnzip mode");
+    return -1;
+  }
+  unz_global_info globalInfo;
+  if((fakeThis->p->zipError=unzGetGlobalInfo(p->unzFile_f, &globalInfo))!=UNZ_OK)
+    return p->zipError;
+  return (int)globalInfo.number_entry;
+}
+
+QString QuaZip::getComment()const
+{
+  QuaZip *fakeThis=(QuaZip*)this; // non-const
+  fakeThis->p->zipError=UNZ_OK;
+  if(p->mode!=mdUnzip) {
+    qWarning("QuaZip::getComment(): ZIP is not open in mdUnzip mode");
+    return QString();
+  }
+  unz_global_info globalInfo;
+  QByteArray comment;
+  if((fakeThis->p->zipError=unzGetGlobalInfo(p->unzFile_f, &globalInfo))!=UNZ_OK)
+    return QString();
+  comment.resize(globalInfo.size_comment);
+  if((fakeThis->p->zipError=unzGetGlobalComment(p->unzFile_f, comment.data(), comment.size())) < 0)
+    return QString();
+  fakeThis->p->zipError = UNZ_OK;
+  return p->commentCodec->toUnicode(comment);
+}
+
+bool QuaZip::setCurrentFile(const QString& fileName, CaseSensitivity cs)
+{
+  p->zipError=UNZ_OK;
+  if(p->mode!=mdUnzip) {
+    qWarning("QuaZip::setCurrentFile(): ZIP is not open in mdUnzip mode");
+    return false;
+  }
+  if(fileName.isEmpty()) {
+    p->hasCurrentFile_f=false;
+    return true;
+  }
+  // Unicode-aware reimplementation of the unzLocateFile function
+  if(p->unzFile_f==NULL) {
+    p->zipError=UNZ_PARAMERROR;
+    return false;
+  }
+  if(fileName.length()>MAX_FILE_NAME_LENGTH) {
+    p->zipError=UNZ_PARAMERROR;
+    return false;
+  }
+  bool sens = convertCaseSensitivity(cs) == Qt::CaseSensitive;
+  QString lower, current;
+  if(!sens) lower=fileName.toLower();
+  p->hasCurrentFile_f=false;
+  for(bool more=goToFirstFile(); more; more=goToNextFile()) {
+    current=getCurrentFileName();
+    if(current.isEmpty()) return false;
+    if(sens) {
+      if(current==fileName) break;
+    } else {
+      if(current.toLower()==lower) break;
+    }
+  }
+  return p->hasCurrentFile_f;
+}
+
+bool QuaZip::goToFirstFile()
+{
+  p->zipError=UNZ_OK;
+  if(p->mode!=mdUnzip) {
+    qWarning("QuaZip::goToFirstFile(): ZIP is not open in mdUnzip mode");
+    return false;
+  }
+  p->zipError=unzGoToFirstFile(p->unzFile_f);
+  p->hasCurrentFile_f=p->zipError==UNZ_OK;
+  return p->hasCurrentFile_f;
+}
+
+bool QuaZip::goToNextFile()
+{
+  p->zipError=UNZ_OK;
+  if(p->mode!=mdUnzip) {
+    qWarning("QuaZip::goToFirstFile(): ZIP is not open in mdUnzip mode");
+    return false;
+  }
+  p->zipError=unzGoToNextFile(p->unzFile_f);
+  p->hasCurrentFile_f=p->zipError==UNZ_OK;
+  if(p->zipError==UNZ_END_OF_LIST_OF_FILE)
+    p->zipError=UNZ_OK;
+  return p->hasCurrentFile_f;
+}
+
+bool QuaZip::getCurrentFileInfo(QuaZipFileInfo *info)const
+{
+  QuaZip *fakeThis=(QuaZip*)this; // non-const
+  fakeThis->p->zipError=UNZ_OK;
+  if(p->mode!=mdUnzip) {
+    qWarning("QuaZip::getCurrentFileInfo(): ZIP is not open in mdUnzip mode");
+    return false;
+  }
+  unz_file_info info_z;
+  QByteArray fileName;
+  QByteArray extra;
+  QByteArray comment;
+  if(info==NULL) return false;
+  if(!isOpen()||!hasCurrentFile()) return false;
+  if((fakeThis->p->zipError=unzGetCurrentFileInfo(p->unzFile_f, &info_z, NULL, 0, NULL, 0, NULL, 0))!=UNZ_OK)
+    return false;
+  fileName.resize(info_z.size_filename);
+  extra.resize(info_z.size_file_extra);
+  comment.resize(info_z.size_file_comment);
+  if((fakeThis->p->zipError=unzGetCurrentFileInfo(p->unzFile_f, NULL,
+      fileName.data(), fileName.size(),
+      extra.data(), extra.size(),
+      comment.data(), comment.size()))!=UNZ_OK)
+    return false;
+  info->versionCreated=info_z.version;
+  info->versionNeeded=info_z.version_needed;
+  info->flags=info_z.flag;
+  info->method=info_z.compression_method;
+  info->crc=info_z.crc;
+  info->compressedSize=info_z.compressed_size;
+  info->uncompressedSize=info_z.uncompressed_size;
+  info->diskNumberStart=info_z.disk_num_start;
+  info->internalAttr=info_z.internal_fa;
+  info->externalAttr=info_z.external_fa;
+  info->name=p->fileNameCodec->toUnicode(fileName);
+  info->comment=p->commentCodec->toUnicode(comment);
+  info->extra=extra;
+  info->dateTime=QDateTime(
+      QDate(info_z.tmu_date.tm_year, info_z.tmu_date.tm_mon+1, info_z.tmu_date.tm_mday),
+      QTime(info_z.tmu_date.tm_hour, info_z.tmu_date.tm_min, info_z.tmu_date.tm_sec));
+  return true;
+}
+
+QString QuaZip::getCurrentFileName()const
+{
+  QuaZip *fakeThis=(QuaZip*)this; // non-const
+  fakeThis->p->zipError=UNZ_OK;
+  if(p->mode!=mdUnzip) {
+    qWarning("QuaZip::getCurrentFileName(): ZIP is not open in mdUnzip mode");
+    return QString();
+  }
+  if(!isOpen()||!hasCurrentFile()) return QString();
+  QByteArray fileName(MAX_FILE_NAME_LENGTH, 0);
+  if((fakeThis->p->zipError=unzGetCurrentFileInfo(p->unzFile_f, NULL, fileName.data(), fileName.size(),
+      NULL, 0, NULL, 0))!=UNZ_OK)
+    return QString();
+  return p->fileNameCodec->toUnicode(fileName.constData());
+}
+
+void QuaZip::setFileNameCodec(QTextCodec *fileNameCodec)
+{
+  p->fileNameCodec=fileNameCodec;
+}
+
+void QuaZip::setFileNameCodec(const char *fileNameCodecName)
+{
+  p->fileNameCodec=QTextCodec::codecForName(fileNameCodecName);
+}
+
+QTextCodec *QuaZip::getFileNameCodec()const
+{
+  return p->fileNameCodec;
+}
+
+void QuaZip::setCommentCodec(QTextCodec *commentCodec)
+{
+  p->commentCodec=commentCodec;
+}
+
+void QuaZip::setCommentCodec(const char *commentCodecName)
+{
+  p->commentCodec=QTextCodec::codecForName(commentCodecName);
+}
+
+QTextCodec *QuaZip::getCommentCodec()const
+{
+  return p->commentCodec;
+}
+
+QString QuaZip::getZipName() const
+{
+  return p->zipName;
+}
+
+QIODevice *QuaZip::getIoDevice() const
+{
+  if (!p->zipName.isEmpty()) // opened by name, using an internal QIODevice
+    return NULL;
+  return p->ioDevice;
+}
+
+QuaZip::Mode QuaZip::getMode()const
+{
+  return p->mode;
+}
+
+bool QuaZip::isOpen()const
+{
+  return p->mode!=mdNotOpen;
+}
+
+int QuaZip::getZipError() const
+{
+  return p->zipError;
+}
+
+void QuaZip::setComment(const QString& comment)
+{
+  p->comment=comment;
+}
+
+bool QuaZip::hasCurrentFile()const
+{
+  return p->hasCurrentFile_f;
+}
+
+unzFile QuaZip::getUnzFile()
+{
+  return p->unzFile_f;
+}
+
+zipFile QuaZip::getZipFile()
+{
+  return p->zipFile_f;
+}
+
+void QuaZip::setDataDescriptorWritingEnabled(bool enabled)
+{
+    p->dataDescriptorWritingEnabled = enabled;
+}
+
+bool QuaZip::isDataDescriptorWritingEnabled() const
+{
+    return p->dataDescriptorWritingEnabled;
+}
+
+template<typename TFileInfo>
+TFileInfo QuaZip_getFileInfo(QuaZip *zip, bool *ok);
+
+template<>
+QuaZipFileInfo QuaZip_getFileInfo(QuaZip *zip, bool *ok)
+{
+    QuaZipFileInfo info;
+    *ok = zip->getCurrentFileInfo(&info);
+    return info;
+}
+
+template<>
+QString QuaZip_getFileInfo(QuaZip *zip, bool *ok)
+{
+    QString name = zip->getCurrentFileName();
+    *ok = !name.isEmpty();
+    return name;
+}
+
+template<typename TFileInfo>
+bool QuaZipPrivate::getFileInfoList(QList<TFileInfo> *result) const
+{
+  QuaZipPrivate *fakeThis=const_cast<QuaZipPrivate*>(this);
+  fakeThis->zipError=UNZ_OK;
+  if (mode!=QuaZip::mdUnzip) {
+    qWarning("QuaZip::getFileNameList/getFileInfoList(): "
+            "ZIP is not open in mdUnzip mode");
+    return false;
+  }
+  QString currentFile;
+  if (q->hasCurrentFile()) {
+      currentFile = q->getCurrentFileName();
+  }
+  if (q->goToFirstFile()) {
+      do {
+          bool ok;
+          result->append(QuaZip_getFileInfo<TFileInfo>(q, &ok));
+          if (!ok)
+              return false;
+      } while (q->goToNextFile());
+  }
+  if (zipError != UNZ_OK)
+      return false;
+  if (currentFile.isEmpty()) {
+      if (!q->goToFirstFile())
+          return false;
+  } else {
+      if (!q->setCurrentFile(currentFile))
+          return false;
+  }
+  return true;
+}
+
+QStringList QuaZip::getFileNameList() const
+{
+    QStringList list;
+    if (p->getFileInfoList(&list))
+        return list;
+    else
+        return QStringList();
+}
+
+QList<QuaZipFileInfo> QuaZip::getFileInfoList() const
+{
+    QList<QuaZipFileInfo> list;
+    if (p->getFileInfoList(&list))
+        return list;
+    else
+        return QList<QuaZipFileInfo>();
+}
+
+Qt::CaseSensitivity QuaZip::convertCaseSensitivity(QuaZip::CaseSensitivity cs)
+{
+  if (cs == csDefault) {
+#ifdef Q_WS_WIN
+      return Qt::CaseInsensitive;
+#else
+      return Qt::CaseSensitive;
+#endif
+  } else {
+      return cs == csSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive;
+  }
+}

--- a/src/external/quazip/quazip.h
+++ b/src/external/quazip/quazip.h
@@ -1,0 +1,419 @@
+#ifndef QUA_ZIP_H
+#define QUA_ZIP_H
+
+/*
+Copyright (C) 2005-2011 Sergey A. Tachenov
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2 of the License, or (at
+your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+See COPYING file for the full LGPL text.
+
+Original ZIP package is copyrighted by Gilles Vollant, see
+quazip/(un)zip.h files for details, basically it's zlib license.
+ **/
+
+#include <QString>
+#include <QStringList>
+#include <QTextCodec>
+
+#include "zip.h"
+#include "unzip.h"
+
+#include "quazip_global.h"
+#include "quazipfileinfo.h"
+
+// just in case it will be defined in the later versions of the ZIP/UNZIP
+#ifndef UNZ_OPENERROR
+// define additional error code
+#define UNZ_OPENERROR -1000
+#endif
+
+class QuaZipPrivate;
+
+/// ZIP archive.
+/** \class QuaZip quazip.h <quazip/quazip.h>
+ * This class implements basic interface to the ZIP archive. It can be
+ * used to read table contents of the ZIP archive and retreiving
+ * information about the files inside it.
+ *
+ * You can also use this class to open files inside archive by passing
+ * pointer to the instance of this class to the constructor of the
+ * QuaZipFile class. But see QuaZipFile::QuaZipFile(QuaZip*, QObject*)
+ * for the possible pitfalls.
+ *
+ * This class is indended to provide interface to the ZIP subpackage of
+ * the ZIP/UNZIP package as well as to the UNZIP subpackage. But
+ * currently it supports only UNZIP.
+ *
+ * The use of this class is simple - just create instance using
+ * constructor, then set ZIP archive file name using setFile() function
+ * (if you did not passed the name to the constructor), then open() and
+ * then use different functions to work with it! Well, if you are
+ * paranoid, you may also wish to call close before destructing the
+ * instance, to check for errors on close.
+ *
+ * You may also use getUnzFile() and getZipFile() functions to get the
+ * ZIP archive handle and use it with ZIP/UNZIP package API directly.
+ *
+ * This class supports localized file names inside ZIP archive, but you
+ * have to set up proper codec with setCodec() function. By default,
+ * locale codec will be used, which is probably ok for UNIX systems, but
+ * will almost certainly fail with ZIP archives created in Windows. This
+ * is because Windows ZIP programs have strange habit of using DOS
+ * encoding for file names in ZIP archives. For example, ZIP archive
+ * with cyrillic names created in Windows will have file names in \c
+ * IBM866 encoding instead of \c WINDOWS-1251. I think that calling one
+ * function is not much trouble, but for true platform independency it
+ * would be nice to have some mechanism for file name encoding auto
+ * detection using locale information. Does anyone know a good way to do
+ * it?
+ **/
+class QUAZIP_EXPORT QuaZip {
+  friend class QuaZipPrivate;
+  public:
+    /// Useful constants.
+    enum Constants {
+      MAX_FILE_NAME_LENGTH=256 /**< Maximum file name length. Taken from
+                                 \c UNZ_MAXFILENAMEINZIP constant in
+                                 unzip.c. */
+    };
+    /// Open mode of the ZIP file.
+    enum Mode {
+      mdNotOpen, ///< ZIP file is not open. This is the initial mode.
+      mdUnzip, ///< ZIP file is open for reading files inside it.
+      mdCreate, ///< ZIP file was created with open() call.
+      mdAppend, /**< ZIP file was opened in append mode. This refers to
+                  * \c APPEND_STATUS_CREATEAFTER mode in ZIP/UNZIP package
+                  * and means that zip is appended to some existing file
+                  * what is useful when that file contains
+                  * self-extractor code. This is obviously \em not what
+                  * you whant to use to add files to the existing ZIP
+                  * archive.
+                  **/
+      mdAdd ///< ZIP file was opened for adding files in the archive.
+    };
+    /// Case sensitivity for the file names.
+    /** This is what you specify when accessing files in the archive.
+     * Works perfectly fine with any characters thanks to Qt's great
+     * unicode support. This is different from ZIP/UNZIP API, where
+     * only US-ASCII characters was supported.
+     **/
+    enum CaseSensitivity {
+      csDefault=0, ///< Default for platform. Case sensitive for UNIX, not for Windows.
+      csSensitive=1, ///< Case sensitive.
+      csInsensitive=2 ///< Case insensitive.
+    };
+    /// Returns the actual case sensitivity for the specified QuaZIP one.
+    /**
+      \param cs The value to convert.
+      \returns If CaseSensitivity::csDefault, then returns the default
+      file name case sensitivity for the platform. Otherwise, just
+      returns the appropriate value from the Qt::CaseSensitivity enum.
+      */
+    static Qt::CaseSensitivity convertCaseSensitivity(
+            CaseSensitivity cs);
+  private:
+    QuaZipPrivate *p;
+    // not (and will not be) implemented
+    QuaZip(const QuaZip& that);
+    // not (and will not be) implemented
+    QuaZip& operator=(const QuaZip& that);
+  public:
+    /// Constructs QuaZip object.
+    /** Call setName() before opening constructed object. */
+    QuaZip();
+    /// Constructs QuaZip object associated with ZIP file \a zipName.
+    QuaZip(const QString& zipName);
+    /// Constructs QuaZip object associated with ZIP file represented by \a ioDevice.
+    /** The IO device must be seekable, otherwise an error will occur when opening. */
+    QuaZip(QIODevice *ioDevice);
+    /// Destroys QuaZip object.
+    /** Calls close() if necessary. */
+    ~QuaZip();
+    /// Opens ZIP file.
+    /**
+     * Argument \a mode specifies open mode of the ZIP archive. See Mode
+     * for details. Note that there is zipOpen2() function in the
+     * ZIP/UNZIP API which accepts \a globalcomment argument, but it
+     * does not use it anywhere, so this open() function does not have this
+     * argument. See setComment() if you need to set global comment.
+     *
+     * If the ZIP file is accessed via explicitly set QIODevice, then
+     * this device is opened in the necessary mode. If the device was
+     * already opened by some other means, then the behaviour is defined by
+     * the device implementation, but generally it is not a very good
+     * idea. For example, QFile will at least issue a warning.
+     *
+     * \return \c true if successful, \c false otherwise.
+     *
+     * \note ZIP/UNZIP API open calls do not return error code - they
+     * just return \c NULL indicating an error. But to make things
+     * easier, quazip.h header defines additional error code \c
+     * UNZ_ERROROPEN and getZipError() will return it if the open call
+     * of the ZIP/UNZIP API returns \c NULL.
+     *
+     * Argument \a ioApi specifies IO function set for ZIP/UNZIP
+     * package to use. See unzip.h, zip.h and ioapi.h for details. Note
+     * that IO API for QuaZip is different from the original package.
+     * The file path argument was changed to be of type \c voidpf, and
+     * QuaZip passes a QIODevice pointer there. This QIODevice is either
+     * set explicitly via setIoDevice() or the QuaZip(QIODevice*)
+     * constructor, or it is created internally when opening the archive
+     * by its file name. The default API (qioapi.cpp) just delegates
+     * everything to the QIODevice API. Not only this allows to use a
+     * QIODevice instead of file name, but also has a nice side effect
+     * of raising the file size limit from 2G to 4G.
+     *
+     * In short: just forget about the \a ioApi argument and you'll be
+     * fine.
+     **/
+    bool open(Mode mode, zlib_filefunc_def *ioApi =NULL);
+    /// Closes ZIP file.
+    /** Call getZipError() to determine if the close was successful. The
+     * underlying QIODevice is also closed, regardless of whether it was
+     * set explicitly or not. */
+    void close();
+    /// Sets the codec used to encode/decode file names inside archive.
+    /** This is necessary to access files in the ZIP archive created
+     * under Windows with non-latin characters in file names. For
+     * example, file names with cyrillic letters will be in \c IBM866
+     * encoding.
+     **/
+    void setFileNameCodec(QTextCodec *fileNameCodec);
+    /// Sets the codec used to encode/decode file names inside archive.
+    /** \overload
+     * Equivalent to calling setFileNameCodec(QTextCodec::codecForName(codecName));
+     **/
+    void setFileNameCodec(const char *fileNameCodecName);
+    /// Returns the codec used to encode/decode comments inside archive.
+    QTextCodec* getFileNameCodec() const;
+    /// Sets the codec used to encode/decode comments inside archive.
+    /** This codec defaults to locale codec, which is probably ok.
+     **/
+    void setCommentCodec(QTextCodec *commentCodec);
+    /// Sets the codec used to encode/decode comments inside archive.
+    /** \overload
+     * Equivalent to calling setCommentCodec(QTextCodec::codecForName(codecName));
+     **/
+    void setCommentCodec(const char *commentCodecName);
+    /// Returns the codec used to encode/decode comments inside archive.
+    QTextCodec* getCommentCodec() const;
+    /// Returns the name of the ZIP file.
+    /** Returns null string if no ZIP file name has been set, for
+     * example when the QuaZip instance is set up to use a QIODevice
+     * instead.
+     * \sa setZipName(), setIoDevice(), getIoDevice()
+     **/
+    QString getZipName() const;
+    /// Sets the name of the ZIP file.
+    /** Does nothing if the ZIP file is open.
+     *
+     * Does not reset error code returned by getZipError().
+     * \sa setIoDevice(), getIoDevice(), getZipName()
+     **/
+    void setZipName(const QString& zipName);
+    /// Returns the device representing this ZIP file.
+    /** Returns null string if no device has been set explicitly, for
+     * example when opening a ZIP file by name.
+     * \sa setIoDevice(), getZipName(), setZipName()
+     **/
+    QIODevice *getIoDevice() const;
+    /// Sets the device representing the ZIP file.
+    /** Does nothing if the ZIP file is open.
+     *
+     * Does not reset error code returned by getZipError().
+     * \sa getIoDevice(), getZipName(), setZipName()
+     **/
+    void setIoDevice(QIODevice *ioDevice);
+    /// Returns the mode in which ZIP file was opened.
+    Mode getMode() const;
+    /// Returns \c true if ZIP file is open, \c false otherwise.
+    bool isOpen() const;
+    /// Returns the error code of the last operation.
+    /** Returns \c UNZ_OK if the last operation was successful.
+     *
+     * Error code resets to \c UNZ_OK every time you call any function
+     * that accesses something inside ZIP archive, even if it is \c
+     * const (like getEntriesCount()). open() and close() calls reset
+     * error code too. See documentation for the specific functions for
+     * details on error detection.
+     **/
+    int getZipError() const;
+    /// Returns number of the entries in the ZIP central directory.
+    /** Returns negative error code in the case of error. The same error
+     * code will be returned by subsequent getZipError() call.
+     **/
+    int getEntriesCount() const;
+    /// Returns global comment in the ZIP file.
+    QString getComment() const;
+    /// Sets the global comment in the ZIP file.
+    /** The comment will be written to the archive on close operation.
+     * QuaZip makes a distinction between a null QByteArray() comment 
+     * and an empty &quot;&quot; comment in the QuaZip::mdAdd mode. 
+     * A null comment is the default and it means &quot;don't change 
+     * the comment&quot;. An empty comment removes the original comment.
+     *
+     * \sa open()
+     **/
+    void setComment(const QString& comment);
+    /// Sets the current file to the first file in the archive.
+    /** Returns \c true on success, \c false otherwise. Call
+     * getZipError() to get the error code.
+     **/
+    bool goToFirstFile();
+    /// Sets the current file to the next file in the archive.
+    /** Returns \c true on success, \c false otherwise. Call
+     * getZipError() to determine if there was an error.
+     *
+     * Should be used only in QuaZip::mdUnzip mode.
+     *
+     * \note If the end of file was reached, getZipError() will return
+     * \c UNZ_OK instead of \c UNZ_END_OF_LIST_OF_FILE. This is to make
+     * things like this easier:
+     * \code
+     * for(bool more=zip.goToFirstFile(); more; more=zip.goToNextFile()) {
+     *   // do something
+     * }
+     * if(zip.getZipError()==UNZ_OK) {
+     *   // ok, there was no error
+     * }
+     * \endcode
+     **/
+    bool goToNextFile();
+    /// Sets current file by its name.
+    /** Returns \c true if successful, \c false otherwise. Argument \a
+     * cs specifies case sensitivity of the file name. Call
+     * getZipError() in the case of a failure to get error code.
+     *
+     * This is not a wrapper to unzLocateFile() function. That is
+     * because I had to implement locale-specific case-insensitive
+     * comparison.
+     *
+     * Here are the differences from the original implementation:
+     *
+     * - If the file was not found, error code is \c UNZ_OK, not \c
+     *   UNZ_END_OF_LIST_OF_FILE (see also goToNextFile()).
+     * - If this function fails, it unsets the current file rather than
+     *   resetting it back to what it was before the call.
+     *
+     * If \a fileName is null string then this function unsets the
+     * current file and return \c true. Note that you should close the
+     * file first if it is open! See
+     * QuaZipFile::QuaZipFile(QuaZip*,QObject*) for the details.
+     *
+     * Should be used only in QuaZip::mdUnzip mode.
+     *
+     * \sa setFileNameCodec(), CaseSensitivity
+     **/
+    bool setCurrentFile(const QString& fileName, CaseSensitivity cs =csDefault);
+    /// Returns \c true if the current file has been set.
+    bool hasCurrentFile() const;
+    /// Retrieves information about the current file.
+    /** Fills the structure pointed by \a info. Returns \c true on
+     * success, \c false otherwise. In the latter case structure pointed
+     * by \a info remains untouched. If there was an error,
+     * getZipError() returns error code.
+     *
+     * Should be used only in QuaZip::mdUnzip mode.
+     *
+     * Does nothing and returns \c false in any of the following cases.
+     * - ZIP is not open;
+     * - ZIP does not have current file;
+     * - \a info is \c NULL;
+     *
+     * In all these cases getZipError() returns \c UNZ_OK since there
+     * is no ZIP/UNZIP API call.
+     **/
+    bool getCurrentFileInfo(QuaZipFileInfo* info)const;
+    /// Returns the current file name.
+    /** Equivalent to calling getCurrentFileInfo() and then getting \c
+     * name field of the QuaZipFileInfo structure, but faster and more
+     * convenient.
+     *
+     * Should be used only in QuaZip::mdUnzip mode.
+     **/
+    QString getCurrentFileName()const;
+    /// Returns \c unzFile handle.
+    /** You can use this handle to directly call UNZIP part of the
+     * ZIP/UNZIP package functions (see unzip.h).
+     *
+     * \warning When using the handle returned by this function, please
+     * keep in mind that QuaZip class is unable to detect any changes
+     * you make in the ZIP file state (e. g. changing current file, or
+     * closing the handle). So please do not do anything with this
+     * handle that is possible to do with the functions of this class.
+     * Or at least return the handle in the original state before
+     * calling some another function of this class (including implicit
+     * destructor calls and calls from the QuaZipFile objects that refer
+     * to this QuaZip instance!). So if you have changed the current
+     * file in the ZIP archive - then change it back or you may
+     * experience some strange behavior or even crashes.
+     **/
+    unzFile getUnzFile();
+    /// Returns \c zipFile handle.
+    /** You can use this handle to directly call ZIP part of the
+     * ZIP/UNZIP package functions (see zip.h). Warnings about the
+     * getUnzFile() function also apply to this function.
+     **/
+    zipFile getZipFile();
+    /// Changes the data descriptor writing mode.
+    /**
+      According to the ZIP format specification, a file inside archive
+      may have a data descriptor immediately following the file
+      data. This is reflected by a special flag in the local file header
+      and in the central directory. By default, QuaZIP sets this flag
+      and writes the data descriptor unless both method and level were
+      set to 0, in which case it operates in 1.0-compatible mode and
+      never writes data descriptors.
+
+      By setting this flag to false, it is possible to disable data
+      descriptor writing, thus increasing compatibility with archive
+      readers that don't understand this feature of the ZIP file format.
+
+      Setting this flag affects all the QuaZipFile instances that are
+      opened after this flag is set.
+
+      The data descriptor writing mode is enabled by default.
+
+      \param enabled If \c true, enable local descriptor writing,
+      disable it otherwise.
+
+      \sa QuaZipFile::setDataDescriptorWritingEnabled()
+      */
+    void setDataDescriptorWritingEnabled(bool enabled);
+    /// Returns the data descriptor default writing mode.
+    /**
+      \sa setDataDescriptorWritingEnabled()
+      */
+    bool isDataDescriptorWritingEnabled() const;
+    /// Returns a list of files inside the archive.
+    /**
+      \return A list of file names or an empty list if there
+      was an error or if the archive is empty (call getZipError() to
+      figure out which).
+      \sa getFileInfoList()
+      */
+    QStringList getFileNameList() const;
+    /// Returns information list about all files inside the archive.
+    /**
+      \return A list of QuaZipFileInfo objects or an empty list if there
+      was an error or if the archive is empty (call getZipError() to
+      figure out which).
+      \sa getFileNameList()
+      */
+    QList<QuaZipFileInfo> getFileInfoList() const;
+};
+
+#endif

--- a/src/external/quazip/quazip_global.h
+++ b/src/external/quazip/quazip_global.h
@@ -1,0 +1,55 @@
+/**
+Copyright (C) 2005-2011 Sergey A. Tachenov
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2 of the License, or (at
+your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+See COPYING file for the full LGPL text.
+
+Original ZIP package is copyrighted by Gilles Vollant, see
+quazip/(un)zip.h files for details, basically it's zlib license.
+ */
+
+#ifndef QUAZIP_GLOBAL_H
+#define QUAZIP_GLOBAL_H
+
+#include <QtCore/qglobal.h>
+
+/**
+  This is automatically defined when building a static library, but when
+  including QuaZip sources directly into a project, QUAZIP_STATIC should
+  be defined explicitly to avoid possible troubles with unnecessary
+  importing/exporting.
+  */
+#ifdef QUAZIP_STATIC
+#define QUAZIP_EXPORT
+#else
+/**
+ * When building a DLL with MSVC, QUAZIP_BUILD must be defined.
+ * qglobal.h takes care of defining Q_DECL_* correctly for msvc/gcc.
+ */
+#if defined(QUAZIP_BUILD)
+	#define QUAZIP_EXPORT Q_DECL_EXPORT
+#else
+	#define QUAZIP_EXPORT Q_DECL_IMPORT
+#endif
+#endif // QUAZIP_STATIC
+
+#ifdef __GNUC__
+#define UNUSED __attribute__((__unused__))
+#else
+#define UNUSED
+#endif
+
+#endif // QUAZIP_GLOBAL_H

--- a/src/external/quazip/quazipfile.cpp
+++ b/src/external/quazip/quazipfile.cpp
@@ -1,0 +1,488 @@
+/*
+Copyright (C) 2005-2011 Sergey A. Tachenov
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2 of the License, or (at
+your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+See COPYING file for the full LGPL text.
+
+Original ZIP package is copyrighted by Gilles Vollant, see
+quazip/(un)zip.h files for details, basically it's zlib license.
+ **/
+
+#include "quazipfile.h"
+
+using namespace std;
+
+/// The implementation class for QuaZip.
+/**
+\internal
+
+This class contains all the private stuff for the QuaZipFile class, thus
+allowing to preserve binary compatibility between releases, the
+technique known as the Pimpl (private implementation) idiom.
+*/
+class QuaZipFilePrivate {
+  friend class QuaZipFile;
+  private:
+    /// The pointer to the associated QuaZipFile instance.
+    QuaZipFile *q;
+    /// The QuaZip object to work with.
+    QuaZip *zip;
+    /// The file name.
+    QString fileName;
+    /// Case sensitivity mode.
+    QuaZip::CaseSensitivity caseSensitivity;
+    /// Whether this file is opened in the raw mode.
+    bool raw;
+    /// Write position to keep track of.
+    /**
+      QIODevice::pos() is broken for non-seekable devices, so we need
+      our own position.
+      */
+    qint64 writePos;
+    /// Uncompressed size to write along with a raw file.
+    ulong uncompressedSize;
+    /// CRC to write along with a raw file.
+    quint32 crc;
+    /// Whether \ref zip points to an internal QuaZip instance.
+    /**
+      This is true if the archive was opened by name, rather than by
+      supplying an existing QuaZip instance.
+      */
+    bool internal;
+    /// The last error.
+    int zipError;
+    /// Resets \ref zipError.
+    inline void resetZipError() const {setZipError(UNZ_OK);}
+    /// Sets the zip error.
+    /**
+      This function is marked as const although it changes one field.
+      This allows to call it from const functions that don't change
+      anything by themselves.
+      */
+    void setZipError(int zipError) const;
+    /// The constructor for the corresponding QuaZipFile constructor.
+    inline QuaZipFilePrivate(QuaZipFile *q):
+      q(q), zip(NULL), internal(true), zipError(UNZ_OK) {}
+    /// The constructor for the corresponding QuaZipFile constructor.
+    inline QuaZipFilePrivate(QuaZipFile *q, const QString &zipName):
+      q(q), internal(true), zipError(UNZ_OK)
+      {
+        zip=new QuaZip(zipName);
+      }
+    /// The constructor for the corresponding QuaZipFile constructor.
+    inline QuaZipFilePrivate(QuaZipFile *q, const QString &zipName, const QString &fileName,
+        QuaZip::CaseSensitivity cs):
+      q(q), internal(true), zipError(UNZ_OK)
+      {
+        zip=new QuaZip(zipName);
+        this->fileName=fileName;
+        if (this->fileName.startsWith('/'))
+            this->fileName = this->fileName.mid(1);
+        this->caseSensitivity=cs;
+      }
+    /// The constructor for the QuaZipFile constructor accepting a file name.
+    inline QuaZipFilePrivate(QuaZipFile *q, QuaZip *zip):
+      q(q), zip(zip), internal(false), zipError(UNZ_OK) {}
+    /// The destructor.
+    inline ~QuaZipFilePrivate()
+    {
+      if (internal)
+        delete zip;
+    }
+};
+
+QuaZipFile::QuaZipFile():
+  p(new QuaZipFilePrivate(this))
+{
+}
+
+QuaZipFile::QuaZipFile(QObject *parent):
+  QIODevice(parent),
+  p(new QuaZipFilePrivate(this))
+{
+}
+
+QuaZipFile::QuaZipFile(const QString& zipName, QObject *parent):
+  QIODevice(parent),
+  p(new QuaZipFilePrivate(this, zipName))
+{
+}
+
+QuaZipFile::QuaZipFile(const QString& zipName, const QString& fileName,
+    QuaZip::CaseSensitivity cs, QObject *parent):
+  QIODevice(parent),
+  p(new QuaZipFilePrivate(this, zipName, fileName, cs))
+{
+}
+
+QuaZipFile::QuaZipFile(QuaZip *zip, QObject *parent):
+  QIODevice(parent),
+  p(new QuaZipFilePrivate(this, zip))
+{
+}
+
+QuaZipFile::~QuaZipFile()
+{
+  if (isOpen())
+    close();
+  delete p;
+}
+
+QString QuaZipFile::getZipName() const
+{
+  return p->zip==NULL ? QString() : p->zip->getZipName();
+}
+
+QuaZip *QuaZipFile::getZip() const
+{
+    return p->internal ? NULL : p->zip;
+}
+
+QString QuaZipFile::getActualFileName()const
+{
+  p->setZipError(UNZ_OK);
+  if (p->zip == NULL || (openMode() & WriteOnly))
+    return QString();
+  QString name=p->zip->getCurrentFileName();
+  if(name.isNull())
+    p->setZipError(p->zip->getZipError());
+  return name;
+}
+
+void QuaZipFile::setZipName(const QString& zipName)
+{
+  if(isOpen()) {
+    qWarning("QuaZipFile::setZipName(): file is already open - can not set ZIP name");
+    return;
+  }
+  if(p->zip!=NULL && p->internal)
+    delete p->zip;
+  p->zip=new QuaZip(zipName);
+  p->internal=true;
+}
+
+void QuaZipFile::setZip(QuaZip *zip)
+{
+  if(isOpen()) {
+    qWarning("QuaZipFile::setZip(): file is already open - can not set ZIP");
+    return;
+  }
+  if(p->zip!=NULL && p->internal)
+    delete p->zip;
+  p->zip=zip;
+  p->fileName=QString();
+  p->internal=false;
+}
+
+void QuaZipFile::setFileName(const QString& fileName, QuaZip::CaseSensitivity cs)
+{
+  if(p->zip==NULL) {
+    qWarning("QuaZipFile::setFileName(): call setZipName() first");
+    return;
+  }
+  if(!p->internal) {
+    qWarning("QuaZipFile::setFileName(): should not be used when not using internal QuaZip");
+    return;
+  }
+  if(isOpen()) {
+    qWarning("QuaZipFile::setFileName(): can not set file name for already opened file");
+    return;
+  }
+  p->fileName=fileName;
+  if (p->fileName.startsWith('/'))
+      p->fileName = p->fileName.mid(1);
+  p->caseSensitivity=cs;
+}
+
+void QuaZipFilePrivate::setZipError(int zipError) const
+{
+  QuaZipFilePrivate *fakeThis = const_cast<QuaZipFilePrivate*>(this); // non-const
+  fakeThis->zipError=zipError;
+  if(zipError==UNZ_OK)
+    q->setErrorString(QString());
+  else
+    q->setErrorString(q->tr("ZIP/UNZIP API error %1").arg(zipError));
+}
+
+bool QuaZipFile::open(OpenMode mode)
+{
+  return open(mode, NULL);
+}
+
+bool QuaZipFile::open(OpenMode mode, int *method, int *level, bool raw, const char *password)
+{
+  p->resetZipError();
+  if(isOpen()) {
+    qWarning("QuaZipFile::open(): already opened");
+    return false;
+  }
+  if(mode&Unbuffered) {
+    qWarning("QuaZipFile::open(): Unbuffered mode is not supported");
+    return false;
+  }
+  if((mode&ReadOnly)&&!(mode&WriteOnly)) {
+    if(p->internal) {
+      if(!p->zip->open(QuaZip::mdUnzip)) {
+        p->setZipError(p->zip->getZipError());
+        return false;
+      }
+      if(!p->zip->setCurrentFile(p->fileName, p->caseSensitivity)) {
+        p->setZipError(p->zip->getZipError());
+        p->zip->close();
+        return false;
+      }
+    } else {
+      if(p->zip==NULL) {
+        qWarning("QuaZipFile::open(): zip is NULL");
+        return false;
+      }
+      if(p->zip->getMode()!=QuaZip::mdUnzip) {
+        qWarning("QuaZipFile::open(): file open mode %d incompatible with ZIP open mode %d",
+            (int)mode, (int)p->zip->getMode());
+        return false;
+      }
+      if(!p->zip->hasCurrentFile()) {
+        qWarning("QuaZipFile::open(): zip does not have current file");
+        return false;
+      }
+    }
+    p->setZipError(unzOpenCurrentFile3(p->zip->getUnzFile(), method, level, (int)raw, password));
+    if(p->zipError==UNZ_OK) {
+      setOpenMode(mode);
+      p->raw=raw;
+      return true;
+    } else
+      return false;
+  }
+  qWarning("QuaZipFile::open(): open mode %d not supported by this function", (int)mode);
+  return false;
+}
+
+bool QuaZipFile::open(OpenMode mode, const QuaZipNewInfo& info,
+    const char *password, quint32 crc,
+    int method, int level, bool raw,
+    int windowBits, int memLevel, int strategy)
+{
+  zip_fileinfo info_z;
+  p->resetZipError();
+  if(isOpen()) {
+    qWarning("QuaZipFile::open(): already opened");
+    return false;
+  }
+  if((mode&WriteOnly)&&!(mode&ReadOnly)) {
+    if(p->internal) {
+      qWarning("QuaZipFile::open(): write mode is incompatible with internal QuaZip approach");
+      return false;
+    }
+    if(p->zip==NULL) {
+      qWarning("QuaZipFile::open(): zip is NULL");
+      return false;
+    }
+    if(p->zip->getMode()!=QuaZip::mdCreate&&p->zip->getMode()!=QuaZip::mdAppend&&p->zip->getMode()!=QuaZip::mdAdd) {
+      qWarning("QuaZipFile::open(): file open mode %d incompatible with ZIP open mode %d",
+          (int)mode, (int)p->zip->getMode());
+      return false;
+    }
+    info_z.tmz_date.tm_year=info.dateTime.date().year();
+    info_z.tmz_date.tm_mon=info.dateTime.date().month() - 1;
+    info_z.tmz_date.tm_mday=info.dateTime.date().day();
+    info_z.tmz_date.tm_hour=info.dateTime.time().hour();
+    info_z.tmz_date.tm_min=info.dateTime.time().minute();
+    info_z.tmz_date.tm_sec=info.dateTime.time().second();
+    info_z.dosDate = 0;
+    info_z.internal_fa=(uLong)info.internalAttr;
+    info_z.external_fa=(uLong)info.externalAttr;
+    if (!p->zip->isDataDescriptorWritingEnabled())
+        zipClearFlags(p->zip->getZipFile(), ZIP_WRITE_DATA_DESCRIPTOR);
+    p->setZipError(zipOpenNewFileInZip3(p->zip->getZipFile(),
+          p->zip->getFileNameCodec()->fromUnicode(info.name).constData(), &info_z,
+          info.extraLocal.constData(), info.extraLocal.length(),
+          info.extraGlobal.constData(), info.extraGlobal.length(),
+          p->zip->getCommentCodec()->fromUnicode(info.comment).constData(),
+          method, level, (int)raw,
+          windowBits, memLevel, strategy,
+          password, (uLong)crc));
+    if(p->zipError==UNZ_OK) {
+      p->writePos=0;
+      setOpenMode(mode);
+      p->raw=raw;
+      if(raw) {
+        p->crc=crc;
+        p->uncompressedSize=info.uncompressedSize;
+      }
+      return true;
+    } else
+      return false;
+  }
+  qWarning("QuaZipFile::open(): open mode %d not supported by this function", (int)mode);
+  return false;
+}
+
+bool QuaZipFile::isSequential()const
+{
+  return true;
+}
+
+qint64 QuaZipFile::pos()const
+{
+  if(p->zip==NULL) {
+    qWarning("QuaZipFile::pos(): call setZipName() or setZip() first");
+    return -1;
+  }
+  if(!isOpen()) {
+    qWarning("QuaZipFile::pos(): file is not open");
+    return -1;
+  }
+  if(openMode()&ReadOnly)
+      // QIODevice::pos() is broken for sequential devices,
+      // but thankfully bytesAvailable() returns the number of
+      // bytes buffered, so we know how far ahead we are.
+    return unztell(p->zip->getUnzFile()) - QIODevice::bytesAvailable();
+  else
+    return p->writePos;
+}
+
+bool QuaZipFile::atEnd()const
+{
+  if(p->zip==NULL) {
+    qWarning("QuaZipFile::atEnd(): call setZipName() or setZip() first");
+    return false;
+  }
+  if(!isOpen()) {
+    qWarning("QuaZipFile::atEnd(): file is not open");
+    return false;
+  }
+  if(openMode()&ReadOnly)
+      // the same problem as with pos()
+    return QIODevice::bytesAvailable() == 0
+        && unzeof(p->zip->getUnzFile())==1;
+  else
+    return true;
+}
+
+qint64 QuaZipFile::size()const
+{
+  if(!isOpen()) {
+    qWarning("QuaZipFile::atEnd(): file is not open");
+    return -1;
+  }
+  if(openMode()&ReadOnly)
+    return p->raw?csize():usize();
+  else
+    return p->writePos;
+}
+
+qint64 QuaZipFile::csize()const
+{
+  unz_file_info info_z;
+  p->setZipError(UNZ_OK);
+  if(p->zip==NULL||p->zip->getMode()!=QuaZip::mdUnzip) return -1;
+  p->setZipError(unzGetCurrentFileInfo(p->zip->getUnzFile(), &info_z, NULL, 0, NULL, 0, NULL, 0));
+  if(p->zipError!=UNZ_OK)
+    return -1;
+  return info_z.compressed_size;
+}
+
+qint64 QuaZipFile::usize()const
+{
+  unz_file_info info_z;
+  p->setZipError(UNZ_OK);
+  if(p->zip==NULL||p->zip->getMode()!=QuaZip::mdUnzip) return -1;
+  p->setZipError(unzGetCurrentFileInfo(p->zip->getUnzFile(), &info_z, NULL, 0, NULL, 0, NULL, 0));
+  if(p->zipError!=UNZ_OK)
+    return -1;
+  return info_z.uncompressed_size;
+}
+
+bool QuaZipFile::getFileInfo(QuaZipFileInfo *info)
+{
+  if(p->zip==NULL||p->zip->getMode()!=QuaZip::mdUnzip) return false;
+  p->zip->getCurrentFileInfo(info);
+  p->setZipError(p->zip->getZipError());
+  return p->zipError==UNZ_OK;
+}
+
+void QuaZipFile::close()
+{
+  p->resetZipError();
+  if(p->zip==NULL||!p->zip->isOpen()) return;
+  if(!isOpen()) {
+    qWarning("QuaZipFile::close(): file isn't open");
+    return;
+  }
+  if(openMode()&ReadOnly)
+    p->setZipError(unzCloseCurrentFile(p->zip->getUnzFile()));
+  else if(openMode()&WriteOnly)
+    if(isRaw()) p->setZipError(zipCloseFileInZipRaw(p->zip->getZipFile(), p->uncompressedSize, p->crc));
+    else p->setZipError(zipCloseFileInZip(p->zip->getZipFile()));
+  else {
+    qWarning("Wrong open mode: %d", (int)openMode());
+    return;
+  }
+  if(p->zipError==UNZ_OK) setOpenMode(QIODevice::NotOpen);
+  else return;
+  if(p->internal) {
+    p->zip->close();
+    p->setZipError(p->zip->getZipError());
+  }
+}
+
+qint64 QuaZipFile::readData(char *data, qint64 maxSize)
+{
+  p->setZipError(UNZ_OK);
+  qint64 bytesRead=unzReadCurrentFile(p->zip->getUnzFile(), data, (unsigned)maxSize);
+  if (bytesRead < 0) {
+    p->setZipError((int) bytesRead);
+    return -1;
+  }
+  return bytesRead;
+}
+
+qint64 QuaZipFile::writeData(const char* data, qint64 maxSize)
+{
+  p->setZipError(ZIP_OK);
+  p->setZipError(zipWriteInFileInZip(p->zip->getZipFile(), data, (uint)maxSize));
+  if(p->zipError!=ZIP_OK) return -1;
+  else {
+    p->writePos+=maxSize;
+    return maxSize;
+  }
+}
+
+QString QuaZipFile::getFileName() const
+{
+  return p->fileName;
+}
+
+QuaZip::CaseSensitivity QuaZipFile::getCaseSensitivity() const
+{
+  return p->caseSensitivity;
+}
+
+bool QuaZipFile::isRaw() const
+{
+  return p->raw;
+}
+
+int QuaZipFile::getZipError() const
+{
+  return p->zipError;
+}
+
+qint64 QuaZipFile::bytesAvailable() const
+{
+    return size() - pos();
+}

--- a/src/external/quazip/quazipfile.h
+++ b/src/external/quazip/quazipfile.h
@@ -1,0 +1,442 @@
+#ifndef QUA_ZIPFILE_H
+#define QUA_ZIPFILE_H
+
+/*
+Copyright (C) 2005-2011 Sergey A. Tachenov
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2 of the License, or (at
+your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+See COPYING file for the full LGPL text.
+
+Original ZIP package is copyrighted by Gilles Vollant, see
+quazip/(un)zip.h files for details, basically it's zlib license.
+ **/
+
+#include <QIODevice>
+
+#include "quazip_global.h"
+#include "quazip.h"
+#include "quazipnewinfo.h"
+
+class QuaZipFilePrivate;
+
+/// A file inside ZIP archive.
+/** \class QuaZipFile quazipfile.h <quazip/quazipfile.h>
+ * This is the most interesting class. Not only it provides C++
+ * interface to the ZIP/UNZIP package, but also integrates it with Qt by
+ * subclassing QIODevice. This makes possible to access files inside ZIP
+ * archive using QTextStream or QDataStream, for example. Actually, this
+ * is the main purpose of the whole QuaZIP library.
+ *
+ * You can either use existing QuaZip instance to create instance of
+ * this class or pass ZIP archive file name to this class, in which case
+ * it will create internal QuaZip object. See constructors' descriptions
+ * for details. Writing is only possible with the existing instance.
+ *
+ * Note that due to the underlying library's limitation it is not
+ * possible to use multiple QuaZipFile instances to open several files
+ * in the same archive at the same time. If you need to write to
+ * multiple files in parallel, then you should write to temporary files
+ * first, then pack them all at once when you have finished writing. If
+ * you need to read multiple files inside the same archive in parallel,
+ * you should extract them all into a temporary directory first.
+ *
+ * \section quazipfile-sequential Sequential or random-access?
+ *
+ * At the first thought, QuaZipFile has fixed size, the start and the
+ * end and should be therefore considered random-access device. But
+ * there is one major obstacle to making it random-access: ZIP/UNZIP API
+ * does not support seek() operation and the only way to implement it is
+ * through reopening the file and re-reading to the required position,
+ * but this is prohibitively slow.
+ *
+ * Therefore, QuaZipFile is considered to be a sequential device. This
+ * has advantage of availability of the ungetChar() operation (QIODevice
+ * does not implement it properly for non-sequential devices unless they
+ * support seek()). Disadvantage is a somewhat strange behaviour of the
+ * size() and pos() functions. This should be kept in mind while using
+ * this class.
+ *
+ **/
+class QUAZIP_EXPORT QuaZipFile: public QIODevice {
+  friend class QuaZipFilePrivate;
+  Q_OBJECT
+  private:
+    QuaZipFilePrivate *p;
+    // these are not supported nor implemented
+    QuaZipFile(const QuaZipFile& that);
+    QuaZipFile& operator=(const QuaZipFile& that);
+  protected:
+    /// Implementation of the QIODevice::readData().
+    qint64 readData(char *data, qint64 maxSize);
+    /// Implementation of the QIODevice::writeData().
+    qint64 writeData(const char *data, qint64 maxSize);
+  public:
+    /// Constructs a QuaZipFile instance.
+    /** You should use setZipName() and setFileName() or setZip() before
+     * trying to call open() on the constructed object.
+     **/
+    QuaZipFile();
+    /// Constructs a QuaZipFile instance.
+    /** \a parent argument specifies this object's parent object.
+     *
+     * You should use setZipName() and setFileName() or setZip() before
+     * trying to call open() on the constructed object.
+     **/
+    QuaZipFile(QObject *parent);
+    /// Constructs a QuaZipFile instance.
+    /** \a parent argument specifies this object's parent object and \a
+     * zipName specifies ZIP archive file name.
+     *
+     * You should use setFileName() before trying to call open() on the
+     * constructed object.
+     *
+     * QuaZipFile constructed by this constructor can be used for read
+     * only access. Use QuaZipFile(QuaZip*,QObject*) for writing.
+     **/
+    QuaZipFile(const QString& zipName, QObject *parent =NULL);
+    /// Constructs a QuaZipFile instance.
+    /** \a parent argument specifies this object's parent object, \a
+     * zipName specifies ZIP archive file name and \a fileName and \a cs
+     * specify a name of the file to open inside archive.
+     *
+     * QuaZipFile constructed by this constructor can be used for read
+     * only access. Use QuaZipFile(QuaZip*,QObject*) for writing.
+     *
+     * \sa QuaZip::setCurrentFile()
+     **/
+    QuaZipFile(const QString& zipName, const QString& fileName,
+        QuaZip::CaseSensitivity cs =QuaZip::csDefault, QObject *parent =NULL);
+    /// Constructs a QuaZipFile instance.
+    /** \a parent argument specifies this object's parent object.
+     *
+     * \a zip is the pointer to the existing QuaZip object. This
+     * QuaZipFile object then can be used to read current file in the
+     * \a zip or to write to the file inside it.
+     *
+     * \warning Using this constructor for reading current file can be
+     * tricky. Let's take the following example:
+     * \code
+     * QuaZip zip("archive.zip");
+     * zip.open(QuaZip::mdUnzip);
+     * zip.setCurrentFile("file-in-archive");
+     * QuaZipFile file(&zip);
+     * file.open(QIODevice::ReadOnly);
+     * // ok, now we can read from the file
+     * file.read(somewhere, some);
+     * zip.setCurrentFile("another-file-in-archive"); // oops...
+     * QuaZipFile anotherFile(&zip);
+     * anotherFile.open(QIODevice::ReadOnly);
+     * anotherFile.read(somewhere, some); // this is still ok...
+     * file.read(somewhere, some); // and this is NOT
+     * \endcode
+     * So, what exactly happens here? When we change current file in the
+     * \c zip archive, \c file that references it becomes invalid
+     * (actually, as far as I understand ZIP/UNZIP sources, it becomes
+     * closed, but QuaZipFile has no means to detect it).
+     *
+     * Summary: do not close \c zip object or change its current file as
+     * long as QuaZipFile is open. Even better - use another constructors
+     * which create internal QuaZip instances, one per object, and
+     * therefore do not cause unnecessary trouble. This constructor may
+     * be useful, though, if you already have a QuaZip instance and do
+     * not want to access several files at once. Good example:
+     * \code
+     * QuaZip zip("archive.zip");
+     * zip.open(QuaZip::mdUnzip);
+     * // first, we need some information about archive itself
+     * QByteArray comment=zip.getComment();
+     * // and now we are going to access files inside it
+     * QuaZipFile file(&zip);
+     * for(bool more=zip.goToFirstFile(); more; more=zip.goToNextFile()) {
+     *   file.open(QIODevice::ReadOnly);
+     *   // do something cool with file here
+     *   file.close(); // do not forget to close!
+     * }
+     * zip.close();
+     * \endcode
+     **/
+    QuaZipFile(QuaZip *zip, QObject *parent =NULL);
+    /// Destroys a QuaZipFile instance.
+    /** Closes file if open, destructs internal QuaZip object (if it
+     * exists and \em is internal, of course).
+     **/
+    virtual ~QuaZipFile();
+    /// Returns the ZIP archive file name.
+    /** If this object was created by passing QuaZip pointer to the
+     * constructor, this function will return that QuaZip's file name
+     * (or null string if that object does not have file name yet).
+     *
+     * Otherwise, returns associated ZIP archive file name or null
+     * string if there are no name set yet.
+     *
+     * \sa setZipName() getFileName()
+     **/
+    QString getZipName()const;
+    /// Returns a pointer to the associated QuaZip object.
+    /** Returns \c NULL if there is no associated QuaZip or it is
+     * internal (so you will not mess with it).
+     **/
+    QuaZip* getZip()const;
+    /// Returns file name.
+    /** This function returns file name you passed to this object either
+     * by using
+     * QuaZipFile(const QString&,const QString&,QuaZip::CaseSensitivity,QObject*)
+     * or by calling setFileName(). Real name of the file may differ in
+     * case if you used case-insensitivity.
+     *
+     * Returns null string if there is no file name set yet. This is the
+     * case when this QuaZipFile operates on the existing QuaZip object
+     * (constructor QuaZipFile(QuaZip*,QObject*) or setZip() was used).
+     * 
+     * \sa getActualFileName
+     **/
+    QString getFileName() const;
+    /// Returns case sensitivity of the file name.
+    /** This function returns case sensitivity argument you passed to
+     * this object either by using
+     * QuaZipFile(const QString&,const QString&,QuaZip::CaseSensitivity,QObject*)
+     * or by calling setFileName().
+     *
+     * Returns unpredictable value if getFileName() returns null string
+     * (this is the case when you did not used setFileName() or
+     * constructor above).
+     *
+     * \sa getFileName
+     **/
+    QuaZip::CaseSensitivity getCaseSensitivity() const;
+    /// Returns the actual file name in the archive.
+    /** This is \em not a ZIP archive file name, but a name of file inside
+     * archive. It is not necessary the same name that you have passed
+     * to the
+     * QuaZipFile(const QString&,const QString&,QuaZip::CaseSensitivity,QObject*),
+     * setFileName() or QuaZip::setCurrentFile() - this is the real file
+     * name inside archive, so it may differ in case if the file name
+     * search was case-insensitive.
+     *
+     * Equivalent to calling getCurrentFileName() on the associated
+     * QuaZip object. Returns null string if there is no associated
+     * QuaZip object or if it does not have a current file yet. And this
+     * is the case if you called setFileName() but did not open the
+     * file yet. So this is perfectly fine:
+     * \code
+     * QuaZipFile file("somezip.zip");
+     * file.setFileName("somefile");
+     * QString name=file.getName(); // name=="somefile"
+     * QString actual=file.getActualFileName(); // actual is null string
+     * file.open(QIODevice::ReadOnly);
+     * QString actual=file.getActualFileName(); // actual can be "SoMeFiLe" on Windows
+     * \endcode
+     *
+     * \sa getZipName(), getFileName(), QuaZip::CaseSensitivity
+     **/
+    QString getActualFileName()const;
+    /// Sets the ZIP archive file name.
+    /** Automatically creates internal QuaZip object and destroys
+     * previously created internal QuaZip object, if any.
+     *
+     * Will do nothing if this file is already open. You must close() it
+     * first.
+     **/
+    void setZipName(const QString& zipName);
+    /// Returns \c true if the file was opened in raw mode.
+    /** If the file is not open, the returned value is undefined.
+     *
+     * \sa open(OpenMode,int*,int*,bool,const char*)
+     **/
+    bool isRaw() const;
+    /// Binds to the existing QuaZip instance.
+    /** This function destroys internal QuaZip object, if any, and makes
+     * this QuaZipFile to use current file in the \a zip object for any
+     * further operations. See QuaZipFile(QuaZip*,QObject*) for the
+     * possible pitfalls.
+     *
+     * Will do nothing if the file is currently open. You must close()
+     * it first.
+     **/
+    void setZip(QuaZip *zip);
+    /// Sets the file name.
+    /** Will do nothing if at least one of the following conditions is
+     * met:
+     * - ZIP name has not been set yet (getZipName() returns null
+     *   string).
+     * - This QuaZipFile is associated with external QuaZip. In this
+     *   case you should call that QuaZip's setCurrentFile() function
+     *   instead!
+     * - File is already open so setting the name is meaningless.
+     *
+     * \sa QuaZip::setCurrentFile
+     **/
+    void setFileName(const QString& fileName, QuaZip::CaseSensitivity cs =QuaZip::csDefault);
+    /// Opens a file for reading.
+    /** Returns \c true on success, \c false otherwise.
+     * Call getZipError() to get error code.
+     *
+     * \note Since ZIP/UNZIP API provides buffered reading only,
+     * QuaZipFile does not support unbuffered reading. So do not pass
+     * QIODevice::Unbuffered flag in \a mode, or open will fail.
+     **/
+    virtual bool open(OpenMode mode);
+    /// Opens a file for reading.
+    /** \overload
+     * Argument \a password specifies a password to decrypt the file. If
+     * it is NULL then this function behaves just like open(OpenMode).
+     **/
+    inline bool open(OpenMode mode, const char *password)
+    {return open(mode, NULL, NULL, false, password);}
+    /// Opens a file for reading.
+    /** \overload
+     * Argument \a password specifies a password to decrypt the file.
+     *
+     * An integers pointed by \a method and \a level will receive codes
+     * of the compression method and level used. See unzip.h.
+     *
+     * If raw is \c true then no decompression is performed.
+     *
+     * \a method should not be \c NULL. \a level can be \c NULL if you
+     * don't want to know the compression level.
+     **/
+    bool open(OpenMode mode, int *method, int *level, bool raw, const char *password =NULL);
+    /// Opens a file for writing.
+    /** \a info argument specifies information about file. It should at
+     * least specify a correct file name. Also, it is a good idea to
+     * specify correct timestamp (by default, current time will be
+     * used). See QuaZipNewInfo.
+     *
+     * The \a password argument specifies the password for crypting. Pass NULL
+     * if you don't need any crypting. The \a crc argument was supposed
+     * to be used for crypting too, but then it turned out that it's
+     * false information, so you need to set it to 0 unless you want to
+     * use the raw mode (see below).
+     *
+     * Arguments \a method and \a level specify compression method and
+     * level. The only method supported is Z_DEFLATED, but you may also
+     * specify 0 for no compression. If all of the files in the archive
+     * use both method 0 and either level 0 is explicitly specified or
+     * data descriptor writing is disabled with
+     * QuaZip::setDataDescriptorWritingEnabled(), then the
+     * resulting archive is supposed to be compatible with the 1.0 ZIP
+     * format version, should you need that. Except for this, \a level
+     * has no other effects with method 0.
+     *
+     * If \a raw is \c true, no compression is performed. In this case,
+     * \a crc and uncompressedSize field of the \a info are required.
+     *
+     * Arguments \a windowBits, \a memLevel, \a strategy provide zlib
+     * algorithms tuning. See deflateInit2() in zlib.
+     **/
+    bool open(OpenMode mode, const QuaZipNewInfo& info,
+        const char *password =NULL, quint32 crc =0,
+        int method =Z_DEFLATED, int level =Z_DEFAULT_COMPRESSION, bool raw =false,
+        int windowBits =-MAX_WBITS, int memLevel =DEF_MEM_LEVEL, int strategy =Z_DEFAULT_STRATEGY);
+    /// Returns \c true, but \ref quazipfile-sequential "beware"!
+    virtual bool isSequential()const;
+    /// Returns current position in the file.
+    /** Implementation of the QIODevice::pos(). When reading, this
+     * function is a wrapper to the ZIP/UNZIP unztell(), therefore it is
+     * unable to keep track of the ungetChar() calls (which is
+     * non-virtual and therefore is dangerous to reimplement). So if you
+     * are using ungetChar() feature of the QIODevice, this function
+     * reports incorrect value until you get back characters which you
+     * ungot.
+     *
+     * When writing, pos() returns number of bytes already written
+     * (uncompressed unless you use raw mode).
+     *
+     * \note Although
+     * \ref quazipfile-sequential "QuaZipFile is a sequential device"
+     * and therefore pos() should always return zero, it does not,
+     * because it would be misguiding. Keep this in mind.
+     *
+     * This function returns -1 if the file or archive is not open.
+     *
+     * Error code returned by getZipError() is not affected by this
+     * function call.
+     **/
+    virtual qint64 pos()const;
+    /// Returns \c true if the end of file was reached.
+    /** This function returns \c false in the case of error. This means
+     * that you called this function on either not open file, or a file
+     * in the not open archive or even on a QuaZipFile instance that
+     * does not even have QuaZip instance associated. Do not do that
+     * because there is no means to determine whether \c false is
+     * returned because of error or because end of file was reached.
+     * Well, on the other side you may interpret \c false return value
+     * as "there is no file open to check for end of file and there is
+     * no end of file therefore".
+     *
+     * When writing, this function always returns \c true (because you
+     * are always writing to the end of file).
+     *
+     * Error code returned by getZipError() is not affected by this
+     * function call.
+     **/
+    virtual bool atEnd()const;
+    /// Returns file size.
+    /** This function returns csize() if the file is open for reading in
+     * raw mode, usize() if it is open for reading in normal mode and
+     * pos() if it is open for writing.
+     *
+     * Returns -1 on error, call getZipError() to get error code.
+     *
+     * \note This function returns file size despite that
+     * \ref quazipfile-sequential "QuaZipFile is considered to be sequential device",
+     * for which size() should return bytesAvailable() instead. But its
+     * name would be very misguiding otherwise, so just keep in mind
+     * this inconsistence.
+     **/
+    virtual qint64 size()const;
+    /// Returns compressed file size.
+    /** Equivalent to calling getFileInfo() and then getting
+     * compressedSize field, but more convenient and faster.
+     *
+     * File must be open for reading before calling this function.
+     *
+     * Returns -1 on error, call getZipError() to get error code.
+     **/
+    qint64 csize()const;
+    /// Returns uncompressed file size.
+    /** Equivalent to calling getFileInfo() and then getting
+     * uncompressedSize field, but more convenient and faster. See
+     * getFileInfo() for a warning.
+     *
+     * File must be open for reading before calling this function.
+     *
+     * Returns -1 on error, call getZipError() to get error code.
+     **/
+    qint64 usize()const;
+    /// Gets information about current file.
+    /** This function does the same thing as calling
+     * QuaZip::getCurrentFileInfo() on the associated QuaZip object,
+     * but you can not call getCurrentFileInfo() if the associated
+     * QuaZip is internal (because you do not have access to it), while
+     * you still can call this function in that case.
+     *
+     * File must be open for reading before calling this function.
+     *
+     * Returns \c false in the case of an error.
+     **/
+    bool getFileInfo(QuaZipFileInfo *info);
+    /// Closes the file.
+    /** Call getZipError() to determine if the close was successful.
+     **/
+    virtual void close();
+    /// Returns the error code returned by the last ZIP/UNZIP API call.
+    int getZipError() const;
+    /// Returns the number of bytes available for reading.
+    virtual qint64 bytesAvailable() const;
+};
+
+#endif

--- a/src/external/quazip/quazipfileinfo.cpp
+++ b/src/external/quazip/quazipfileinfo.cpp
@@ -1,0 +1,26 @@
+#include "quazipfileinfo.h"
+
+QFile::Permissions QuaZipFileInfo::getPermissions() const
+{
+    quint32 uPerm = (externalAttr & 0xFFFF0000u) >> 16;
+    QFile::Permissions perm = 0;
+    if ((uPerm & 0400) != 0)
+        perm |= QFile::ReadOwner;
+    if ((uPerm & 0200) != 0)
+        perm |= QFile::WriteOwner;
+    if ((uPerm & 0100) != 0)
+        perm |= QFile::ExeOwner;
+    if ((uPerm & 0040) != 0)
+        perm |= QFile::ReadGroup;
+    if ((uPerm & 0020) != 0)
+        perm |= QFile::WriteGroup;
+    if ((uPerm & 0010) != 0)
+        perm |= QFile::ExeGroup;
+    if ((uPerm & 0004) != 0)
+        perm |= QFile::ReadOther;
+    if ((uPerm & 0002) != 0)
+        perm |= QFile::WriteOther;
+    if ((uPerm & 0001) != 0)
+        perm |= QFile::ExeOther;
+    return perm;
+}

--- a/src/external/quazip/quazipfileinfo.h
+++ b/src/external/quazip/quazipfileinfo.h
@@ -1,0 +1,73 @@
+#ifndef QUA_ZIPFILEINFO_H
+#define QUA_ZIPFILEINFO_H
+
+/*
+Copyright (C) 2005-2011 Sergey A. Tachenov
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2 of the License, or (at
+your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+See COPYING file for the full LGPL text.
+
+Original ZIP package is copyrighted by Gilles Vollant, see
+quazip/(un)zip.h files for details, basically it's zlib license.
+ **/
+
+#include <QByteArray>
+#include <QDateTime>
+#include <QFile>
+
+#include "quazip_global.h"
+
+/// Information about a file inside archive.
+/** Call QuaZip::getCurrentFileInfo() or QuaZipFile::getFileInfo() to
+ * fill this structure. */
+struct QUAZIP_EXPORT QuaZipFileInfo {
+  /// File name.
+  QString name;
+  /// Version created by.
+  quint16 versionCreated;
+  /// Version needed to extract.
+  quint16 versionNeeded;
+  /// General purpose flags.
+  quint16 flags;
+  /// Compression method.
+  quint16 method;
+  /// Last modification date and time.
+  QDateTime dateTime;
+  /// CRC.
+  quint32 crc;
+  /// Compressed file size.
+  quint32 compressedSize;
+  /// Uncompressed file size.
+  quint32 uncompressedSize;
+  /// Disk number start.
+  quint16 diskNumberStart;
+  /// Internal file attributes.
+  quint16 internalAttr;
+  /// External file attributes.
+  quint32 externalAttr;
+  /// Comment.
+  QString comment;
+  /// Extra field.
+  QByteArray extra;
+  /// Get the file permissions.
+  /**
+    Returns the high 16 bits of external attributes converted to
+    QFile::Permissions.
+    */
+  QFile::Permissions getPermissions() const;
+};
+
+#endif

--- a/src/external/quazip/quazipnewinfo.cpp
+++ b/src/external/quazip/quazipnewinfo.cpp
@@ -1,0 +1,89 @@
+/*
+Copyright (C) 2005-2011 Sergey A. Tachenov
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2 of the License, or (at
+your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+See COPYING file for the full LGPL text.
+
+Original ZIP package is copyrighted by Gilles Vollant, see
+quazip/(un)zip.h files for details, basically it's zlib license.
+*/
+
+#include <QFileInfo>
+
+#include "quazipnewinfo.h"
+
+static void QuaZipNewInfo_setPermissions(QuaZipNewInfo *info,
+        QFile::Permissions perm, bool isDir)
+{
+    quint32 uPerm = isDir ? 0040000 : 0100000;
+    if ((perm & QFile::ReadOwner) != 0)
+        uPerm |= 0400;
+    if ((perm & QFile::WriteOwner) != 0)
+        uPerm |= 0200;
+    if ((perm & QFile::ExeOwner) != 0)
+        uPerm |= 0100;
+    if ((perm & QFile::ReadGroup) != 0)
+        uPerm |= 0040;
+    if ((perm & QFile::WriteGroup) != 0)
+        uPerm |= 0020;
+    if ((perm & QFile::ExeGroup) != 0)
+        uPerm |= 0010;
+    if ((perm & QFile::ReadOther) != 0)
+        uPerm |= 0004;
+    if ((perm & QFile::WriteOther) != 0)
+        uPerm |= 0002;
+    if ((perm & QFile::ExeOther) != 0)
+        uPerm |= 0001;
+    info->externalAttr = (info->externalAttr & ~0xFFFF0000u) | (uPerm << 16);
+}
+
+QuaZipNewInfo::QuaZipNewInfo(const QString& name):
+  name(name), dateTime(QDateTime::currentDateTime()), internalAttr(0), externalAttr(0)
+{
+}
+
+QuaZipNewInfo::QuaZipNewInfo(const QString& name, const QString& file):
+  name(name), internalAttr(0), externalAttr(0)
+{
+  QFileInfo info(file);
+  QDateTime lm = info.lastModified();
+  if (!info.exists()) {
+    dateTime = QDateTime::currentDateTime();
+  } else {
+    dateTime = lm;
+    QuaZipNewInfo_setPermissions(this, info.permissions(), info.isDir());
+  }
+}
+
+void QuaZipNewInfo::setFileDateTime(const QString& file)
+{
+  QFileInfo info(file);
+  QDateTime lm = info.lastModified();
+  if (info.exists())
+    dateTime = lm;
+}
+
+void QuaZipNewInfo::setFilePermissions(const QString &file)
+{
+    QFileInfo info = QFileInfo(file);
+    QFile::Permissions perm = info.permissions();
+    QuaZipNewInfo_setPermissions(this, perm, info.isDir());
+}
+
+void QuaZipNewInfo::setPermissions(QFile::Permissions permissions)
+{
+    QuaZipNewInfo_setPermissions(this, permissions, name.endsWith('/'));
+}

--- a/src/external/quazip/quazipnewinfo.h
+++ b/src/external/quazip/quazipnewinfo.h
@@ -1,0 +1,121 @@
+#ifndef QUA_ZIPNEWINFO_H
+#define QUA_ZIPNEWINFO_H
+
+/*
+Copyright (C) 2005-2011 Sergey A. Tachenov
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2 of the License, or (at
+your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser
+General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+See COPYING file for the full LGPL text.
+
+Original ZIP package is copyrighted by Gilles Vollant, see
+quazip/(un)zip.h files for details, basically it's zlib license.
+ **/
+
+#include <QDateTime>
+#include <QString>
+
+#include "quazip_global.h"
+
+/// Information about a file to be created.
+/** This structure holds information about a file to be created inside
+ * ZIP archive. At least name should be set to something correct before
+ * passing this structure to
+ * QuaZipFile::open(OpenMode,const QuaZipNewInfo&,int,int,bool).
+ **/
+struct QUAZIP_EXPORT QuaZipNewInfo {
+  /// File name.
+  /** This field holds file name inside archive, including path relative
+   * to archive root.
+   **/
+  QString name;
+  /// File timestamp.
+  /** This is the last file modification date and time. Will be stored
+   * in the archive central directory. It is a good practice to set it
+   * to the source file timestamp instead of archive creating time. Use
+   * setFileDateTime() or QuaZipNewInfo(const QString&, const QString&).
+   **/
+  QDateTime dateTime;
+  /// File internal attributes.
+  quint16 internalAttr;
+  /// File external attributes.
+  /**
+    The highest 16 bits contain Unix file permissions and type (dir or
+    file). The constructor QuaZipNewInfo(const QString&, const QString&)
+    takes permissions from the provided file.
+    */
+  quint32 externalAttr;
+  /// File comment.
+  /** Will be encoded using QuaZip::getCommentCodec().
+   **/
+  QString comment;
+  /// File local extra field.
+  QByteArray extraLocal;
+  /// File global extra field.
+  QByteArray extraGlobal;
+  /// Uncompressed file size.
+  /** This is only needed if you are using raw file zipping mode, i. e.
+   * adding precompressed file in the zip archive.
+   **/
+  ulong uncompressedSize;
+  /// Constructs QuaZipNewInfo instance.
+  /** Initializes name with \a name, dateTime with current date and
+   * time. Attributes are initialized with zeros, comment and extra
+   * field with null values.
+   **/
+  QuaZipNewInfo(const QString& name);
+  /// Constructs QuaZipNewInfo instance.
+  /** Initializes name with \a name. Timestamp and permissions are taken
+   * from the specified file. If the \a file does not exists or its timestamp
+   * is inaccessible (e. g. you do not have read permission for the
+   * directory file in), uses current time and zero permissions. Other attributes are
+   * initialized with zeros, comment and extra field with null values.
+   * 
+   * \sa setFileDateTime()
+   **/
+  QuaZipNewInfo(const QString& name, const QString& file);
+  /// Sets the file timestamp from the existing file.
+  /** Use this function to set the file timestamp from the existing
+   * file. Use it like this:
+   * \code
+   * QuaZipFile zipFile(&zip);
+   * QFile file("file-to-add");
+   * file.open(QIODevice::ReadOnly);
+   * QuaZipNewInfo info("file-name-in-archive");
+   * info.setFileDateTime("file-to-add"); // take the timestamp from file
+   * zipFile.open(QIODevice::WriteOnly, info);
+   * \endcode
+   *
+   * This function does not change dateTime if some error occured (e. g.
+   * file is inaccessible).
+   **/
+  void setFileDateTime(const QString& file);
+  /// Sets the file permissions from the existing file.
+  /**
+    Takes permissions from the file and sets the high 16 bits of
+    external attributes. Uses QFileInfo to get permissions on all
+    platforms.
+    */
+  void setFilePermissions(const QString &file);
+  /// Sets the file permissions.
+  /**
+    Modifies the highest 16 bits of external attributes. The type part
+    is set to dir if the name ends with a slash, and to regular file
+    otherwise.
+    */
+  void setPermissions(QFile::Permissions permissions);
+};
+
+#endif

--- a/src/external/quazip/unzip.c
+++ b/src/external/quazip/unzip.c
@@ -1,0 +1,1603 @@
+/* unzip.c -- IO for uncompress .zip files using zlib
+   Version 1.01e, February 12th, 2005
+
+   Copyright (C) 1998-2005 Gilles Vollant
+
+   Read unzip.h for more info
+
+   Modified by Sergey A. Tachenov to integrate with Qt.
+*/
+
+/* Decryption code comes from crypt.c by Info-ZIP but has been greatly reduced in terms of
+compatibility with older software. The following is from the original crypt.c. Code
+woven in by Terry Thorsen 1/2003.
+*/
+/*
+  Copyright (c) 1990-2000 Info-ZIP.  All rights reserved.
+
+  See the accompanying file LICENSE, version 2000-Apr-09 or later
+  (the contents of which are also included in zip.h) for terms of use.
+  If, for some reason, all these files are missing, the Info-ZIP license
+  also may be found at:  ftp://ftp.info-zip.org/pub/infozip/license.html
+*/
+/*
+  crypt.c (full version) by Info-ZIP.      Last revised:  [see crypt.h]
+
+  The encryption/decryption parts of this source code (as opposed to the
+  non-echoing password parts) were originally written in Europe.  The
+  whole source package can be freely distributed, including from the USA.
+  (Prior to January 2000, re-export from the US was a violation of US law.)
+ */
+
+/*
+  This encryption code is a direct transcription of the algorithm from
+  Roger Schlafly, described by Phil Katz in the file appnote.txt.  This
+  file (appnote.txt) is distributed with the PKZIP program (even in the
+  version without encryption capabilities).
+ */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "zlib.h"
+#include "unzip.h"
+
+#ifdef STDC
+#  include <stddef.h>
+#  include <string.h>
+#  include <stdlib.h>
+#endif
+#ifdef NO_ERRNO_H
+    extern int errno;
+#else
+#   include <errno.h>
+#endif
+
+
+#ifndef local
+#  define local static
+#endif
+/* compile with -Dlocal if your debugger can't find static symbols */
+
+
+#ifndef CASESENSITIVITYDEFAULT_NO
+#  if !defined(unix) && !defined(CASESENSITIVITYDEFAULT_YES)
+#    define CASESENSITIVITYDEFAULT_NO
+#  endif
+#endif
+
+
+#ifndef UNZ_BUFSIZE
+#define UNZ_BUFSIZE (16384)
+#endif
+
+#ifndef UNZ_MAXFILENAMEINZIP
+#define UNZ_MAXFILENAMEINZIP (256)
+#endif
+
+#ifndef ALLOC
+# define ALLOC(size) (malloc(size))
+#endif
+#ifndef TRYFREE
+# define TRYFREE(p) {if (p) free(p);}
+#endif
+
+#define SIZECENTRALDIRITEM (0x2e)
+#define SIZEZIPLOCALHEADER (0x1e)
+
+
+
+
+const char unz_copyright[] =
+   " unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
+
+/* unz_file_info_interntal contain internal info about a file in zipfile*/
+typedef struct unz_file_info_internal_s
+{
+    uLong offset_curfile;/* relative offset of local header 4 bytes */
+} unz_file_info_internal;
+
+
+/* file_in_zip_read_info_s contain internal information about a file in zipfile,
+    when reading and decompress it */
+typedef struct
+{
+    char  *read_buffer;         /* internal buffer for compressed data */
+    z_stream stream;            /* zLib stream structure for inflate */
+
+    uLong pos_in_zipfile;       /* position in byte on the zipfile, for fseek*/
+    uLong stream_initialised;   /* flag set if stream structure is initialised*/
+
+    uLong offset_local_extrafield;/* offset of the local extra field */
+    uInt  size_local_extrafield;/* size of the local extra field */
+    uLong pos_local_extrafield;   /* position in the local extra field in read*/
+
+    uLong crc32;                /* crc32 of all data uncompressed */
+    uLong crc32_wait;           /* crc32 we must obtain after decompress all */
+    uLong rest_read_compressed; /* number of byte to be decompressed */
+    uLong rest_read_uncompressed;/*number of byte to be obtained after decomp*/
+    zlib_filefunc_def z_filefunc;
+    voidpf filestream;        /* io structore of the zipfile */
+    uLong compression_method;   /* compression method (0==store) */
+    uLong byte_before_the_zipfile;/* byte before the zipfile, (>0 for sfx)*/
+    int   raw;
+} file_in_zip_read_info_s;
+
+
+/* unz_s contain internal information about the zipfile
+*/
+typedef struct
+{
+    zlib_filefunc_def z_filefunc;
+    voidpf filestream;        /* io structore of the zipfile */
+    unz_global_info gi;       /* public global information */
+    uLong byte_before_the_zipfile;/* byte before the zipfile, (>0 for sfx)*/
+    uLong num_file;             /* number of the current file in the zipfile*/
+    uLong pos_in_central_dir;   /* pos of the current file in the central dir*/
+    uLong current_file_ok;      /* flag about the usability of the current file*/
+    uLong central_pos;          /* position of the beginning of the central dir*/
+
+    uLong size_central_dir;     /* size of the central directory  */
+    uLong offset_central_dir;   /* offset of start of central directory with
+                                   respect to the starting disk number */
+
+    unz_file_info cur_file_info; /* public info about the current file in zip*/
+    unz_file_info_internal cur_file_info_internal; /* private info about it*/
+    file_in_zip_read_info_s* pfile_in_zip_read; /* structure about the current
+                                        file if we are decompressing it */
+    int encrypted;
+#    ifndef NOUNCRYPT
+    unsigned long keys[3];     /* keys defining the pseudo-random sequence */
+    const unsigned long* pcrc_32_tab;
+#    endif
+} unz_s;
+
+
+#ifndef NOUNCRYPT
+#include "crypt.h"
+#endif
+
+/* ===========================================================================
+     Read a byte from a gz_stream; update next_in and avail_in. Return EOF
+   for end of file.
+   IN assertion: the stream s has been sucessfully opened for reading.
+*/
+
+
+local int unzlocal_getByte OF((
+    const zlib_filefunc_def* pzlib_filefunc_def,
+    voidpf filestream,
+    int *pi));
+
+local int unzlocal_getByte(pzlib_filefunc_def,filestream,pi)
+    const zlib_filefunc_def* pzlib_filefunc_def;
+    voidpf filestream;
+    int *pi;
+{
+    unsigned char c;
+    int err = (int)ZREAD(*pzlib_filefunc_def,filestream,&c,1);
+    if (err==1)
+    {
+        *pi = (int)c;
+        return UNZ_OK;
+    }
+    else
+    {
+        if (ZERROR(*pzlib_filefunc_def,filestream))
+            return UNZ_ERRNO;
+        else
+            return UNZ_EOF;
+    }
+}
+
+
+/* ===========================================================================
+   Reads a long in LSB order from the given gz_stream. Sets
+*/
+local int unzlocal_getShort OF((
+    const zlib_filefunc_def* pzlib_filefunc_def,
+    voidpf filestream,
+    uLong *pX));
+
+local int unzlocal_getShort (pzlib_filefunc_def,filestream,pX)
+    const zlib_filefunc_def* pzlib_filefunc_def;
+    voidpf filestream;
+    uLong *pX;
+{
+    uLong x ;
+    int i;
+    int err;
+
+    err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x = (uLong)i;
+
+    if (err==UNZ_OK)
+        err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<8;
+
+    if (err==UNZ_OK)
+        *pX = x;
+    else
+        *pX = 0;
+    return err;
+}
+
+local int unzlocal_getLong OF((
+    const zlib_filefunc_def* pzlib_filefunc_def,
+    voidpf filestream,
+    uLong *pX));
+
+local int unzlocal_getLong (pzlib_filefunc_def,filestream,pX)
+    const zlib_filefunc_def* pzlib_filefunc_def;
+    voidpf filestream;
+    uLong *pX;
+{
+    uLong x ;
+    int i;
+    int err;
+
+    err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x = (uLong)i;
+
+    if (err==UNZ_OK)
+        err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<8;
+
+    if (err==UNZ_OK)
+        err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<16;
+
+    if (err==UNZ_OK)
+        err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<24;
+
+    if (err==UNZ_OK)
+        *pX = x;
+    else
+        *pX = 0;
+    return err;
+}
+
+
+/* My own strcmpi / strcasecmp */
+local int strcmpcasenosensitive_internal (fileName1,fileName2)
+    const char* fileName1;
+    const char* fileName2;
+{
+    for (;;)
+    {
+        char c1=*(fileName1++);
+        char c2=*(fileName2++);
+        if ((c1>='a') && (c1<='z'))
+            c1 -= 0x20;
+        if ((c2>='a') && (c2<='z'))
+            c2 -= 0x20;
+        if (c1=='\0')
+            return ((c2=='\0') ? 0 : -1);
+        if (c2=='\0')
+            return 1;
+        if (c1<c2)
+            return -1;
+        if (c1>c2)
+            return 1;
+    }
+}
+
+
+#ifdef  CASESENSITIVITYDEFAULT_NO
+#define CASESENSITIVITYDEFAULTVALUE 2
+#else
+#define CASESENSITIVITYDEFAULTVALUE 1
+#endif
+
+#ifndef STRCMPCASENOSENTIVEFUNCTION
+#define STRCMPCASENOSENTIVEFUNCTION strcmpcasenosensitive_internal
+#endif
+
+/*
+   Compare two filename (fileName1,fileName2).
+   If iCaseSenisivity = 1, comparision is case sensitivity (like strcmp)
+   If iCaseSenisivity = 2, comparision is not case sensitivity (like strcmpi
+                                                                or strcasecmp)
+   If iCaseSenisivity = 0, case sensitivity is defaut of your operating system
+        (like 1 on Unix, 2 on Windows)
+
+*/
+extern int ZEXPORT unzStringFileNameCompare (fileName1,fileName2,iCaseSensitivity)
+    const char* fileName1;
+    const char* fileName2;
+    int iCaseSensitivity;
+{
+    if (iCaseSensitivity==0)
+        iCaseSensitivity=CASESENSITIVITYDEFAULTVALUE;
+
+    if (iCaseSensitivity==1)
+        return strcmp(fileName1,fileName2);
+
+    return STRCMPCASENOSENTIVEFUNCTION(fileName1,fileName2);
+}
+
+#ifndef BUFREADCOMMENT
+#define BUFREADCOMMENT (0x400)
+#endif
+
+/*
+  Locate the Central directory of a zipfile (at the end, just before
+    the global comment)
+*/
+local uLong unzlocal_SearchCentralDir OF((
+    const zlib_filefunc_def* pzlib_filefunc_def,
+    voidpf filestream));
+
+local uLong unzlocal_SearchCentralDir(pzlib_filefunc_def,filestream)
+    const zlib_filefunc_def* pzlib_filefunc_def;
+    voidpf filestream;
+{
+    unsigned char* buf;
+    uLong uSizeFile;
+    uLong uBackRead;
+    uLong uMaxBack=0xffff; /* maximum size of global comment */
+    uLong uPosFound=0;
+
+    if (ZSEEK(*pzlib_filefunc_def,filestream,0,ZLIB_FILEFUNC_SEEK_END) != 0)
+        return 0;
+
+
+    uSizeFile = ZTELL(*pzlib_filefunc_def,filestream);
+
+    if (uMaxBack>uSizeFile)
+        uMaxBack = uSizeFile;
+
+    buf = (unsigned char*)ALLOC(BUFREADCOMMENT+4);
+    if (buf==NULL)
+        return 0;
+
+    uBackRead = 4;
+    while (uBackRead<uMaxBack)
+    {
+        uLong uReadSize,uReadPos ;
+        int i;
+        if (uBackRead+BUFREADCOMMENT>uMaxBack)
+            uBackRead = uMaxBack;
+        else
+            uBackRead+=BUFREADCOMMENT;
+        uReadPos = uSizeFile-uBackRead ;
+
+        uReadSize = ((BUFREADCOMMENT+4) < (uSizeFile-uReadPos)) ?
+                     (BUFREADCOMMENT+4) : (uSizeFile-uReadPos);
+        if (ZSEEK(*pzlib_filefunc_def,filestream,uReadPos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+            break;
+
+        if (ZREAD(*pzlib_filefunc_def,filestream,buf,uReadSize)!=uReadSize)
+            break;
+
+        for (i=(int)uReadSize-3; (i--)>0;)
+            if (((*(buf+i))==0x50) && ((*(buf+i+1))==0x4b) &&
+                ((*(buf+i+2))==0x05) && ((*(buf+i+3))==0x06))
+            {
+                uPosFound = uReadPos+i;
+                break;
+            }
+
+        if (uPosFound!=0)
+            break;
+    }
+    TRYFREE(buf);
+    return uPosFound;
+}
+
+/*
+  Open a Zip file. path contain the full pathname (by example,
+     on a Windows NT computer "c:\\test\\zlib114.zip" or on an Unix computer
+     "zlib/zlib114.zip".
+     If the zipfile cannot be opened (file doesn't exist or in not valid), the
+       return value is NULL.
+     Else, the return value is a unzFile Handle, usable with other function
+       of this unzip package.
+*/
+extern unzFile ZEXPORT unzOpen2 (file, pzlib_filefunc_def)
+    voidpf file;
+    zlib_filefunc_def* pzlib_filefunc_def;
+{
+    unz_s us;
+    unz_s *s;
+    uLong central_pos,uL;
+
+    uLong number_disk;          /* number of the current dist, used for
+                                   spaning ZIP, unsupported, always 0*/
+    uLong number_disk_with_CD;  /* number the the disk with central dir, used
+                                   for spaning ZIP, unsupported, always 0*/
+    uLong number_entry_CD;      /* total number of entries in
+                                   the central dir
+                                   (same than number_entry on nospan) */
+
+    int err=UNZ_OK;
+
+    if (unz_copyright[0]!=' ')
+        return NULL;
+
+    if (pzlib_filefunc_def==NULL)
+        fill_qiodevice_filefunc(&us.z_filefunc);
+    else
+        us.z_filefunc = *pzlib_filefunc_def;
+
+    us.filestream= (*(us.z_filefunc.zopen_file))(us.z_filefunc.opaque,
+                                                 file,
+                                                 ZLIB_FILEFUNC_MODE_READ |
+                                                 ZLIB_FILEFUNC_MODE_EXISTING);
+    if (us.filestream==NULL)
+        return NULL;
+
+    central_pos = unzlocal_SearchCentralDir(&us.z_filefunc,us.filestream);
+    if (central_pos==0)
+        err=UNZ_ERRNO;
+
+    if (ZSEEK(us.z_filefunc, us.filestream,
+                                      central_pos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+        err=UNZ_ERRNO;
+
+    /* the signature, already checked */
+    if (unzlocal_getLong(&us.z_filefunc, us.filestream,&uL)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    /* number of this disk */
+    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&number_disk)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    /* number of the disk with the start of the central directory */
+    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&number_disk_with_CD)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    /* total number of entries in the central dir on this disk */
+    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&us.gi.number_entry)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    /* total number of entries in the central dir */
+    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&number_entry_CD)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if ((number_entry_CD!=us.gi.number_entry) ||
+        (number_disk_with_CD!=0) ||
+        (number_disk!=0))
+        err=UNZ_BADZIPFILE;
+
+    /* size of the central directory */
+    if (unzlocal_getLong(&us.z_filefunc, us.filestream,&us.size_central_dir)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    /* offset of start of central directory with respect to the
+          starting disk number */
+    if (unzlocal_getLong(&us.z_filefunc, us.filestream,&us.offset_central_dir)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    /* zipfile comment length */
+    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&us.gi.size_comment)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if ((central_pos<us.offset_central_dir+us.size_central_dir) &&
+        (err==UNZ_OK))
+        err=UNZ_BADZIPFILE;
+
+    if (err!=UNZ_OK)
+    {
+        ZCLOSE(us.z_filefunc, us.filestream);
+        return NULL;
+    }
+
+    us.byte_before_the_zipfile = central_pos -
+                            (us.offset_central_dir+us.size_central_dir);
+    us.central_pos = central_pos;
+    us.pfile_in_zip_read = NULL;
+    us.encrypted = 0;
+
+
+    s=(unz_s*)ALLOC(sizeof(unz_s));
+    *s=us;
+    unzGoToFirstFile((unzFile)s);
+    return (unzFile)s;
+}
+
+
+extern unzFile ZEXPORT unzOpen (file)
+    voidpf file;
+{
+    return unzOpen2(file, NULL);
+}
+
+/*
+  Close a ZipFile opened with unzipOpen.
+  If there is files inside the .Zip opened with unzipOpenCurrentFile (see later),
+    these files MUST be closed with unzipCloseCurrentFile before call unzipClose.
+  return UNZ_OK if there is no problem. */
+extern int ZEXPORT unzClose (file)
+    unzFile file;
+{
+    unz_s* s;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+
+    if (s->pfile_in_zip_read!=NULL)
+        unzCloseCurrentFile(file);
+
+    ZCLOSE(s->z_filefunc, s->filestream);
+    TRYFREE(s);
+    return UNZ_OK;
+}
+
+
+/*
+  Write info about the ZipFile in the *pglobal_info structure.
+  No preparation of the structure is needed
+  return UNZ_OK if there is no problem. */
+extern int ZEXPORT unzGetGlobalInfo (file,pglobal_info)
+    unzFile file;
+    unz_global_info *pglobal_info;
+{
+    unz_s* s;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    *pglobal_info=s->gi;
+    return UNZ_OK;
+}
+
+
+/*
+   Translate date/time from Dos format to tm_unz (readable more easilty)
+*/
+local void unzlocal_DosDateToTmuDate (ulDosDate, ptm)
+    uLong ulDosDate;
+    tm_unz* ptm;
+{
+    uLong uDate;
+    uDate = (uLong)(ulDosDate>>16);
+    ptm->tm_mday = (uInt)(uDate&0x1f) ;
+    ptm->tm_mon =  (uInt)((((uDate)&0x1E0)/0x20)-1) ;
+    ptm->tm_year = (uInt)(((uDate&0x0FE00)/0x0200)+1980) ;
+
+    ptm->tm_hour = (uInt) ((ulDosDate &0xF800)/0x800);
+    ptm->tm_min =  (uInt) ((ulDosDate&0x7E0)/0x20) ;
+    ptm->tm_sec =  (uInt) (2*(ulDosDate&0x1f)) ;
+}
+
+/*
+  Get Info about the current file in the zipfile, with internal only info
+*/
+local int unzlocal_GetCurrentFileInfoInternal OF((unzFile file,
+                                                  unz_file_info *pfile_info,
+                                                  unz_file_info_internal
+                                                  *pfile_info_internal,
+                                                  char *szFileName,
+                                                  uLong fileNameBufferSize,
+                                                  void *extraField,
+                                                  uLong extraFieldBufferSize,
+                                                  char *szComment,
+                                                  uLong commentBufferSize));
+
+local int unzlocal_GetCurrentFileInfoInternal (file,
+                                              pfile_info,
+                                              pfile_info_internal,
+                                              szFileName, fileNameBufferSize,
+                                              extraField, extraFieldBufferSize,
+                                              szComment,  commentBufferSize)
+    unzFile file;
+    unz_file_info *pfile_info;
+    unz_file_info_internal *pfile_info_internal;
+    char *szFileName;
+    uLong fileNameBufferSize;
+    void *extraField;
+    uLong extraFieldBufferSize;
+    char *szComment;
+    uLong commentBufferSize;
+{
+    unz_s* s;
+    unz_file_info file_info;
+    unz_file_info_internal file_info_internal;
+    int err=UNZ_OK;
+    uLong uMagic;
+    uLong uSeek=0;
+
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    if (ZSEEK(s->z_filefunc, s->filestream,
+              s->pos_in_central_dir+s->byte_before_the_zipfile,
+              ZLIB_FILEFUNC_SEEK_SET)!=0)
+        err=UNZ_ERRNO;
+
+
+    /* we check the magic */
+    if (err==UNZ_OK) {
+        if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
+            err=UNZ_ERRNO;
+        else if (uMagic!=0x02014b50)
+            err=UNZ_BADZIPFILE;
+    }
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.version) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.version_needed) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.flag) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.compression_method) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.dosDate) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    unzlocal_DosDateToTmuDate(file_info.dosDate,&file_info.tmu_date);
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.crc) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.compressed_size) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.uncompressed_size) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.size_filename) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.size_file_extra) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.size_file_comment) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.disk_num_start) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.internal_fa) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.external_fa) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info_internal.offset_curfile) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    uSeek+=file_info.size_filename;
+    if ((err==UNZ_OK) && (szFileName!=NULL))
+    {
+        uLong uSizeRead ;
+        if (file_info.size_filename<fileNameBufferSize)
+        {
+            *(szFileName+file_info.size_filename)='\0';
+            uSizeRead = file_info.size_filename;
+        }
+        else
+            uSizeRead = fileNameBufferSize;
+
+        if ((file_info.size_filename>0) && (fileNameBufferSize>0))
+            if (ZREAD(s->z_filefunc, s->filestream,szFileName,uSizeRead)!=uSizeRead)
+                err=UNZ_ERRNO;
+        uSeek -= uSizeRead;
+    }
+
+
+    if ((err==UNZ_OK) && (extraField!=NULL))
+    {
+        uLong uSizeRead ;
+        if (file_info.size_file_extra<extraFieldBufferSize)
+            uSizeRead = file_info.size_file_extra;
+        else
+            uSizeRead = extraFieldBufferSize;
+
+        if (uSeek!=0) {
+            if (ZSEEK(s->z_filefunc, s->filestream,uSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
+                uSeek=0;
+            else
+                err=UNZ_ERRNO;
+        }
+        if ((file_info.size_file_extra>0) && (extraFieldBufferSize>0))
+            if (ZREAD(s->z_filefunc, s->filestream,extraField,uSizeRead)!=uSizeRead)
+                err=UNZ_ERRNO;
+        uSeek += file_info.size_file_extra - uSizeRead;
+    }
+    else
+        uSeek+=file_info.size_file_extra;
+
+
+    if ((err==UNZ_OK) && (szComment!=NULL))
+    {
+        uLong uSizeRead ;
+        if (file_info.size_file_comment<commentBufferSize)
+        {
+            *(szComment+file_info.size_file_comment)='\0';
+            uSizeRead = file_info.size_file_comment;
+        }
+        else
+            uSizeRead = commentBufferSize;
+
+        if (uSeek!=0) {
+            if (ZSEEK(s->z_filefunc, s->filestream,uSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
+                uSeek=0;
+            else
+                err=UNZ_ERRNO;
+        }
+        if ((file_info.size_file_comment>0) && (commentBufferSize>0))
+            if (ZREAD(s->z_filefunc, s->filestream,szComment,uSizeRead)!=uSizeRead)
+                err=UNZ_ERRNO;
+        uSeek+=file_info.size_file_comment - uSizeRead;
+    }
+    else
+        uSeek+=file_info.size_file_comment;
+
+    if ((err==UNZ_OK) && (pfile_info!=NULL))
+        *pfile_info=file_info;
+
+    if ((err==UNZ_OK) && (pfile_info_internal!=NULL))
+        *pfile_info_internal=file_info_internal;
+
+    return err;
+}
+
+
+
+/*
+  Write info about the ZipFile in the *pglobal_info structure.
+  No preparation of the structure is needed
+  return UNZ_OK if there is no problem.
+*/
+extern int ZEXPORT unzGetCurrentFileInfo (file,
+                                          pfile_info,
+                                          szFileName, fileNameBufferSize,
+                                          extraField, extraFieldBufferSize,
+                                          szComment,  commentBufferSize)
+    unzFile file;
+    unz_file_info *pfile_info;
+    char *szFileName;
+    uLong fileNameBufferSize;
+    void *extraField;
+    uLong extraFieldBufferSize;
+    char *szComment;
+    uLong commentBufferSize;
+{
+    return unzlocal_GetCurrentFileInfoInternal(file,pfile_info,NULL,
+                                                szFileName,fileNameBufferSize,
+                                                extraField,extraFieldBufferSize,
+                                                szComment,commentBufferSize);
+}
+
+/*
+  Set the current file of the zipfile to the first file.
+  return UNZ_OK if there is no problem
+*/
+extern int ZEXPORT unzGoToFirstFile (file)
+    unzFile file;
+{
+    int err=UNZ_OK;
+    unz_s* s;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    s->pos_in_central_dir=s->offset_central_dir;
+    s->num_file=0;
+    err=unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
+                                             &s->cur_file_info_internal,
+                                             NULL,0,NULL,0,NULL,0);
+    s->current_file_ok = (err == UNZ_OK);
+    return err;
+}
+
+/*
+  Set the current file of the zipfile to the next file.
+  return UNZ_OK if there is no problem
+  return UNZ_END_OF_LIST_OF_FILE if the actual file was the latest.
+*/
+extern int ZEXPORT unzGoToNextFile (file)
+    unzFile file;
+{
+    unz_s* s;
+    int err;
+
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    if (!s->current_file_ok)
+        return UNZ_END_OF_LIST_OF_FILE;
+    if (s->gi.number_entry != 0xffff)    /* 2^16 files overflow hack */
+      if (s->num_file+1==s->gi.number_entry)
+        return UNZ_END_OF_LIST_OF_FILE;
+
+    s->pos_in_central_dir += SIZECENTRALDIRITEM + s->cur_file_info.size_filename +
+            s->cur_file_info.size_file_extra + s->cur_file_info.size_file_comment ;
+    s->num_file++;
+    err = unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
+                                               &s->cur_file_info_internal,
+                                               NULL,0,NULL,0,NULL,0);
+    s->current_file_ok = (err == UNZ_OK);
+    return err;
+}
+
+
+/*
+  Try locate the file szFileName in the zipfile.
+  For the iCaseSensitivity signification, see unzipStringFileNameCompare
+
+  return value :
+  UNZ_OK if the file is found. It becomes the current file.
+  UNZ_END_OF_LIST_OF_FILE if the file is not found
+*/
+extern int ZEXPORT unzLocateFile (file, szFileName, iCaseSensitivity)
+    unzFile file;
+    const char *szFileName;
+    int iCaseSensitivity;
+{
+    unz_s* s;
+    int err;
+
+    /* We remember the 'current' position in the file so that we can jump
+     * back there if we fail.
+     */
+    unz_file_info cur_file_infoSaved;
+    unz_file_info_internal cur_file_info_internalSaved;
+    uLong num_fileSaved;
+    uLong pos_in_central_dirSaved;
+
+
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+
+    if (strlen(szFileName)>=UNZ_MAXFILENAMEINZIP)
+        return UNZ_PARAMERROR;
+
+    s=(unz_s*)file;
+    if (!s->current_file_ok)
+        return UNZ_END_OF_LIST_OF_FILE;
+
+    /* Save the current state */
+    num_fileSaved = s->num_file;
+    pos_in_central_dirSaved = s->pos_in_central_dir;
+    cur_file_infoSaved = s->cur_file_info;
+    cur_file_info_internalSaved = s->cur_file_info_internal;
+
+    err = unzGoToFirstFile(file);
+
+    while (err == UNZ_OK)
+    {
+        char szCurrentFileName[UNZ_MAXFILENAMEINZIP+1];
+        err = unzGetCurrentFileInfo(file,NULL,
+                                    szCurrentFileName,sizeof(szCurrentFileName)-1,
+                                    NULL,0,NULL,0);
+        if (err == UNZ_OK)
+        {
+            if (unzStringFileNameCompare(szCurrentFileName,
+                                            szFileName,iCaseSensitivity)==0)
+                return UNZ_OK;
+            err = unzGoToNextFile(file);
+        }
+    }
+
+    /* We failed, so restore the state of the 'current file' to where we
+     * were.
+     */
+    s->num_file = num_fileSaved ;
+    s->pos_in_central_dir = pos_in_central_dirSaved ;
+    s->cur_file_info = cur_file_infoSaved;
+    s->cur_file_info_internal = cur_file_info_internalSaved;
+    return err;
+}
+
+
+/*
+///////////////////////////////////////////
+// Contributed by Ryan Haksi (mailto://cryogen@infoserve.net)
+// I need random access
+//
+// Further optimization could be realized by adding an ability
+// to cache the directory in memory. The goal being a single
+// comprehensive file read to put the file I need in a memory.
+*/
+
+/*
+typedef struct unz_file_pos_s
+{
+    uLong pos_in_zip_directory;   // offset in file
+    uLong num_of_file;            // # of file
+} unz_file_pos;
+*/
+
+extern int ZEXPORT unzGetFilePos(file, file_pos)
+    unzFile file;
+    unz_file_pos* file_pos;
+{
+    unz_s* s;
+
+    if (file==NULL || file_pos==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    if (!s->current_file_ok)
+        return UNZ_END_OF_LIST_OF_FILE;
+
+    file_pos->pos_in_zip_directory  = s->pos_in_central_dir;
+    file_pos->num_of_file           = s->num_file;
+
+    return UNZ_OK;
+}
+
+extern int ZEXPORT unzGoToFilePos(file, file_pos)
+    unzFile file;
+    unz_file_pos* file_pos;
+{
+    unz_s* s;
+    int err;
+
+    if (file==NULL || file_pos==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+
+    /* jump to the right spot */
+    s->pos_in_central_dir = file_pos->pos_in_zip_directory;
+    s->num_file           = file_pos->num_of_file;
+
+    /* set the current file */
+    err = unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
+                                               &s->cur_file_info_internal,
+                                               NULL,0,NULL,0,NULL,0);
+    /* return results */
+    s->current_file_ok = (err == UNZ_OK);
+    return err;
+}
+
+/*
+// Unzip Helper Functions - should be here?
+///////////////////////////////////////////
+*/
+
+/*
+  Read the local header of the current zipfile
+  Check the coherency of the local header and info in the end of central
+        directory about this file
+  store in *piSizeVar the size of extra info in local header
+        (filename and size of extra field data)
+*/
+local int unzlocal_CheckCurrentFileCoherencyHeader (s,piSizeVar,
+                                                    poffset_local_extrafield,
+                                                    psize_local_extrafield)
+    unz_s* s;
+    uInt* piSizeVar;
+    uLong *poffset_local_extrafield;
+    uInt  *psize_local_extrafield;
+{
+    uLong uMagic,uData,uFlags;
+    uLong size_filename;
+    uLong size_extra_field;
+    int err=UNZ_OK;
+
+    *piSizeVar = 0;
+    *poffset_local_extrafield = 0;
+    *psize_local_extrafield = 0;
+
+    if (ZSEEK(s->z_filefunc, s->filestream,s->cur_file_info_internal.offset_curfile +
+                                s->byte_before_the_zipfile,ZLIB_FILEFUNC_SEEK_SET)!=0)
+        return UNZ_ERRNO;
+
+
+    if (err==UNZ_OK) {
+        if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
+            err=UNZ_ERRNO;
+        else if (uMagic!=0x04034b50)
+            err=UNZ_BADZIPFILE;
+    }
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&uData) != UNZ_OK)
+        err=UNZ_ERRNO;
+/*
+    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.wVersion))
+        err=UNZ_BADZIPFILE;
+*/
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&uFlags) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&uData) != UNZ_OK)
+        err=UNZ_ERRNO;
+    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.compression_method))
+        err=UNZ_BADZIPFILE;
+
+    if ((err==UNZ_OK) && (s->cur_file_info.compression_method!=0) &&
+                         (s->cur_file_info.compression_method!=Z_DEFLATED))
+        err=UNZ_BADZIPFILE;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* date/time */
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* crc */
+        err=UNZ_ERRNO;
+    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.crc) &&
+                              ((uFlags & 8)==0))
+        err=UNZ_BADZIPFILE;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* size compr */
+        err=UNZ_ERRNO;
+    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.compressed_size) &&
+                              ((uFlags & 8)==0))
+        err=UNZ_BADZIPFILE;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* size uncompr */
+        err=UNZ_ERRNO;
+    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.uncompressed_size) &&
+                              ((uFlags & 8)==0))
+        err=UNZ_BADZIPFILE;
+
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&size_filename) != UNZ_OK)
+        err=UNZ_ERRNO;
+    else if ((err==UNZ_OK) && (size_filename!=s->cur_file_info.size_filename))
+        err=UNZ_BADZIPFILE;
+
+    *piSizeVar += (uInt)size_filename;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&size_extra_field) != UNZ_OK)
+        err=UNZ_ERRNO;
+    *poffset_local_extrafield= s->cur_file_info_internal.offset_curfile +
+                                    SIZEZIPLOCALHEADER + size_filename;
+    *psize_local_extrafield = (uInt)size_extra_field;
+
+    *piSizeVar += (uInt)size_extra_field;
+
+    return err;
+}
+
+/*
+  Open for reading data the current file in the zipfile.
+  If there is no error and the file is opened, the return value is UNZ_OK.
+*/
+extern int ZEXPORT unzOpenCurrentFile3 (file, method, level, raw, password)
+    unzFile file;
+    int* method;
+    int* level;
+    int raw;
+    const char* password;
+{
+    int err=UNZ_OK;
+    uInt iSizeVar;
+    unz_s* s;
+    file_in_zip_read_info_s* pfile_in_zip_read_info;
+    uLong offset_local_extrafield;  /* offset of the local extra field */
+    uInt  size_local_extrafield;    /* size of the local extra field */
+#    ifndef NOUNCRYPT
+    char source[12];
+#    else
+    if (password != NULL)
+        return UNZ_PARAMERROR;
+#    endif
+
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    if (!s->current_file_ok)
+        return UNZ_PARAMERROR;
+
+    if (s->pfile_in_zip_read != NULL)
+        unzCloseCurrentFile(file);
+
+    if (unzlocal_CheckCurrentFileCoherencyHeader(s,&iSizeVar,
+                &offset_local_extrafield,&size_local_extrafield)!=UNZ_OK)
+        return UNZ_BADZIPFILE;
+
+    pfile_in_zip_read_info = (file_in_zip_read_info_s*)
+                                        ALLOC(sizeof(file_in_zip_read_info_s));
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_INTERNALERROR;
+
+    pfile_in_zip_read_info->read_buffer=(char*)ALLOC(UNZ_BUFSIZE);
+    pfile_in_zip_read_info->offset_local_extrafield = offset_local_extrafield;
+    pfile_in_zip_read_info->size_local_extrafield = size_local_extrafield;
+    pfile_in_zip_read_info->pos_local_extrafield=0;
+    pfile_in_zip_read_info->raw=raw;
+
+    if (pfile_in_zip_read_info->read_buffer==NULL)
+    {
+        TRYFREE(pfile_in_zip_read_info);
+        return UNZ_INTERNALERROR;
+    }
+
+    pfile_in_zip_read_info->stream_initialised=0;
+
+    if (method!=NULL)
+        *method = (int)s->cur_file_info.compression_method;
+
+    if (level!=NULL)
+    {
+        *level = 6;
+        switch (s->cur_file_info.flag & 0x06)
+        {
+          case 6 : *level = 1; break;
+          case 4 : *level = 2; break;
+          case 2 : *level = 9; break;
+        }
+    }
+
+    if ((s->cur_file_info.compression_method!=0) &&
+        (s->cur_file_info.compression_method!=Z_DEFLATED))
+        err=UNZ_BADZIPFILE;
+
+    pfile_in_zip_read_info->crc32_wait=s->cur_file_info.crc;
+    pfile_in_zip_read_info->crc32=0;
+    pfile_in_zip_read_info->compression_method =
+            s->cur_file_info.compression_method;
+    pfile_in_zip_read_info->filestream=s->filestream;
+    pfile_in_zip_read_info->z_filefunc=s->z_filefunc;
+    pfile_in_zip_read_info->byte_before_the_zipfile=s->byte_before_the_zipfile;
+
+    pfile_in_zip_read_info->stream.total_out = 0;
+
+    if ((s->cur_file_info.compression_method==Z_DEFLATED) &&
+        (!raw))
+    {
+      pfile_in_zip_read_info->stream.zalloc = (alloc_func)0;
+      pfile_in_zip_read_info->stream.zfree = (free_func)0;
+      pfile_in_zip_read_info->stream.opaque = (voidpf)0;
+      pfile_in_zip_read_info->stream.next_in = (voidpf)0;
+      pfile_in_zip_read_info->stream.avail_in = 0;
+
+      err=inflateInit2(&pfile_in_zip_read_info->stream, -MAX_WBITS);
+      if (err == Z_OK)
+        pfile_in_zip_read_info->stream_initialised=1;
+      else
+      {
+        TRYFREE(pfile_in_zip_read_info);
+        return err;
+      }
+        /* windowBits is passed < 0 to tell that there is no zlib header.
+         * Note that in this case inflate *requires* an extra "dummy" byte
+         * after the compressed stream in order to complete decompression and
+         * return Z_STREAM_END.
+         * In unzip, i don't wait absolutely Z_STREAM_END because I known the
+         * size of both compressed and uncompressed data
+         */
+    }
+    pfile_in_zip_read_info->rest_read_compressed =
+            s->cur_file_info.compressed_size ;
+    pfile_in_zip_read_info->rest_read_uncompressed =
+            s->cur_file_info.uncompressed_size ;
+
+
+    pfile_in_zip_read_info->pos_in_zipfile =
+            s->cur_file_info_internal.offset_curfile + SIZEZIPLOCALHEADER +
+              iSizeVar;
+
+    pfile_in_zip_read_info->stream.avail_in = (uInt)0;
+
+    s->pfile_in_zip_read = pfile_in_zip_read_info;
+
+#    ifndef NOUNCRYPT
+    if (password != NULL)
+    {
+        int i;
+        s->pcrc_32_tab = get_crc_table();
+        init_keys(password,s->keys,s->pcrc_32_tab);
+        if (ZSEEK(s->z_filefunc, s->filestream,
+                  s->pfile_in_zip_read->pos_in_zipfile +
+                     s->pfile_in_zip_read->byte_before_the_zipfile,
+                  SEEK_SET)!=0)
+            return UNZ_INTERNALERROR;
+        if(ZREAD(s->z_filefunc, s->filestream,source, 12)<12)
+            return UNZ_INTERNALERROR;
+
+        for (i = 0; i<12; i++)
+            zdecode(s->keys,s->pcrc_32_tab,source[i]);
+
+        s->pfile_in_zip_read->pos_in_zipfile+=12;
+        s->encrypted=1;
+    }
+#    endif
+
+
+    return UNZ_OK;
+}
+
+extern int ZEXPORT unzOpenCurrentFile (file)
+    unzFile file;
+{
+    return unzOpenCurrentFile3(file, NULL, NULL, 0, NULL);
+}
+
+extern int ZEXPORT unzOpenCurrentFilePassword (file, password)
+    unzFile file;
+    const char* password;
+{
+    return unzOpenCurrentFile3(file, NULL, NULL, 0, password);
+}
+
+extern int ZEXPORT unzOpenCurrentFile2 (file,method,level,raw)
+    unzFile file;
+    int* method;
+    int* level;
+    int raw;
+{
+    return unzOpenCurrentFile3(file, method, level, raw, NULL);
+}
+
+/*
+  Read bytes from the current file.
+  buf contain buffer where data must be copied
+  len the size of buf.
+
+  return the number of byte copied if somes bytes are copied
+  return 0 if the end of file was reached
+  return <0 with error code if there is an error
+    (UNZ_ERRNO for IO error, or zLib error for uncompress error)
+*/
+extern int ZEXPORT unzReadCurrentFile  (file, buf, len)
+    unzFile file;
+    voidp buf;
+    unsigned len;
+{
+    int err=UNZ_OK;
+    uInt iRead = 0;
+    unz_s* s;
+    file_in_zip_read_info_s* pfile_in_zip_read_info;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
+
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
+
+
+    if ((pfile_in_zip_read_info->read_buffer == NULL))
+        return UNZ_END_OF_LIST_OF_FILE;
+    if (len==0)
+        return 0;
+
+    pfile_in_zip_read_info->stream.next_out = (Bytef*)buf;
+
+    pfile_in_zip_read_info->stream.avail_out = (uInt)len;
+
+    if ((len>pfile_in_zip_read_info->rest_read_uncompressed) &&
+        (!(pfile_in_zip_read_info->raw)))
+        pfile_in_zip_read_info->stream.avail_out =
+            (uInt)pfile_in_zip_read_info->rest_read_uncompressed;
+
+    if ((len>pfile_in_zip_read_info->rest_read_compressed+
+           pfile_in_zip_read_info->stream.avail_in) &&
+         (pfile_in_zip_read_info->raw))
+        pfile_in_zip_read_info->stream.avail_out =
+            (uInt)pfile_in_zip_read_info->rest_read_compressed+
+            pfile_in_zip_read_info->stream.avail_in;
+
+    while (pfile_in_zip_read_info->stream.avail_out>0)
+    {
+        if ((pfile_in_zip_read_info->stream.avail_in==0) &&
+            (pfile_in_zip_read_info->rest_read_compressed>0))
+        {
+            uInt uReadThis = UNZ_BUFSIZE;
+            if (pfile_in_zip_read_info->rest_read_compressed<uReadThis)
+                uReadThis = (uInt)pfile_in_zip_read_info->rest_read_compressed;
+            if (uReadThis == 0)
+                return UNZ_EOF;
+            if (ZSEEK(pfile_in_zip_read_info->z_filefunc,
+                      pfile_in_zip_read_info->filestream,
+                      pfile_in_zip_read_info->pos_in_zipfile +
+                         pfile_in_zip_read_info->byte_before_the_zipfile,
+                         ZLIB_FILEFUNC_SEEK_SET)!=0)
+                return UNZ_ERRNO;
+            if (ZREAD(pfile_in_zip_read_info->z_filefunc,
+                      pfile_in_zip_read_info->filestream,
+                      pfile_in_zip_read_info->read_buffer,
+                      uReadThis)!=uReadThis)
+                return UNZ_ERRNO;
+
+
+#            ifndef NOUNCRYPT
+            if(s->encrypted)
+            {
+                uInt i;
+                for(i=0;i<uReadThis;i++)
+                  pfile_in_zip_read_info->read_buffer[i] =
+                      zdecode(s->keys,s->pcrc_32_tab,
+                              pfile_in_zip_read_info->read_buffer[i]);
+            }
+#            endif
+
+
+            pfile_in_zip_read_info->pos_in_zipfile += uReadThis;
+
+            pfile_in_zip_read_info->rest_read_compressed-=uReadThis;
+
+            pfile_in_zip_read_info->stream.next_in =
+                (Bytef*)pfile_in_zip_read_info->read_buffer;
+            pfile_in_zip_read_info->stream.avail_in = (uInt)uReadThis;
+        }
+
+        if ((pfile_in_zip_read_info->compression_method==0) || (pfile_in_zip_read_info->raw))
+        {
+            uInt uDoCopy,i ;
+
+            if ((pfile_in_zip_read_info->stream.avail_in == 0) &&
+                (pfile_in_zip_read_info->rest_read_compressed == 0))
+                return (iRead==0) ? UNZ_EOF : iRead;
+
+            if (pfile_in_zip_read_info->stream.avail_out <
+                            pfile_in_zip_read_info->stream.avail_in)
+                uDoCopy = pfile_in_zip_read_info->stream.avail_out ;
+            else
+                uDoCopy = pfile_in_zip_read_info->stream.avail_in ;
+
+            for (i=0;i<uDoCopy;i++)
+                *(pfile_in_zip_read_info->stream.next_out+i) =
+                        *(pfile_in_zip_read_info->stream.next_in+i);
+
+            pfile_in_zip_read_info->crc32 = crc32(pfile_in_zip_read_info->crc32,
+                                pfile_in_zip_read_info->stream.next_out,
+                                uDoCopy);
+            pfile_in_zip_read_info->rest_read_uncompressed-=uDoCopy;
+            pfile_in_zip_read_info->stream.avail_in -= uDoCopy;
+            pfile_in_zip_read_info->stream.avail_out -= uDoCopy;
+            pfile_in_zip_read_info->stream.next_out += uDoCopy;
+            pfile_in_zip_read_info->stream.next_in += uDoCopy;
+            pfile_in_zip_read_info->stream.total_out += uDoCopy;
+            iRead += uDoCopy;
+        }
+        else
+        {
+            uLong uTotalOutBefore,uTotalOutAfter;
+            const Bytef *bufBefore;
+            uLong uOutThis;
+            int flush=Z_SYNC_FLUSH;
+
+            uTotalOutBefore = pfile_in_zip_read_info->stream.total_out;
+            bufBefore = pfile_in_zip_read_info->stream.next_out;
+
+            /*
+            if ((pfile_in_zip_read_info->rest_read_uncompressed ==
+                     pfile_in_zip_read_info->stream.avail_out) &&
+                (pfile_in_zip_read_info->rest_read_compressed == 0))
+                flush = Z_FINISH;
+            */
+            err=inflate(&pfile_in_zip_read_info->stream,flush);
+
+            if ((err>=0) && (pfile_in_zip_read_info->stream.msg!=NULL))
+              err = Z_DATA_ERROR;
+
+            uTotalOutAfter = pfile_in_zip_read_info->stream.total_out;
+            uOutThis = uTotalOutAfter-uTotalOutBefore;
+
+            pfile_in_zip_read_info->crc32 =
+                crc32(pfile_in_zip_read_info->crc32,bufBefore,
+                        (uInt)(uOutThis));
+
+            pfile_in_zip_read_info->rest_read_uncompressed -=
+                uOutThis;
+
+            iRead += (uInt)(uTotalOutAfter - uTotalOutBefore);
+
+            if (err==Z_STREAM_END)
+                return (iRead==0) ? UNZ_EOF : iRead;
+            if (err!=Z_OK)
+                break;
+        }
+    }
+
+    if (err==Z_OK)
+        return iRead;
+    return err;
+}
+
+
+/*
+  Give the current position in uncompressed data
+*/
+extern z_off_t ZEXPORT unztell (file)
+    unzFile file;
+{
+    unz_s* s;
+    file_in_zip_read_info_s* pfile_in_zip_read_info;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
+
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
+
+    return (z_off_t)pfile_in_zip_read_info->stream.total_out;
+}
+
+
+/*
+  return 1 if the end of file was reached, 0 elsewhere
+*/
+extern int ZEXPORT unzeof (file)
+    unzFile file;
+{
+    unz_s* s;
+    file_in_zip_read_info_s* pfile_in_zip_read_info;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
+
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
+
+    if (pfile_in_zip_read_info->rest_read_uncompressed == 0)
+        return 1;
+    else
+        return 0;
+}
+
+
+
+/*
+  Read extra field from the current file (opened by unzOpenCurrentFile)
+  This is the local-header version of the extra field (sometimes, there is
+    more info in the local-header version than in the central-header)
+
+  if buf==NULL, it return the size of the local extra field that can be read
+
+  if buf!=NULL, len is the size of the buffer, the extra header is copied in
+    buf.
+  the return value is the number of bytes copied in buf, or (if <0)
+    the error code
+*/
+extern int ZEXPORT unzGetLocalExtrafield (file,buf,len)
+    unzFile file;
+    voidp buf;
+    unsigned len;
+{
+    unz_s* s;
+    file_in_zip_read_info_s* pfile_in_zip_read_info;
+    uInt read_now;
+    uLong size_to_read;
+
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
+
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
+
+    size_to_read = (pfile_in_zip_read_info->size_local_extrafield -
+                pfile_in_zip_read_info->pos_local_extrafield);
+
+    if (buf==NULL)
+        return (int)size_to_read;
+
+    if (len>size_to_read)
+        read_now = (uInt)size_to_read;
+    else
+        read_now = (uInt)len ;
+
+    if (read_now==0)
+        return 0;
+
+    if (ZSEEK(pfile_in_zip_read_info->z_filefunc,
+              pfile_in_zip_read_info->filestream,
+              pfile_in_zip_read_info->offset_local_extrafield +
+              pfile_in_zip_read_info->pos_local_extrafield,
+              ZLIB_FILEFUNC_SEEK_SET)!=0)
+        return UNZ_ERRNO;
+
+    if (ZREAD(pfile_in_zip_read_info->z_filefunc,
+              pfile_in_zip_read_info->filestream,
+              buf,read_now)!=read_now)
+        return UNZ_ERRNO;
+
+    return (int)read_now;
+}
+
+/*
+  Close the file in zip opened with unzipOpenCurrentFile
+  Return UNZ_CRCERROR if all the file was read but the CRC is not good
+*/
+extern int ZEXPORT unzCloseCurrentFile (file)
+    unzFile file;
+{
+    int err=UNZ_OK;
+
+    unz_s* s;
+    file_in_zip_read_info_s* pfile_in_zip_read_info;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
+
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
+
+
+    if ((pfile_in_zip_read_info->rest_read_uncompressed == 0) &&
+        (!pfile_in_zip_read_info->raw))
+    {
+        if (pfile_in_zip_read_info->crc32 != pfile_in_zip_read_info->crc32_wait)
+            err=UNZ_CRCERROR;
+    }
+
+
+    TRYFREE(pfile_in_zip_read_info->read_buffer);
+    pfile_in_zip_read_info->read_buffer = NULL;
+    if (pfile_in_zip_read_info->stream_initialised)
+        inflateEnd(&pfile_in_zip_read_info->stream);
+
+    pfile_in_zip_read_info->stream_initialised = 0;
+    TRYFREE(pfile_in_zip_read_info);
+
+    s->pfile_in_zip_read=NULL;
+
+    return err;
+}
+
+
+/*
+  Get the global comment string of the ZipFile, in the szComment buffer.
+  uSizeBuf is the size of the szComment buffer.
+  return the number of byte copied or an error code <0
+*/
+extern int ZEXPORT unzGetGlobalComment (file, szComment, uSizeBuf)
+    unzFile file;
+    char *szComment;
+    uLong uSizeBuf;
+{
+    unz_s* s;
+    uLong uReadThis ;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+
+    uReadThis = uSizeBuf;
+    if (uReadThis>s->gi.size_comment)
+        uReadThis = s->gi.size_comment;
+
+    if (ZSEEK(s->z_filefunc,s->filestream,s->central_pos+22,ZLIB_FILEFUNC_SEEK_SET)!=0)
+        return UNZ_ERRNO;
+
+    if (uReadThis>0)
+    {
+      *szComment='\0';
+      if (ZREAD(s->z_filefunc,s->filestream,szComment,uReadThis)!=uReadThis)
+        return UNZ_ERRNO;
+    }
+
+    if ((szComment != NULL) && (uSizeBuf > s->gi.size_comment))
+        *(szComment+s->gi.size_comment)='\0';
+    return (int)uReadThis;
+}
+
+/* Additions by RX '2004 */
+extern uLong ZEXPORT unzGetOffset (file)
+    unzFile file;
+{
+    unz_s* s;
+
+    if (file==NULL)
+          return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    if (!s->current_file_ok)
+      return 0;
+    if (s->gi.number_entry != 0 && s->gi.number_entry != 0xffff)
+      if (s->num_file==s->gi.number_entry)
+         return 0;
+    return s->pos_in_central_dir;
+}
+
+extern int ZEXPORT unzSetOffset (file, pos)
+        unzFile file;
+        uLong pos;
+{
+    unz_s* s;
+    int err;
+
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+
+    s->pos_in_central_dir = pos;
+    s->num_file = s->gi.number_entry;      /* hack */
+    err = unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
+                                              &s->cur_file_info_internal,
+                                              NULL,0,NULL,0,NULL,0);
+    s->current_file_ok = (err == UNZ_OK);
+    return err;
+}

--- a/src/external/quazip/unzip.h
+++ b/src/external/quazip/unzip.h
@@ -1,0 +1,356 @@
+/* unzip.h -- IO for uncompress .zip files using zlib
+   Version 1.01e, February 12th, 2005
+
+   Copyright (C) 1998-2005 Gilles Vollant
+
+   This unzip package allow extract file from .ZIP file, compatible with PKZip 2.04g
+     WinZip, InfoZip tools and compatible.
+
+   Multi volume ZipFile (span) are not supported.
+   Encryption compatible with pkzip 2.04g only supported
+   Old compressions used by old PKZip 1.x are not supported
+
+
+   I WAIT FEEDBACK at mail info@winimage.com
+   Visit also http://www.winimage.com/zLibDll/unzip.htm for evolution
+
+   Condition of use and distribution are the same than zlib :
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+   Modified by Sergey A. Tachenov to integrate with Qt.
+
+
+*/
+
+/* for more info about .ZIP format, see
+      http://www.info-zip.org/pub/infozip/doc/appnote-981119-iz.zip
+      http://www.info-zip.org/pub/infozip/doc/
+   PkWare has also a specification at :
+      ftp://ftp.pkware.com/probdesc.zip
+*/
+
+#ifndef _unz_H
+#define _unz_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef _ZLIB_H
+#include "zlib.h"
+#endif
+
+#ifndef _ZLIBIOAPI_H
+#include "ioapi.h"
+#endif
+
+#if defined(STRICTUNZIP) || defined(STRICTZIPUNZIP)
+/* like the STRICT of WIN32, we define a pointer that cannot be converted
+    from (void*) without cast */
+typedef struct TagunzFile__ { int unused; } unzFile__;
+typedef unzFile__ *unzFile;
+#else
+typedef voidp unzFile;
+#endif
+
+
+#define UNZ_OK                          (0)
+#define UNZ_END_OF_LIST_OF_FILE         (-100)
+#define UNZ_ERRNO                       (Z_ERRNO)
+#define UNZ_EOF                         (0)
+#define UNZ_PARAMERROR                  (-102)
+#define UNZ_BADZIPFILE                  (-103)
+#define UNZ_INTERNALERROR               (-104)
+#define UNZ_CRCERROR                    (-105)
+
+/* tm_unz contain date/time info */
+typedef struct tm_unz_s
+{
+    uInt tm_sec;            /* seconds after the minute - [0,59] */
+    uInt tm_min;            /* minutes after the hour - [0,59] */
+    uInt tm_hour;           /* hours since midnight - [0,23] */
+    uInt tm_mday;           /* day of the month - [1,31] */
+    uInt tm_mon;            /* months since January - [0,11] */
+    uInt tm_year;           /* years - [1980..2044] */
+} tm_unz;
+
+/* unz_global_info structure contain global data about the ZIPfile
+   These data comes from the end of central dir */
+typedef struct unz_global_info_s
+{
+    uLong number_entry;         /* total number of entries in
+                       the central dir on this disk */
+    uLong size_comment;         /* size of the global comment of the zipfile */
+} unz_global_info;
+
+
+/* unz_file_info contain information about a file in the zipfile */
+typedef struct unz_file_info_s
+{
+    uLong version;              /* version made by                 2 bytes */
+    uLong version_needed;       /* version needed to extract       2 bytes */
+    uLong flag;                 /* general purpose bit flag        2 bytes */
+    uLong compression_method;   /* compression method              2 bytes */
+    uLong dosDate;              /* last mod file date in Dos fmt   4 bytes */
+    uLong crc;                  /* crc-32                          4 bytes */
+    uLong compressed_size;      /* compressed size                 4 bytes */
+    uLong uncompressed_size;    /* uncompressed size               4 bytes */
+    uLong size_filename;        /* filename length                 2 bytes */
+    uLong size_file_extra;      /* extra field length              2 bytes */
+    uLong size_file_comment;    /* file comment length             2 bytes */
+
+    uLong disk_num_start;       /* disk number start               2 bytes */
+    uLong internal_fa;          /* internal file attributes        2 bytes */
+    uLong external_fa;          /* external file attributes        4 bytes */
+
+    tm_unz tmu_date;
+} unz_file_info;
+
+extern int ZEXPORT unzStringFileNameCompare OF ((const char* fileName1,
+                                                 const char* fileName2,
+                                                 int iCaseSensitivity));
+/*
+   Compare two filename (fileName1,fileName2).
+   If iCaseSenisivity = 1, comparision is case sensitivity (like strcmp)
+   If iCaseSenisivity = 2, comparision is not case sensitivity (like strcmpi
+                                or strcasecmp)
+   If iCaseSenisivity = 0, case sensitivity is defaut of your operating system
+    (like 1 on Unix, 2 on Windows)
+*/
+
+
+extern unzFile ZEXPORT unzOpen OF((voidpf file));
+/*
+  Open a Zip file. path contain whatever zopen_file from the IO API
+  accepts. For Qt implementation it is a pointer to QIODevice, for
+  fopen() implementation it's a file name.
+     If the zipfile cannot be opened (file don't exist or in not valid), the
+       return value is NULL.
+     Else, the return value is a unzFile Handle, usable with other function
+       of this unzip package.
+*/
+
+extern unzFile ZEXPORT unzOpen2 OF((voidpf file,
+                                    zlib_filefunc_def* pzlib_filefunc_def));
+/*
+   Open a Zip file, like unzOpen, but provide a set of file low level API
+      for read/write the zip file (see ioapi.h)
+*/
+
+extern int ZEXPORT unzClose OF((unzFile file));
+/*
+  Close a ZipFile opened with unzipOpen.
+  If there is files inside the .Zip opened with unzOpenCurrentFile (see later),
+    these files MUST be closed with unzipCloseCurrentFile before call unzipClose.
+  return UNZ_OK if there is no problem. */
+
+extern int ZEXPORT unzGetGlobalInfo OF((unzFile file,
+                                        unz_global_info *pglobal_info));
+/*
+  Write info about the ZipFile in the *pglobal_info structure.
+  No preparation of the structure is needed
+  return UNZ_OK if there is no problem. */
+
+
+extern int ZEXPORT unzGetGlobalComment OF((unzFile file,
+                                           char *szComment,
+                                           uLong uSizeBuf));
+/*
+  Get the global comment string of the ZipFile, in the szComment buffer.
+  uSizeBuf is the size of the szComment buffer.
+  return the number of byte copied or an error code <0
+*/
+
+
+/***************************************************************************/
+/* Unzip package allow you browse the directory of the zipfile */
+
+extern int ZEXPORT unzGoToFirstFile OF((unzFile file));
+/*
+  Set the current file of the zipfile to the first file.
+  return UNZ_OK if there is no problem
+*/
+
+extern int ZEXPORT unzGoToNextFile OF((unzFile file));
+/*
+  Set the current file of the zipfile to the next file.
+  return UNZ_OK if there is no problem
+  return UNZ_END_OF_LIST_OF_FILE if the actual file was the latest.
+*/
+
+extern int ZEXPORT unzLocateFile OF((unzFile file,
+                     const char *szFileName,
+                     int iCaseSensitivity));
+/*
+  Try locate the file szFileName in the zipfile.
+  For the iCaseSensitivity signification, see unzStringFileNameCompare
+
+  return value :
+  UNZ_OK if the file is found. It becomes the current file.
+  UNZ_END_OF_LIST_OF_FILE if the file is not found
+*/
+
+
+/* ****************************************** */
+/* Ryan supplied functions */
+/* unz_file_info contain information about a file in the zipfile */
+typedef struct unz_file_pos_s
+{
+    uLong pos_in_zip_directory;   /* offset in zip file directory */
+    uLong num_of_file;            /* # of file */
+} unz_file_pos;
+
+extern int ZEXPORT unzGetFilePos(
+    unzFile file,
+    unz_file_pos* file_pos);
+
+extern int ZEXPORT unzGoToFilePos(
+    unzFile file,
+    unz_file_pos* file_pos);
+
+/* ****************************************** */
+
+extern int ZEXPORT unzGetCurrentFileInfo OF((unzFile file,
+                         unz_file_info *pfile_info,
+                         char *szFileName,
+                         uLong fileNameBufferSize,
+                         void *extraField,
+                         uLong extraFieldBufferSize,
+                         char *szComment,
+                         uLong commentBufferSize));
+/*
+  Get Info about the current file
+  if pfile_info!=NULL, the *pfile_info structure will contain somes info about
+        the current file
+  if szFileName!=NULL, the filemane string will be copied in szFileName
+            (fileNameBufferSize is the size of the buffer)
+  if extraField!=NULL, the extra field information will be copied in extraField
+            (extraFieldBufferSize is the size of the buffer).
+            This is the Central-header version of the extra field
+  if szComment!=NULL, the comment string of the file will be copied in szComment
+            (commentBufferSize is the size of the buffer)
+*/
+
+/***************************************************************************/
+/* for reading the content of the current zipfile, you can open it, read data
+   from it, and close it (you can close it before reading all the file)
+   */
+
+extern int ZEXPORT unzOpenCurrentFile OF((unzFile file));
+/*
+  Open for reading data the current file in the zipfile.
+  If there is no error, the return value is UNZ_OK.
+*/
+
+extern int ZEXPORT unzOpenCurrentFilePassword OF((unzFile file,
+                                                  const char* password));
+/*
+  Open for reading data the current file in the zipfile.
+  password is a crypting password
+  If there is no error, the return value is UNZ_OK.
+*/
+
+extern int ZEXPORT unzOpenCurrentFile2 OF((unzFile file,
+                                           int* method,
+                                           int* level,
+                                           int raw));
+/*
+  Same than unzOpenCurrentFile, but open for read raw the file (not uncompress)
+    if raw==1
+  *method will receive method of compression, *level will receive level of
+     compression
+  note : you can set level parameter as NULL (if you did not want known level,
+         but you CANNOT set method parameter as NULL
+*/
+
+extern int ZEXPORT unzOpenCurrentFile3 OF((unzFile file,
+                                           int* method,
+                                           int* level,
+                                           int raw,
+                                           const char* password));
+/*
+  Same than unzOpenCurrentFile, but open for read raw the file (not uncompress)
+    if raw==1
+  *method will receive method of compression, *level will receive level of
+     compression
+  note : you can set level parameter as NULL (if you did not want known level,
+         but you CANNOT set method parameter as NULL
+*/
+
+
+extern int ZEXPORT unzCloseCurrentFile OF((unzFile file));
+/*
+  Close the file in zip opened with unzOpenCurrentFile
+  Return UNZ_CRCERROR if all the file was read but the CRC is not good
+*/
+
+extern int ZEXPORT unzReadCurrentFile OF((unzFile file,
+                      voidp buf,
+                      unsigned len));
+/*
+  Read bytes from the current file (opened by unzOpenCurrentFile)
+  buf contain buffer where data must be copied
+  len the size of buf.
+
+  return the number of byte copied if somes bytes are copied
+  return 0 if the end of file was reached
+  return <0 with error code if there is an error
+    (UNZ_ERRNO for IO error, or zLib error for uncompress error)
+*/
+
+extern z_off_t ZEXPORT unztell OF((unzFile file));
+/*
+  Give the current position in uncompressed data
+*/
+
+extern int ZEXPORT unzeof OF((unzFile file));
+/*
+  return 1 if the end of file was reached, 0 elsewhere
+*/
+
+extern int ZEXPORT unzGetLocalExtrafield OF((unzFile file,
+                                             voidp buf,
+                                             unsigned len));
+/*
+  Read extra field from the current file (opened by unzOpenCurrentFile)
+  This is the local-header version of the extra field (sometimes, there is
+    more info in the local-header version than in the central-header)
+
+  if buf==NULL, it return the size of the local extra field
+
+  if buf!=NULL, len is the size of the buffer, the extra header is copied in
+    buf.
+  the return value is the number of bytes copied in buf, or (if <0)
+    the error code
+*/
+
+/***************************************************************************/
+
+/* Get the current file offset */
+extern uLong ZEXPORT unzGetOffset (unzFile file);
+
+/* Set the current file offset */
+extern int ZEXPORT unzSetOffset (unzFile file, uLong pos);
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _unz_H */

--- a/src/external/quazip/zip.c
+++ b/src/external/quazip/zip.c
@@ -1,0 +1,1282 @@
+/* zip.c -- IO on .zip files using zlib
+   Version 1.01e, February 12th, 2005
+
+   27 Dec 2004 Rolf Kalbermatter
+   Modification to zipOpen2 to support globalComment retrieval.
+
+   Copyright (C) 1998-2005 Gilles Vollant
+
+   Read zip.h for more info
+
+   Modified by Sergey A. Tachenov to integrate with Qt.
+*/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <zlib.h>
+#include "zip.h"
+#include "quazip_global.h"
+
+#ifdef STDC
+#  include <stddef.h>
+#  include <string.h>
+#  include <stdlib.h>
+#endif
+#ifdef NO_ERRNO_H
+    extern int errno;
+#else
+#   include <errno.h>
+#endif
+
+
+#ifndef local
+#  define local static
+#endif
+/* compile with -Dlocal if your debugger can't find static symbols */
+
+#ifndef VERSIONMADEBY
+# define VERSIONMADEBY   (0x031e) /* best for standard pkware crypt */
+#endif
+
+#ifndef Z_BUFSIZE
+#define Z_BUFSIZE (16384)
+#endif
+
+#ifndef Z_MAXFILENAMEINZIP
+#define Z_MAXFILENAMEINZIP (256)
+#endif
+
+#ifndef ALLOC
+# define ALLOC(size) (malloc(size))
+#endif
+#ifndef TRYFREE
+# define TRYFREE(p) {if (p) free(p);}
+#endif
+
+/*
+#define SIZECENTRALDIRITEM (0x2e)
+#define SIZEZIPLOCALHEADER (0x1e)
+*/
+
+/* I've found an old Unix (a SunOS 4.1.3_U1) without all SEEK_* defined.... */
+
+#ifndef SEEK_CUR
+#define SEEK_CUR    1
+#endif
+
+#ifndef SEEK_END
+#define SEEK_END    2
+#endif
+
+#ifndef SEEK_SET
+#define SEEK_SET    0
+#endif
+
+#ifndef DEF_MEM_LEVEL
+#if MAX_MEM_LEVEL >= 8
+#  define DEF_MEM_LEVEL 8
+#else
+#  define DEF_MEM_LEVEL  MAX_MEM_LEVEL
+#endif
+#endif
+const char zip_copyright[] =
+   " zip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
+
+
+#define SIZEDATA_INDATABLOCK (4096-(4*4))
+
+#define LOCALHEADERMAGIC    (0x04034b50)
+#define DESCRIPTORHEADERMAGIC    (0x08074b50)
+#define CENTRALHEADERMAGIC  (0x02014b50)
+#define ENDHEADERMAGIC      (0x06054b50)
+
+#define FLAG_LOCALHEADER_OFFSET (0x06)
+#define CRC_LOCALHEADER_OFFSET  (0x0e)
+
+#define SIZECENTRALHEADER (0x2e) /* 46 */
+
+typedef struct linkedlist_datablock_internal_s
+{
+  struct linkedlist_datablock_internal_s* next_datablock;
+  uLong  avail_in_this_block;
+  uLong  filled_in_this_block;
+  uLong  unused; /* for future use and alignement */
+  unsigned char data[SIZEDATA_INDATABLOCK];
+} linkedlist_datablock_internal;
+
+typedef struct linkedlist_data_s
+{
+    linkedlist_datablock_internal* first_block;
+    linkedlist_datablock_internal* last_block;
+} linkedlist_data;
+
+
+typedef struct
+{
+    z_stream stream;            /* zLib stream structure for inflate */
+    int  stream_initialised;    /* 1 is stream is initialised */
+    uInt pos_in_buffered_data;  /* last written byte in buffered_data */
+
+    uLong pos_local_header;     /* offset of the local header of the file
+                                     currenty writing */
+    char* central_header;       /* central header data for the current file */
+    uLong size_centralheader;   /* size of the central header for cur file */
+    uLong flag;                 /* flag of the file currently writing */
+
+    int  method;                /* compression method of file currenty wr.*/
+    int  raw;                   /* 1 for directly writing raw data */
+    Byte buffered_data[Z_BUFSIZE];/* buffer contain compressed data to be writ*/
+    uLong dosDate;
+    uLong crc32;
+    int  encrypt;
+#ifndef NOCRYPT
+    unsigned long keys[3];     /* keys defining the pseudo-random sequence */
+    const unsigned long* pcrc_32_tab;
+    int crypt_header_size;
+#endif
+} curfile_info;
+
+typedef struct
+{
+    zlib_filefunc_def z_filefunc;
+    voidpf filestream;        /* io structore of the zipfile */
+    linkedlist_data central_dir;/* datablock with central dir in construction*/
+    int  in_opened_file_inzip;  /* 1 if a file in the zip is currently writ.*/
+    curfile_info ci;            /* info on the file curretly writing */
+
+    uLong begin_pos;            /* position of the beginning of the zipfile */
+    uLong add_position_when_writting_offset;
+    uLong number_entry;
+#ifndef NO_ADDFILEINEXISTINGZIP
+    char *globalcomment;
+#endif
+    unsigned flags;
+} zip_internal;
+
+
+
+#ifndef NOCRYPT
+#define INCLUDECRYPTINGCODE_IFCRYPTALLOWED
+#include "crypt.h"
+#endif
+
+local linkedlist_datablock_internal* allocate_new_datablock()
+{
+    linkedlist_datablock_internal* ldi;
+    ldi = (linkedlist_datablock_internal*)
+                 ALLOC(sizeof(linkedlist_datablock_internal));
+    if (ldi!=NULL)
+    {
+        ldi->next_datablock = NULL ;
+        ldi->filled_in_this_block = 0 ;
+        ldi->avail_in_this_block = SIZEDATA_INDATABLOCK ;
+    }
+    return ldi;
+}
+
+local void free_datablock(ldi)
+    linkedlist_datablock_internal* ldi;
+{
+    while (ldi!=NULL)
+    {
+        linkedlist_datablock_internal* ldinext = ldi->next_datablock;
+        TRYFREE(ldi);
+        ldi = ldinext;
+    }
+}
+
+local void init_linkedlist(ll)
+    linkedlist_data* ll;
+{
+    ll->first_block = ll->last_block = NULL;
+}
+
+#if 0 // unused
+local void free_linkedlist(ll)
+    linkedlist_data* ll;
+{
+    free_datablock(ll->first_block);
+    ll->first_block = ll->last_block = NULL;
+}
+#endif
+
+local int add_data_in_datablock(ll,buf,len)
+    linkedlist_data* ll;
+    const void* buf;
+    uLong len;
+{
+    linkedlist_datablock_internal* ldi;
+    const unsigned char* from_copy;
+
+    if (ll==NULL)
+        return ZIP_INTERNALERROR;
+
+    if (ll->last_block == NULL)
+    {
+        ll->first_block = ll->last_block = allocate_new_datablock();
+        if (ll->first_block == NULL)
+            return ZIP_INTERNALERROR;
+    }
+
+    ldi = ll->last_block;
+    from_copy = (unsigned char*)buf;
+
+    while (len>0)
+    {
+        uInt copy_this;
+        uInt i;
+        unsigned char* to_copy;
+
+        if (ldi->avail_in_this_block==0)
+        {
+            ldi->next_datablock = allocate_new_datablock();
+            if (ldi->next_datablock == NULL)
+                return ZIP_INTERNALERROR;
+            ldi = ldi->next_datablock ;
+            ll->last_block = ldi;
+        }
+
+        if (ldi->avail_in_this_block < len)
+            copy_this = (uInt)ldi->avail_in_this_block;
+        else
+            copy_this = (uInt)len;
+
+        to_copy = &(ldi->data[ldi->filled_in_this_block]);
+
+        for (i=0;i<copy_this;i++)
+            *(to_copy+i)=*(from_copy+i);
+
+        ldi->filled_in_this_block += copy_this;
+        ldi->avail_in_this_block -= copy_this;
+        from_copy += copy_this ;
+        len -= copy_this;
+    }
+    return ZIP_OK;
+}
+
+
+
+/****************************************************************************/
+
+#ifndef NO_ADDFILEINEXISTINGZIP
+/* ===========================================================================
+   Inputs a long in LSB order to the given file
+   nbByte == 1, 2 or 4 (byte, short or long)
+*/
+
+local int ziplocal_putValue OF((const zlib_filefunc_def* pzlib_filefunc_def,
+                                voidpf filestream, uLong x, int nbByte));
+local int ziplocal_putValue (pzlib_filefunc_def, filestream, x, nbByte)
+    const zlib_filefunc_def* pzlib_filefunc_def;
+    voidpf filestream;
+    uLong x;
+    int nbByte;
+{
+    unsigned char buf[4];
+    int n;
+    for (n = 0; n < nbByte; n++)
+    {
+        buf[n] = (unsigned char)(x & 0xff);
+        x >>= 8;
+    }
+    if (x != 0)
+      {     /* data overflow - hack for ZIP64 (X Roche) */
+      for (n = 0; n < nbByte; n++)
+        {
+          buf[n] = 0xff;
+        }
+      }
+
+    if (ZWRITE(*pzlib_filefunc_def,filestream,buf,nbByte)!=(uLong)nbByte)
+        return ZIP_ERRNO;
+    else
+        return ZIP_OK;
+}
+
+local void ziplocal_putValue_inmemory OF((void* dest, uLong x, int nbByte));
+local void ziplocal_putValue_inmemory (dest, x, nbByte)
+    void* dest;
+    uLong x;
+    int nbByte;
+{
+    unsigned char* buf=(unsigned char*)dest;
+    int n;
+    for (n = 0; n < nbByte; n++) {
+        buf[n] = (unsigned char)(x & 0xff);
+        x >>= 8;
+    }
+
+    if (x != 0)
+    {     /* data overflow - hack for ZIP64 */
+       for (n = 0; n < nbByte; n++)
+       {
+          buf[n] = 0xff;
+       }
+    }
+}
+
+/****************************************************************************/
+
+
+local uLong ziplocal_TmzDateToDosDate(ptm,dosDate)
+    const tm_zip* ptm;
+    uLong dosDate UNUSED;
+{
+    uLong year = (uLong)ptm->tm_year;
+    if (year>1980)
+        year-=1980;
+    else if (year>80)
+        year-=80;
+    return
+      (uLong) (((ptm->tm_mday) + (32 * (ptm->tm_mon+1)) + (512 * year)) << 16) |
+        ((ptm->tm_sec/2) + (32* ptm->tm_min) + (2048 * (uLong)ptm->tm_hour));
+}
+
+
+/****************************************************************************/
+
+local int ziplocal_getByte OF((
+    const zlib_filefunc_def* pzlib_filefunc_def,
+    voidpf filestream,
+    int *pi));
+
+local int ziplocal_getByte(pzlib_filefunc_def,filestream,pi)
+    const zlib_filefunc_def* pzlib_filefunc_def;
+    voidpf filestream;
+    int *pi;
+{
+    unsigned char c;
+    int err = (int)ZREAD(*pzlib_filefunc_def,filestream,&c,1);
+    if (err==1)
+    {
+        *pi = (int)c;
+        return ZIP_OK;
+    }
+    else
+    {
+        if (ZERROR(*pzlib_filefunc_def,filestream))
+            return ZIP_ERRNO;
+        else
+            return ZIP_EOF;
+    }
+}
+
+
+/* ===========================================================================
+   Reads a long in LSB order from the given gz_stream. Sets
+*/
+local int ziplocal_getShort OF((
+    const zlib_filefunc_def* pzlib_filefunc_def,
+    voidpf filestream,
+    uLong *pX));
+
+local int ziplocal_getShort (pzlib_filefunc_def,filestream,pX)
+    const zlib_filefunc_def* pzlib_filefunc_def;
+    voidpf filestream;
+    uLong *pX;
+{
+    uLong x ;
+    int i;
+    int err;
+
+    err = ziplocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x = (uLong)i;
+
+    if (err==ZIP_OK)
+        err = ziplocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<8;
+
+    if (err==ZIP_OK)
+        *pX = x;
+    else
+        *pX = 0;
+    return err;
+}
+
+local int ziplocal_getLong OF((
+    const zlib_filefunc_def* pzlib_filefunc_def,
+    voidpf filestream,
+    uLong *pX));
+
+local int ziplocal_getLong (pzlib_filefunc_def,filestream,pX)
+    const zlib_filefunc_def* pzlib_filefunc_def;
+    voidpf filestream;
+    uLong *pX;
+{
+    uLong x ;
+    int i;
+    int err;
+
+    err = ziplocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x = (uLong)i;
+
+    if (err==ZIP_OK)
+        err = ziplocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<8;
+
+    if (err==ZIP_OK)
+        err = ziplocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<16;
+
+    if (err==ZIP_OK)
+        err = ziplocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<24;
+
+    if (err==ZIP_OK)
+        *pX = x;
+    else
+        *pX = 0;
+    return err;
+}
+
+#ifndef BUFREADCOMMENT
+#define BUFREADCOMMENT (0x400)
+#endif
+/*
+  Locate the Central directory of a zipfile (at the end, just before
+    the global comment)
+*/
+local uLong ziplocal_SearchCentralDir OF((
+    const zlib_filefunc_def* pzlib_filefunc_def,
+    voidpf filestream));
+
+local uLong ziplocal_SearchCentralDir(pzlib_filefunc_def,filestream)
+    const zlib_filefunc_def* pzlib_filefunc_def;
+    voidpf filestream;
+{
+    unsigned char* buf;
+    uLong uSizeFile;
+    uLong uBackRead;
+    uLong uMaxBack=0xffff; /* maximum size of global comment */
+    uLong uPosFound=0;
+
+    if (ZSEEK(*pzlib_filefunc_def,filestream,0,ZLIB_FILEFUNC_SEEK_END) != 0)
+        return 0;
+
+
+    uSizeFile = ZTELL(*pzlib_filefunc_def,filestream);
+
+    if (uMaxBack>uSizeFile)
+        uMaxBack = uSizeFile;
+
+    buf = (unsigned char*)ALLOC(BUFREADCOMMENT+4);
+    if (buf==NULL)
+        return 0;
+
+    uBackRead = 4;
+    while (uBackRead<uMaxBack)
+    {
+        uLong uReadSize,uReadPos ;
+        int i;
+        if (uBackRead+BUFREADCOMMENT>uMaxBack)
+            uBackRead = uMaxBack;
+        else
+            uBackRead+=BUFREADCOMMENT;
+        uReadPos = uSizeFile-uBackRead ;
+
+        uReadSize = ((BUFREADCOMMENT+4) < (uSizeFile-uReadPos)) ?
+                     (BUFREADCOMMENT+4) : (uSizeFile-uReadPos);
+        if (ZSEEK(*pzlib_filefunc_def,filestream,uReadPos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+            break;
+
+        if (ZREAD(*pzlib_filefunc_def,filestream,buf,uReadSize)!=uReadSize)
+            break;
+
+        for (i=(int)uReadSize-3; (i--)>0;)
+            if (((*(buf+i))==0x50) && ((*(buf+i+1))==0x4b) &&
+                ((*(buf+i+2))==0x05) && ((*(buf+i+3))==0x06))
+            {
+                uPosFound = uReadPos+i;
+                break;
+            }
+
+        if (uPosFound!=0)
+            break;
+    }
+    TRYFREE(buf);
+    return uPosFound;
+}
+#endif /* !NO_ADDFILEINEXISTINGZIP*/
+
+/************************************************************/
+extern zipFile ZEXPORT zipOpen2 (file, append, globalcomment, pzlib_filefunc_def)
+    voidpf file;
+    int append;
+    zipcharpc* globalcomment;
+    zlib_filefunc_def* pzlib_filefunc_def;
+{
+    zip_internal ziinit;
+    zip_internal* zi;
+    int err=ZIP_OK;
+
+
+    if (pzlib_filefunc_def==NULL)
+        fill_qiodevice_filefunc(&ziinit.z_filefunc);
+    else
+        ziinit.z_filefunc = *pzlib_filefunc_def;
+
+    ziinit.filestream = (*(ziinit.z_filefunc.zopen_file))
+                 (ziinit.z_filefunc.opaque,
+                  file,
+                  (append == APPEND_STATUS_CREATE) ?
+                  (ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_WRITE | ZLIB_FILEFUNC_MODE_CREATE) :
+                    (ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_WRITE | ZLIB_FILEFUNC_MODE_EXISTING));
+
+    if (ziinit.filestream == NULL)
+        return NULL;
+    ziinit.begin_pos = ZTELL(ziinit.z_filefunc,ziinit.filestream);
+    ziinit.in_opened_file_inzip = 0;
+    ziinit.ci.stream_initialised = 0;
+    ziinit.number_entry = 0;
+    ziinit.add_position_when_writting_offset = 0;
+    ziinit.flags = ZIP_WRITE_DATA_DESCRIPTOR;
+    init_linkedlist(&(ziinit.central_dir));
+
+
+    zi = (zip_internal*)ALLOC(sizeof(zip_internal));
+    if (zi==NULL)
+    {
+        ZCLOSE(ziinit.z_filefunc,ziinit.filestream);
+        return NULL;
+    }
+
+    /* now we add file in a zipfile */
+#    ifndef NO_ADDFILEINEXISTINGZIP
+    ziinit.globalcomment = NULL;
+    if (append == APPEND_STATUS_ADDINZIP)
+    {
+        uLong byte_before_the_zipfile;/* byte before the zipfile, (>0 for sfx)*/
+
+        uLong size_central_dir;     /* size of the central directory  */
+        uLong offset_central_dir;   /* offset of start of central directory */
+        uLong central_pos,uL;
+
+        uLong number_disk;          /* number of the current dist, used for
+                                    spaning ZIP, unsupported, always 0*/
+        uLong number_disk_with_CD;  /* number the the disk with central dir, used
+                                    for spaning ZIP, unsupported, always 0*/
+        uLong number_entry;
+        uLong number_entry_CD;      /* total number of entries in
+                                    the central dir
+                                    (same than number_entry on nospan) */
+        uLong size_comment;
+
+        central_pos = ziplocal_SearchCentralDir(&ziinit.z_filefunc,ziinit.filestream);
+        if (central_pos==0)
+            err=ZIP_ERRNO;
+
+        if (ZSEEK(ziinit.z_filefunc, ziinit.filestream,
+                                        central_pos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+            err=ZIP_ERRNO;
+
+        /* the signature, already checked */
+        if (ziplocal_getLong(&ziinit.z_filefunc, ziinit.filestream,&uL)!=ZIP_OK)
+            err=ZIP_ERRNO;
+
+        /* number of this disk */
+        if (ziplocal_getShort(&ziinit.z_filefunc, ziinit.filestream,&number_disk)!=ZIP_OK)
+            err=ZIP_ERRNO;
+
+        /* number of the disk with the start of the central directory */
+        if (ziplocal_getShort(&ziinit.z_filefunc, ziinit.filestream,&number_disk_with_CD)!=ZIP_OK)
+            err=ZIP_ERRNO;
+
+        /* total number of entries in the central dir on this disk */
+        if (ziplocal_getShort(&ziinit.z_filefunc, ziinit.filestream,&number_entry)!=ZIP_OK)
+            err=ZIP_ERRNO;
+
+        /* total number of entries in the central dir */
+        if (ziplocal_getShort(&ziinit.z_filefunc, ziinit.filestream,&number_entry_CD)!=ZIP_OK)
+            err=ZIP_ERRNO;
+
+        if ((number_entry_CD!=number_entry) ||
+            (number_disk_with_CD!=0) ||
+            (number_disk!=0))
+            err=ZIP_BADZIPFILE;
+
+        /* size of the central directory */
+        if (ziplocal_getLong(&ziinit.z_filefunc, ziinit.filestream,&size_central_dir)!=ZIP_OK)
+            err=ZIP_ERRNO;
+
+        /* offset of start of central directory with respect to the
+            starting disk number */
+        if (ziplocal_getLong(&ziinit.z_filefunc, ziinit.filestream,&offset_central_dir)!=ZIP_OK)
+            err=ZIP_ERRNO;
+
+        /* zipfile global comment length */
+        if (ziplocal_getShort(&ziinit.z_filefunc, ziinit.filestream,&size_comment)!=ZIP_OK)
+            err=ZIP_ERRNO;
+
+        if ((central_pos<offset_central_dir+size_central_dir) &&
+            (err==ZIP_OK))
+            err=ZIP_BADZIPFILE;
+
+        if (err!=ZIP_OK)
+        {
+            ZCLOSE(ziinit.z_filefunc, ziinit.filestream);
+            TRYFREE(zi);
+            return NULL;
+        }
+
+        if (size_comment>0)
+        {
+            ziinit.globalcomment = ALLOC(size_comment+1);
+            if (ziinit.globalcomment)
+            {
+               size_comment = ZREAD(ziinit.z_filefunc, ziinit.filestream,ziinit.globalcomment,size_comment);
+               ziinit.globalcomment[size_comment]=0;
+            }
+        }
+
+        byte_before_the_zipfile = central_pos -
+                                (offset_central_dir+size_central_dir);
+        ziinit.add_position_when_writting_offset = byte_before_the_zipfile;
+
+        {
+            uLong size_central_dir_to_read = size_central_dir;
+            size_t buf_size = SIZEDATA_INDATABLOCK;
+            void* buf_read = (void*)ALLOC(buf_size);
+            if (ZSEEK(ziinit.z_filefunc, ziinit.filestream,
+                  offset_central_dir + byte_before_the_zipfile,
+                  ZLIB_FILEFUNC_SEEK_SET) != 0)
+                  err=ZIP_ERRNO;
+
+            while ((size_central_dir_to_read>0) && (err==ZIP_OK))
+            {
+                uLong read_this = SIZEDATA_INDATABLOCK;
+                if (read_this > size_central_dir_to_read)
+                    read_this = size_central_dir_to_read;
+                if (ZREAD(ziinit.z_filefunc, ziinit.filestream,buf_read,read_this) != read_this)
+                    err=ZIP_ERRNO;
+
+                if (err==ZIP_OK)
+                    err = add_data_in_datablock(&ziinit.central_dir,buf_read,
+                                                (uLong)read_this);
+                size_central_dir_to_read-=read_this;
+            }
+            TRYFREE(buf_read);
+        }
+        ziinit.begin_pos = byte_before_the_zipfile;
+        ziinit.number_entry = number_entry_CD;
+
+        if (ZSEEK(ziinit.z_filefunc, ziinit.filestream,
+                  offset_central_dir+byte_before_the_zipfile,ZLIB_FILEFUNC_SEEK_SET)!=0)
+            err=ZIP_ERRNO;
+    }
+
+    if (globalcomment)
+    {
+      *globalcomment = ziinit.globalcomment;
+    }
+#    endif /* !NO_ADDFILEINEXISTINGZIP*/
+
+    if (err != ZIP_OK)
+    {
+#    ifndef NO_ADDFILEINEXISTINGZIP
+        TRYFREE(ziinit.globalcomment);
+#    endif /* !NO_ADDFILEINEXISTINGZIP*/
+        TRYFREE(zi);
+        return NULL;
+    }
+    else
+    {
+        *zi = ziinit;
+        return (zipFile)zi;
+    }
+}
+
+extern zipFile ZEXPORT zipOpen (file, append)
+    voidpf file;
+    int append;
+{
+    return zipOpen2(file,append,NULL,NULL);
+}
+
+extern int ZEXPORT zipOpenNewFileInZip3 (file, filename, zipfi,
+                                         extrafield_local, size_extrafield_local,
+                                         extrafield_global, size_extrafield_global,
+                                         comment, method, level, raw,
+                                         windowBits, memLevel, strategy,
+                                         password, crcForCrypting)
+    zipFile file;
+    const char* filename;
+    const zip_fileinfo* zipfi;
+    const void* extrafield_local;
+    uInt size_extrafield_local;
+    const void* extrafield_global;
+    uInt size_extrafield_global;
+    const char* comment;
+    int method;
+    int level;
+    int raw;
+    int windowBits;
+    int memLevel;
+    int strategy;
+    const char* password;
+    uLong crcForCrypting;
+{
+    zip_internal* zi;
+    uInt size_filename;
+    uInt size_comment;
+    uInt i;
+    int err = ZIP_OK;
+    uLong version_to_extract;
+
+#    ifdef NOCRYPT
+    if (password != NULL)
+        return ZIP_PARAMERROR;
+#    endif
+
+    if (file == NULL)
+        return ZIP_PARAMERROR;
+    if ((method!=0) && (method!=Z_DEFLATED))
+        return ZIP_PARAMERROR;
+
+    zi = (zip_internal*)file;
+
+    if (zi->in_opened_file_inzip == 1)
+    {
+        err = zipCloseFileInZip (file);
+        if (err != ZIP_OK)
+            return err;
+    }
+
+    if (method == 0
+            && (level == 0 || (zi->flags & ZIP_WRITE_DATA_DESCRIPTOR) == 0))
+    {
+        version_to_extract = 10;
+    }
+    else
+    {
+        version_to_extract = 20;
+    }
+
+
+    if (filename==NULL)
+        filename="-";
+
+    if (comment==NULL)
+        size_comment = 0;
+    else
+        size_comment = (uInt)strlen(comment);
+
+    size_filename = (uInt)strlen(filename);
+
+    if (zipfi == NULL)
+        zi->ci.dosDate = 0;
+    else
+    {
+        if (zipfi->dosDate != 0)
+            zi->ci.dosDate = zipfi->dosDate;
+        else zi->ci.dosDate = ziplocal_TmzDateToDosDate(&zipfi->tmz_date,zipfi->dosDate);
+    }
+
+    zi->ci.flag = 0;
+    if ((level==8) || (level==9))
+      zi->ci.flag |= 2;
+    if ((level==2))
+      zi->ci.flag |= 4;
+    if ((level==1))
+      zi->ci.flag |= 6;
+    if (password != NULL)
+    {
+      zi->ci.flag |= 1;
+    }
+    if (version_to_extract >= 20
+            && (zi->flags & ZIP_WRITE_DATA_DESCRIPTOR) != 0)
+        zi->ci.flag |= 8;
+    zi->ci.crc32 = 0;
+    zi->ci.method = method;
+    zi->ci.encrypt = 0;
+    zi->ci.stream_initialised = 0;
+    zi->ci.pos_in_buffered_data = 0;
+    zi->ci.raw = raw;
+    zi->ci.pos_local_header = ZTELL(zi->z_filefunc,zi->filestream) ;
+    zi->ci.size_centralheader = SIZECENTRALHEADER + size_filename +
+                                      size_extrafield_global + size_comment;
+    zi->ci.central_header = (char*)ALLOC((uInt)zi->ci.size_centralheader);
+
+    ziplocal_putValue_inmemory(zi->ci.central_header,(uLong)CENTRALHEADERMAGIC,4);
+    /* version info */
+    ziplocal_putValue_inmemory(zi->ci.central_header+4,(uLong)VERSIONMADEBY,2);
+    ziplocal_putValue_inmemory(zi->ci.central_header+6,(uLong)version_to_extract,2);
+    ziplocal_putValue_inmemory(zi->ci.central_header+8,(uLong)zi->ci.flag,2);
+    ziplocal_putValue_inmemory(zi->ci.central_header+10,(uLong)zi->ci.method,2);
+    ziplocal_putValue_inmemory(zi->ci.central_header+12,(uLong)zi->ci.dosDate,4);
+    ziplocal_putValue_inmemory(zi->ci.central_header+16,(uLong)0,4); /*crc*/
+    ziplocal_putValue_inmemory(zi->ci.central_header+20,(uLong)0,4); /*compr size*/
+    ziplocal_putValue_inmemory(zi->ci.central_header+24,(uLong)0,4); /*uncompr size*/
+    ziplocal_putValue_inmemory(zi->ci.central_header+28,(uLong)size_filename,2);
+    ziplocal_putValue_inmemory(zi->ci.central_header+30,(uLong)size_extrafield_global,2);
+    ziplocal_putValue_inmemory(zi->ci.central_header+32,(uLong)size_comment,2);
+    ziplocal_putValue_inmemory(zi->ci.central_header+34,(uLong)0,2); /*disk nm start*/
+
+    if (zipfi==NULL)
+        ziplocal_putValue_inmemory(zi->ci.central_header+36,(uLong)0,2);
+    else
+        ziplocal_putValue_inmemory(zi->ci.central_header+36,(uLong)zipfi->internal_fa,2);
+
+    if (zipfi==NULL)
+        ziplocal_putValue_inmemory(zi->ci.central_header+38,(uLong)0,4);
+    else
+        ziplocal_putValue_inmemory(zi->ci.central_header+38,(uLong)zipfi->external_fa,4);
+
+    ziplocal_putValue_inmemory(zi->ci.central_header+42,(uLong)zi->ci.pos_local_header- zi->add_position_when_writting_offset,4);
+
+    for (i=0;i<size_filename;i++)
+        *(zi->ci.central_header+SIZECENTRALHEADER+i) = *(filename+i);
+
+    for (i=0;i<size_extrafield_global;i++)
+        *(zi->ci.central_header+SIZECENTRALHEADER+size_filename+i) =
+              *(((const char*)extrafield_global)+i);
+
+    for (i=0;i<size_comment;i++)
+        *(zi->ci.central_header+SIZECENTRALHEADER+size_filename+
+              size_extrafield_global+i) = *(comment+i);
+    if (zi->ci.central_header == NULL)
+        return ZIP_INTERNALERROR;
+
+    /* write the local header */
+    err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)LOCALHEADERMAGIC,4);
+
+    if (err==ZIP_OK)
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)version_to_extract,2);
+    if (err==ZIP_OK)
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)zi->ci.flag,2);
+
+    if (err==ZIP_OK)
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)zi->ci.method,2);
+
+    if (err==ZIP_OK)
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)zi->ci.dosDate,4);
+
+    if (err==ZIP_OK)
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)0,4); /* crc 32, unknown */
+    if (err==ZIP_OK)
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)0,4); /* compressed size, unknown */
+    if (err==ZIP_OK)
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)0,4); /* uncompressed size, unknown */
+
+    if (err==ZIP_OK)
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)size_filename,2);
+
+    if (err==ZIP_OK)
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)size_extrafield_local,2);
+
+    if ((err==ZIP_OK) && (size_filename>0))
+        if (ZWRITE(zi->z_filefunc,zi->filestream,filename,size_filename)!=size_filename)
+                err = ZIP_ERRNO;
+
+    if ((err==ZIP_OK) && (size_extrafield_local>0))
+        if (ZWRITE(zi->z_filefunc,zi->filestream,extrafield_local,size_extrafield_local)
+                                                                           !=size_extrafield_local)
+                err = ZIP_ERRNO;
+
+    memset(&zi->ci.stream, '\0', sizeof zi->ci.stream);
+    zi->ci.stream.avail_in = (uInt)0;
+    zi->ci.stream.avail_out = (uInt)Z_BUFSIZE;
+    zi->ci.stream.next_out = zi->ci.buffered_data;
+    zi->ci.stream.total_in = 0;
+    zi->ci.stream.total_out = 0;
+
+    if ((err==ZIP_OK) && (zi->ci.method == Z_DEFLATED) && (!zi->ci.raw))
+    {
+        zi->ci.stream.zalloc = (alloc_func)0;
+        zi->ci.stream.zfree = (free_func)0;
+        zi->ci.stream.opaque = (voidpf)0;
+
+        if (windowBits>0)
+            windowBits = -windowBits;
+
+        err = deflateInit2(&zi->ci.stream, level,
+               Z_DEFLATED, windowBits, memLevel, strategy);
+
+        if (err==Z_OK)
+            zi->ci.stream_initialised = 1;
+    }
+#    ifndef NOCRYPT
+    zi->ci.crypt_header_size = 0;
+    if ((err==Z_OK) && (password != NULL))
+    {
+        unsigned char bufHead[RAND_HEAD_LEN];
+        unsigned int sizeHead;
+        zi->ci.encrypt = 1;
+        zi->ci.pcrc_32_tab = get_crc_table();
+        /*init_keys(password,zi->ci.keys,zi->ci.pcrc_32_tab);*/
+
+        crcForCrypting = (uLong)zi->ci.dosDate << 16; // ATTANTION! Without this row, you don't unpack your password protected archive in other app.
+
+        sizeHead=crypthead(password,bufHead,RAND_HEAD_LEN,zi->ci.keys,zi->ci.pcrc_32_tab,crcForCrypting);
+        zi->ci.crypt_header_size = sizeHead;
+
+        if (ZWRITE(zi->z_filefunc,zi->filestream,bufHead,sizeHead) != sizeHead)
+                err = ZIP_ERRNO;
+    }
+#    endif
+
+    if (err==Z_OK)
+        zi->in_opened_file_inzip = 1;
+    return err;
+}
+
+extern int ZEXPORT zipOpenNewFileInZip2(file, filename, zipfi,
+                                        extrafield_local, size_extrafield_local,
+                                        extrafield_global, size_extrafield_global,
+                                        comment, method, level, raw)
+    zipFile file;
+    const char* filename;
+    const zip_fileinfo* zipfi;
+    const void* extrafield_local;
+    uInt size_extrafield_local;
+    const void* extrafield_global;
+    uInt size_extrafield_global;
+    const char* comment;
+    int method;
+    int level;
+    int raw;
+{
+    return zipOpenNewFileInZip3 (file, filename, zipfi,
+                                 extrafield_local, size_extrafield_local,
+                                 extrafield_global, size_extrafield_global,
+                                 comment, method, level, raw,
+                                 -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
+                                 NULL, 0);
+}
+
+extern int ZEXPORT zipOpenNewFileInZip (file, filename, zipfi,
+                                        extrafield_local, size_extrafield_local,
+                                        extrafield_global, size_extrafield_global,
+                                        comment, method, level)
+    zipFile file;
+    const char* filename;
+    const zip_fileinfo* zipfi;
+    const void* extrafield_local;
+    uInt size_extrafield_local;
+    const void* extrafield_global;
+    uInt size_extrafield_global;
+    const char* comment;
+    int method;
+    int level;
+{
+    return zipOpenNewFileInZip2 (file, filename, zipfi,
+                                 extrafield_local, size_extrafield_local,
+                                 extrafield_global, size_extrafield_global,
+                                 comment, method, level, 0);
+}
+
+local int zipFlushWriteBuffer(zi)
+  zip_internal* zi;
+{
+    int err=ZIP_OK;
+
+    if (zi->ci.encrypt != 0)
+    {
+#ifndef NOCRYPT
+        uInt i;
+        int t;
+        for (i=0;i<zi->ci.pos_in_buffered_data;i++)
+            zi->ci.buffered_data[i] = zencode(zi->ci.keys, zi->ci.pcrc_32_tab,
+                                       zi->ci.buffered_data[i],t);
+#endif
+    }
+    if (ZWRITE(zi->z_filefunc,zi->filestream,zi->ci.buffered_data,zi->ci.pos_in_buffered_data)
+                                                                    !=zi->ci.pos_in_buffered_data)
+      err = ZIP_ERRNO;
+    zi->ci.pos_in_buffered_data = 0;
+    return err;
+}
+
+extern int ZEXPORT zipWriteInFileInZip (file, buf, len)
+    zipFile file;
+    const void* buf;
+    unsigned len;
+{
+    zip_internal* zi;
+    int err=ZIP_OK;
+
+    if (file == NULL)
+        return ZIP_PARAMERROR;
+    zi = (zip_internal*)file;
+
+    if (zi->in_opened_file_inzip == 0)
+        return ZIP_PARAMERROR;
+
+    zi->ci.stream.next_in = (void*)buf;
+    zi->ci.stream.avail_in = len;
+    zi->ci.crc32 = crc32(zi->ci.crc32,buf,len);
+
+    while ((err==ZIP_OK) && (zi->ci.stream.avail_in>0))
+    {
+        if (zi->ci.stream.avail_out == 0)
+        {
+            if (zipFlushWriteBuffer(zi) == ZIP_ERRNO)
+                err = ZIP_ERRNO;
+            zi->ci.stream.avail_out = (uInt)Z_BUFSIZE;
+            zi->ci.stream.next_out = zi->ci.buffered_data;
+        }
+
+
+        if(err != ZIP_OK)
+            break;
+
+        if ((zi->ci.method == Z_DEFLATED) && (!zi->ci.raw))
+        {
+            uLong uTotalOutBefore = zi->ci.stream.total_out;
+            err=deflate(&zi->ci.stream,  Z_NO_FLUSH);
+            zi->ci.pos_in_buffered_data += (uInt)(zi->ci.stream.total_out - uTotalOutBefore) ;
+
+        }
+        else
+        {
+            uInt copy_this,i;
+            if (zi->ci.stream.avail_in < zi->ci.stream.avail_out)
+                copy_this = zi->ci.stream.avail_in;
+            else
+                copy_this = zi->ci.stream.avail_out;
+            for (i=0;i<copy_this;i++)
+                *(((char*)zi->ci.stream.next_out)+i) =
+                    *(((const char*)zi->ci.stream.next_in)+i);
+            {
+                zi->ci.stream.avail_in -= copy_this;
+                zi->ci.stream.avail_out-= copy_this;
+                zi->ci.stream.next_in+= copy_this;
+                zi->ci.stream.next_out+= copy_this;
+                zi->ci.stream.total_in+= copy_this;
+                zi->ci.stream.total_out+= copy_this;
+                zi->ci.pos_in_buffered_data += copy_this;
+            }
+        }
+    }
+
+    return err;
+}
+
+extern int ZEXPORT zipCloseFileInZipRaw (file, uncompressed_size, crc32)
+    zipFile file;
+    uLong uncompressed_size;
+    uLong crc32;
+{
+    zip_internal* zi;
+    uLong compressed_size;
+    int err=ZIP_OK;
+
+    if (file == NULL)
+        return ZIP_PARAMERROR;
+    zi = (zip_internal*)file;
+
+    if (zi->in_opened_file_inzip == 0)
+        return ZIP_PARAMERROR;
+    zi->ci.stream.avail_in = 0;
+
+    if ((zi->ci.method == Z_DEFLATED) && (!zi->ci.raw))
+        while (err==ZIP_OK)
+    {
+        uLong uTotalOutBefore;
+        if (zi->ci.stream.avail_out == 0)
+        {
+            if (zipFlushWriteBuffer(zi) == ZIP_ERRNO)
+                err = ZIP_ERRNO;
+            zi->ci.stream.avail_out = (uInt)Z_BUFSIZE;
+            zi->ci.stream.next_out = zi->ci.buffered_data;
+        }
+        uTotalOutBefore = zi->ci.stream.total_out;
+        err=deflate(&zi->ci.stream,  Z_FINISH);
+        zi->ci.pos_in_buffered_data += (uInt)(zi->ci.stream.total_out - uTotalOutBefore) ;
+    }
+
+    if (err==Z_STREAM_END)
+        err=ZIP_OK; /* this is normal */
+
+    if ((zi->ci.pos_in_buffered_data>0) && (err==ZIP_OK))
+        if (zipFlushWriteBuffer(zi)==ZIP_ERRNO)
+            err = ZIP_ERRNO;
+
+    if ((zi->ci.method == Z_DEFLATED) && (!zi->ci.raw))
+    {
+        err=deflateEnd(&zi->ci.stream);
+        zi->ci.stream_initialised = 0;
+    }
+
+    if (!zi->ci.raw)
+    {
+        crc32 = (uLong)zi->ci.crc32;
+        uncompressed_size = (uLong)zi->ci.stream.total_in;
+    }
+    compressed_size = (uLong)zi->ci.stream.total_out;
+#    ifndef NOCRYPT
+    compressed_size += zi->ci.crypt_header_size;
+#    endif
+
+    ziplocal_putValue_inmemory(zi->ci.central_header+16,crc32,4); /*crc*/
+    ziplocal_putValue_inmemory(zi->ci.central_header+20,
+                                compressed_size,4); /*compr size*/
+    if (zi->ci.stream.data_type == Z_ASCII)
+        ziplocal_putValue_inmemory(zi->ci.central_header+36,(uLong)Z_ASCII,2);
+    ziplocal_putValue_inmemory(zi->ci.central_header+24,
+                                uncompressed_size,4); /*uncompr size*/
+
+    if (err==ZIP_OK)
+        err = add_data_in_datablock(&zi->central_dir,zi->ci.central_header,
+                                       (uLong)zi->ci.size_centralheader);
+    free(zi->ci.central_header);
+
+    if (err==ZIP_OK)
+    {
+        uLong cur_pos_inzip = ZTELL(zi->z_filefunc,zi->filestream);
+        if (ZSEEK(zi->z_filefunc,zi->filestream,
+                  zi->ci.pos_local_header + 14,ZLIB_FILEFUNC_SEEK_SET)!=0)
+            err = ZIP_ERRNO;
+
+        if (err==ZIP_OK)
+            err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,crc32,4); /* crc 32, unknown */
+
+        if (err==ZIP_OK) /* compressed size, unknown */
+            err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,compressed_size,4);
+
+        if (err==ZIP_OK) /* uncompressed size, unknown */
+            err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,uncompressed_size,4);
+
+        if (ZSEEK(zi->z_filefunc,zi->filestream,
+                  cur_pos_inzip,ZLIB_FILEFUNC_SEEK_SET)!=0)
+            err = ZIP_ERRNO;
+
+        if ((zi->ci.flag & 8) != 0) {
+            /* Write local Descriptor after file data */
+            if (err==ZIP_OK)
+                err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)DESCRIPTORHEADERMAGIC,4);
+
+            if (err==ZIP_OK)
+                err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,crc32,4); /* crc 32, unknown */
+
+            if (err==ZIP_OK) /* compressed size, unknown */
+                err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,compressed_size,4);
+
+            if (err==ZIP_OK) /* uncompressed size, unknown */
+                err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,uncompressed_size,4);
+        }
+
+
+    }
+
+    zi->number_entry ++;
+    zi->in_opened_file_inzip = 0;
+
+    return err;
+}
+
+extern int ZEXPORT zipCloseFileInZip (file)
+    zipFile file;
+{
+    return zipCloseFileInZipRaw (file,0,0);
+}
+
+extern int ZEXPORT zipClose (file, global_comment)
+    zipFile file;
+    const char* global_comment;
+{
+    zip_internal* zi;
+    int err = 0;
+    uLong size_centraldir = 0;
+    uLong centraldir_pos_inzip;
+    uInt size_global_comment;
+    if (file == NULL)
+        return ZIP_PARAMERROR;
+    zi = (zip_internal*)file;
+
+    if (zi->in_opened_file_inzip == 1)
+    {
+        err = zipCloseFileInZip (file);
+    }
+
+#ifndef NO_ADDFILEINEXISTINGZIP
+    if (global_comment==NULL)
+        global_comment = zi->globalcomment;
+#endif
+    if (global_comment==NULL)
+        size_global_comment = 0;
+    else
+        size_global_comment = (uInt)strlen(global_comment);
+
+    centraldir_pos_inzip = ZTELL(zi->z_filefunc,zi->filestream);
+    if (err==ZIP_OK)
+    {
+        linkedlist_datablock_internal* ldi = zi->central_dir.first_block ;
+        while (ldi!=NULL)
+        {
+            if ((err==ZIP_OK) && (ldi->filled_in_this_block>0))
+                if (ZWRITE(zi->z_filefunc,zi->filestream,
+                           ldi->data,ldi->filled_in_this_block)
+                              !=ldi->filled_in_this_block )
+                    err = ZIP_ERRNO;
+
+            size_centraldir += ldi->filled_in_this_block;
+            ldi = ldi->next_datablock;
+        }
+    }
+    free_datablock(zi->central_dir.first_block);
+
+    if (err==ZIP_OK) /* Magic End */
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)ENDHEADERMAGIC,4);
+
+    if (err==ZIP_OK) /* number of this disk */
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)0,2);
+
+    if (err==ZIP_OK) /* number of the disk with the start of the central directory */
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)0,2);
+
+    if (err==ZIP_OK) /* total number of entries in the central dir on this disk */
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)zi->number_entry,2);
+
+    if (err==ZIP_OK) /* total number of entries in the central dir */
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)zi->number_entry,2);
+
+    if (err==ZIP_OK) /* size of the central directory */
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)size_centraldir,4);
+
+    if (err==ZIP_OK) /* offset of start of central directory with respect to the
+                            starting disk number */
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,
+                                (uLong)(centraldir_pos_inzip - zi->add_position_when_writting_offset),4);
+
+    if (err==ZIP_OK) /* zipfile comment length */
+        err = ziplocal_putValue(&zi->z_filefunc,zi->filestream,(uLong)size_global_comment,2);
+
+    if ((err==ZIP_OK) && (size_global_comment>0))
+        if (ZWRITE(zi->z_filefunc,zi->filestream,
+                   global_comment,size_global_comment) != size_global_comment)
+                err = ZIP_ERRNO;
+
+    if (ZCLOSE(zi->z_filefunc,zi->filestream) != 0)
+        if (err == ZIP_OK)
+            err = ZIP_ERRNO;
+
+#ifndef NO_ADDFILEINEXISTINGZIP
+    TRYFREE(zi->globalcomment);
+#endif
+    TRYFREE(zi);
+
+    return err;
+}
+
+extern int ZEXPORT zipSetFlags(zipFile file, unsigned flags)
+{
+    zip_internal* zi;
+    if (file == NULL)
+        return ZIP_PARAMERROR;
+    zi = (zip_internal*)file;
+    zi->flags |= flags;
+    return ZIP_OK;
+}
+
+extern int ZEXPORT zipClearFlags(zipFile file, unsigned flags)
+{
+    zip_internal* zi;
+    if (file == NULL)
+        return ZIP_PARAMERROR;
+    zi = (zip_internal*)file;
+    zi->flags &= ~flags;
+    return ZIP_OK;
+}

--- a/src/external/quazip/zip.h
+++ b/src/external/quazip/zip.h
@@ -1,0 +1,245 @@
+/* zip.h -- IO for compress .zip files using zlib
+   Version 1.01e, February 12th, 2005
+
+   Copyright (C) 1998-2005 Gilles Vollant
+
+   This unzip package allow creates .ZIP file, compatible with PKZip 2.04g
+     WinZip, InfoZip tools and compatible.
+   Multi volume ZipFile (span) are not supported.
+   Encryption compatible with pkzip 2.04g only supported
+   Old compressions used by old PKZip 1.x are not supported
+
+  For uncompress .zip file, look at unzip.h
+
+
+   I WAIT FEEDBACK at mail info@winimage.com
+   Visit also http://www.winimage.com/zLibDll/unzip.html for evolution
+
+   Condition of use and distribution are the same than zlib :
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+   Modified by Sergey A. Tachenov to integrate with Qt.
+
+
+*/
+
+/* for more info about .ZIP format, see
+      http://www.info-zip.org/pub/infozip/doc/appnote-981119-iz.zip
+      http://www.info-zip.org/pub/infozip/doc/
+   PkWare has also a specification at :
+      ftp://ftp.pkware.com/probdesc.zip
+*/
+
+#ifndef _zip_H
+#define _zip_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef _ZLIB_H
+#include "zlib.h"
+#endif
+
+#ifndef _ZLIBIOAPI_H
+#include "ioapi.h"
+#endif
+
+#if defined(STRICTZIP) || defined(STRICTZIPUNZIP)
+/* like the STRICT of WIN32, we define a pointer that cannot be converted
+    from (void*) without cast */
+typedef struct TagzipFile__ { int unused; } zipFile__;
+typedef zipFile__ *zipFile;
+#else
+typedef voidp zipFile;
+#endif
+
+#define ZIP_OK                          (0)
+#define ZIP_EOF                         (0)
+#define ZIP_ERRNO                       (Z_ERRNO)
+#define ZIP_PARAMERROR                  (-102)
+#define ZIP_BADZIPFILE                  (-103)
+#define ZIP_INTERNALERROR               (-104)
+
+#define ZIP_WRITE_DATA_DESCRIPTOR 0x8u
+
+#ifndef DEF_MEM_LEVEL
+#  if MAX_MEM_LEVEL >= 8
+#    define DEF_MEM_LEVEL 8
+#  else
+#    define DEF_MEM_LEVEL  MAX_MEM_LEVEL
+#  endif
+#endif
+/* default memLevel */
+
+/* tm_zip contain date/time info */
+typedef struct tm_zip_s
+{
+    uInt tm_sec;            /* seconds after the minute - [0,59] */
+    uInt tm_min;            /* minutes after the hour - [0,59] */
+    uInt tm_hour;           /* hours since midnight - [0,23] */
+    uInt tm_mday;           /* day of the month - [1,31] */
+    uInt tm_mon;            /* months since January - [0,11] */
+    uInt tm_year;           /* years - [1980..2044] */
+} tm_zip;
+
+typedef struct
+{
+    tm_zip      tmz_date;       /* date in understandable format           */
+    uLong       dosDate;       /* if dos_date == 0, tmu_date is used      */
+/*    uLong       flag;        */   /* general purpose bit flag        2 bytes */
+
+    uLong       internal_fa;    /* internal file attributes        2 bytes */
+    uLong       external_fa;    /* external file attributes        4 bytes */
+} zip_fileinfo;
+
+typedef const char* zipcharpc;
+
+
+#define APPEND_STATUS_CREATE        (0)
+#define APPEND_STATUS_CREATEAFTER   (1)
+#define APPEND_STATUS_ADDINZIP      (2)
+
+extern zipFile ZEXPORT zipOpen OF((voidpf file, int append));
+/*
+  Create a zipfile.
+     file is whatever the IO API accepts. For Qt IO API it's a pointer to
+       QIODevice. For fopen() IO API it's a file name (const char*).
+     if the file pathname exist and append==APPEND_STATUS_CREATEAFTER, the zip
+       will be created at the end of the file.
+         (useful if the file contain a self extractor code)
+     if the file pathname exist and append==APPEND_STATUS_ADDINZIP, we will
+       add files in existing zip (be sure you don't add file that doesn't exist)
+     If the zipfile cannot be opened, the return value is NULL.
+     Else, the return value is a zipFile Handle, usable with other function
+       of this zip package.
+*/
+
+/* Note : there is no delete function into a zipfile.
+   If you want delete file into a zipfile, you must open a zipfile, and create another
+   Of couse, you can use RAW reading and writing to copy the file you did not want delte
+*/
+
+extern zipFile ZEXPORT zipOpen2 OF((voidpf file,
+                                   int append,
+                                   zipcharpc* globalcomment,
+                                   zlib_filefunc_def* pzlib_filefunc_def));
+
+extern int ZEXPORT zipOpenNewFileInZip OF((zipFile file,
+                       const char* filename,
+                       const zip_fileinfo* zipfi,
+                       const void* extrafield_local,
+                       uInt size_extrafield_local,
+                       const void* extrafield_global,
+                       uInt size_extrafield_global,
+                       const char* comment,
+                       int method,
+                       int level));
+/*
+  Open a file in the ZIP for writing.
+  filename : the filename in zip (if NULL, '-' without quote will be used
+  *zipfi contain supplemental information
+  if extrafield_local!=NULL and size_extrafield_local>0, extrafield_local
+    contains the extrafield data the the local header
+  if extrafield_global!=NULL and size_extrafield_global>0, extrafield_global
+    contains the extrafield data the the local header
+  if comment != NULL, comment contain the comment string
+  method contain the compression method (0 for store, Z_DEFLATED for deflate)
+  level contain the level of compression (can be Z_DEFAULT_COMPRESSION)
+*/
+
+
+extern int ZEXPORT zipOpenNewFileInZip2 OF((zipFile file,
+                                            const char* filename,
+                                            const zip_fileinfo* zipfi,
+                                            const void* extrafield_local,
+                                            uInt size_extrafield_local,
+                                            const void* extrafield_global,
+                                            uInt size_extrafield_global,
+                                            const char* comment,
+                                            int method,
+                                            int level,
+                                            int raw));
+
+/*
+  Same than zipOpenNewFileInZip, except if raw=1, we write raw file
+ */
+
+extern int ZEXPORT zipOpenNewFileInZip3 OF((zipFile file,
+                                            const char* filename,
+                                            const zip_fileinfo* zipfi,
+                                            const void* extrafield_local,
+                                            uInt size_extrafield_local,
+                                            const void* extrafield_global,
+                                            uInt size_extrafield_global,
+                                            const char* comment,
+                                            int method,
+                                            int level,
+                                            int raw,
+                                            int windowBits,
+                                            int memLevel,
+                                            int strategy,
+                                            const char* password,
+                                            uLong crcForCtypting));
+
+/*
+  Same than zipOpenNewFileInZip2, except
+    windowBits,memLevel,,strategy : see parameter strategy in deflateInit2
+    password : crypting password (NULL for no crypting)
+    crcForCtypting : crc of file to compress (needed for crypting)
+ */
+
+
+extern int ZEXPORT zipWriteInFileInZip OF((zipFile file,
+                       const void* buf,
+                       unsigned len));
+/*
+  Write data in the zipfile
+*/
+
+extern int ZEXPORT zipCloseFileInZip OF((zipFile file));
+/*
+  Close the current file in the zipfile
+*/
+
+extern int ZEXPORT zipCloseFileInZipRaw OF((zipFile file,
+                                            uLong uncompressed_size,
+                                            uLong crc32));
+/*
+  Close the current file in the zipfile, for fiel opened with
+    parameter raw=1 in zipOpenNewFileInZip2
+  uncompressed_size and crc32 are value for the uncompressed size
+*/
+
+extern int ZEXPORT zipClose OF((zipFile file,
+                const char* global_comment));
+/*
+  Close the zipfile
+*/
+
+/*
+   Added by Sergey A. Tachenov to tweak zipping behaviour.
+   */
+extern int ZEXPORT zipSetFlags(zipFile file, unsigned flags);
+extern int ZEXPORT zipClearFlags(zipFile file, unsigned flags);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _zip_H */

--- a/src/interface/mainwindow2.cpp
+++ b/src/interface/mainwindow2.cpp
@@ -44,6 +44,8 @@ GNU General Public License for more details.
 #include "colorbox.h"
 #include "util.h"
 
+#include "fileformat.h"		//contains constants used by Pencil File Format
+#include "JlCompress.h"		//compress and decompress New Pencil File Format
 #include "recentfilemenu.h"
 
 #include "mainwindow2.h"
@@ -366,7 +368,7 @@ void MainWindow2::openDocument()
                     this,
                     tr("Open File..."),
                     myPath,
-                    tr("PCL (*.pcl);;Any files (*)"));
+                    tr(PFF_OPEN_ALL_FILE_FILTER));
 
         if (fileName.isEmpty())
         {
@@ -402,10 +404,10 @@ bool MainWindow2::saveAsNewDocument()
 
     if (strDefaultFileName.isEmpty())
     {
-        strDefaultFileName = QDir::homePath() + "/untitled.pcl";
+        strDefaultFileName = QDir::homePath() + "/" + PFF_DEFAULT_FILENAME;
     }
 
-    QString fileName = QFileDialog::getSaveFileName(this, tr("Save As..."),strDefaultFileName ,tr("PCL (*.pcl)"));
+    QString fileName = QFileDialog::getSaveFileName(this, tr("Save As..."),strDefaultFileName ,tr(PFF_CLOSE_ALL_FILE_FILTER));
 
     if (fileName.isEmpty())
     {
@@ -413,9 +415,9 @@ bool MainWindow2::saveAsNewDocument()
     }
     else
     {
-        if (! fileName.endsWith(".pcl"))
+        if ( ! fileName.endsWith(PFF_OLD_EXTENSION) && ! fileName.endsWith(PFF_EXTENSION) )
         {
-            fileName =  fileName + ".pcl";
+            fileName =  fileName + PFF_EXTENSION;
         }
         QSettings settings("Pencil","Pencil");
         settings.setValue("lastFilePath", QVariant(fileName));
@@ -446,23 +448,64 @@ void MainWindow2::openFile(QString filename)
 
 bool MainWindow2::openObject(QString filePath)
 {
+	bool openingTheOLDWAY = true;
+	QString realXMLFilePath = filePath;
+	QString tmpFilePath;
+	
     // ---- test before opening ----
-    QScopedPointer<QFile> file(new QFile(filePath));
+	QStringList zippedFileList = JlCompress::getFileList(filePath);
+	if (!zippedFileList.empty())
+	{
+		qDebug() << "Recognized New zipped Pencil File Format !";
+		openingTheOLDWAY = false;
+		
+	    // ---- now decompress PFF -----
+		QFileInfo fileInfo(filePath);
+		QDir dir(QDir::tempPath());
+		tmpFilePath = QDir::tempPath() + "/" + fileInfo.completeBaseName() + PFF_TMP_DECOMPRESS_EXT;
+		if(fileInfo.exists()) {
+			dir.rmpath(tmpFilePath); // --removes an old decompression directory
+			removePFFTmpDirectory(tmpFilePath); // --removes an old decompression directory - better approach
+		}
+		dir.mkpath(tmpFilePath); // --creates a new decompression directory
+
+		JlCompress::extractDir(filePath, tmpFilePath);
+		
+		realXMLFilePath = tmpFilePath + "/" + PFF_XML_FILE_NAME;
+	}
+	else
+	{
+		qDebug() << "Recognized Old Pencil File Format !";
+	}
+
+    QScopedPointer<QFile> file(new QFile(realXMLFilePath));
 
     //QFile* file = new QFile(filePath);
     if (!file->open(QFile::ReadOnly))
     {
+		if (!openingTheOLDWAY)
+		{
+			removePFFTmpDirectory(tmpFilePath); // --removes temporary decompression directory
+		}
         return false;
     }
 
     QDomDocument doc;
     if (!doc.setContent(file.data()))
     {
+		if (!openingTheOLDWAY)
+		{
+			removePFFTmpDirectory(tmpFilePath); // --removes temporary decompression directory
+		}
         return false; // this is not a XML file
     }
     QDomDocumentType type = doc.doctype();
     if (type.name() != "PencilDocument" && type.name() != "MyObject")
     {
+		if (!openingTheOLDWAY)
+		{
+			removePFFTmpDirectory(tmpFilePath); // --removes temporary decompression directory
+		}
         return false; // this is not a Pencil document
     }
 
@@ -481,8 +524,18 @@ bool MainWindow2::openObject(QString filePath)
     //QSettings settings("Pencil","Pencil");
     //settings.setValue("lastFilePath", QVariant(object->strCurrentFilePath) );
 
+	QString dataLayersDir;
+	if (openingTheOLDWAY)
+	{
+		dataLayersDir = filePath + "." + PFF_LAYERS_DIR;
+	}
+	else
+	{
+		dataLayersDir = tmpFilePath + "/" + PFF_LAYERS_DIR;
+	}
+
     Object* newObject = new Object();
-    if (!newObject->loadPalette(filePath+".data"))
+    if (!newObject->loadPalette(dataLayersDir))
     {
         newObject->loadDefaultPalette();
     }
@@ -520,8 +573,8 @@ bool MainWindow2::openObject(QString filePath)
                 else if (element.tagName() == "object")
                 {
                     qDebug("  Load object");
-                    ok = newObject->loadDomElement(element, filePath);
-                    qDebug() << "    filePath:" << filePath;
+                    ok = newObject->loadDomElement(element, dataLayersDir);
+                    qDebug() << "    dataDir:" << dataLayersDir;
                 }
             }
             tag = tag.nextSibling();
@@ -540,6 +593,11 @@ bool MainWindow2::openObject(QString filePath)
     {
         editor->updateObject();
 
+		if (!openingTheOLDWAY)
+		{
+			removePFFTmpDirectory(tmpFilePath); // --removes temporary decompression directory
+		}
+
         m_recentFileMenu->addRecentFile(filePath);
         m_recentFileMenu->saveToDisk();
 
@@ -547,7 +605,10 @@ bool MainWindow2::openObject(QString filePath)
         setWindowTitle(newObject->strCurrentFilePath);
 
         // FIXME: need to free the old object. but delete object will crash app, don't know why.
+        // fixed by shoshon... don't know if it's right
+        Object* objectToDelete = m_object;
         m_object = newObject;
+        delete objectToDelete;
     }
 
     progress.setValue(100);
@@ -610,14 +671,42 @@ bool MainWindow2::saveObject(QString strSavedFilename)
 {
     QString filePath = strSavedFilename;
 
+	bool savingTheOLDWAY = filePath.endsWith(PFF_OLD_EXTENSION);
+	
     QFileInfo fileInfo(filePath);
     if (fileInfo.isDir()) return false;
+    
+    QString tmpFilePath;
+    if (!savingTheOLDWAY)
+    {// create temporary directory for compressing files
+		tmpFilePath = QDir::tempPath() + "/" + fileInfo.completeBaseName() + PFF_TMP_COMPRESS_EXT;
+		QFileInfo tmpDataInfo(tmpFilePath);
+		if(!tmpDataInfo.exists())
+		{
+			QDir dir(QDir::tempPath()); // --the directory where filePath is or will be saved
+			dir.mkpath(tmpFilePath); // --creates a directory with the same name +".data"
+		}
+	}
+	else
+	{
+		tmpFilePath = fileInfo.absolutePath();
+	}
 
-    QFileInfo dataInfo(filePath+".data");
+	
+    QString dataLayersDir;
+    if (savingTheOLDWAY)
+    {
+		dataLayersDir = filePath + "." + PFF_LAYERS_DIR;
+	}
+	else
+	{
+		dataLayersDir = tmpFilePath + "/" + PFF_LAYERS_DIR;
+	}
+    QFileInfo dataInfo(dataLayersDir);
     if (!dataInfo.exists())
     {
-        QDir dir(fileInfo.absolutePath()); // the directory where filePath is or will be saved
-        dir.mkpath(filePath+".data"); // creates a directory with the same name +".data"
+        QDir dir(tmpFilePath); // the directory where filePath is or will be saved
+        dir.mkpath(dataLayersDir); // creates a directory with the same name +".data"
     }
 
     //savedName = filePath;
@@ -639,16 +728,25 @@ bool MainWindow2::saveObject(QString strSavedFilename)
 
         progressValue = (i * 100) / nLayers;
         progress.setValue(progressValue);
-        if (layer->type == Layer::BITMAP) ((LayerBitmap*)layer)->saveImages(filePath+".data", i);
-        if (layer->type == Layer::VECTOR) ((LayerVector*)layer)->saveImages(filePath+".data", i);
-        if (layer->type == Layer::SOUND) ((LayerSound*)layer)->saveImages(filePath+".data", i);
+        if (layer->type == Layer::BITMAP) ((LayerBitmap*)layer)->saveImages(dataLayersDir, i);
+        if (layer->type == Layer::VECTOR) ((LayerVector*)layer)->saveImages(dataLayersDir, i);
+        if (layer->type == Layer::SOUND) ((LayerSound*)layer)->saveImages(dataLayersDir, i);
     }
 
     // save palette
-    m_object->savePalette(filePath+".data");
+    m_object->savePalette(dataLayersDir);
 
     // -------- save main XML file -----------
-    QFile* file = new QFile(filePath);
+    QString mainXMLfile;
+    if (!savingTheOLDWAY)
+    {
+		mainXMLfile = tmpFilePath + "/" + PFF_XML_FILE_NAME;
+	}
+	else
+	{
+		mainXMLfile = filePath;
+	}
+    QFile* file = new QFile(mainXMLfile);
     if (!file->open(QFile::WriteOnly | QFile::Text))
     {
         //QMessageBox::warning(this, "Warning", "Cannot write file");
@@ -672,6 +770,16 @@ bool MainWindow2::saveObject(QString strSavedFilename)
     int IndentSize = 2;
     doc.save(out, IndentSize);
     // -----------------------------------
+
+    if (!savingTheOLDWAY)
+    {
+		qDebug() << "Now compressing data to PFF - PCLX ...";
+
+		JlCompress::compressDir(filePath, tmpFilePath);
+		removePFFTmpDirectory(tmpFilePath); // --removing temporary files
+
+		qDebug() << "Compressed. File saved.";
+	}
 
     progress.setValue(100);
 

--- a/src/structure/layer.h
+++ b/src/structure/layer.h
@@ -53,7 +53,7 @@ public:
     // export element
     virtual QDomElement createDomElement(QDomDocument& doc); // constructs an dom/xml representation of the layer for the document doc
     virtual void loadDomElement(QDomElement element); // construct a layer from a dom/xml representation
-    virtual void loadDomElement(QDomElement element, QString filePath) = 0;
+    virtual void loadDomElement(QDomElement element, QString dataDirPath) = 0;
 
     // graphic representation -- could be put in another class
     virtual void paintTrack(QPainter& painter, TimeLineCells* cells, int x, int y, int height, int width, bool selected, int frameSize);

--- a/src/structure/layerbitmap.cpp
+++ b/src/structure/layerbitmap.cpp
@@ -169,7 +169,7 @@ QDomElement LayerBitmap::createDomElement(QDomDocument& doc)
     return layerTag;
 }
 
-void LayerBitmap::loadDomElement(QDomElement element, QString filePath)
+void LayerBitmap::loadDomElement(QDomElement element, QString dataDirPath)
 {
     if (!element.attribute("id").isNull()) id = element.attribute("id").toInt();
     name = element.attribute("name");
@@ -184,7 +184,8 @@ void LayerBitmap::loadDomElement(QDomElement element, QString filePath)
         {
             if (imageElement.tagName() == "image")
             {
-                QString path =  filePath +".data/" + imageElement.attribute("src"); // the file is supposed to be in the data directory
+                QString path =  dataDirPath +"/" + imageElement.attribute("src"); // the file is supposed to be in the data directory
+     //qDebug() << "LAY_BITMAP  dataDirPath=" << dataDirPath << "   ;path=" << path;  //added for debugging puproses
                 QFileInfo fi(path);
                 if (!fi.exists()) path = imageElement.attribute("src");
                 int position = imageElement.attribute("frame").toInt();

--- a/src/structure/layerbitmap.h
+++ b/src/structure/layerbitmap.h
@@ -43,7 +43,7 @@ public:
     QString fileName(int index, int layerNumber);
 
     QDomElement createDomElement(QDomDocument& doc);
-    void loadDomElement(QDomElement element, QString filePath);
+    void loadDomElement(QDomElement element, QString dataDirPath);
 
     // graphic representation -- could be put in another class
     BitmapImage* getBitmapImageAtIndex(int index);

--- a/src/structure/layercamera.cpp
+++ b/src/structure/layercamera.cpp
@@ -310,9 +310,9 @@ QDomElement LayerCamera::createDomElement(QDomDocument& doc)
     return layerTag;
 }
 
-void LayerCamera::loadDomElement(QDomElement element, QString filePath)
+void LayerCamera::loadDomElement(QDomElement element, QString dataDirPath)
 {
-    Q_UNUSED(filePath);
+    Q_UNUSED(dataDirPath);
     name = element.attribute("name");
     //visible = (element.attribute("visibility") == "1");
     visible = true;

--- a/src/structure/layercamera.h
+++ b/src/structure/layercamera.h
@@ -67,7 +67,7 @@ public:
     void editProperties();
 
     QDomElement createDomElement(QDomDocument& doc);
-    void loadDomElement(QDomElement element, QString filePath);
+    void loadDomElement(QDomElement element, QString dataDirPath);
 
     Camera* getCameraAtIndex(int index);
     Camera* getCameraAtFrame(int frameNumber);

--- a/src/structure/layersound.cpp
+++ b/src/structure/layersound.cpp
@@ -256,7 +256,7 @@ QDomElement LayerSound::createDomElement(QDomDocument& doc)
     return layerTag;
 }
 
-void LayerSound::loadDomElement(QDomElement element, QString filePath)
+void LayerSound::loadDomElement(QDomElement element, QString dataDirPath)
 {
     if (!element.attribute("id").isNull()) id = element.attribute("id").toInt();
     name = element.attribute("name");
@@ -271,7 +271,8 @@ void LayerSound::loadDomElement(QDomElement element, QString filePath)
         {
             if (soundElement.tagName() == "sound")
             {
-                QString path = filePath + ".data/" + soundElement.attribute("src"); // the file is supposed to be in the data directory
+                QString path = dataDirPath + "/" + soundElement.attribute("src"); // the file is supposed to be in the data directory
+     //qDebug() << "LAY_SOUND  dataDirPath=" << dataDirPath << "   ;path=" << path;  //added for debugging puproses
                 QFileInfo fi(path);
                 if (!fi.exists()) path = soundElement.attribute("src");
                 int position = soundElement.attribute("position").toInt();

--- a/src/structure/layersound.h
+++ b/src/structure/layersound.h
@@ -32,7 +32,7 @@ public:
     LayerSound(Object* object);
     ~LayerSound();
     QDomElement createDomElement(QDomDocument& doc);
-    void loadDomElement(QDomElement element, QString filePath);
+    void loadDomElement(QDomElement element, QString dataDirPath);
 
     bool addImageAtFrame(int frameNumber);
     void removeImageAtFrame(int frameNumber);

--- a/src/structure/layervector.cpp
+++ b/src/structure/layervector.cpp
@@ -290,7 +290,7 @@ QDomElement LayerVector::createDomElement(QDomDocument& doc)
     return layerTag;
 }
 
-void LayerVector::loadDomElement(QDomElement element, QString filePath)
+void LayerVector::loadDomElement(QDomElement element, QString dataDirPath)
 {
     if (!element.attribute("id").isNull()) id = element.attribute("id").toInt();
     name = element.attribute("name");
@@ -307,7 +307,8 @@ void LayerVector::loadDomElement(QDomElement element, QString filePath)
             {
                 if (!imageElement.attribute("src").isNull())
                 {
-                    QString path =  filePath +".data/" + imageElement.attribute("src"); // the file is supposed to be in the data irectory
+                    QString path =  dataDirPath +"/" + imageElement.attribute("src"); // the file is supposed to be in the data irectory
+      //qDebug() << "LAY_VECTOR  dataDirPath=" << dataDirPath << "   ;path=" << path;  //added for debugging puproses
                     QFileInfo fi(path);
                     if (!fi.exists()) path = imageElement.attribute("src");
                     int position = imageElement.attribute("frame").toInt();

--- a/src/structure/layervector.h
+++ b/src/structure/layervector.h
@@ -51,7 +51,7 @@ public:
     void setModified(int frameNumber, bool trueOrFalse);
 
     QDomElement createDomElement(QDomDocument& doc);
-    virtual void loadDomElement(QDomElement element,  QString filePath);
+    virtual void loadDomElement(QDomElement element,  QString dataDirPath);
 
     // graphic representation -- could be put in another class
     //void paint(QPainter &painter, int verticalPosition, int layerHeight, int frameSize, int timeLineWidth);

--- a/src/structure/object.cpp
+++ b/src/structure/object.cpp
@@ -67,7 +67,7 @@ QDomElement Object::createDomElement(QDomDocument& doc)
     return tag;
 }
 
-bool Object::loadDomElement(QDomElement docElem, QString filePath)
+bool Object::loadDomElement(QDomElement docElem, QString dataDirPath)
 {
     if (docElem.isNull())
     {
@@ -90,28 +90,28 @@ bool Object::loadDomElement(QDomElement docElem, QString filePath)
                 {
                     addNewBitmapLayer();
                     layerNumber++;
-                    ((LayerBitmap*)(getLayer(layerNumber)))->loadDomElement( element, filePath );
+                    ((LayerBitmap*)(getLayer(layerNumber)))->loadDomElement( element, dataDirPath );
                 }
                 // --- vector layer ---
                 if (element.attribute("type").toInt() == Layer::VECTOR)
                 {
                     addNewVectorLayer();
                     layerNumber++;
-                    ((LayerVector*)(getLayer(layerNumber)))->loadDomElement( element, filePath );
+                    ((LayerVector*)(getLayer(layerNumber)))->loadDomElement( element, dataDirPath );
                 }
                 // --- sound layer ---
                 if (element.attribute("type").toInt() == Layer::SOUND)
                 {
                     addNewSoundLayer();
                     layerNumber++;
-                    ((LayerSound*)(getLayer(layerNumber)))->loadDomElement( element, filePath );
+                    ((LayerSound*)(getLayer(layerNumber)))->loadDomElement( element, dataDirPath );
                 }
                 // --- camera layer ---
                 if (element.attribute("type").toInt() == Layer::CAMERA)
                 {
                     addNewCameraLayer();
                     layerNumber++;
-                    ((LayerCamera*)(getLayer(layerNumber)))->loadDomElement( element, filePath );
+                    ((LayerCamera*)(getLayer(layerNumber)))->loadDomElement( element, dataDirPath );
                 }
 
             }

--- a/src/structure/object.h
+++ b/src/structure/object.h
@@ -52,7 +52,7 @@ public:
     QString strCurrentFilePath;
 
     QDomElement createDomElement(QDomDocument& doc);
-    bool loadDomElement(QDomElement element,  QString filePath);
+    bool loadDomElement(QDomElement element,  QString dataDirPath);
 
     bool read(QString filePath);
     bool write(QString filePath);

--- a/src/util/fileformat.cpp
+++ b/src/util/fileformat.cpp
@@ -1,0 +1,52 @@
+/*
+
+Pencil - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2008-2009 Mj Mendoza IV
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation;
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+
+#include <QDir>
+
+#include "fileformat.h"
+
+
+bool removePFFTmpDirectory (const QString & dirName)
+{
+	bool result;
+	QDir dir(dirName + "/" + PFF_LAYERS_DIR);
+	
+	Q_FOREACH(QFileInfo info, dir.entryInfoList(QDir::NoDotAndDotDot | QDir::Files, QDir::DirsFirst))
+	{
+		result = QFile::remove(info.absoluteFilePath());
+
+		if (!result)
+			return result;
+	}
+	
+	QDir dir2(dirName);
+	result = dir2.rmdir(dirName + "/" + PFF_LAYERS_DIR);
+	if (!result)
+		return result;
+	
+	result = QFile::remove(dirName + "/" + PFF_XML_FILE_NAME);
+	if (!result)
+		return result;
+
+	result = dir2.cdUp();
+	if (!result)
+		return result;
+
+	result = dir2.rmdir(dirName);
+
+	return result;
+}

--- a/src/util/fileformat.h
+++ b/src/util/fileformat.h
@@ -1,0 +1,45 @@
+/*
+
+Pencil - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation;
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+#ifndef PENCIL_FILE_FORMAT_H
+#define PENCIL_FILE_FORMAT_H
+
+#include <QString>
+
+//Pencil File Format
+//PFF - acronym for "Pencil File Format"
+#define PFF_OLD_EXTENSION				".pcl"
+#define PFF_OLD_BIG_LETTER_EXTENSION	"PCL"
+#define PFF_OLD_SINGLE_FILTER			"Pencil Animation File PCL (*.pcl)"
+#define PFF_EXTENSION				".pclx"
+#define PFF_BIG_LETTER_EXTENSION	"PCLX"
+#define PFF_SINGLE_FILTER			"New Pencil Animation File PCLX (*.pclx)"
+
+#define PFF_OPEN_ALL_FILE_FILTER	"Pencil Animation File PCL (*.pcl);;New Pencil Animation File PCLX(*.pclx);;All Pencil Files PCL & PCLX(*.pcl *.pclx);;Any files (*)"
+
+#define PFF_CLOSE_ALL_FILE_FILTER	"Pencil Animation File PCL (*.pcl);;New Pencil Animation File PCLX(*.pclx)"
+
+#define PFF_DEFAULT_FILENAME	"untitled.pclx"
+
+#define PFF_LAYERS_DIR 			"data"
+#define PFF_XML_FILE_NAME 		"main.xml"
+#define PFF_TMP_COMPRESS_EXT 	".Y2xC"
+#define PFF_TMP_DECOMPRESS_EXT 	".Y2xD"
+
+
+bool removePFFTmpDirectory (const QString & dirName);
+
+
+#endif


### PR DESCRIPTION
This commit makes Pencil able to read and write in 2 file formats:
1. old simple - file format used by Pencil "all the time" - PCL file + DATA directory,
2. new zipped file format - single PCLX file

When you choose "Save as..." from File Menu - you write filename,
and then if filename extension is PCL - Pencil saves your work in old Pencil file format,
when you choose another extension - Pencil saves your work in new zipped file format - in a single file

When you open a file - Pencil checks this file if is zipped or no (here Pencil pay no attention at file extension),
and if file is zipped - Pencil tries to open it as a PCLX file,
and if file is not zipped - Pencil tries to open it as a regular PCL file.

This commit has been checked only on Linux,
I tried to compile it on Windows but it was for me unsuccessful.

In order to use zip functionality I have used QuaZip library.
