### PR TITLE
Additional timeline features

### DIFF
--- a/core_lib/interface/editor.cpp
+++ b/core_lib/interface/editor.cpp
@@ -1366,6 +1366,33 @@ void Editor::scrubBackward()
     }
 }
 
+void Editor::moveFrameForward()
+{
+    Layer* layer = layers()->currentLayer();
+    if ( layer != NULL )
+    {
+        if ( layer->moveKeyFrameForward( currentFrame() ) )
+        {
+            mScribbleArea->updateAllFrames();
+            scrubForward();
+        }
+    }
+}
+
+void Editor::moveFrameBackward()
+{
+    Layer* layer = layers()->currentLayer();
+    if ( layer != NULL )
+    {
+        if ( layer->moveKeyFrameBackward( currentFrame() ) )
+        {
+            mScribbleArea->updateAllFrames();
+            scrubBackward();
+        }
+    }
+}
+
+
 void Editor::previousLayer()
 {
     layers()->gotoPreviouslayer();

--- a/core_lib/interface/editor.h
+++ b/core_lib/interface/editor.h
@@ -134,6 +134,9 @@ public slots:
     void duplicateKey();
     void removeKey();
 
+    void moveFrameForward();
+    void moveFrameBackward();
+
     void resetUI();
 
     void updateObject();

--- a/core_lib/interface/mainwindow2.cpp
+++ b/core_lib/interface/mainwindow2.cpp
@@ -248,6 +248,8 @@ void MainWindow2::createMenus()
     connect(ui->actionNext_KeyFrame, &QAction::triggered, mEditor, &Editor::scrubNextKeyFrame );
     connect(ui->actionPrev_KeyFrame, &QAction::triggered, mEditor, &Editor::scrubPreviousKeyFrame );
     connect(ui->actionDuplicate_Frame, &QAction::triggered, mEditor, &Editor::duplicateKey );
+    connect(ui->actionMove_Frame_Forward, &QAction::triggered, mEditor, &Editor::moveFrameForward ); //HERE
+    connect(ui->actionMove_Frame_Backward, &QAction::triggered, mEditor, &Editor::moveFrameBackward );
 
     /// --- Tool Menu ---
     connect(ui->actionMove, &QAction::triggered, mToolBox, &ToolBoxWidget::moveOn );

--- a/core_lib/interface/mainwindow2.ui
+++ b/core_lib/interface/mainwindow2.ui
@@ -20,7 +20,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>21</height>
+     <height>27</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -136,6 +136,9 @@
     <addaction name="actionAdd_Frame"/>
     <addaction name="actionDuplicate_Frame"/>
     <addaction name="actionRemove_Frame"/>
+    <addaction name="separator"/>
+    <addaction name="actionMove_Frame_Forward"/>
+    <addaction name="actionMove_Frame_Backward"/>
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
@@ -818,6 +821,22 @@
   <action name="actionFlip_Y">
    <property name="text">
     <string>Flip Y</string>
+   </property>
+  </action>
+  <action name="actionMove_Frame_Forward">
+   <property name="text">
+    <string>Move Frame Forward</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+.</string>
+   </property>
+  </action>
+  <action name="actionMove_Frame_Backward">
+   <property name="text">
+    <string>Move Frame Backward</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+,</string>
    </property>
   </action>
  </widget>

--- a/core_lib/structure/layer.cpp
+++ b/core_lib/structure/layer.cpp
@@ -137,11 +137,11 @@ bool Layer::addKeyFrame( int position, KeyFrame* pKeyFrame )
 
 bool Layer::removeKeyFrame( int position )
 {
-    if ( position == 1 )
-    {
-        // you can't delete 1st frame.
-        return true;
-    }
+//    if ( position == 1 )
+//    {
+//        // you can't delete 1st frame.
+//        //return true;
+//    }
 
     auto it = mKeyFrames.find( position );
     if ( it != mKeyFrames.end() )
@@ -150,7 +150,84 @@ bool Layer::removeKeyFrame( int position )
         mKeyFrames.erase( it );
     }
 
+    if ( position == 1 )
+    {
+        // you can't delete 1st frame.
+        //return true;
+        addNewKeyFrameAt( 1 ); // replacing
+    }
+
     return true;
+}
+
+bool Layer::moveKeyFrameForward( int position )
+{
+    return swapKeyFrames( position, position + 1 );
+}
+
+bool Layer::moveKeyFrameBackward( int position )
+{
+    if ( position != 1 ) {
+        return swapKeyFrames( position, position - 1 );
+    } else {
+        return true;
+    }
+}
+
+bool Layer::swapKeyFrames( int position1, int position2 ) //Current behaviour, need to refresh the swapped cels
+{
+
+    bool keyPosition1 = false, keyPosition2 = false;
+    KeyFrame* pFirstFrame;
+    KeyFrame* pSecondFrame;
+
+
+    if ( hasKeyFrameAtPosition( position1 ) )
+    {
+        auto firstFrame = mKeyFrames.find( position1 );
+        pFirstFrame = firstFrame->second;
+
+        mKeyFrames.erase( position1 );
+
+        //pFirstFrame = getKeyFrameAtPosition( position1 );
+        //removeKeyFrame( position1 );
+
+        keyPosition1 = true;
+    }
+
+    if ( hasKeyFrameAtPosition( position2 ))
+    {
+        auto secondFrame = mKeyFrames.find( position2 );
+        pSecondFrame = secondFrame->second;
+
+        mKeyFrames.erase( position2 );
+
+        //pSecondFrame = getKeyFrameAtPosition( position2 );
+        //removeKeyFrame( position2 );
+
+        keyPosition2 = true;
+    }
+
+    if ( keyPosition2 )
+    {
+        //addKeyFrame( position1, pSecondFrame );
+        pSecondFrame->setPos( position1 );
+        mKeyFrames.insert( std::make_pair( position1, pSecondFrame ) );
+    } else if ( position1 == 1 ) {
+        addNewKeyFrameAt( position1 );
+    }
+
+    if ( keyPosition1 )
+    {
+        //addKeyFrame( position2, pFirstFrame );
+        pFirstFrame->setPos( position2 );
+        mKeyFrames.insert( std::make_pair( position2, pFirstFrame ) );
+    } else if ( position2 == 1 ) {
+        addNewKeyFrameAt( position2 );
+    }
+
+    return true;
+
 }
 
 bool Layer::loadKey( KeyFrame* pKey )

--- a/core_lib/structure/layer.h
+++ b/core_lib/structure/layer.h
@@ -76,6 +76,9 @@ public:
 
     bool addKeyFrame( int position, KeyFrame* );
     bool removeKeyFrame( int position );
+    bool swapKeyFrames( int position1, int position2 );
+    bool moveKeyFrameForward( int position );
+    bool moveKeyFrameBackward( int position );
     bool loadKey( KeyFrame* );
     KeyFrame* getKeyFrameAtPosition( int position );
     KeyFrame* getLastKeyFrameAtPosition( int position );


### PR DESCRIPTION
Move and swap keyframes forward and backward.
The delete button when used on the first keyframe clears it instead of
doing nothing.
