### PR TITLE
Tool should not be changed on a tablet event

### DIFF
--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -455,10 +455,6 @@ void ScribbleArea::tabletEvent( QTabletEvent *event )
     {
         editor()->tools()->tabletSwitchToEraser();
     }
-    else
-    {
-        editor()->tools()->tabletRestorePrevTool();
-    }
     event->ignore(); // indicates that the tablet event is not accepted yet, so that it is propagated as a mouse event)
 }
 


### PR DESCRIPTION
This prevents switching tools/ causes flashing tool switching during drawing.
