### PR TITLE
Fix build failure on unix but not-linux arches (like kfreebsd-* and hurd...

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -14,7 +14,7 @@ macx {
    LIBS += -lobjc -framework AppKit -framework Carbon
 }
 
-linux-* {
+unix:!macx {
     QMAKE_CXXFLAGS += -std=c++11
     QMAKE_LINK = $$QMAKE_CXX
     QMAKE_LINK_SHLIB = $$QMAKE_CXX

--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -200,7 +200,7 @@ macx {
     SOURCES += external/macosx/macosx.cpp
 }
 
-linux-* {
+unix:!macx {
     INCLUDEPATH += external/linux
     SOURCES += external/linux/linux.cpp
 }


### PR DESCRIPTION
linux-specific code and compile options are fine also on those arches based on
GNU but with a different kernel (lik kfreebsd and hurd)