### PR TITLE
Add options to onion skinning so user may define the number of frames shown

### DIFF
--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -770,9 +770,10 @@ void MainWindow2::preferences()
     connect( m_pPreferences, SIGNAL( autosaveChange( int ) ), mEditor, SLOT( changeAutosave( int ) ) );
     connect( m_pPreferences, SIGNAL( autosaveNumberChange( int ) ), mEditor, SLOT( changeAutosaveNumber( int ) ) );
 
-    connect( m_pPreferences, SIGNAL( onionLayer1OpacityChange( int ) ), mEditor, SLOT( onionLayer1OpacityChangeSlot( int ) ) );
-    connect( m_pPreferences, SIGNAL( onionLayer2OpacityChange( int ) ), mEditor, SLOT( onionLayer2OpacityChangeSlot( int ) ) );
-    connect( m_pPreferences, SIGNAL( onionLayer3OpacityChange( int ) ), mEditor, SLOT( onionLayer3OpacityChangeSlot( int ) ) );
+    connect( m_pPreferences, SIGNAL( onionMaxOpacityChange( int ) ), mEditor, SLOT( onionMaxOpacityChangeSlot( int ) ) );
+    connect( m_pPreferences, SIGNAL( onionMinOpacityChange( int ) ), mEditor, SLOT( onionMinOpacityChangeSlot( int ) ) );
+    connect( m_pPreferences, SIGNAL( onionPrevFramesNumChange( int ) ), mEditor, SLOT( onionPrevFramesNumChangeSlot( int ) ) );
+    connect( m_pPreferences, SIGNAL( onionNextFramesNumChange( int ) ), mEditor, SLOT( onionNextFramesNumChangeSlot( int ) ) );
 
     clearKeyboardShortcuts();
     connect( m_pPreferences, &Preferences::destroyed, [=] { setupKeyboardShortcuts(); } );

--- a/core_lib/interface/editor.cpp
+++ b/core_lib/interface/editor.cpp
@@ -79,12 +79,15 @@ Editor::Editor( QObject* parent ) : QObject( parent )
     clipboardBitmapOk = false;
     clipboardVectorOk = false;
 
-    if ( settings.value( "onionLayer1Opacity" ).isNull() ) settings.setValue( "onionLayer1Opacity", 50 );
-    if ( settings.value( "onionLayer2Opacity" ).isNull() ) settings.setValue( "onionLayer2Opacity", 0 );
-    if ( settings.value( "onionLayer3Opacity" ).isNull() ) settings.setValue( "onionLayer3Opacity", 0 );
-    onionLayer1Opacity = settings.value( "onionLayer1Opacity" ).toInt();
-    onionLayer2Opacity = settings.value( "onionLayer2Opacity" ).toInt();
-    onionLayer3Opacity = settings.value( "onionLayer3Opacity" ).toInt();
+    if ( settings.value( SETTING_ONION_MAX_OPACITY ).isNull() ) settings.setValue( SETTING_ONION_MAX_OPACITY, 50 );
+    if ( settings.value( SETTING_ONION_MIN_OPACITY ).isNull() ) settings.setValue( SETTING_ONION_MIN_OPACITY, 20 );
+    if ( settings.value( SETTING_ONION_PREV_FRAMES_NUM ).isNull() ) settings.setValue( SETTING_ONION_PREV_FRAMES_NUM, 1 );
+    if ( settings.value( SETTING_ONION_NEXT_FRAMES_NUM ).isNull() ) settings.setValue( SETTING_ONION_NEXT_FRAMES_NUM, 1 );
+    
+    onionMaxOpacity = settings.value( SETTING_ONION_MAX_OPACITY ).toInt();
+    onionMinOpacity = settings.value( SETTING_ONION_MIN_OPACITY ).toInt();
+    onionPrevFramesNum = settings.value( SETTING_ONION_PREV_FRAMES_NUM ).toInt();
+    onionNextFramesNum = settings.value( SETTING_ONION_NEXT_FRAMES_NUM ).toInt();
 
     //qDebug() << QLibraryInfo::location( QLibraryInfo::PluginsPath );
     //qDebug() << QLibraryInfo::location( QLibraryInfo::BinariesPath );
@@ -189,25 +192,34 @@ void Editor::changeAutosaveNumber( int number )
     settings.setValue( "autosaveNumber", number );
 }
 
-void Editor::onionLayer1OpacityChangeSlot( int number )
+void Editor::onionMaxOpacityChangeSlot( int number )
 {
-    onionLayer1Opacity = number;
-    QSettings settings( "Pencil", "Pencil" );
-    settings.setValue( "onionLayer1Opacity", number );
+    onionMaxOpacity = number;
+    QSettings settings( PENCIL2D, PENCIL2D );
+    settings.setValue( SETTING_ONION_MAX_OPACITY, number );
 }
 
-void Editor::onionLayer2OpacityChangeSlot( int number )
+void Editor::onionMinOpacityChangeSlot( int number )
 {
-    onionLayer2Opacity = number;
-    QSettings settings( "Pencil", "Pencil" );
-    settings.setValue( "onionLayer2Opacity", number );
+    onionMinOpacity = number;
+    QSettings settings( PENCIL2D, PENCIL2D );
+    settings.setValue( SETTING_ONION_MIN_OPACITY, number );
 }
 
-void Editor::onionLayer3OpacityChangeSlot( int number )
+void Editor::onionPrevFramesNumChangeSlot( int number )
 {
-    onionLayer3Opacity = number;
-    QSettings settings( "Pencil", "Pencil" );
-    settings.setValue( "onionLayer3Opacity", number );
+    onionPrevFramesNum = number;
+    QSettings settings( PENCIL2D, PENCIL2D );
+    settings.setValue( SETTING_ONION_PREV_FRAMES_NUM, number );
+    mScribbleArea->updateAllFrames();
+}
+
+void Editor::onionNextFramesNumChangeSlot( int number )
+{
+    onionNextFramesNum = number;
+    QSettings settings( PENCIL2D, PENCIL2D );
+    settings.setValue( SETTING_ONION_NEXT_FRAMES_NUM, number );
+    mScribbleArea->updateAllFrames();
 }
 
 void Editor::currentKeyFrameModification()

--- a/core_lib/interface/editor.h
+++ b/core_lib/interface/editor.h
@@ -74,9 +74,10 @@ public:
     int  allLayers();
     bool exportSeqCLI( QString, QString );
 
-    int getOnionLayer1Opacity() { return onionLayer1Opacity; }
-    int getOnionLayer2Opacity() { return onionLayer2Opacity; }
-    int getOnionLayer3Opacity() { return onionLayer3Opacity; }
+    int getOnionMaxOpacity() { return onionMaxOpacity; }
+    int getOnionMinOpacity() { return onionMinOpacity; }
+    int getOnionPrevFramesNum() { return onionPrevFramesNum; }
+    int getOnionNextFramesNum() { return onionNextFramesNum; }
 
     void importMovie( QString filePath, int fps );
 
@@ -106,6 +107,12 @@ Q_SIGNALS:
     // save
     void needSave();
     void fileLoaded();
+    
+public slots:
+    void onionMaxOpacityChangeSlot( int );
+    void onionMinOpacityChangeSlot( int );
+    void onionPrevFramesNumChangeSlot( int );
+    void onionNextFramesNumChangeSlot( int );
 
 public: //slots
     void clearCurrentFrame();
@@ -150,10 +157,6 @@ public: //slots
 
     void changeAutosave( int );
     void changeAutosaveNumber( int );
-
-    void onionLayer1OpacityChangeSlot( int );
-    void onionLayer2OpacityChangeSlot( int );
-    void onionLayer3OpacityChangeSlot( int );
 
     void currentKeyFrameModification();
     void modification( int );
@@ -205,9 +208,10 @@ private:
     bool mIsAutosave;
     int autosaveNumber;
 
-    int onionLayer1Opacity;
-    int onionLayer2Opacity;
-    int onionLayer3Opacity;
+    int onionMaxOpacity;
+    int onionMinOpacity;
+    int onionNextFramesNum;
+    int onionPrevFramesNum;
 
     void makeConnections();
     void addKeyFame( int layerNumber, int frameNumber );

--- a/core_lib/interface/preferences.cpp
+++ b/core_lib/interface/preferences.cpp
@@ -396,37 +396,47 @@ ToolsPage::ToolsPage(QWidget* parent) : QWidget(parent)
     QVBoxLayout* lay = new QVBoxLayout();
 
     QGroupBox* onionSkinBox = new QGroupBox(tr("Onion skin"));
-    QLabel* onionLayer1OpacityLabel = new QLabel(tr("Onion layer 1 opacity - % (50 is recommended):"));
-    QSpinBox* onionLayer1OpacityBox = new QSpinBox();
-    QLabel* onionLayer2OpacityLabel = new QLabel(tr("Onion layer 2 opacity - % (30 is recommended):"));
-    QSpinBox* onionLayer2OpacityBox = new QSpinBox();
-    QLabel* onionLayer3OpacityLabel = new QLabel(tr("Onion layer 3 opacity - % (20 is recommended):"));
-    QSpinBox* onionLayer3OpacityBox = new QSpinBox();
+    
+    QLabel* onionMaxOpacityLabel = new QLabel(tr("Maximum onion opacity %"));
+    QSpinBox* onionMaxOpacityBox = new QSpinBox();
+    QLabel* onionMinOpacityLabel = new QLabel(tr("Minimum onion opacity %"));
+    QSpinBox* onionMinOpacityBox = new QSpinBox();
+    QLabel* onionPrevFramesNumLabel = new QLabel(tr("Number of previous onion frames shown"));
+    QSpinBox* onionPrevFramesNumBox = new QSpinBox();
+    QLabel* onionNextFramesNumLabel = new QLabel(tr("Number of next onion frames shown"));
+    QSpinBox* onionNextFramesNumBox = new QSpinBox();
 
-    onionLayer1OpacityBox->setMinimum(0);
-    onionLayer1OpacityBox->setMaximum(100);
-    onionLayer1OpacityBox->setFixedWidth(50);
-    onionLayer2OpacityBox->setMinimum(0);
-    onionLayer2OpacityBox->setMaximum(100);
-    onionLayer2OpacityBox->setFixedWidth(50);
-    onionLayer3OpacityBox->setMinimum(0);
-    onionLayer3OpacityBox->setMaximum(100);
-    onionLayer3OpacityBox->setFixedWidth(50);
+    onionMaxOpacityBox->setMinimum(0);
+    onionMaxOpacityBox->setMaximum(100);
+    onionMaxOpacityBox->setFixedWidth(50);
+    onionMinOpacityBox->setMinimum(0);
+    onionMinOpacityBox->setMaximum(100);
+    onionMinOpacityBox->setFixedWidth(50);
+    onionPrevFramesNumBox->setMinimum(1);
+    onionPrevFramesNumBox->setMaximum(60);
+    onionPrevFramesNumBox->setFixedWidth(50);
+    onionNextFramesNumBox->setMinimum(1);
+    onionNextFramesNumBox->setMaximum(60);
+    onionNextFramesNumBox->setFixedWidth(50);
 
-    onionLayer1OpacityBox->setValue(settings.value("onionLayer1Opacity").toInt());
-    onionLayer2OpacityBox->setValue(settings.value("onionLayer2Opacity").toInt());
-    onionLayer3OpacityBox->setValue(settings.value("onionLayer3Opacity").toInt());
+    onionMaxOpacityBox->setValue(settings.value( SETTING_ONION_MAX_OPACITY ).toInt());
+    onionMinOpacityBox->setValue(settings.value( SETTING_ONION_MIN_OPACITY ).toInt());
+    onionPrevFramesNumBox->setValue(settings.value( SETTING_ONION_PREV_FRAMES_NUM).toInt());
+    onionNextFramesNumBox->setValue(settings.value( SETTING_ONION_NEXT_FRAMES_NUM ).toInt());
 
-    connect(onionLayer1OpacityBox, SIGNAL(valueChanged(int)), parent, SIGNAL(onionLayer1OpacityChange(int)));
-    connect(onionLayer2OpacityBox, SIGNAL(valueChanged(int)), parent, SIGNAL(onionLayer2OpacityChange(int)));
-    connect(onionLayer3OpacityBox, SIGNAL(valueChanged(int)), parent, SIGNAL(onionLayer3OpacityChange(int)));
+    connect(onionMaxOpacityBox, SIGNAL(valueChanged(int)), parent, SIGNAL(onionMaxOpacityChange(int)));
+    connect(onionMinOpacityBox, SIGNAL(valueChanged(int)), parent, SIGNAL(onionMinOpacityChange(int)));
+    connect(onionPrevFramesNumBox, SIGNAL(valueChanged(int)), parent, SIGNAL(onionPrevFramesNumChange(int)));
+    connect(onionNextFramesNumBox, SIGNAL(valueChanged(int)), parent, SIGNAL(onionNextFramesNumChange(int)));
 
-    lay->addWidget(onionLayer1OpacityLabel);
-    lay->addWidget(onionLayer1OpacityBox);
-    lay->addWidget(onionLayer2OpacityLabel);
-    lay->addWidget(onionLayer2OpacityBox);
-    lay->addWidget(onionLayer3OpacityLabel);
-    lay->addWidget(onionLayer3OpacityBox);
+    lay->addWidget(onionMaxOpacityLabel);
+    lay->addWidget(onionMaxOpacityBox);
+    lay->addWidget(onionMinOpacityLabel);
+    lay->addWidget(onionMinOpacityBox);
+    lay->addWidget(onionPrevFramesNumLabel);
+    lay->addWidget(onionPrevFramesNumBox);
+    lay->addWidget(onionNextFramesNumLabel);
+    lay->addWidget(onionNextFramesNumBox);
     onionSkinBox->setLayout(lay);
 
     QVBoxLayout* lay2 = new QVBoxLayout();

--- a/core_lib/interface/preferences.h
+++ b/core_lib/interface/preferences.h
@@ -54,9 +54,10 @@ signals:
     void labelChange(int);
     void scrubChange(int);
 
-    void onionLayer1OpacityChange(int);
-    void onionLayer2OpacityChange(int);
-    void onionLayer3OpacityChange(int);
+    void onionMaxOpacityChange(int);
+    void onionMinOpacityChange(int);
+    void onionPrevFramesNumChange(int);
+    void onionNextFramesNumChange(int);
 
 private:
     void createIcons();

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1035,23 +1035,18 @@ void ScribbleArea::drawCanvas( int frame, QRect rect )
                     // previous frame (onion skin)
                     if ( isEffectOn( EFFECT_PREV_ONION ) )
                     {
-                        BitmapImage *previousImage = layerBitmap->getLastBitmapImageAtFrame( frame, -1 );
-                        if ( previousImage != NULL )
+                        int prevFramesNum = mEditor->getOnionPrevFramesNum();
+                        float onionOpacity = mEditor->getOnionMaxOpacity();
+                        
+                        for ( int j = 0; j < prevFramesNum; j++ )
                         {
-                            painter.setOpacity( opacity * mEditor->getOnionLayer1Opacity() / 100.0 );
-                            previousImage->paintImage( painter );
-                        }
-                        BitmapImage *previousImage2 = layerBitmap->getLastBitmapImageAtFrame( frame, -2 );
-                        if ( previousImage2 != NULL )
-                        {
-                            painter.setOpacity( opacity * mEditor->getOnionLayer2Opacity() / 100.0 );
-                            previousImage2->paintImage( painter );
-                        }
-                        BitmapImage *previousImage3 = layerBitmap->getLastBitmapImageAtFrame( frame, -3 );
-                        if ( previousImage3 != NULL )
-                        {
-                            painter.setOpacity( opacity * mEditor->getOnionLayer3Opacity() / 100.0 );
-                            previousImage3->paintImage( painter );
+                            BitmapImage *previousImage = layerBitmap->getLastBitmapImageAtFrame( frame, -(j + 1) );
+                            if ( previousImage != NULL)
+                            {
+                                painter.setOpacity( opacity * onionOpacity / 100.0 );
+                                previousImage->paintImage( painter );
+                                if ( prevFramesNum != 1 ) onionOpacity -= (mEditor->getOnionMaxOpacity() - mEditor->getOnionMinOpacity()) / (prevFramesNum - 1);
+                            }
                         }
                         if ( onionBlue || onionRed )
                         {
@@ -1072,23 +1067,18 @@ void ScribbleArea::drawCanvas( int frame, QRect rect )
                     // next frame (onion skin)
                     if ( isEffectOn( EFFECT_NEXT_ONION ) )
                     {
-                        BitmapImage *nextImage = layerBitmap->getLastBitmapImageAtFrame( frame, 1 );
-                        if ( nextImage != NULL )
+                        int nextFramesNum = mEditor->getOnionNextFramesNum();
+                        float onionOpacity = mEditor->getOnionMaxOpacity();
+                        
+                        for ( int j = 0; j < nextFramesNum; j++ )
                         {
-                            painter.setOpacity( opacity * mEditor->getOnionLayer1Opacity() / 100.0 );
-                            nextImage->paintImage( painter );
-                        }
-                        BitmapImage *nextImage2 = layerBitmap->getLastBitmapImageAtFrame( frame, 2 );
-                        if ( nextImage2 != NULL )
-                        {
-                            painter.setOpacity( opacity * mEditor->getOnionLayer2Opacity() / 100.0 );
-                            nextImage2->paintImage( painter );
-                        }
-                        BitmapImage *nextImage3 = layerBitmap->getLastBitmapImageAtFrame( frame, 3 );
-                        if ( nextImage3 != NULL )
-                        {
-                            painter.setOpacity( opacity * mEditor->getOnionLayer3Opacity() / 100.0 );
-                            nextImage3->paintImage( painter );
+                            BitmapImage *nextImage = layerBitmap->getLastBitmapImageAtFrame( frame, j + 1 );
+                            if ( nextImage != NULL )
+                            {
+                                painter.setOpacity( opacity * onionOpacity / 100.0 );
+                                nextImage->paintImage( painter );
+                                if ( nextFramesNum != 1 ) onionOpacity -= (mEditor->getOnionMaxOpacity() - mEditor->getOnionMinOpacity()) / (nextFramesNum - 1);
+                            }
                         }
                         if ( onionBlue || onionRed )
                         {
@@ -1118,21 +1108,18 @@ void ScribbleArea::drawCanvas( int frame, QRect rect )
                 if ( isEffectOn( EFFECT_PREV_ONION ) )
                 {
                     QTransform viewTransform = mEditor->view()->getView();
-                    VectorImage* pVectorImage = layerVector->getLastVectorImageAtFrame( frame, -3 );
-                    pVectorImage->outputImage( pImage.data(), viewTransform, mIsSimplified, mShowThinLines, isEffectOn( EFFECT_ANTIALIAS ) );
-                    painter.setOpacity( opacity * mEditor->getOnionLayer3Opacity() / 100.0 );
-                    painter.drawImage( QPoint( 0, 0 ), *pImage );
-
-                    pVectorImage = layerVector->getLastVectorImageAtFrame( frame, -2 );
-                    pVectorImage->outputImage( pImage.data(), viewTransform, mIsSimplified, mShowThinLines, isEffectOn( EFFECT_ANTIALIAS ) );
-                    painter.setOpacity( opacity * mEditor->getOnionLayer2Opacity() / 100.0 );
-                    painter.drawImage( QPoint( 0, 0 ), *pImage );
-
-                    pVectorImage = layerVector->getLastVectorImageAtFrame( frame, -1 );
-                    pVectorImage->outputImage( pImage.data(), viewTransform, mIsSimplified, mShowThinLines, isEffectOn( EFFECT_ANTIALIAS ) );
-                    painter.setOpacity( opacity * mEditor->getOnionLayer1Opacity() / 100.0 );
-                    painter.drawImage( QPoint( 0, 0 ), *pImage );
-
+                    int prevFramesNum = mEditor->getOnionPrevFramesNum();
+                    float onionOpacity = mEditor->getOnionMinOpacity();
+                    
+                    for ( int j = 0; j < prevFramesNum; j++ )
+                    {
+                        VectorImage* pVectorImage = layerVector->getLastVectorImageAtFrame( frame, -(prevFramesNum - j));
+                        pVectorImage->outputImage( pImage.data(), viewTransform, mIsSimplified, mShowThinLines, isEffectOn( EFFECT_ANTIALIAS ) );
+                        painter.setOpacity( opacity * onionOpacity / 100.0 );
+                        painter.drawImage( QPoint( 0, 0 ), *pImage );
+                        if (prevFramesNum != 1) onionOpacity += (mEditor->getOnionMaxOpacity() - mEditor->getOnionMinOpacity()) / (prevFramesNum - 1);
+                    }
+                    
                     if ( onionBlue || onionRed )
                     {
                         painter.setOpacity( 1.0 );
@@ -1153,20 +1140,17 @@ void ScribbleArea::drawCanvas( int frame, QRect rect )
                 if ( isEffectOn( EFFECT_NEXT_ONION ) )
                 {
                     QTransform viewTransform = mEditor->view()->getView();
-                    VectorImage* pVectorImage = layerVector->getLastVectorImageAtFrame( frame, 3 );
-                    pVectorImage->outputImage( pImage.data(), viewTransform, mIsSimplified, mShowThinLines, isEffectOn( EFFECT_ANTIALIAS ) );
-                    painter.setOpacity( opacity * mEditor->getOnionLayer3Opacity() / 100.0 );
-                    painter.drawImage( QPoint( 0, 0 ), *pImage );
-
-                    pVectorImage = layerVector->getLastVectorImageAtFrame( frame, 2 );
-                    pVectorImage->outputImage( pImage.data(), viewTransform, mIsSimplified, mShowThinLines, isEffectOn( EFFECT_ANTIALIAS ) );
-                    painter.setOpacity( opacity * mEditor->getOnionLayer2Opacity() / 100.0 );
-                    painter.drawImage( QPoint( 0, 0 ), *pImage );
-
-                    pVectorImage = layerVector->getLastVectorImageAtFrame( frame, 1 );
-                    pVectorImage->outputImage( pImage.data(), viewTransform, mIsSimplified, mShowThinLines, isEffectOn( EFFECT_ANTIALIAS ) );
-                    painter.setOpacity( opacity * mEditor->getOnionLayer1Opacity() / 100.0 );
-                    painter.drawImage( QPoint( 0, 0 ), *pImage );
+                    int nextFramesNum = mEditor->getOnionNextFramesNum();
+                    float onionOpacity = mEditor->getOnionMinOpacity();
+                    
+                    for ( int j = 0; j < nextFramesNum; j++ )
+                    {
+                        VectorImage* pVectorImage = layerVector->getLastVectorImageAtFrame( frame, nextFramesNum - j);
+                        pVectorImage->outputImage( pImage.data(), viewTransform, mIsSimplified, mShowThinLines, isEffectOn( EFFECT_ANTIALIAS ) );
+                        painter.setOpacity( opacity * onionOpacity / 100.0 );
+                        painter.drawImage( QPoint( 0, 0 ), *pImage );
+                        if (nextFramesNum != 1) onionOpacity += (mEditor->getOnionMaxOpacity() - mEditor->getOnionMinOpacity()) / (nextFramesNum - 1);
+                    }
 
                     if ( onionBlue || onionRed )
                     {

--- a/core_lib/util/pencildef.h
+++ b/core_lib/util/pencildef.h
@@ -138,4 +138,9 @@ enum BackgroundStyle
 #define SETTING_WINDOW_STATE    "WindowState"
 #define SETTING_DISPLAY_EFFECT  "RenderEffect"
 
+#define SETTING_ONION_MAX_OPACITY     "onionMaxOpacity"
+#define SETTING_ONION_MIN_OPACITY     "onionMinOpacity"
+#define SETTING_ONION_PREV_FRAMES_NUM "onionPrevFramesNum"
+#define SETTING_ONION_NEXT_FRAMES_NUM "onionNextFramesNum"
+
 #endif // PENCILDEF_H


### PR DESCRIPTION
Implement this request: https://github.com/pencil2d/pencil/issues/17 . This first step adds these options to a setting menu. A better GUI interface, as discussed in the request, should be added later.

Adds options in Edit > Preferences > Tools so that the user may define how many previous and next frames are shown when previous and/or next onion skinning is toggled on. The user may also define a maximum opacity value and a minimum opacity value, which will be gradated between all of the frames shown. Replaces the previous options here which allowed the user to define the opacity values for the next or previous 3 onion frames explicitly; these settings were broken and did not work.