### PR TITLE
Make translations a static library

### DIFF
--- a/resources/translations/translations.pro
+++ b/resources/translations/translations.pro
@@ -1,5 +1,8 @@
 # l10n stuff
 
+TEMPLATE = lib
+CONFIG += qt staticlib console
+
 TRANSLATIONS += pencil.ts \
                 pencil2d_cs.ts \
                 pencil2d_it.ts \


### PR DESCRIPTION
If the translations lib is not defined as a static library, build fails because the compiler is looking for a main file that doesn't exist.