### PR TITLE
Fixes on bitmap brush engine.

### DIFF
--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -97,6 +97,7 @@ MainWindow2::MainWindow2( QWidget *parent ) : QMainWindow( parent )
     //connect( mScribbleArea, &ScribbleArea::refreshPreview, mPreview, &PreviewWidget::updateImage );
 
     mEditor->setCurrentLayer( mEditor->object()->getLayerCount() - 1 );
+    mEditor->tools()->setDefaultTool();
 }
 
 MainWindow2::~MainWindow2()
@@ -164,6 +165,7 @@ void MainWindow2::createDockWidgets()
     makeConnections( mEditor, pColorBox );
     makeConnections( mEditor, mColorPalette );
     makeConnections( mEditor, mDisplayOptionWidget );
+    makeConnections( mEditor, mToolOptions );
     mToolOptions->makeConnectionToEditor(mEditor);
 }
 
@@ -1065,6 +1067,12 @@ void MainWindow2::makeConnections(Editor* editor, DisplayOptionWidget* display)
 {
     display->makeConnectionToEditor( editor );
 }
+
+void MainWindow2::makeConnections(Editor* editor, ToolOptionWidget* toolOptions)
+{
+    connect( editor->tools(), &ToolManager::displayToolOptions, toolOptions, &ToolOptionWidget::displayToolOptions );
+}
+
 
 void MainWindow2::makeConnections( Editor* pEditor, ColorPaletteWidget* pColorPalette )
 {

--- a/app/mainwindow2.h
+++ b/app/mainwindow2.h
@@ -93,6 +93,7 @@ private:
     void makeConnections( Editor*, ColorPaletteWidget* );
     void makeConnections( Editor*, TimeLine* );
     void makeConnections( Editor*, DisplayOptionWidget* );
+    void makeConnections( Editor*, ToolOptionWidget*);
 
     // UI: central Drawing Area
     ScribbleArea* mScribbleArea;

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -452,6 +452,9 @@ void ScribbleArea::tabletEvent( QTabletEvent *event )
     {
         editor()->tools()->tabletSwitchToEraser();
     }
+    else {
+        editor()->tools()->tabletRestorePrevTool();
+    }
     event->ignore(); // indicates that the tablet event is not accepted yet, so that it is propagated as a mouse event)
 }
 

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -750,8 +750,11 @@ void ScribbleArea::refreshBitmap( const QRectF& rect, int rad )
 
 void ScribbleArea::refreshVector( const QRectF& rect, int rad )
 {
-    QRectF updatedRect = mEditor->view()->mapCanvasToScreen( rect.normalized().adjusted( -rad, -rad, +rad, +rad ) );
-    update( updatedRect.toRect() );
+    // Does not work
+//    QRectF updatedRect = mEditor->view()->mapCanvasToScreen( rect.normalized().adjusted( -rad, -rad, +rad, +rad ) );
+//    update( updatedRect.toRect() );
+
+    update();
 }
 
 void ScribbleArea::paintEvent( QPaintEvent* event )

--- a/core_lib/interface/spinslider.cpp
+++ b/core_lib/interface/spinslider.cpp
@@ -78,5 +78,6 @@ void SpinSlider::sliderReleased()
 void SpinSlider::sliderMoved(int value)
 {
     changeValue(value);
-    emit valueChanged(this->value);
+    // Don't update value while the slider is still moving.
+    //emit valueChanged(this->value);
 }

--- a/core_lib/interface/tooloptiondockwidget.cpp
+++ b/core_lib/interface/tooloptiondockwidget.cpp
@@ -116,3 +116,43 @@ void ToolOptionWidget::setPreserveAlpha( int x )   // x = -1, 0, 1
     preserveAlphaBox->setEnabled( true );
     preserveAlphaBox->setChecked( x > 0 );
 }
+
+void ToolOptionWidget::disableAllOptions()
+{
+    sizeSlider->hide();
+    featherSlider->hide();
+    usePressureBox->hide();
+    makeInvisibleBox->hide();
+    preserveAlphaBox->hide();
+}
+
+void ToolOptionWidget::displayToolOptions(QHash<ToolPropertyType, bool> options)
+{
+    disableAllOptions();
+    QHash<ToolPropertyType, bool>::iterator i;
+    for (i = options.begin(); i != options.end(); ++i) {
+        if (i.value()) {
+
+            switch ( i.key() ) {
+            case WIDTH:
+              sizeSlider->show();
+              break;
+            case FEATHER:
+              featherSlider->show();
+              break;
+            case PRESSURE:
+              usePressureBox->show();
+              break;
+            case INVISIBILITY:
+              makeInvisibleBox->show();
+              break;
+            case PRESERVEALPHA:
+              preserveAlphaBox->show();
+              break;
+            default:
+              break;
+            }
+        }
+    }
+
+}

--- a/core_lib/interface/tooloptiondockwidget.h
+++ b/core_lib/interface/tooloptiondockwidget.h
@@ -2,6 +2,7 @@
 #define TOOLOPTIONDOCKWIDGET_H
 
 #include <QDockWidget>
+#include "pencildef.h"
 
 
 class QToolButton;
@@ -31,7 +32,10 @@ public slots:
     void setPressure(int);
     void setPreserveAlpha(int);
 
+    void displayToolOptions(QHash<ToolPropertyType, bool> options);
+
 private:
+    void disableAllOptions();
     void createUI();
 };
 

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -151,8 +151,9 @@ void ToolManager::setPressure( int isPressureOn )
 
 void ToolManager::tabletSwitchToEraser()
 {
-    if ( currentTool()->type() != ERASER )
+    if ( !isSwitchedToEraser && currentTool()->type() != ERASER )
     {
+        isSwitchedToEraser = true;
         m_eTabletBackupTool = currentTool()->type();
         setCurrentTool( ERASER );
     }
@@ -160,8 +161,9 @@ void ToolManager::tabletSwitchToEraser()
 
 void ToolManager::tabletRestorePrevTool()
 {
-    if ( currentTool()->type() != ERASER )
+    if ( isSwitchedToEraser )
     {
+        isSwitchedToEraser = false;
         if ( m_eTabletBackupTool == INVALID_TOOL )
         {
             m_eTabletBackupTool = PEN;

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -25,6 +25,8 @@ ToolManager::ToolManager(QObject* parent )
 
 bool ToolManager::init()
 {
+    isSwitchedToEraser = false;
+
     m_toolSetHash.insert( PEN, new PenTool );
     m_toolSetHash.insert( PENCIL, new PencilTool );
     m_toolSetHash.insert( BRUSH, new BrushTool );
@@ -107,68 +109,44 @@ void ToolManager::resetAllTools()
 
 void ToolManager::setWidth( float newWidth )
 {
-    // Always returns false when selecting a new tool
-//    if ( currentTool()->properties.width != newWidth )
-//    {
-        currentTool()->setWidth(newWidth);
-        emit penWidthValueChange( newWidth );
-        emit toolPropertyChanged();
-//    }
+    currentTool()->setWidth(newWidth);
+    emit penWidthValueChange( newWidth );
+    emit toolPropertyChanged();
 }
 
 void ToolManager::setFeather( float newFeather )
 {
-    // Always returns false when selecting a new tool
-//    if ( currentTool()->properties.feather != newFeather )
-//    {
-        currentTool()->properties.feather = newFeather;
-        emit penFeatherValueChange( newFeather );
-        emit toolPropertyChanged();
-//    }
+    currentTool()->setFeather(newFeather);
+    emit penFeatherValueChange( newFeather );
+    emit toolPropertyChanged();
 }
 
 void ToolManager::setInvisibility( int isInvisible  )
 {
-    // Always returns false when selecting a new tool
-//    if ( currentTool()->properties.invisibility != isInvisible )
-//    {
-        currentTool()->properties.invisibility = isInvisible;
-        emit penInvisiblityValueChange( isInvisible );
-        emit toolPropertyChanged();
-//    }
+    currentTool()->setInvisibility(isInvisible);
+    emit penInvisiblityValueChange( isInvisible );
+    emit toolPropertyChanged();
 }
 
 void ToolManager::setPreserveAlpha( int isPreserveAlpha )
 {
-    // Always returns false when selecting a new tool
-//    if ( currentTool()->properties.preserveAlpha != isPreserveAlpha )
-//    {
-        currentTool()->properties.preserveAlpha = isPreserveAlpha;
-        emit penPreserveAlphaValueChange( isPreserveAlpha );
-        emit toolPropertyChanged();
-//    }
+    currentTool()->setPreserveAlpha(isPreserveAlpha);
+    emit penPreserveAlphaValueChange( isPreserveAlpha );
+    emit toolPropertyChanged();
 }
 
 void ToolManager::setPressure( int isPressureOn )
 {
-    // Always returns false when selecting a new tool
-//    if ( currentTool()->properties.pressure != isPressureOn )
-//    {
-        currentTool()->properties.pressure = isPressureOn;
-        emit penPressureValueChange( isPressureOn );
-        emit toolPropertyChanged();
-//    }
+    currentTool()->setPressure(isPressureOn);
+    emit penPressureValueChange( isPressureOn );
+    emit toolPropertyChanged();
 }
 
 void ToolManager::tabletSwitchToEraser()
 {
-    // Always returns false when selecting a new tool
-//    if ( !isSwitchedToEraser && currentTool()->type() != ERASER )
-//    {
-        isSwitchedToEraser = true;
-        m_eTabletBackupTool = currentTool()->type();
-        setCurrentTool( ERASER );
-//    }
+    isSwitchedToEraser = true;
+    m_eTabletBackupTool = currentTool()->type();
+    setCurrentTool( ERASER );
 }
 
 void ToolManager::tabletRestorePrevTool()

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -105,7 +105,7 @@ void ToolManager::setWidth( float newWidth )
     // Always returns false when selecting a new tool
 //    if ( currentTool()->properties.width != newWidth )
 //    {
-        currentTool()->properties.width = newWidth;
+        currentTool()->setWidth(newWidth);
         emit penWidthValueChange( newWidth );
         emit toolPropertyChanged();
 //    }

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -73,6 +73,7 @@ void ToolManager::setCurrentTool( ToolType eToolType )
     setPreserveAlpha( m_pCurrentTool->properties.preserveAlpha );
     setInvisibility( m_pCurrentTool->properties.invisibility ); // by definition the pencil is invisible in vector mode
 
+
     emit toolChanged( eToolType );
     emit displayToolOptions(m_pCurrentTool->m_enabledProperties);
 }
@@ -144,9 +145,13 @@ void ToolManager::setPressure( int isPressureOn )
 
 void ToolManager::tabletSwitchToEraser()
 {
-    isSwitchedToEraser = true;
-    m_eTabletBackupTool = currentTool()->type();
-    setCurrentTool( ERASER );
+    if (!isSwitchedToEraser)
+    {
+        isSwitchedToEraser = true;
+
+        m_eTabletBackupTool = m_pCurrentTool->type();
+        setCurrentTool( ERASER );
+    }
 }
 
 void ToolManager::tabletRestorePrevTool()
@@ -156,7 +161,7 @@ void ToolManager::tabletRestorePrevTool()
         isSwitchedToEraser = false;
         if ( m_eTabletBackupTool == INVALID_TOOL )
         {
-            m_eTabletBackupTool = PEN;
+            m_eTabletBackupTool = PENCIL;
         }
         setCurrentTool( m_eTabletBackupTool );
     }

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -43,6 +43,7 @@ bool ToolManager::init()
     }
 
     m_pCurrentTool = getTool( PENCIL );
+    m_eTabletBackupTool = m_pCurrentTool->type();
 
     return true;
 }

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -42,9 +42,6 @@ bool ToolManager::init()
         pTool->initialize( editor(), editor()->getScribbleArea() );
     }
 
-    m_pCurrentTool = getTool( PENCIL );
-    m_eTabletBackupTool = m_pCurrentTool->type();
-
     return true;
 }
 
@@ -54,20 +51,28 @@ BaseTool* ToolManager::getTool(ToolType eToolType)
     return m_toolSetHash[ eToolType ];
 }
 
+void ToolManager::setDefaultTool()
+{
+    // Set default tool
+    // (called by the main window init)
+    ToolType defaultToolType = PENCIL;
+
+    setCurrentTool(defaultToolType);
+    m_eTabletBackupTool = defaultToolType;
+}
+
 void ToolManager::setCurrentTool( ToolType eToolType )
 {
-    if ( m_pCurrentTool->type() != eToolType )
-    {
-        m_pCurrentTool = getTool( eToolType );
+    m_pCurrentTool = getTool( eToolType );
 
-        setWidth( m_pCurrentTool->properties.width );
-        setFeather( m_pCurrentTool->properties.feather );
-        setPressure( m_pCurrentTool->properties.pressure );
-        setPreserveAlpha( m_pCurrentTool->properties.preserveAlpha );
-        setInvisibility( m_pCurrentTool->properties.invisibility ); // by definition the pencil is invisible in vector mode
+    setWidth( m_pCurrentTool->properties.width );
+    setFeather( m_pCurrentTool->properties.feather );
+    setPressure( m_pCurrentTool->properties.pressure );
+    setPreserveAlpha( m_pCurrentTool->properties.preserveAlpha );
+    setInvisibility( m_pCurrentTool->properties.invisibility ); // by definition the pencil is invisible in vector mode
 
-        emit toolChanged( eToolType );
-    }
+    emit toolChanged( eToolType );
+    emit displayToolOptions(m_pCurrentTool->m_enabledProperties);
 }
 
 void ToolManager::cleanupAllToolsData()

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -102,62 +102,68 @@ void ToolManager::resetAllTools()
 
 void ToolManager::setWidth( float newWidth )
 {
-    if ( currentTool()->properties.width != newWidth )
-    {
+    // Always returns false when selecting a new tool
+//    if ( currentTool()->properties.width != newWidth )
+//    {
         currentTool()->properties.width = newWidth;
         emit penWidthValueChange( newWidth );
         emit toolPropertyChanged();
-    }
+//    }
 }
 
 void ToolManager::setFeather( float newFeather )
 {
-    if ( currentTool()->properties.feather != newFeather )
-    {
+    // Always returns false when selecting a new tool
+//    if ( currentTool()->properties.feather != newFeather )
+//    {
         currentTool()->properties.feather = newFeather;
         emit penFeatherValueChange( newFeather );
         emit toolPropertyChanged();
-    }
+//    }
 }
 
 void ToolManager::setInvisibility( int isInvisible  )
 {
-    if ( currentTool()->properties.invisibility != isInvisible )
-    {
+    // Always returns false when selecting a new tool
+//    if ( currentTool()->properties.invisibility != isInvisible )
+//    {
         currentTool()->properties.invisibility = isInvisible;
         emit penInvisiblityValueChange( isInvisible );
         emit toolPropertyChanged();
-    }
+//    }
 }
 
 void ToolManager::setPreserveAlpha( int isPreserveAlpha )
 {
-    if ( currentTool()->properties.preserveAlpha != isPreserveAlpha )
-    {
+    // Always returns false when selecting a new tool
+//    if ( currentTool()->properties.preserveAlpha != isPreserveAlpha )
+//    {
         currentTool()->properties.preserveAlpha = isPreserveAlpha;
         emit penPreserveAlphaValueChange( isPreserveAlpha );
         emit toolPropertyChanged();
-    }
+//    }
 }
 
 void ToolManager::setPressure( int isPressureOn )
 {
-    if ( currentTool()->properties.pressure != isPressureOn )
-    {
+    // Always returns false when selecting a new tool
+//    if ( currentTool()->properties.pressure != isPressureOn )
+//    {
         currentTool()->properties.pressure = isPressureOn;
         emit penPressureValueChange( isPressureOn );
         emit toolPropertyChanged();
-    }
+//    }
 }
 
 void ToolManager::tabletSwitchToEraser()
 {
-    if ( !isSwitchedToEraser && currentTool()->type() != ERASER )
-    {
+    // Always returns false when selecting a new tool
+//    if ( !isSwitchedToEraser && currentTool()->type() != ERASER )
+//    {
         isSwitchedToEraser = true;
         m_eTabletBackupTool = currentTool()->type();
         setCurrentTool( ERASER );
-    }
+//    }
 }
 
 void ToolManager::tabletRestorePrevTool()

--- a/core_lib/managers/toolmanager.h
+++ b/core_lib/managers/toolmanager.h
@@ -47,6 +47,7 @@ public slots:
 private:
     BaseTool* m_pCurrentTool;
     ToolType  m_eTabletBackupTool;
+    bool isSwitchedToEraser;
     QHash<ToolType, BaseTool*> m_toolSetHash;
 
 };

--- a/core_lib/managers/toolmanager.h
+++ b/core_lib/managers/toolmanager.h
@@ -19,6 +19,7 @@ public:
 
     BaseTool* currentTool() { return m_pCurrentTool; }
     BaseTool* getTool( ToolType eToolType );
+    void      setDefaultTool();
     void      setCurrentTool( ToolType eToolType );
     void      cleanupAllToolsData();
 
@@ -33,6 +34,7 @@ signals:
     void penPressureValueChange( int );
 
     void toolChanged( ToolType );
+    void displayToolOptions(QHash<ToolPropertyType, bool> options);
     void toolPropertyChanged();
 
 public slots:

--- a/core_lib/tool/basetool.cpp
+++ b/core_lib/tool/basetool.cpp
@@ -228,3 +228,28 @@ QPointF BaseTool::getLastPressPoint()
 {
     return mEditor->view()->mapScreenToCanvas( getLastPressPixel() );
 }
+
+void BaseTool::setWidth( const qreal width )
+{
+    properties.width = width;
+}
+
+void BaseTool::setFeather( const qreal feather )
+{
+    properties.feather = feather;
+}
+
+void BaseTool::setInvisibility( const qreal invisibility )
+{
+    properties.invisibility = invisibility;
+}
+
+void BaseTool::setPressure( const bool pressure )
+{
+    properties.pressure = pressure;
+}
+
+void BaseTool::setPreserveAlpha( const bool preserveAlpha )
+{
+    properties.preserveAlpha = preserveAlpha;
+}

--- a/core_lib/tool/basetool.cpp
+++ b/core_lib/tool/basetool.cpp
@@ -36,6 +36,13 @@ QString BaseTool::TypeName( ToolType type )
 BaseTool::BaseTool( QObject *parent ) :
 QObject( parent )
 {
+    m_enabledProperties.insert( WIDTH,          false  );
+    m_enabledProperties.insert( FEATHER,        false  );
+    m_enabledProperties.insert( OPACITY,        false  );
+    m_enabledProperties.insert( COLOURNUMBER,   false  );
+    m_enabledProperties.insert( PRESSURE,       false  );
+    m_enabledProperties.insert( INVISIBILITY,   false  );
+    m_enabledProperties.insert( PRESERVEALPHA,  false  );
 }
 
 

--- a/core_lib/tool/basetool.h
+++ b/core_lib/tool/basetool.h
@@ -24,6 +24,7 @@ public:
     int pressure;
     int invisibility;
     int preserveAlpha;
+
 };
 
 const int ON = 1;
@@ -70,12 +71,11 @@ public:
     static bool isAdjusting;
     QCursor circleCursors(); //precision circular cursor: used for assisted cursor adjustment (wysiwyg)
 
-    void setWidth( const qreal width );
-    void setFeather( const qreal feather );
-    void setOpacity( const qreal opacity );
-    void setInvisibility( const qreal invisibility );
-    void setPressure( const bool pressure );
-    void setPreserveAlpha( const bool preserveAlpha );
+    virtual void setWidth( const qreal width );
+    virtual void setFeather( const qreal feather );
+    virtual void setInvisibility( const qreal invisibility );
+    virtual void setPressure( const bool pressure );
+    virtual void setPreserveAlpha( const bool preserveAlpha );
 
     Properties properties;
 

--- a/core_lib/tool/basetool.h
+++ b/core_lib/tool/basetool.h
@@ -86,6 +86,8 @@ public:
     QPointF getLastPressPixel();
     QPointF getLastPressPoint();
 
+    QHash<ToolPropertyType, bool> m_enabledProperties;
+
 protected:
     Editor* editor() { return mEditor; }
 

--- a/core_lib/tool/brushtool.cpp
+++ b/core_lib/tool/brushtool.cpp
@@ -25,6 +25,11 @@ ToolType BrushTool::type()
 
 void BrushTool::loadSettings()
 {
+    m_enabledProperties[WIDTH] = true;
+    m_enabledProperties[FEATHER] = true;
+
+
+
     QSettings settings( "Pencil", "Pencil" );
 
     properties.width = settings.value( "brushWidth" ).toDouble();

--- a/core_lib/tool/brushtool.cpp
+++ b/core_lib/tool/brushtool.cpp
@@ -46,6 +46,29 @@ void BrushTool::loadSettings()
     }
 }
 
+void BrushTool::setWidth(const qreal width)
+{
+    // Set current property
+    properties.width = width;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("brushWidth", width);
+    settings.sync();
+}
+
+void BrushTool::setFeather( const qreal feather )
+{
+    // Set current property
+    properties.feather = feather;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("brushFeather", feather);
+    settings.sync();
+}
+
+
 QCursor BrushTool::cursor()
 {
     if ( isAdjusting ) // being dynamically resized

--- a/core_lib/tool/brushtool.cpp
+++ b/core_lib/tool/brushtool.cpp
@@ -27,6 +27,7 @@ void BrushTool::loadSettings()
 {
     m_enabledProperties[WIDTH] = true;
     m_enabledProperties[FEATHER] = true;
+    m_enabledProperties[PRESSURE] = true;
 
 
 
@@ -35,19 +36,17 @@ void BrushTool::loadSettings()
     properties.width = settings.value( "brushWidth" ).toDouble();
     properties.feather = settings.value( "brushFeather" ).toDouble();
 
-    properties.pressure = ON;
+    properties.pressure = settings.value( "brushPressure" ).toBool();
     properties.invisibility = DISABLED;
     properties.preserveAlpha = OFF;
 
+    // First run
+    //
     if ( properties.width <= 0 )
     {
-        properties.width = 15;
-        settings.setValue( "brushWidth", properties.width );
-    }
-    if ( properties.feather <= 0 )
-    {
-        properties.feather = 200;
-        settings.setValue( "brushFeather", properties.feather );
+        setWidth(15);
+        setFeather(15);
+        setPressure(1);
     }
 }
 
@@ -73,6 +72,17 @@ void BrushTool::setFeather( const qreal feather )
     settings.sync();
 }
 
+void BrushTool::setPressure( const bool pressure )
+{
+    // Set current property
+    properties.pressure = pressure;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("brushPressure", pressure);
+    settings.sync();
+}
+
 
 QCursor BrushTool::cursor()
 {
@@ -90,7 +100,7 @@ QCursor BrushTool::cursor()
 void BrushTool::adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice )
 {
     mCurrentWidth = properties.width;
-    if ( mScribbleArea->usePressure() && !mouseDevice )
+    if ( properties.pressure && !mouseDevice )
     {
         mCurrentPressure = pressure;
     }

--- a/core_lib/tool/brushtool.h
+++ b/core_lib/tool/brushtool.h
@@ -21,6 +21,9 @@ public:
     void drawStroke();
     void paintAt( QPointF point );
 
+    void setWidth( const qreal width );
+    void setFeather( const qreal feather );
+
 protected:
     QPointF lastBrushPoint;
 };

--- a/core_lib/tool/brushtool.h
+++ b/core_lib/tool/brushtool.h
@@ -23,6 +23,7 @@ public:
 
     void setWidth( const qreal width );
     void setFeather( const qreal feather );
+    void setPressure( const bool pressure );
 
 protected:
     QPointF lastBrushPoint;

--- a/core_lib/tool/erasertool.cpp
+++ b/core_lib/tool/erasertool.cpp
@@ -27,6 +27,7 @@ void EraserTool::loadSettings()
 {
     m_enabledProperties[WIDTH] = true;
     m_enabledProperties[FEATHER] = true;
+    m_enabledProperties[PRESSURE] = true;
 
 
     QSettings settings( "Pencil", "Pencil" );
@@ -34,19 +35,16 @@ void EraserTool::loadSettings()
     properties.width = settings.value( "eraserWidth" ).toDouble();
     properties.feather = settings.value( "eraserFeather" ).toDouble();
 
-    properties.pressure = ON;
+    properties.pressure = settings.value( "eraserPressure" ).toBool();
     properties.invisibility = DISABLED;
     properties.preserveAlpha = OFF;
 
+    // First run
     if ( properties.width <= 0 )
     {
-        properties.width = 25;
-        settings.setValue( "eraserWidth", properties.width );
-    }
-    if ( properties.feather <= 0 )
-    {
-        properties.feather = 50;
-        settings.setValue( "eraserFeather", properties.feather );
+        setWidth(25);
+        setFeather(50);
+        setPressure(1);
     }
 }
 
@@ -72,6 +70,17 @@ void EraserTool::setFeather( const qreal feather )
     settings.sync();
 }
 
+void EraserTool::setPressure( const bool pressure )
+{
+    // Set current property
+    properties.pressure = pressure;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("eraserPressure", pressure);
+    settings.sync();
+}
+
 QCursor EraserTool::cursor()
 {
     if ( isAdjusting ) // being dynamically resized
@@ -88,7 +97,7 @@ QCursor EraserTool::cursor()
 void EraserTool::adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice )
 {
     mCurrentWidth = properties.width;
-    if ( mScribbleArea->usePressure() && !mouseDevice )
+    if ( properties.pressure && !mouseDevice )
     {
         mCurrentPressure = pressure;
     }

--- a/core_lib/tool/erasertool.cpp
+++ b/core_lib/tool/erasertool.cpp
@@ -25,6 +25,10 @@ ToolType EraserTool::type()
 
 void EraserTool::loadSettings()
 {
+    m_enabledProperties[WIDTH] = true;
+    m_enabledProperties[FEATHER] = true;
+
+
     QSettings settings( "Pencil", "Pencil" );
 
     properties.width = settings.value( "eraserWidth" ).toDouble();

--- a/core_lib/tool/erasertool.cpp
+++ b/core_lib/tool/erasertool.cpp
@@ -46,6 +46,28 @@ void EraserTool::loadSettings()
     }
 }
 
+void EraserTool::setWidth(const qreal width)
+{
+    // Set current property
+    properties.width = width;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("eraserWidth", width);
+    settings.sync();
+}
+
+void EraserTool::setFeather( const qreal feather )
+{
+    // Set current property
+    properties.feather = feather;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("eraserFeather", feather);
+    settings.sync();
+}
+
 QCursor EraserTool::cursor()
 {
     if ( isAdjusting ) // being dynamically resized

--- a/core_lib/tool/erasertool.h
+++ b/core_lib/tool/erasertool.h
@@ -22,6 +22,9 @@ public:
 
     void paintAt( QPointF point );
 
+    void setWidth( const qreal width );
+    void setFeather( const qreal feather );
+
 protected:
     QPointF lastBrushPoint;
 };

--- a/core_lib/tool/erasertool.h
+++ b/core_lib/tool/erasertool.h
@@ -24,6 +24,7 @@ public:
 
     void setWidth( const qreal width );
     void setFeather( const qreal feather );
+    void setPressure( const bool pressure );
 
 protected:
     QPointF lastBrushPoint;

--- a/core_lib/tool/penciltool.cpp
+++ b/core_lib/tool/penciltool.cpp
@@ -31,7 +31,7 @@ void PencilTool::loadSettings()
 
     if ( properties.width <= 0 )
     {
-        properties.width = 2;
+        properties.width = 3;
         settings.setValue( "pencilWidth", properties.width );
     }
     if ( properties.feather > -1 ) // replace with: <=0 to allow feather

--- a/core_lib/tool/penciltool.cpp
+++ b/core_lib/tool/penciltool.cpp
@@ -24,7 +24,7 @@ void PencilTool::loadSettings()
     QSettings settings( "Pencil", "Pencil" );
 
     properties.width = settings.value( "pencilWidth" ).toDouble();
-    properties.feather = settings.value( "pencilFeather" ).toDouble();
+    properties.feather = -1; //Feather isn't implemented in the Pencil tool;
     properties.pressure = 1;
     properties.invisibility = 1;
     properties.preserveAlpha = 0;
@@ -34,12 +34,43 @@ void PencilTool::loadSettings()
         properties.width = 3;
         settings.setValue( "pencilWidth", properties.width );
     }
-    if ( properties.feather > -1 ) // replace with: <=0 to allow feather
-    {
-        properties.feather = -1;
-        settings.setValue( "pencilFeather", properties.feather );
-    }
 }
+
+void PencilTool::setWidth(const qreal width)
+{
+    // Set current property
+    properties.width = width;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("pencilWidth", width);
+    settings.sync();
+}
+
+void PencilTool::setFeather( const qreal feather )
+{
+    // force value
+    properties.feather = -1;
+}
+
+void PencilTool::setInvisibility( const qreal invisibility )
+{
+    // force value
+    properties.invisibility = 1;
+}
+
+void PencilTool::setPressure( const bool pressure )
+{
+    // force value
+    properties.pressure = 1;
+}
+
+void PencilTool::setPreserveAlpha( const bool preserveAlpha )
+{
+    // force value
+    properties.preserveAlpha = 0;
+}
+
 
 QCursor PencilTool::cursor()
 {

--- a/core_lib/tool/penciltool.cpp
+++ b/core_lib/tool/penciltool.cpp
@@ -19,8 +19,13 @@ StrokeTool( parent )
 {
 }
 
+
 void PencilTool::loadSettings()
 {
+    m_enabledProperties[WIDTH] = true;
+
+
+
     QSettings settings( "Pencil", "Pencil" );
 
     properties.width = settings.value( "pencilWidth" ).toDouble();
@@ -31,7 +36,10 @@ void PencilTool::loadSettings()
 
     if ( properties.width <= 0 )
     {
-        properties.width = 3;
+        // setting the default value to 4
+        // seems to give great results with pressure on
+        //
+        properties.width = 4;
         settings.setValue( "pencilWidth", properties.width );
     }
 }

--- a/core_lib/tool/penciltool.cpp
+++ b/core_lib/tool/penciltool.cpp
@@ -23,25 +23,28 @@ StrokeTool( parent )
 void PencilTool::loadSettings()
 {
     m_enabledProperties[WIDTH] = true;
+    m_enabledProperties[PRESSURE] = true;
 
 
 
     QSettings settings( "Pencil", "Pencil" );
-
     properties.width = settings.value( "pencilWidth" ).toDouble();
     properties.feather = -1; //Feather isn't implemented in the Pencil tool;
-    properties.pressure = 1;
+    properties.pressure = settings.value( "pencilPressure" ).toBool();
     properties.invisibility = 1;
     properties.preserveAlpha = 0;
 
+    // First run
+    //
     if ( properties.width <= 0 )
     {
         // setting the default value to 4
         // seems to give great results with pressure on
         //
-        properties.width = 4;
-        settings.setValue( "pencilWidth", properties.width );
+        setWidth(4);
+        setPressure(1);
     }
+
 }
 
 void PencilTool::setWidth(const qreal width)
@@ -68,9 +71,14 @@ void PencilTool::setInvisibility( const qreal invisibility )
 }
 
 void PencilTool::setPressure( const bool pressure )
-{
-    // force value
-    properties.pressure = 1;
+{   
+    // Set current property
+    properties.pressure = pressure;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("pencilPressure", pressure);
+    settings.sync();
 }
 
 void PencilTool::setPreserveAlpha( const bool preserveAlpha )
@@ -185,8 +193,10 @@ void PencilTool::adjustPressureSensitiveProperties( qreal pressure, bool mouseDe
         currentPressuredColor.setAlphaF( currentColor.alphaF() / softness );
     }
 
+
     mCurrentWidth = properties.width;
-    if ( mScribbleArea->usePressure() && !mouseDevice )
+
+    if ( properties.pressure && !mouseDevice )
     {
         mCurrentPressure = pressure;
     }

--- a/core_lib/tool/penciltool.cpp
+++ b/core_lib/tool/penciltool.cpp
@@ -34,9 +34,9 @@ void PencilTool::loadSettings()
         properties.width = 2;
         settings.setValue( "pencilWidth", properties.width );
     }
-    if ( properties.feather <=0 ) // replace with: <=0 to allow feather
+    if ( properties.feather > -1 ) // replace with: <=0 to allow feather
     {
-        properties.feather = 15;
+        properties.feather = -1;
         settings.setValue( "pencilFeather", properties.feather );
     }
 }

--- a/core_lib/tool/penciltool.h
+++ b/core_lib/tool/penciltool.h
@@ -20,6 +20,12 @@ public:
 
     void adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice );
 
+    void setWidth( const qreal width );
+    void setFeather( const qreal feather );
+    void setInvisibility( const qreal invisibility );
+    void setPressure( const bool pressure );
+    void setPreserveAlpha( const bool preserveAlpha );
+
 private:
     QColor currentPressuredColor;
 };

--- a/core_lib/tool/pentool.cpp
+++ b/core_lib/tool/pentool.cpp
@@ -39,6 +39,28 @@ void PenTool::loadSettings()
     mCurrentWidth = properties.width;
 }
 
+void PenTool::setWidth(const qreal width)
+{
+    // Set current property
+    properties.width = width;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("penWidth", width);
+    settings.sync();
+}
+
+void PenTool::setFeather( const qreal feather )
+{
+    // Set current property
+    properties.feather = feather;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("penFeather", feather);
+    settings.sync();
+}
+
 QCursor PenTool::cursor()
 {
     if ( isAdjusting ) // being dynamically resized

--- a/core_lib/tool/pentool.cpp
+++ b/core_lib/tool/pentool.cpp
@@ -22,6 +22,11 @@ ToolType PenTool::type()
 
 void PenTool::loadSettings()
 {
+    m_enabledProperties[WIDTH] = true;
+    m_enabledProperties[FEATHER] = true;
+
+
+
     QSettings settings( "Pencil", "Pencil" );
 
     properties.width = settings.value( "penWidth" ).toDouble();

--- a/core_lib/tool/pentool.cpp
+++ b/core_lib/tool/pentool.cpp
@@ -23,22 +23,23 @@ ToolType PenTool::type()
 void PenTool::loadSettings()
 {
     m_enabledProperties[WIDTH] = true;
-    m_enabledProperties[FEATHER] = true;
+    m_enabledProperties[PRESSURE] = true;
 
 
 
     QSettings settings( "Pencil", "Pencil" );
 
     properties.width = settings.value( "penWidth" ).toDouble();
-	properties.feather = settings.value( "penFeather" ).toDouble();;
-    properties.pressure = ON;
+    properties.feather = 0;
+    properties.pressure = settings.value( "penPressure" ).toBool();
     properties.invisibility = OFF;
     properties.preserveAlpha = OFF;
 
+    // First run
     if ( properties.width <= 0 )
     {
-        properties.width = 1.5;
-        settings.setValue( "penWidth", properties.width );
+        setWidth(1.5);
+        setPressure(1);
     }
 
     mCurrentWidth = properties.width;
@@ -66,6 +67,17 @@ void PenTool::setFeather( const qreal feather )
     settings.sync();
 }
 
+void PenTool::setPressure( const bool pressure )
+{
+    // Set current property
+    properties.pressure = pressure;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("penPressure", pressure);
+    settings.sync();
+}
+
 QCursor PenTool::cursor()
 {
     if ( isAdjusting ) // being dynamically resized
@@ -81,7 +93,7 @@ QCursor PenTool::cursor()
 
 void PenTool::adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice )
 {
-    if ( mScribbleArea->usePressure() && !mouseDevice )
+    if ( properties.pressure && !mouseDevice )
     {
         mCurrentWidth = 2.0 * properties.width * pressure;
     }

--- a/core_lib/tool/pentool.h
+++ b/core_lib/tool/pentool.h
@@ -19,6 +19,9 @@ public:
     void drawStroke();
 
     void adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice );
+
+    void setWidth( const qreal width );
+    void setFeather( const qreal feather );
 };
 
 #endif // PENTOOL_H

--- a/core_lib/tool/pentool.h
+++ b/core_lib/tool/pentool.h
@@ -22,6 +22,7 @@ public:
 
     void setWidth( const qreal width );
     void setFeather( const qreal feather );
+    void setPressure( const bool pressure );
 };
 
 #endif // PENTOOL_H

--- a/core_lib/tool/polylinetool.cpp
+++ b/core_lib/tool/polylinetool.cpp
@@ -30,14 +30,14 @@ void PolylineTool::loadSettings()
 
     properties.width = settings.value( "polyLineWidth" ).toDouble();
     properties.feather = -1;
-    properties.pressure = ON;
+    properties.pressure = 0;
     properties.invisibility = OFF;
     properties.preserveAlpha = OFF;
 
+    // First run
     if ( properties.width <= 0 )
     {
-        properties.width = 1.5;
-        settings.setValue( "polyLineWidth", properties.width );
+        setWidth(1.5);
     }
 }
 

--- a/core_lib/tool/polylinetool.cpp
+++ b/core_lib/tool/polylinetool.cpp
@@ -22,6 +22,10 @@ ToolType PolylineTool::type()
 
 void PolylineTool::loadSettings()
 {
+    m_enabledProperties[WIDTH] = true;
+
+
+
     QSettings settings( "Pencil", "Pencil" );
 
     properties.width = settings.value( "polyLineWidth" ).toDouble();

--- a/core_lib/tool/polylinetool.cpp
+++ b/core_lib/tool/polylinetool.cpp
@@ -37,6 +37,22 @@ void PolylineTool::loadSettings()
     }
 }
 
+void PolylineTool::setWidth(const qreal width)
+{
+    // Set current property
+    properties.width = width;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("polyLineWidth", width);
+    settings.sync();
+}
+
+void PolylineTool::setFeather( const qreal feather )
+{
+    properties.feather = -1;
+}
+
 QCursor PolylineTool::cursor() //Not working this one, any guru to fix it?
 {
     if ( isAdjusting ) { // being dynamically resized

--- a/core_lib/tool/polylinetool.h
+++ b/core_lib/tool/polylinetool.h
@@ -22,6 +22,9 @@ public:
 
     void clear();
 
+    void setWidth( const qreal width );
+    void setFeather( const qreal feather );
+
 private:
     QList<QPointF> points;
 };

--- a/core_lib/tool/smudgetool.cpp
+++ b/core_lib/tool/smudgetool.cpp
@@ -25,22 +25,20 @@ ToolType SmudgeTool::type()
 void SmudgeTool::loadSettings()
 {
     m_enabledProperties[WIDTH] = true;
-
+    m_enabledProperties[FEATHER] = true;
 
 
     QSettings settings("Pencil", "Pencil");
     properties.width = settings.value("smudgeWidth").toDouble();
     properties.feather = settings.value("smudgeFeather").toDouble();
+    properties.pressure = 0;
 
+    // First run
     if (properties.width <= 0)
     {
-        properties.width = 25;
-        settings.setValue("smudgeWidth", properties.width);
-    }
-    if (properties.feather <= 0)
-    {
-        properties.feather = 200;
-        settings.setValue("smudgeFeather", properties.feather);
+        setWidth(25);
+        setFeather(200);
+        setPressure(0);
     }
 }
 
@@ -66,6 +64,17 @@ void SmudgeTool::setFeather( const qreal feather )
     settings.sync();
 }
 
+void SmudgeTool::setPressure( const bool pressure )
+{
+    // Set current property
+    properties.pressure = pressure;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("smudgePressure", pressure);
+    settings.sync();
+}
+
 QCursor SmudgeTool::cursor()
 {
     qDebug() << "smudge tool";
@@ -83,7 +92,7 @@ QCursor SmudgeTool::cursor()
 void SmudgeTool::adjustPressureSensitiveProperties(qreal pressure, bool mouseDevice)
 {
     mCurrentWidth = properties.width;
-    if (mScribbleArea->usePressure() && !mouseDevice)
+    if (properties.pressure && !mouseDevice)
     {
         mCurrentPressure = pressure;
     }

--- a/core_lib/tool/smudgetool.cpp
+++ b/core_lib/tool/smudgetool.cpp
@@ -24,6 +24,10 @@ ToolType SmudgeTool::type()
 
 void SmudgeTool::loadSettings()
 {
+    m_enabledProperties[WIDTH] = true;
+
+
+
     QSettings settings("Pencil", "Pencil");
     properties.width = settings.value("smudgeWidth").toDouble();
     properties.feather = settings.value("smudgeFeather").toDouble();

--- a/core_lib/tool/smudgetool.cpp
+++ b/core_lib/tool/smudgetool.cpp
@@ -40,6 +40,28 @@ void SmudgeTool::loadSettings()
     }
 }
 
+void SmudgeTool::setWidth(const qreal width)
+{
+    // Set current property
+    properties.width = width;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("smudgeWidth", width);
+    settings.sync();
+}
+
+void SmudgeTool::setFeather( const qreal feather )
+{
+    // Set current property
+    properties.feather = feather;
+
+    // Update settings
+    QSettings settings( "Pencil", "Pencil" );
+    settings.setValue("smudgeFeather", feather);
+    settings.sync();
+}
+
 QCursor SmudgeTool::cursor()
 {
     qDebug() << "smudge tool";

--- a/core_lib/tool/smudgetool.h
+++ b/core_lib/tool/smudgetool.h
@@ -22,6 +22,9 @@ public:
     void adjustPressureSensitiveProperties(qreal pressure, bool mouseDevice);
     void drawStroke();
 
+    void setWidth( const qreal width );
+    void setFeather( const qreal feather );
+
 signals:
     
 public slots:

--- a/core_lib/tool/smudgetool.h
+++ b/core_lib/tool/smudgetool.h
@@ -24,6 +24,7 @@ public:
 
     void setWidth( const qreal width );
     void setFeather( const qreal feather );
+    void setPressure( const bool pressure );
 
 signals:
     


### PR DESCRIPTION
When working on a tablet, erasing with the back of the stylus worked but the current selected tool wasn't restored when using the point of the stylus again. It is fixed with this commit.

I also fixed the fact that when selecting a new tool, its settings where not updated correctly.

Finally, I made the pencil tool feel more like a real pencil.

Updates : I also fixed most of the tools options and made their controls appear or disappear depending on the option's availability for the selected tool. The non working options never appear.

Most of the bitmap brush engine is fixed in this version and is very usable! Only the polyline tool is not working completely as expected.

Thanks!