### PR TITLE
Weekly updates

### DIFF
--- a/app/colorbox.cpp
+++ b/app/colorbox.cpp
@@ -5,7 +5,7 @@
 
 ColorBox::ColorBox( const QString& strTitle, QWidget* parent ) : BaseDockWidget( strTitle, parent )
 {
-    QVBoxLayout* layout = new QVBoxLayout(this);
+    QVBoxLayout* layout = new QVBoxLayout();
 
     m_colorWheel = new ColorWheel(this);
     m_colorInspector = new ColorInspector(this);

--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -68,10 +68,24 @@ MainWindow2::MainWindow2( QWidget *parent ) : QMainWindow( parent )
     ui = new Ui::MainWindow2;
     ui->setupUi( this );
 
-    // Central widget
-    mScribbleArea = new ScribbleArea( this );
+    mBackground = new BackgroundWidget( this );
+
+    mScribbleArea = new ScribbleArea( mBackground );
     mScribbleArea->setFocusPolicy( Qt::StrongFocus );
-    //setCentralWidget( mScribbleArea );
+
+    // Show the UI over the background
+    //
+    QVBoxLayout* layout = new QVBoxLayout();
+    layout->setSpacing(0);
+    layout->setMargin(0);
+    layout->setContentsMargins(0,0,0,0);
+    layout->addWidget(mScribbleArea);
+
+    mBackground->setLayout(layout);
+
+    // Central widget
+    setCentralWidget(mBackground);
+
 
     Object* object = new Object();
     object->init();
@@ -83,14 +97,13 @@ MainWindow2::MainWindow2( QWidget *parent ) : QMainWindow( parent )
     mScribbleArea->setCore( mEditor );
     mScribbleArea->init();
 
-    //loadBackground();
 
     mEditor->setScribbleArea( mScribbleArea );
     makeConnections( mEditor, mScribbleArea );
 
     mCommands = new CommandCenter( this );
     mCommands->setCore( mEditor );
-    
+
     createDockWidgets();
     createMenus();
     setupKeyboardShortcuts();
@@ -107,21 +120,7 @@ MainWindow2::MainWindow2( QWidget *parent ) : QMainWindow( parent )
     mEditor->setCurrentLayer( mEditor->object()->getLayerCount() - 1 );
     mEditor->tools()->setDefaultTool();
 
-
-    // Show the UI over the background
-    //
-    mBackground = new BackgroundWidget();
     mBackground->init(mEditor->preference());
-
-    QVBoxLayout* layout = new QVBoxLayout();
-    layout->setSpacing(0);
-    layout->setMargin(0);
-    layout->setContentsMargins(0,0,0,0);
-    layout->addWidget(mScribbleArea);
-
-    mBackground->setLayout(layout);
-
-    setCentralWidget(mBackground);
 }
 
 MainWindow2::~MainWindow2()
@@ -152,7 +151,7 @@ void MainWindow2::createDockWidgets()
     mToolBox = new ToolBoxWidget( tr( "Tools", "Window title of tool box." ), this );
     mToolBox->setObjectName( "ToolBox" );
 
-    mDockWidgets 
+    mDockWidgets
         << mTimeLine
         << mColorWheel
         << mColorPalette

--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -493,6 +493,9 @@ bool MainWindow2::openObject( QString strFilePath )
     // Refresh the Palette
     mColorPalette->refreshColorList();
 
+    // Reset view
+    mEditor->view()->resetView();
+
     progress.setValue( 100 );
     return true;
 }

--- a/core_lib/canvasrenderer.cpp
+++ b/core_lib/canvasrenderer.cpp
@@ -261,7 +261,7 @@ void CanvasRenderer::paintVectorFrame( QPainter& painter, Layer* layer, int nFra
                                     false);
     }
 
-    painter.setWorldMatrixEnabled( false );
+    painter.setWorldMatrixEnabled( false ); //Don't tranform the image here as we used the viewTransform in the image output
     tempBitmapImage->paintImage( painter );
 
     delete tempBitmapImage;

--- a/core_lib/canvasrenderer.cpp
+++ b/core_lib/canvasrenderer.cpp
@@ -269,25 +269,34 @@ void CanvasRenderer::paintVectorFrame( QPainter& painter, Layer* layer, int nFra
 
 void CanvasRenderer::paintCurrentFrame( QPainter& painter )
 {
-    painter.setOpacity( 0.8 );
+    if (mOptions.nShowAllLayers > 0) {
 
-    for ( int i = 0; i < mObject->getLayerCount(); ++i )
-    {
-        Layer* layer = mObject->getLayer( i );
-        if ( i == mLayerIndex )
-        {
-            continue; // current layer should be paint at last.
+        if (mOptions.nShowAllLayers == 1) {
+            painter.setOpacity( 0.8 );
+        }
+        else {
+            painter.setOpacity( 1.0 );
         }
 
-        switch ( layer->type() )
+        for ( int i = 0; i < mObject->getLayerCount(); ++i )
         {
-            case Layer::BITMAP: { paintBitmapFrame( painter, layer, mFrameNumber ); break; }
-            case Layer::VECTOR: { paintVectorFrame( painter, layer, mFrameNumber ); break; }
-            case Layer::CAMERA: break;
-            case Layer::SOUND: break;
-            default: Q_ASSERT( false ); break;
+            Layer* layer = mObject->getLayer( i );
+            if ( i == mLayerIndex )
+            {
+                continue; // current layer should be paint at last.
+            }
+
+            switch ( layer->type() )
+            {
+                case Layer::BITMAP: { paintBitmapFrame( painter, layer, mFrameNumber ); break; }
+                case Layer::VECTOR: { paintVectorFrame( painter, layer, mFrameNumber ); break; }
+                case Layer::CAMERA: break;
+                case Layer::SOUND: break;
+                default: Q_ASSERT( false ); break;
+            }
         }
     }
+
 
     painter.setOpacity( 1.0 );
 

--- a/core_lib/canvasrenderer.cpp
+++ b/core_lib/canvasrenderer.cpp
@@ -329,7 +329,7 @@ void CanvasRenderer::paintGrid( QPainter& painter )
 {
     const int gridSize = 30;
 
-    QRectF boundingRect = painter.window();
+    QRectF boundingRect = mCanvas->rect();
 
     int w = boundingRect.width();
     int h = boundingRect.height();
@@ -342,9 +342,10 @@ void CanvasRenderer::paintGrid( QPainter& painter )
     int bottom = round100( boundingRect.bottom(), gridSize ) + gridSize;
 
     QPen pen( Qt::lightGray );
+    pen.setWidth(0); // 0 will draw a 1px line always independent from the transformation
     pen.setCosmetic( true );
     painter.setPen( pen );
-    painter.setWorldMatrixEnabled( true );
+    painter.setWorldMatrixEnabled( false );
     painter.setBrush( Qt::NoBrush );
 
     for ( int x = left; x < right; x += gridSize )

--- a/core_lib/canvasrenderer.cpp
+++ b/core_lib/canvasrenderer.cpp
@@ -107,7 +107,7 @@ void CanvasRenderer::paintOnionSkin( QPainter& painter )
     {
         qreal prevOpacityIncrement = (maxOpacity - minOpacity) / mOptions.nPrevOnionSkinCount;
 
-        int onionPosition = mOptions.nPrevOnionSkinCount - mFrameNumber + iStartFrame - 1;
+        int onionPosition = mOptions.nPrevOnionSkinCount - mFrameNumber + iStartFrame;
 
         qreal opacity = minOpacity + (prevOpacityIncrement * onionPosition);
 

--- a/core_lib/canvasrenderer.h
+++ b/core_lib/canvasrenderer.h
@@ -61,6 +61,8 @@ public:
     void setViewTransform( QTransform viewTransform );
     void setOptions( RenderOptions p ) { mOptions = p; }
     void setBackgroundBrush(QBrush brush);
+    void setTransformedSelection( QRect selection, QTransform transform );
+    void ignoreTransformedSelection();
 
     void paint( Object* object, int layer, int frame, QRect rect );
 
@@ -71,6 +73,8 @@ private:
 
     void paintBitmapFrame( QPainter&, Layer* layer, int nFrame, bool colorize = false , bool useLastKeyFrame = true );
     void paintVectorFrame(QPainter&, Layer* layer, int nFrame, bool colorize = false , bool useLastKeyFrame = true );
+
+    void paintTransformedSelection( QPainter& painter );
 
     void paintAxis( QPainter& painter );
     void paintGrid( QPainter& painter );
@@ -86,6 +90,12 @@ private:
     bool bMultiLayerOnionSkin = false;
     
     RenderOptions mOptions;
+
+    // Handle selection transformation
+    //
+    bool mRenderTransform = false;
+    QRect mSelection;
+    QTransform mSelectionTransform;
 
     QLoggingCategory mLog;
 };

--- a/core_lib/canvasrenderer.h
+++ b/core_lib/canvasrenderer.h
@@ -45,6 +45,7 @@ struct RenderOptions
     bool  bAxis = false;
     bool  bThinLines = false;
     bool  bOutlines = false;
+    int   nShowAllLayers = 3;
 };
 
 

--- a/core_lib/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/graphics/bitmap/bitmapimage.cpp
@@ -345,7 +345,24 @@ void BitmapImage::transform(QRect newBoundaries, bool smoothTransform)
         painter.end();
         //if (image != NULL) delete image;
         mImage = newImage;
-    //}
+        //}
+}
+
+BitmapImage BitmapImage::transformed(QRect selection, QTransform transform, bool smoothTransform)
+{
+    BitmapImage selectedPart = copy(selection);
+
+    // Get the transformed image
+    //
+    QImage transformedImage;
+    if (smoothTransform) {
+        transformedImage = selectedPart.image()->transformed(transform, Qt::SmoothTransformation);
+    }
+    else {
+        transformedImage = selectedPart.image()->transformed(transform);
+    }
+
+    return BitmapImage(transform.mapRect(selection), transformedImage);
 }
 
 BitmapImage BitmapImage::transformed(QRect newBoundaries, bool smoothTransform)

--- a/core_lib/graphics/bitmap/bitmapimage.h
+++ b/core_lib/graphics/bitmap/bitmapimage.h
@@ -59,6 +59,7 @@ public:
     void moveTopLeft( QPointF point ) { moveTopLeft( point.toPoint() ); }
     void transform( QRect rectangle, bool smoothTransform );
     void transform( QRectF rectangle, bool smoothTransform )  { transform( rectangle.toRect(), smoothTransform ); }
+    BitmapImage transformed( QRect selection, QTransform transform, bool smoothTransform );
     BitmapImage transformed( QRect rectangle, bool smoothTransform );
     BitmapImage transformed( QRectF rectangle, bool smoothTransform ) { return transformed( rectangle.toRect(), smoothTransform ); }
 

--- a/core_lib/graphics/vector/beziercurve.cpp
+++ b/core_lib/graphics/vector/beziercurve.cpp
@@ -466,7 +466,7 @@ QPainterPath BezierCurve::getSimplePath()
 
 QPainterPath BezierCurve::getStrokedPath()
 {
-    return getStrokedPath( 2.0 * width );
+    return getStrokedPath( width );
 }
 
 QPainterPath BezierCurve::getStrokedPath(qreal width)
@@ -483,7 +483,7 @@ QPainterPath BezierCurve::getStrokedPath(qreal width, bool usePressure)
     int n = vertex.size();
     normalVec = QPointF(-(c1.at(0) - origin).y(), (c1.at(0) - origin).x());
     normalise(normalVec);
-    if (usePressure) width2 = width * 0.5 * pressure.at(0);
+    if (usePressure) width2 = width * pressure.at(0);
     if (n==1 && width2 == 0.0)  width2 = 0.15 * width;
     path.moveTo(origin + width2*normalVec);
     for(int i=0; i<n; i++)

--- a/core_lib/graphics/vector/vectorimage.cpp
+++ b/core_lib/graphics/vector/vectorimage.cpp
@@ -808,9 +808,14 @@ void VectorImage::paste(VectorImage vectorImage)
     selectionRect = QRect(0,0,0,0);
     int n = m_curves.size();
     QList<int> selectedCurves;
+
+    bool hasSelection = getFirstSelectedCurve() < -1;
+
     for(int i=0; i < vectorImage.m_curves.size() ; i++)
     {
-        if ( vectorImage.m_curves.at(i).isSelected() )
+        // If nothing is selected, paste everything
+        //
+        if ( !hasSelection || vectorImage.m_curves.at(i).isSelected() )
         {
             m_curves.append( vectorImage.m_curves.at(i) );
             selectedCurves << i;
@@ -825,7 +830,10 @@ void VectorImage::paste(VectorImage vectorImage)
         {
             int curveNumber = newArea.vertex.at(j).curveNumber;
             int vertexNumber = newArea.vertex.at(j).vertexNumber;
-            if ( vectorImage.m_curves.at(curveNumber).isSelected() )
+
+            // If nothing is selected, paste everything
+            //
+            if ( !hasSelection || vectorImage.m_curves.at(curveNumber).isSelected() )
             {
                 newArea.vertex[j] = VertexRef( selectedCurves.indexOf(curveNumber) + n, vertexNumber );
             }

--- a/core_lib/interface/backgroundwidget.cpp
+++ b/core_lib/interface/backgroundwidget.cpp
@@ -21,6 +21,15 @@ GNU General Public License for more details.
 
 BackgroundWidget::BackgroundWidget(QWidget *parent) : QWidget(parent)
 {
+    setObjectName( "BackgroundWidget" );
+
+    // Qt::WA_StaticContents ensure that the widget contents are rooted to the top-left corner
+    // and don't change when the widget is resized.
+    setAttribute( Qt::WA_StaticContents );
+}
+
+BackgroundWidget::~BackgroundWidget()
+{
 
 }
 
@@ -28,6 +37,10 @@ void BackgroundWidget::init(PreferenceManager *prefs)
 {
     mPrefs = prefs;
     connect(mPrefs, &PreferenceManager::optionChanged, this, &BackgroundWidget::settingUpdated);
+
+    loadBackgroundStyle();
+    mHasShadow = mPrefs->isOn(SETTING::SHADOW);
+
     update();
 }
 
@@ -36,11 +49,17 @@ void BackgroundWidget::settingUpdated(SETTING setting)
     switch ( setting )
     {
     case SETTING::BACKGROUND_STYLE:
+
+        loadBackgroundStyle();
         update();
         break;
+
     case SETTING::SHADOW:
+
+        mHasShadow = mPrefs->isOn(SETTING::SHADOW);
         update();
         break;
+
     default:
         break;
     }
@@ -48,53 +67,47 @@ void BackgroundWidget::settingUpdated(SETTING setting)
 
 void BackgroundWidget::paintEvent(QPaintEvent *)
 {
-    bool hasShadow = mPrefs->isOn(SETTING::SHADOW);
-
-    QString sStyle = getBackgroundStyle();
-
-    setStyleSheet(sStyle);
-
     QStyleOption opt;
     opt.init(this);
     QPainter painter(this);
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &painter, this);
 
-    if (hasShadow) {
+    if (mHasShadow) {
         drawShadow(painter);
     }
 }
 
-QString BackgroundWidget::getBackgroundStyle()
+void BackgroundWidget::loadBackgroundStyle()
 {
     QString bgName = mPrefs->getString(SETTING::BACKGROUND_STYLE);
-    QString style = "background-color:white; border: 1px solid lightGrey;";
+    mStyle = "background-color:white; border: 1px solid lightGrey;";
 
     if ( bgName == "white" )
     {
-        style = "background-color:white; border: 1px solid lightGrey;";
+        mStyle = "background-color:white; border: 1px solid lightGrey;";
     }
     else if ( bgName == "grey" )
     {
-        style = "background-color:lightGrey; border: 1px solid grey;";
+        mStyle = "background-color:lightGrey; border: 1px solid grey;";
     }
     else if ( bgName == "checkerboard" )
     {
-        style = "background-image: url(:background/checkerboard.png); background-repeat: repeat-xy; border: 1px solid lightGrey;";
+        mStyle = "background-image: url(:background/checkerboard.png); background-repeat: repeat-xy; border: 1px solid lightGrey;";
     }
     else if ( bgName == "dots" )
     {
-        style = "background-image: url(:background/dots.png); background-repeat: repeat-xy; border: 1px solid lightGrey;";
+        mStyle = "background-image: url(:background/dots.png); background-repeat: repeat-xy; border: 1px solid lightGrey;";
     }
     else if ( bgName == "weave" )
     {
-        style = "background-image: url(:background/weave.jpg); background-repeat: repeat-xy; border: 1px solid lightGrey;";
+        mStyle = "background-image: url(:background/weave.jpg); background-repeat: repeat-xy; border: 1px solid lightGrey;";
     }
     else if ( bgName == "grid" )
     {
-        style = "background-image: url(:background/grid.jpg); background-repeat: repeat-xy; border: 1px solid lightGrey;";
+        mStyle = "background-image: url(:background/grid.jpg); background-repeat: repeat-xy; border: 1px solid lightGrey;";
     }
 
-    return style;
+    setStyleSheet(mStyle);
 }
 
 void BackgroundWidget::drawShadow( QPainter& painter )

--- a/core_lib/interface/backgroundwidget.h
+++ b/core_lib/interface/backgroundwidget.h
@@ -25,7 +25,8 @@ class BackgroundWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit BackgroundWidget(QWidget *parent = 0);
+    BackgroundWidget( QWidget *parent );
+    ~BackgroundWidget();
 
     void init(PreferenceManager* prefs);
 
@@ -45,9 +46,12 @@ private slots:
 private:
 
     void drawShadow(QPainter &painter);
-    QString getBackgroundStyle();
+    void loadBackgroundStyle();
 
-    PreferenceManager* mPrefs;
+    PreferenceManager* mPrefs = nullptr;
+
+    QString mStyle;
+    bool mHasShadow = false;
 
 };
 

--- a/core_lib/interface/editor.cpp
+++ b/core_lib/interface/editor.cpp
@@ -861,23 +861,20 @@ void Editor::duplicateKey()
 	Layer* layer = mObject->getLayer( layers()->currentLayerIndex() );
 	if ( layer != NULL )
 	{
-		if ( layer->type() == Layer::VECTOR )
+        if ( layer->type() == Layer::VECTOR || layer->type() == Layer::BITMAP )
 		{
-			mScribbleArea->selectAll();
-			clipboardVectorOk = true;
-			g_clipboardVectorImage = *( ( (LayerVector*)layer )->getLastVectorImageAtFrame( currentFrame(), 0 ) );  // copy the image (that works but I should also provide a copy() method)
-			addNewKey();
-			VectorImage* vectorImage = ( (LayerVector*)layer )->getLastVectorImageAtFrame( currentFrame(), 0 );
-			vectorImage->paste( g_clipboardVectorImage ); // paste the clipboard
-			mScribbleArea->setModified( layers()->currentLayerIndex(), currentFrame() );
-			mScribbleArea->update();
-		}
-		if ( layer->type() == Layer::BITMAP )
-		{
-			mScribbleArea->selectAll();
-			copy();
-			addNewKey();
-			paste();
+            // Will copy the selection if any or the entire image if there is none
+            //
+            if(!mScribbleArea->somethingSelected) {
+                mScribbleArea->selectAll();
+            }
+
+            copy();
+            addNewKey();
+            paste();
+
+            mScribbleArea->setModified( layers()->currentLayerIndex(), currentFrame() );
+            mScribbleArea->update();
 		}
 	}
 }

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -131,6 +131,9 @@ void ScribbleArea::settingUpdated(SETTING setting)
     case SETTING::ONION_MAX_OPACITY:
         updateAllFrames();
         break;
+    case SETTING::GRID:
+        updateAllFrames();
+        break;
     default:
         break;
     }

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -349,6 +349,9 @@ void ScribbleArea::keyPressEvent( QKeyEvent *event )
         case Qt::Key_Space:
             setTemporaryTool( HAND ); // just call "setTemporaryTool()" to activate temporarily any tool
             break;
+        case Qt::Key_Alt:
+            setTemporaryTool( EYEDROPPER ); // just call "setTemporaryTool()" to activate temporarily any tool
+            break;
         default:
             event->ignore();
     }

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -75,6 +75,7 @@ bool ScribbleArea::init()
     mShowAllLayers = 1;
 
     mBufferImg = new BitmapImage;
+//    mBitmapSelection = new BitmapImage;
 
     QRect newSelection( QPoint( 0, 0 ), QSize( 0, 0 ) );
     mySelection = newSelection;
@@ -1241,16 +1242,29 @@ void ScribbleArea::calculateSelectionTransformation() // Vector layer transform
     c1y = 0.5 * ( myTempTransformedSelection.top() + myTempTransformedSelection.bottom() );
     c2x = 0.5 * ( mySelection.left() + mySelection.right() );
     c2y = 0.5 * ( mySelection.top() + mySelection.bottom() );
-    if ( mySelection.width() == 0 ) { scaleX = 1.0; }
-    else { scaleX = myTempTransformedSelection.width() / mySelection.width(); }
-    if ( mySelection.height() == 0 ) { scaleY = 1.0; }
-    else { scaleY = myTempTransformedSelection.height() / mySelection.height(); }
+
+    if ( mySelection.width() == 0 ) {
+        scaleX = 1.0;
+    }
+    else {
+        scaleX = myTempTransformedSelection.width() / mySelection.width();
+    }
+
+    if ( mySelection.height() == 0 ) {
+        scaleY = 1.0;
+    }
+    else {
+        scaleY = myTempTransformedSelection.height() / mySelection.height();
+    }
+
     selectionTransformation.reset();
     selectionTransformation.translate( c1x, c1y );
     selectionTransformation.scale( scaleX, scaleY );
     selectionTransformation.translate( -c2x, -c2y );
+
     //modification();
 }
+
 
 void ScribbleArea::paintTransformedSelection()
 {
@@ -1262,42 +1276,86 @@ void ScribbleArea::paintTransformedSelection()
 
     if ( somethingSelected )    // there is something selected
     {
-        if ( layer->type() == Layer::BITMAP && ( myRotatedAngle != 0.0 || myTransformedSelection != mySelection || myFlipX != 1 || myFlipY != 1 ) )
+        if ( layer->type() == Layer::BITMAP )
         {
-            //backup();
-            BitmapImage *bitmapImage = ( ( LayerBitmap * )layer )->getLastBitmapImageAtFrame( mEditor->currentFrame(), 0 );
-            if ( bitmapImage == NULL )
-            {
-                qDebug() << "NULL image pointer!"
-                    << mEditor->layers()->currentLayerIndex()
-                    << mEditor->currentFrame();
-                return;
-            }
-
-            bool smoothTransform = false;
-            if ( myTransformedSelection.width() != mySelection.width() || myTransformedSelection.height() != mySelection.height() || mMoveMode == ROTATION ) { smoothTransform = true; }
-            QTransform rm;
-            rm.scale( myFlipX, myFlipY );
-            rm.rotate( myRotatedAngle );
-            BitmapImage selectionClip = bitmapImage->copy( mySelection.toRect() );
-            selectionClip.transform( myTransformedSelection, smoothTransform );
-            QImage* rotImg = new QImage( selectionClip.image()->transformed( rm, Qt::SmoothTransformation ) );
-            QPoint dxy = QPoint( ( myTempTransformedSelection.width() - rotImg->rect().width() ) / 2,
-                                 ( myTempTransformedSelection.height() - rotImg->rect().height() ) / 2 );
-            selectionClip.setImage( rotImg ); // TODO: find/create a func. (*object = data is not very orthodox)
-            selectionClip.bounds().translate( dxy );
-            bitmapImage->clear( mySelection.toRect() );
-            bitmapImage->paste( &selectionClip );
+            mCanvasRenderer.setTransformedSelection(mySelection.toRect(), selectionTransformation);
         }
         else if ( layer->type() == Layer::VECTOR )
         {
             // vector transformation
             LayerVector *layerVector = ( LayerVector * )layer;
             VectorImage *vectorImage = layerVector->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 );
-            vectorImage->applySelectionTransformation();
-            selectionTransformation.reset();
+            vectorImage->setSelectionTransformation( selectionTransformation );
+
         }
         setModified( mEditor->layers()->currentLayerIndex(), mEditor->currentFrame() );
+    }
+}
+
+void ScribbleArea::applyTransformedSelection()
+{
+    mCanvasRenderer.ignoreTransformedSelection();
+
+    Layer* layer = mEditor->layers()->currentLayer();
+    if ( layer == NULL )
+    {
+        return;
+    }
+
+    if ( somethingSelected )    // there is something selected
+    {
+        if ( layer->type() == Layer::BITMAP )
+        {
+            BitmapImage* bitmapImage = dynamic_cast< LayerBitmap* >( layer )->getLastBitmapImageAtFrame( mEditor->currentFrame(), 0 );
+
+            BitmapImage* transformedImage = new BitmapImage(bitmapImage->transformed(mySelection.toRect(), selectionTransformation, mPrefs->isOn(SETTING::ANTIALIAS)));
+
+            bitmapImage->clear(mySelection);
+            bitmapImage->paste(transformedImage, QPainter::CompositionMode_SourceOver);
+
+            delete transformedImage;
+        }
+        else if ( layer->type() == Layer::VECTOR )
+        {
+
+            VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+            vectorImage->applySelectionTransformation();
+
+        }
+
+        setModified( mEditor->layers()->currentLayerIndex(), mEditor->currentFrame() );
+        deselectAll();
+    }
+
+    updateCurrentFrame();
+}
+
+void ScribbleArea::cancelTransformedSelection()
+{
+    mCanvasRenderer.ignoreTransformedSelection();
+
+    if (somethingSelected) {
+
+        Layer* layer = mEditor->layers()->currentLayer();
+        if ( layer == NULL )
+        {
+            return;
+        }
+
+        if ( layer->type() == Layer::VECTOR ) {
+
+            VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+            vectorImage->setSelectionTransformation( QTransform() );
+        }
+
+        setSelection( mySelection, true );
+
+        selectionTransformation.reset();
+
+        mOffset.setX( 0 );
+        mOffset.setY( 0 );
+
+        updateCurrentFrame();
     }
 }
 
@@ -1387,7 +1445,11 @@ void ScribbleArea::deselectAll()
         ( ( LayerVector * )layer )->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 )->deselectAll();
     }
     somethingSelected = false;
+    isTransforming = false;
+
     mBufferImg->clear();
+
+    //mBitmapSelection.clear();
     vectorSelection.clear();
 
     // clear all the data tools may have accumulated

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1350,7 +1350,16 @@ void ScribbleArea::selectAll()
 
     if ( layer->type() == Layer::BITMAP )
     {
-        setSelection( mEditor->view()->mapScreenToCanvas( QRectF( -2, -2, width() + 3, height() + 3 ) ), true ); // TO BE IMPROVED
+        // Only selects the entire screen erea
+        //setSelection( mEditor->view()->mapScreenToCanvas( QRectF( -2, -2, width() + 3, height() + 3 ) ), true ); // TO BE IMPROVED
+
+        // Selects the drawn area (bigger or smaller than the screen). It may be more accurate to select all this way
+        // as the drawing area is not limited
+        //
+        BitmapImage *bitmapImage = ( ( LayerBitmap * )layer )->getLastBitmapImageAtFrame( mEditor->currentFrame(), 0 );
+        setSelection(bitmapImage->bounds(), true);
+
+
     }
     else if ( layer->type() == Layer::VECTOR )
     {

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -721,7 +721,7 @@ void ScribbleArea::paintEvent( QPaintEvent* event )
 {
     //qCDebug( mLog ) << "Paint event!" << QDateTime::currentDateTime() << event->rect();
 
-    if ( !mMouseInUse )
+    if ( !mMouseInUse || currentTool()->type() == MOVE || currentTool()->type() == HAND )
     {
         // --- we retrieve the canvas from the cache; we create it if it doesn't exist
         int curIndex = mEditor->currentFrame();
@@ -825,8 +825,9 @@ void ScribbleArea::paintEvent( QPaintEvent* event )
                 {
                     // ----- paints the closest curves
                     mBufferImg->clear();
-                    QPen pen2( Qt::black, 0.5, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin );
-                    QColor colour = QColor( 100, 100, 255 );
+                    QColor colour = QColor( 100, 100, 255, 50 );
+                    QPen pen2( colour, 3, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin );
+
 
                     for ( int k = 0; k < mClosestCurves.size(); k++ )
                     {

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -954,6 +954,7 @@ void ScribbleArea::drawCanvas( int frame, QRect rect )
     options.bAxis = mPrefs->isOn( SETTING::AXIS );
     options.bThinLines = mPrefs->isOn( SETTING::INVISIBLE_LINES );
     options.bOutlines = mPrefs->isOn( SETTING::OUTLINES );
+    options.nShowAllLayers = mShowAllLayers;
 
     mCanvasRenderer.setOptions( options );
 

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -349,9 +349,6 @@ void ScribbleArea::keyPressEvent( QKeyEvent *event )
         case Qt::Key_Space:
             setTemporaryTool( HAND ); // just call "setTemporaryTool()" to activate temporarily any tool
             break;
-        case Qt::Key_Alt:
-            setTemporaryTool( EYEDROPPER ); // just call "setTemporaryTool()" to activate temporarily any tool
-            break;
         default:
             event->ignore();
     }

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1259,6 +1259,7 @@ void ScribbleArea::calculateSelectionTransformation() // Vector layer transform
 
     selectionTransformation.reset();
     selectionTransformation.translate( c1x, c1y );
+    selectionTransformation.rotate(myRotatedAngle);
     selectionTransformation.scale( scaleX, scaleY );
     selectionTransformation.translate( -c2x, -c2y );
 

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -121,9 +121,11 @@ signals:
 public slots:
     void clearImage();
     void calculateSelectionRect();
-    QTransform getSelectionTransformation() { return selectionTransformation; };
+    QTransform getSelectionTransformation() { return selectionTransformation; }
     void calculateSelectionTransformation();
     void paintTransformedSelection();
+    void applyTransformedSelection();
+    void cancelTransformedSelection();
     void setModified( int layerNumber, int frameNumber );
 
     void selectAll();
@@ -194,6 +196,9 @@ private:
     MoveMode mMoveMode = MIDDLE;
     ToolType mPrevTemporalToolType;
     ToolType mPrevToolType = PEN; // previous tool (except temporal)
+
+    BitmapImage mBitmapSelection; // used to temporary store a transformed portion of a bitmap image
+    bool isTransforming = false;
 
     StrokeManager* mStrokeManager = nullptr;
 

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -121,6 +121,7 @@ signals:
 public slots:
     void clearImage();
     void calculateSelectionRect();
+    QTransform getSelectionTransformation() { return selectionTransformation; };
     void calculateSelectionTransformation();
     void paintTransformedSelection();
     void setModified( int layerNumber, int frameNumber );

--- a/core_lib/managers/viewmanager.cpp
+++ b/core_lib/managers/viewmanager.cpp
@@ -128,6 +128,8 @@ void ViewManager::setCanvasSize( QSize size )
 
 void ViewManager::resetView()
 {
-    mView = QTransform();
+    mRotate = 0.f;
+    mScale = 1.f;
+    translate(0, 0);
     Q_EMIT viewChanged();
 }

--- a/core_lib/structure/object.cpp
+++ b/core_lib/structure/object.cpp
@@ -119,6 +119,13 @@ bool Object::loadXML( QDomElement docElem, QString dataDirPath )
     return someRelevantData;
 }
 
+void Object::loadMissingData()
+{
+    if (mEditorData == nullptr) {
+        setEditorData(new EditorData());
+    }
+}
+
 LayerBitmap* Object::addNewBitmapLayer()
 {
     LayerBitmap* layerBitmap = new LayerBitmap( this );

--- a/core_lib/structure/object.h
+++ b/core_lib/structure/object.h
@@ -108,6 +108,8 @@ public:
     QDomElement saveXML( QDomDocument& doc );
     bool loadXML( QDomElement element, QString dataDirPath );
 
+    void loadMissingData();
+
     void paintImage( QPainter& painter, int frameNumber, bool background, bool antialiasing );
 
     ColourRef getColour( int i );

--- a/core_lib/structure/objectsaveloader.cpp
+++ b/core_lib/structure/objectsaveloader.cpp
@@ -126,6 +126,9 @@ Object* ObjectSaveLoader::load( QString strFileName )
 
     object->setFilePath( strFileName );
 
+    // For backward compatibility, make sure that every required element is present in the object
+    object->loadMissingData();
+
     return object;
 }
 

--- a/core_lib/tool/brushtool.cpp
+++ b/core_lib/tool/brushtool.cpp
@@ -213,7 +213,7 @@ void BrushTool::drawStroke()
             p[ i ] = mEditor->view()->mapScreenToCanvas( p[ i ] );
         }
 
-        qreal opacity = mCurrentPressure;
+        qreal opacity = mCurrentPressure / 2;
         mCurrentWidth = properties.width;
         qreal brushWidth = mCurrentWidth;
 

--- a/core_lib/tool/movetool.cpp
+++ b/core_lib/tool/movetool.cpp
@@ -147,6 +147,7 @@ void MoveTool::mouseMoveEvent( QMouseEvent *event )
     {
         return;
     }
+
     if ( event->buttons() & Qt::LeftButton )   // the user is also pressing the mouse (dragging)
     {
         if ( mScribbleArea->somethingSelected )     // there is something selected

--- a/core_lib/tool/movetool.cpp
+++ b/core_lib/tool/movetool.cpp
@@ -158,11 +158,11 @@ void MoveTool::mouseMoveEvent( QMouseEvent *event )
             {
                 qreal factor = mScribbleArea->mySelection.width() / mScribbleArea->mySelection.height();
 
-                if (mScribbleArea->mMoveMode == ScribbleArea::TOPRIGHT || mScribbleArea->mMoveMode == ScribbleArea::BOTTOMLEFT) {
+                if (mScribbleArea->mMoveMode == ScribbleArea::TOPLEFT || mScribbleArea->mMoveMode == ScribbleArea::BOTTOMRIGHT) {
                     yOffset = xOffset / factor;
                 }
                 else if (mScribbleArea->mMoveMode == ScribbleArea::TOPRIGHT || mScribbleArea->mMoveMode == ScribbleArea::BOTTOMLEFT) {
-                    yOffset = -yOffset;
+                    yOffset = -(xOffset / factor);
                 }
                 else if (mScribbleArea->mMoveMode == ScribbleArea::MIDDLE) {
 

--- a/core_lib/tool/movetool.cpp
+++ b/core_lib/tool/movetool.cpp
@@ -145,6 +145,14 @@ void MoveTool::mouseReleaseEvent( QMouseEvent *event )
             mScribbleArea->calculateSelectionTransformation();
 
             mScribbleArea->myTransformedSelection = mScribbleArea->myTempTransformedSelection;
+
+            if ( layer->type() == Layer::VECTOR )
+            {
+                auto pLayerVector = static_cast< LayerVector* >( layer );
+                VectorImage* vectorImage = pLayerVector->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 );
+                vectorImage->setSelectionTransformation( mScribbleArea->getSelectionTransformation() );
+            }
+
             mScribbleArea->setModified( mEditor->layers()->currentLayerIndex(), mEditor->currentFrame() );
             mScribbleArea->setAllDirty();
         }

--- a/core_lib/tool/movetool.cpp
+++ b/core_lib/tool/movetool.cpp
@@ -151,52 +151,62 @@ void MoveTool::mouseMoveEvent( QMouseEvent *event )
     {
         if ( mScribbleArea->somethingSelected )     // there is something selected
         {
-            if ( event->modifiers() != Qt::ShiftModifier )    // (and the user doesn't press shift)
+            qreal xOffset = mScribbleArea->mOffset.x();
+            qreal yOffset = mScribbleArea->mOffset.y();
+
+            if ( event->modifiers() == Qt::ShiftModifier )    // (makes resize proportional, move linear)
             {
-                switch ( mScribbleArea->mMoveMode )
-                {
-                case ScribbleArea::MIDDLE:
-                    if ( QLineF( getLastPressPixel(), getCurrentPixel() ).length() > 4 )
-                    {
-                        mScribbleArea->myTempTransformedSelection = mScribbleArea->myTransformedSelection.translated( mScribbleArea->mOffset );
-                    }
-                    break;
+                qreal factor = mScribbleArea->mySelection.width() / mScribbleArea->mySelection.height();
 
-                case ScribbleArea::TOPRIGHT:
-                    mScribbleArea->myTempTransformedSelection =
-                            mScribbleArea->myTransformedSelection.adjusted( 0, mScribbleArea->mOffset.y(), mScribbleArea->mOffset.x(), 0 );
-                    break;
+                yOffset = xOffset / factor;
 
-
-                case ScribbleArea::TOPLEFT:
-                    mScribbleArea->myTempTransformedSelection =
-                            mScribbleArea->myTransformedSelection.adjusted( mScribbleArea->mOffset.x(), mScribbleArea->mOffset.y(), 0, 0 );
-                    break;
-
-                    // TOPRIGHT XXX
-
-                case ScribbleArea::BOTTOMLEFT:
-                    mScribbleArea->myTempTransformedSelection =
-                            mScribbleArea->myTransformedSelection.adjusted( mScribbleArea->mOffset.x(), 0, 0, mScribbleArea->mOffset.y() );
-                    break;
-
-                case ScribbleArea::BOTTOMRIGHT:
-                    mScribbleArea->myTempTransformedSelection =
-                            mScribbleArea->myTransformedSelection.adjusted( 0, 0, mScribbleArea->mOffset.x(), mScribbleArea->mOffset.y() );
-                    break;
-                case ScribbleArea::ROTATION:
-                    mScribbleArea->myTempTransformedSelection =
-                            mScribbleArea->myTransformedSelection; // @ necessary?
-                    mScribbleArea->myRotatedAngle = getCurrentPixel().x() - getLastPressPixel().x();
-                    //qDebug() << "rotation" << m_pScribbleArea->myRotatedAngle;
-                    break;
+                if (mScribbleArea->mMoveMode == ScribbleArea::TOPRIGHT || mScribbleArea->mMoveMode == ScribbleArea::BOTTOMLEFT) {
+                    yOffset = -yOffset;
                 }
-
-                mScribbleArea->calculateSelectionTransformation();
-
-                mScribbleArea->paintTransformedSelection();
-
             }
+
+            switch ( mScribbleArea->mMoveMode )
+            {
+            case ScribbleArea::MIDDLE:
+                if ( QLineF( getLastPressPixel(), getCurrentPixel() ).length() > 4 )
+                {
+                    mScribbleArea->myTempTransformedSelection = mScribbleArea->myTransformedSelection.translated( mScribbleArea->mOffset );
+                }
+                break;
+
+            case ScribbleArea::TOPRIGHT:
+                mScribbleArea->myTempTransformedSelection =
+                        mScribbleArea->myTransformedSelection.adjusted( 0, yOffset, xOffset, 0 );
+                break;
+
+
+            case ScribbleArea::TOPLEFT:
+                mScribbleArea->myTempTransformedSelection =
+                        mScribbleArea->myTransformedSelection.adjusted( xOffset, yOffset, 0, 0 );
+                break;
+
+                // TOPRIGHT XXX
+
+            case ScribbleArea::BOTTOMLEFT:
+                mScribbleArea->myTempTransformedSelection =
+                        mScribbleArea->myTransformedSelection.adjusted( xOffset, 0, 0, yOffset );
+                break;
+
+            case ScribbleArea::BOTTOMRIGHT:
+                mScribbleArea->myTempTransformedSelection =
+                        mScribbleArea->myTransformedSelection.adjusted( 0, 0, xOffset, yOffset );
+                break;
+            case ScribbleArea::ROTATION:
+                mScribbleArea->myTempTransformedSelection =
+                        mScribbleArea->myTransformedSelection; // @ necessary?
+                mScribbleArea->myRotatedAngle = getCurrentPixel().x() - getLastPressPixel().x();
+                //qDebug() << "rotation" << m_pScribbleArea->myRotatedAngle;
+                break;
+            }
+
+            mScribbleArea->calculateSelectionTransformation();
+
+            mScribbleArea->paintTransformedSelection();
         }
         else     // there is nothing selected
         {

--- a/core_lib/tool/movetool.cpp
+++ b/core_lib/tool/movetool.cpp
@@ -158,10 +158,26 @@ void MoveTool::mouseMoveEvent( QMouseEvent *event )
             {
                 qreal factor = mScribbleArea->mySelection.width() / mScribbleArea->mySelection.height();
 
-                yOffset = xOffset / factor;
-
                 if (mScribbleArea->mMoveMode == ScribbleArea::TOPRIGHT || mScribbleArea->mMoveMode == ScribbleArea::BOTTOMLEFT) {
+                    yOffset = xOffset / factor;
+                }
+                else if (mScribbleArea->mMoveMode == ScribbleArea::TOPRIGHT || mScribbleArea->mMoveMode == ScribbleArea::BOTTOMLEFT) {
                     yOffset = -yOffset;
+                }
+                else if (mScribbleArea->mMoveMode == ScribbleArea::MIDDLE) {
+
+                    qreal absX = xOffset;
+                    if (absX < 0) {absX = -absX;}
+
+                    qreal absY = yOffset;
+                    if (absY < 0) {absY = -absY;}
+
+                    if (absX > absY) {
+                        yOffset = 0;
+                    }
+                    if (absY > absX) {
+                        xOffset = 0;
+                    }
                 }
             }
 
@@ -170,7 +186,7 @@ void MoveTool::mouseMoveEvent( QMouseEvent *event )
             case ScribbleArea::MIDDLE:
                 if ( QLineF( getLastPressPixel(), getCurrentPixel() ).length() > 4 )
                 {
-                    mScribbleArea->myTempTransformedSelection = mScribbleArea->myTransformedSelection.translated( mScribbleArea->mOffset );
+                    mScribbleArea->myTempTransformedSelection = mScribbleArea->myTransformedSelection.translated( QPointF(xOffset, yOffset) );
                 }
                 break;
 

--- a/core_lib/tool/movetool.cpp
+++ b/core_lib/tool/movetool.cpp
@@ -146,13 +146,6 @@ void MoveTool::mouseReleaseEvent( QMouseEvent *event )
 
             mScribbleArea->myTransformedSelection = mScribbleArea->myTempTransformedSelection;
 
-            if ( layer->type() == Layer::VECTOR )
-            {
-                auto pLayerVector = static_cast< LayerVector* >( layer );
-                VectorImage* vectorImage = pLayerVector->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 );
-                vectorImage->setSelectionTransformation( mScribbleArea->getSelectionTransformation() );
-            }
-
             mScribbleArea->setModified( mEditor->layers()->currentLayerIndex(), mEditor->currentFrame() );
             mScribbleArea->setAllDirty();
         }
@@ -214,8 +207,17 @@ void MoveTool::mouseMoveEvent( QMouseEvent *event )
                 }
 
                 mScribbleArea->calculateSelectionTransformation();
-                mScribbleArea->update();
+
+                if ( layer->type() == Layer::VECTOR )
+                {
+                    auto pLayerVector = static_cast< LayerVector* >( layer );
+                    VectorImage* vectorImage = pLayerVector->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 );
+                    vectorImage->setSelectionTransformation( mScribbleArea->getSelectionTransformation() );
+                }
+
+                mScribbleArea->setModified( mEditor->layers()->currentLayerIndex(), mEditor->currentFrame() );
                 mScribbleArea->setAllDirty();
+                mScribbleArea->updateCurrentFrame();
             }
         }
         else     // there is nothing selected

--- a/core_lib/tool/movetool.h
+++ b/core_lib/tool/movetool.h
@@ -16,6 +16,13 @@ public:
     void mousePressEvent(QMouseEvent *) override;
     void mouseReleaseEvent(QMouseEvent *) override;
     void mouseMoveEvent(QMouseEvent *) override;
+
+    bool keyPressEvent(QKeyEvent *event) override;
+    bool keyReleaseEvent(QKeyEvent *event) override;
+
+private:
+    void cancelChanges();
+    void applyChanges();
 };
 
 #endif

--- a/core_lib/tool/penciltool.cpp
+++ b/core_lib/tool/penciltool.cpp
@@ -176,22 +176,6 @@ void PencilTool::mouseReleaseEvent( QMouseEvent *event )
 
 void PencilTool::adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice )
 {
-//    QColor currentColor = mEditor->color()->frontColor();
-//    currentPressuredColor = currentColor;
-
-//    // Increases the alfa in order to simulates a soft pencil stroke (even with the mouse)
-//    int softness = 8;
-
-//    if ( mScribbleArea->usePressure() && !mouseDevice )
-//    {
-//        currentPressuredColor.setAlphaF( (currentColor.alphaF() * pressure * pressure) / softness );
-//    }
-//    else
-//    {
-//        currentPressuredColor.setAlphaF( currentColor.alphaF() / softness );
-//    }
-
-
     mCurrentWidth = properties.width;
 
     if ( properties.pressure && !mouseDevice )
@@ -244,31 +228,9 @@ void PencilTool::drawStroke()
             }
         }
 
-        //int rad = qRound( brushWidth ) / 2 + 2;
-        //mScribbleArea->refreshBitmap( rect, rad );
+        int rad = qRound( brushWidth ) / 2 + 2;
+        mScribbleArea->refreshBitmap( rect, rad );
 
-//        qreal brushWidth = properties.width * mCurrentPressure;
-
-//        QPen pen( QBrush( currentPressuredColor ), brushWidth, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin );
-//        QBrush brush( currentPressuredColor, Qt::SolidPattern );
-//        rad = qRound( properties.width / 2 ) + 3;
-
-//        for ( int i = 0; i < p.size(); i++ )
-//        {
-//            p[ i ] = mEditor->view()->mapScreenToCanvas( p[ i ] );
-//        }
-
-//        if ( p.size() == 4 )
-//        {
-//            // qDebug() << p;
-//            QPainterPath path( p[ 0 ] );
-//            path.cubicTo( p[ 1 ],
-//                          p[ 2 ],
-//                          p[ 3 ] );
-
-//            mScribbleArea->drawPath( path, pen, brush, QPainter::CompositionMode_SourceOver );
-//            mScribbleArea->refreshBitmap( path.boundingRect().toRect(), rad );
-//        }
     }
     else if ( layer->type() == Layer::VECTOR )
     {

--- a/core_lib/tool/pentool.cpp
+++ b/core_lib/tool/pentool.cpp
@@ -87,15 +87,16 @@ QCursor PenTool::cursor()
 
 void PenTool::adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice )
 {
+    mCurrentWidth = properties.width;
+
     if ( properties.pressure && !mouseDevice )
     {
-        mCurrentWidth = 2.0 * properties.width * pressure;
+        mCurrentPressure = pressure;
     }
     else
     {
-        mCurrentWidth = properties.width;
+        mCurrentPressure = 1.0;
     }
-    // we choose the "normal" width to correspond to a pressure 0.5
 }
 
 void PenTool::mousePressEvent( QMouseEvent *event )
@@ -178,7 +179,7 @@ void PenTool::drawStroke()
         }
 
         qreal opacity = 1.0;
-        qreal brushWidth = (mCurrentWidth + (mCurrentPressure * mCurrentWidth)) * 0.5;
+        qreal brushWidth = mCurrentPressure * mCurrentWidth;
         qreal brushStep = (0.5 * brushWidth) - ((properties.feather/100.0) * brushWidth * 0.5);
         brushStep = qMax( 1.0, brushStep );
 
@@ -210,10 +211,11 @@ void PenTool::drawStroke()
     }
     else if ( layer->type() == Layer::VECTOR )
     {
-        int rad = qRound( ( mCurrentWidth / 2 + 2 ) * mEditor->view()->scaling() );
+        qreal brushWidth = mCurrentPressure * mCurrentWidth;
+        int rad = qRound( ( brushWidth / 2 + 2 ) * mEditor->view()->scaling() );
 
         QPen pen( mEditor->color()->frontColor(),
-                  mCurrentWidth * mEditor->view()->scaling(),
+                  brushWidth * mEditor->view()->scaling(),
                   Qt::SolidLine,
                   Qt::RoundCap,
                   Qt::RoundJoin );

--- a/core_lib/tool/selecttool.cpp
+++ b/core_lib/tool/selecttool.cpp
@@ -151,3 +151,20 @@ void SelectTool::mouseMoveEvent( QMouseEvent *event )
         mScribbleArea->update();
     }
 }
+
+bool SelectTool::keyPressEvent(QKeyEvent *event)
+{
+    switch ( event->key() ) {
+    case Qt::Key_Alt:
+        mScribbleArea->setTemporaryTool( MOVE );
+        break;
+    default:
+        break;
+    }
+    return true;
+}
+
+bool SelectTool::keyReleaseEvent(QKeyEvent *event)
+{
+    return true;
+}

--- a/core_lib/tool/selecttool.h
+++ b/core_lib/tool/selecttool.h
@@ -16,6 +16,9 @@ public:
     void mousePressEvent( QMouseEvent* ) override;
     void mouseReleaseEvent( QMouseEvent* ) override;
     void mouseMoveEvent( QMouseEvent* ) override;
+
+    bool keyPressEvent(QKeyEvent *event) override;
+    bool keyReleaseEvent(QKeyEvent *event) override;
 };
 
 #endif

--- a/core_lib/tool/stroketool.cpp
+++ b/core_lib/tool/stroketool.cpp
@@ -35,6 +35,24 @@ void StrokeTool::startStroke()
     disableCoalescing();
 }
 
+bool StrokeTool::keyPressEvent(QKeyEvent *event)
+{
+    switch ( event->key() ) {
+    case Qt::Key_Alt:
+        mScribbleArea->setTemporaryTool( EYEDROPPER );
+        break;
+    default:
+        break;
+    }
+    return true;
+}
+
+bool StrokeTool::keyReleaseEvent(QKeyEvent *event)
+{
+    return true;
+}
+
+
 void StrokeTool::endStroke()
 {
     mStrokePoints.clear();

--- a/core_lib/tool/stroketool.h
+++ b/core_lib/tool/stroketool.h
@@ -20,6 +20,10 @@ public:
     void drawStroke();
     void endStroke();
 
+    bool keyPressEvent(QKeyEvent *event) override;
+
+    bool keyReleaseEvent(QKeyEvent *event) override;
+
 protected:
     bool mFirstDraw = false;
 


### PR DESCRIPTION
Here is my weekly contribution. The entire app starts to be pretty usable, I am quite happy with the result.

When you select an area with the select tool, you can transform your selection (move, scale, rotate) and cancel your transformation by clicking escape. The transformation is only applied on deselect.

For some reason, the move tool doesn't work well on the vector layer when a key is pressed, which makes rotation impossible on a vector selection. I will fix that for the next pull request.

Duplicating a frame now handles the entire frame and not just the screen area. It is also the case when you do select all. The entire frame is selected even if it is larger that the screen area.

Enjoy! :)