### PR TITLE
Return proper values for stroke key events

### DIFF
--- a/core_lib/tool/stroketool.cpp
+++ b/core_lib/tool/stroketool.cpp
@@ -43,14 +43,12 @@ bool StrokeTool::keyPressEvent(QKeyEvent *event)
     switch ( event->key() ) {
     case Qt::Key_Alt:
         mScribbleArea->setTemporaryTool( EYEDROPPER );
-        break;
+        return true;
     case Qt::Key_Space:
         mScribbleArea->setTemporaryTool( HAND ); // just call "setTemporaryTool()" to activate temporarily any tool
-        break;
-    default:
-        break;
+        return true;
     }
-    return true;
+    return false;
 }
 
 bool StrokeTool::keyReleaseEvent(QKeyEvent *event)


### PR DESCRIPTION
Fixes #402
In the case where the current tool does not handle the event, the event should not be terminated