### PR TITLE
Size shortcut 308

### DIFF
--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -570,7 +570,9 @@ void ScribbleArea::mouseMoveEvent( QMouseEvent *event )
         // --- use SHIFT + drag to resize WIDTH / use CTRL + drag to resize FEATHER ---
         if ( currentTool()->isAdjusting )
         {
-            currentTool()->adjustCursor( mOffset.x(), mOffset.y() ); //updates cursors given org width or feather and x
+            ToolPropertyType tool_type;
+            tool_type = event->modifiers() & Qt::ControlModifier ? FEATHER : WIDTH;
+            currentTool()->adjustCursor( mOffset.x(), tool_type ); //updates cursors given org width or feather and x
             return;
         }
     }

--- a/core_lib/interface/tooloptiondockwidget.cpp
+++ b/core_lib/interface/tooloptiondockwidget.cpp
@@ -56,12 +56,12 @@ void ToolOptionWidget::createUI()
 
     QSettings settings( "Pencil", "Pencil" );
 
-    mSizeSlider = new SpinSlider( tr( "Size" ), SpinSlider::LOG, SpinSlider::FLOAT, 0.1, 200.0, this );
-    mSizeSlider->setValue( settings.value( "pencilWidth" ).toDouble() );
+    mSizeSlider = new SpinSlider( tr( "Size" ), SpinSlider::LOG, SpinSlider::INTEGER, 1, 200, this );
+    mSizeSlider->setValue( settings.value( "brushWidth" ).toDouble() );
     mSizeSlider->setToolTip( tr( "Set Pen Width <br><b>[SHIFT]+drag</b><br>for quick adjustment" ) );
 
-    mFeatherSlider = new SpinSlider( tr( "Feather" ), SpinSlider::LOG, SpinSlider::FLOAT, 2.0, 64.0, this );
-    mFeatherSlider->setValue( settings.value( "pencilFeather" ).toDouble() );
+    mFeatherSlider = new SpinSlider( tr( "Feather" ), SpinSlider::LOG, SpinSlider::INTEGER, 2, 64, this );
+    mFeatherSlider->setValue( settings.value( "brushFeather" ).toDouble() );
     mFeatherSlider->setToolTip( tr( "Set Pen Feather <br><b>[CTRL]+drag</b><br>for quick adjustment" ) );
 
     mUsePressureBox = new QCheckBox( tr( "Pressure" ) );

--- a/core_lib/tool/basetool.cpp
+++ b/core_lib/tool/basetool.cpp
@@ -208,57 +208,42 @@ void BaseTool::stopAdjusting()
     mEditor->getScribbleArea()->setCursor( cursor() );
 }
 
-void BaseTool::adjustCursor( qreal argOffsetX, qreal argOffsetY ) //offsetx x-lastx ...
+void BaseTool::adjustCursor( qreal argOffsetX, ToolPropertyType type ) //offsetx x-lastx ...
 {
-    qreal incx = pow( OriginalSettingValue * 100, 0.5 );
-    qreal incy = incx;
-    qreal newValueX = incx + argOffsetX;
-    qreal newValueY = incy + argOffsetY;
+    qreal inc = pow( OriginalSettingValue * 100, 0.5 );
+    qreal newValue = inc + argOffsetX;
 
-    if ( newValueX < 0 )
+    if ( newValue < 0 )
     {
-        newValueX = 0;
-    }
-    if ( newValueY < 0 )
-    {
-        newValueY = 0;
+        newValue = 0;
     }
 
-    newValueX = pow( newValueX, 2 ) / 100;
-    newValueY = pow( newValueY, 2 ) / 100;
-
+    newValue = pow( newValue, 2 ) / 100;
     if ( adjustmentStep > 0 )
     {
-        int tempValueX = ( int )( newValueX / adjustmentStep ); // + 0.5 ?
-        int tempValueY = ( int )( newValueY / adjustmentStep ); // + 0.5 ?
-        newValueX = tempValueX * adjustmentStep;
-        newValueY = tempValueY * adjustmentStep;
+        int tempValue = ( int )( newValue / adjustmentStep ); // + 0.5 ?
+        newValue = tempValue * adjustmentStep;
+    }
+    if ( newValue < 1 ) // can be optimized for size: min(200,max(0.2,newValueX))
+    {
+        newValue = 1;
+    }
+    else if ( newValue > 200 )
+    {
+        newValue = 200;
     }
 
-    if ( newValueX < 1 ) // can be optimized for size: min(200,max(0.2,newValueX))
-    {
-        newValueX = 1;
-    }
-    else if ( newValueX > 200 )
-    {
-        newValueX = 200;
-    }
-
-    if ( newValueY < 1 ) // can be optimized for size: min(200,max(0.2,newValueX))
-    {
-        newValueY = 1;
-    }
-    else if ( newValueY > 200 )
-    {
-        newValueY = 200;
-    }
-
-    mEditor->tools()->setWidth( newValueX );
-
-    if ( ( this->type() == BRUSH ) || ( this->type() == ERASER ) || ( this->type() == SMUDGE ) )
-    {
-        mEditor->tools()->setFeather( newValueY );
-    }
+    switch (type){
+        case FEATHER:
+            if ( ( this->type() == BRUSH ) || ( this->type() == ERASER ) || ( this->type() == SMUDGE ) )
+            {
+                mEditor->tools()->setFeather( newValue );
+            }
+            break;
+        case WIDTH:
+            mEditor->tools()->setWidth( newValue );
+            break;
+    };
 }
 
 void BaseTool::adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice )

--- a/core_lib/tool/basetool.cpp
+++ b/core_lib/tool/basetool.cpp
@@ -212,6 +212,8 @@ void BaseTool::adjustCursor( qreal argOffsetX, ToolPropertyType type ) //offsetx
 {
     qreal inc = pow( OriginalSettingValue * 100, 0.5 );
     qreal newValue = inc + argOffsetX;
+    int max = type == FEATHER ? 64 : 200;
+    int min = type == FEATHER ? 2 : 1;
 
     if ( newValue < 0 )
     {
@@ -224,13 +226,13 @@ void BaseTool::adjustCursor( qreal argOffsetX, ToolPropertyType type ) //offsetx
         int tempValue = ( int )( newValue / adjustmentStep ); // + 0.5 ?
         newValue = tempValue * adjustmentStep;
     }
-    if ( newValue < 1 ) // can be optimized for size: min(200,max(0.2,newValueX))
+    if ( newValue < min ) // can be optimized for size: min(200,max(0.2,newValueX))
     {
-        newValue = 1;
+        newValue = min;
     }
-    else if ( newValue > 200 )
+    else if ( newValue > max )
     {
-        newValue = 200;
+        newValue = max;
     }
 
     switch (type){

--- a/core_lib/tool/basetool.h
+++ b/core_lib/tool/basetool.h
@@ -61,7 +61,7 @@ public:
     // dynamic cursor adjustment
     virtual void startAdjusting( ToolPropertyType argSettingType, qreal argStep );
     virtual void stopAdjusting();
-    virtual void adjustCursor( qreal argOffsetX, qreal argOffsetY );
+    virtual void adjustCursor( qreal argOffsetX, ToolPropertyType type );
 
     virtual void adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice );
 


### PR DESCRIPTION
Fixes #308 
Shift is used for size
Ctrl is used for feather
Min and max settings for both were changed to 1 to 200 for size and 2 to 64 for feather (both integers now)