### PR TITLE
added option to type brush and feather size

### DIFF
--- a/core_lib/interface/spinslider.cpp
+++ b/core_lib/interface/spinslider.cpp
@@ -25,14 +25,9 @@ SpinSlider::SpinSlider( QString text, GROWTH_TYPE type, VALUE_TYPE dataType, qre
     QLabel* label = new QLabel(text+": ");
     label->setFont( QFont( "Helvetica", 10 ) );
 
-    mValueLabel = new QLabel( "--" );
-    mValueLabel->setFont( QFont( "Helvetica", 10 ) );
-
-    mValueLabel->setAlignment( Qt::AlignRight | Qt::AlignVCenter );
-
     mSlider = new QSlider(Qt::Horizontal, this);
-    mSlider->setMinimum( 0 );
-    mSlider->setMaximum( 100 );
+    mSlider->setMinimum( mMin );
+    mSlider->setMaximum( mMax );
     mSlider->setMaximumWidth( 70 );
 
     QGridLayout* layout = new QGridLayout();
@@ -40,7 +35,6 @@ SpinSlider::SpinSlider( QString text, GROWTH_TYPE type, VALUE_TYPE dataType, qre
     layout->setSpacing( 2 );
 
     layout->addWidget( label, 0, 0, 1, 1 );
-    layout->addWidget( mValueLabel, 0, 1, 1, 1 );
     layout->addWidget( mSlider, 1, 0, 1, 2 );
 
     setLayout( layout );
@@ -54,14 +48,8 @@ SpinSlider::SpinSlider( QString text, GROWTH_TYPE type, VALUE_TYPE dataType, qre
 void SpinSlider::changeValue(qreal value)
 {
     mValue = value;
-    if ( mValueType == INTEGER )
-    {
-        mValueLabel->setText( QString::number(qRound(value)) );
-    }
-    else // FLOAT
-    {
-        mValueLabel->setText( QLocale::system().toString(value,'f',1) );
-    }
+    emit valueChanged( value );
+    mSlider->setSliderPosition( value );
 }
 
 void SpinSlider::onSliderValueChanged( int v )
@@ -70,13 +58,13 @@ void SpinSlider::onSliderValueChanged( int v )
     qreal value2 = 0.0;
     if ( mGrowthType == LINEAR )
     {
-        value2 = mMin + v * ( mMax - mMin ) / 100;
+        value2 = mMin + v * ( mMax - mMin ) / mMax;
     }
     else if ( mGrowthType == LOG )
     {
-        value2 = mMin * std::exp( v * std::log( mMax / mMin ) / 100.0 );
+        value2 = mMin * std::exp( v * std::log( mMax / mMin ) / mMax );
     }
-    changeValue( value2 );
+    //changeValue( value2 );
 }
 
 void SpinSlider::setValue( qreal v )
@@ -85,21 +73,20 @@ void SpinSlider::setValue( qreal v )
     int value2 = 0;
     if ( mGrowthType == LINEAR )
     {
-        value2 = std::round( 100 * ( v - mMin ) / ( mMax - mMin ) );
+        value2 = std::round( mMax * ( v - mMin ) / ( mMax - mMin ) );
     }
     if ( mGrowthType == LOG )
     {
-        value2 = std::round( std::log( v / mMin ) * 100.0 / std::log( mMax / mMin ) );
+        value2 = std::round( std::log( v / mMin ) * mMax / std::log( mMax / mMin ) );
     }
     //qDebug() << "Position! " << value2;
-    mSlider->setSliderPosition( value2 );
 
     changeValue( v );
 }
 
 void SpinSlider::sliderReleased()
 {
-    emit valueChanged( mValue );
+    //emit valueChanged( mValue );
 }
 
 void SpinSlider::sliderMoved(int value)

--- a/core_lib/interface/spinslider.cpp
+++ b/core_lib/interface/spinslider.cpp
@@ -58,13 +58,12 @@ void SpinSlider::onSliderValueChanged( int v )
     qreal value2 = 0.0;
     if ( mGrowthType == LINEAR )
     {
-        value2 = mMin + v * ( mMax - mMin ) / mMax;
+        value2 = mMin + v * ( mMax - mMin ) / 100;
     }
     else if ( mGrowthType == LOG )
     {
-        value2 = mMin * std::exp( v * std::log( mMax / mMin ) / mMax );
+        value2 = mMin * std::exp( v * std::log( mMax / mMin ) / 100.0 );
     }
-    //changeValue( value2 );
 }
 
 void SpinSlider::setValue( qreal v )
@@ -73,11 +72,11 @@ void SpinSlider::setValue( qreal v )
     int value2 = 0;
     if ( mGrowthType == LINEAR )
     {
-        value2 = std::round( mMax * ( v - mMin ) / ( mMax - mMin ) );
+        value2 = std::round( 100 * ( v - mMin ) / ( mMax - mMin ) );
     }
     if ( mGrowthType == LOG )
     {
-        value2 = std::round( std::log( v / mMin ) * mMax / std::log( mMax / mMin ) );
+        value2 = std::round( std::log( v / mMin ) * 100 / std::log( mMax / mMin ) );
     }
     //qDebug() << "Position! " << value2;
 

--- a/core_lib/interface/spinslider.h
+++ b/core_lib/interface/spinslider.h
@@ -36,7 +36,6 @@ private:
     void changeValue( qreal );
 
 private:
-    QLabel*  mValueLabel = nullptr;
     QSlider* mSlider     = nullptr;
     qreal mValue = 50.0;
     qreal mMin   = 0.1;

--- a/core_lib/interface/tooloptiondockwidget.cpp
+++ b/core_lib/interface/tooloptiondockwidget.cpp
@@ -1,6 +1,7 @@
 #include <QLabel>
 #include <QToolButton>
 #include <QCheckBox>
+#include <QSpinBox>
 #include <QGridLayout>
 #include <QSettings>
 #include <QDebug>
@@ -31,7 +32,9 @@ void ToolOptionWidget::updateUI()
     disableAllOptions();
 
     mSizeSlider->setVisible( currentTool->isPropertyEnabled( WIDTH ) );
+    mBrushSpinBox->setVisible( currentTool->isPropertyEnabled( WIDTH) );
     mFeatherSlider->setVisible( currentTool->isPropertyEnabled( FEATHER ) );
+    mFeatherSpinBox->setVisible( currentTool->isPropertyEnabled( FEATHER) );
     mUseBezierBox->setVisible( currentTool->isPropertyEnabled( BEZIER ) );
     mUsePressureBox->setVisible( currentTool->isPropertyEnabled( PRESSURE ) );
     mMakeInvisibleBox->setVisible( currentTool->isPropertyEnabled( INVISIBILITY ) );
@@ -48,7 +51,7 @@ void ToolOptionWidget::updateUI()
 
 void ToolOptionWidget::createUI()
 {
-    setMinimumWidth( 110 );
+    setMinimumWidth( 115 );
 
     QFrame* optionGroup = new QFrame();
     QGridLayout* pLayout = new QGridLayout();
@@ -57,13 +60,21 @@ void ToolOptionWidget::createUI()
 
     QSettings settings( "Pencil", "Pencil" );
 
-    mSizeSlider = new SpinSlider( tr( "Size" ), SpinSlider::LOG, SpinSlider::INTEGER, 1, 200, this );
+    mSizeSlider = new SpinSlider( tr( "Brush" ), SpinSlider::LOG, SpinSlider::INTEGER, 1, 200, this );
     mSizeSlider->setValue( settings.value( "brushWidth" ).toDouble() );
     mSizeSlider->setToolTip( tr( "Set Pen Width <br><b>[SHIFT]+drag</b><br>for quick adjustment" ) );
+
+    mBrushSpinBox = new QSpinBox(this);
+    mBrushSpinBox->setRange(1,200);
+    mBrushSpinBox->setValue(settings.value( "brushWidth" ).toDouble() );
 
     mFeatherSlider = new SpinSlider( tr( "Feather" ), SpinSlider::LOG, SpinSlider::INTEGER, 2, 64, this );
     mFeatherSlider->setValue( settings.value( "brushFeather" ).toDouble() );
     mFeatherSlider->setToolTip( tr( "Set Pen Feather <br><b>[CTRL]+drag</b><br>for quick adjustment" ) );
+
+    mFeatherSpinBox = new QSpinBox(this);
+    mFeatherSpinBox->setRange(2,64);
+    mFeatherSpinBox->setValue(settings.value( "brushFeather" ).toDouble() );
 
     mUseBezierBox = new QCheckBox( tr( "Bezier" ) );
     mUseBezierBox->setToolTip( tr( "Bezier curve fitting" ) );
@@ -86,7 +97,9 @@ void ToolOptionWidget::createUI()
     mPreserveAlphaBox->setChecked( false );
 
     pLayout->addWidget( mSizeSlider, 8, 0, 1, 2 );
+    pLayout->addWidget( mBrushSpinBox, 8, 10, 1, 2);
     pLayout->addWidget( mFeatherSlider, 9, 0, 1, 2 );
+    pLayout->addWidget( mFeatherSpinBox, 9, 10, 1, 2 );
     pLayout->addWidget( mUseBezierBox, 10, 0, 1, 2 );
     pLayout->addWidget( mUsePressureBox, 11, 0, 1, 2 );
     pLayout->addWidget( mPreserveAlphaBox, 12, 0, 1, 2 );
@@ -111,6 +124,9 @@ void ToolOptionWidget::makeConnectionToEditor( Editor* editor )
     connect( mSizeSlider, &SpinSlider::valueChanged, toolManager, &ToolManager::setWidth );
     connect( mFeatherSlider, &SpinSlider::valueChanged, toolManager, &ToolManager::setFeather );
 
+    connect( mBrushSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), toolManager, &ToolManager::setWidth );
+    connect( mFeatherSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), toolManager, &ToolManager::setFeather );
+
     connect( toolManager, &ToolManager::toolChanged, this, &ToolOptionWidget::onToolChanged );
     connect( toolManager, &ToolManager::toolPropertyChanged, this, &ToolOptionWidget::onToolPropertyChanged );
 }
@@ -118,10 +134,10 @@ void ToolOptionWidget::makeConnectionToEditor( Editor* editor )
 void ToolOptionWidget::onToolPropertyChanged( ToolType, ToolPropertyType ePropertyType )
 {
     const Properties& p = editor()->tools()->currentTool()->properties;
-    
+
     switch ( ePropertyType )
     {
-        case WIDTH: 
+        case WIDTH:
             setPenWidth( p.width );
             break;
         case FEATHER:
@@ -149,6 +165,8 @@ void ToolOptionWidget::setPenWidth( qreal width )
     QSignalBlocker b( mSizeSlider );
     mSizeSlider->setEnabled( true );
     mSizeSlider->setValue( width );
+    mBrushSpinBox->setEnabled( true );
+    mBrushSpinBox->setValue( width );
 }
 
 void ToolOptionWidget::setPenFeather( qreal featherValue )
@@ -156,6 +174,8 @@ void ToolOptionWidget::setPenFeather( qreal featherValue )
     QSignalBlocker b( mFeatherSlider );
     mFeatherSlider->setEnabled( true );
     mFeatherSlider->setValue( featherValue );
+    mFeatherSpinBox->setEnabled( true );
+    mFeatherSpinBox->setValue( featherValue );
 }
 
 void ToolOptionWidget::setPenInvisibility( int x )
@@ -184,7 +204,9 @@ void ToolOptionWidget::setPreserveAlpha( int x )
 void ToolOptionWidget::disableAllOptions()
 {
     mSizeSlider->hide();
+    mBrushSpinBox->hide();
     mFeatherSlider->hide();
+    mFeatherSpinBox->hide();
     mUseBezierBox->hide();
     mUsePressureBox->hide();
     mMakeInvisibleBox->hide();

--- a/core_lib/interface/tooloptiondockwidget.h
+++ b/core_lib/interface/tooloptiondockwidget.h
@@ -6,6 +6,7 @@
 class QToolButton;
 class SpinSlider;
 class QCheckBox;
+class QSpinBox;
 class Editor;
 class BaseTool;
 
@@ -41,6 +42,8 @@ private:
     QCheckBox* mUsePressureBox   = nullptr;
     QCheckBox* mMakeInvisibleBox = nullptr;
     QCheckBox* mPreserveAlphaBox = nullptr;
+    QSpinBox* mBrushSpinBox          = nullptr;
+    QSpinBox* mFeatherSpinBox        = nullptr;
     SpinSlider* mSizeSlider      = nullptr;
     SpinSlider* mFeatherSlider   = nullptr;
 };

--- a/core_lib/interface/tooloptiondockwidget.h
+++ b/core_lib/interface/tooloptiondockwidget.h
@@ -42,8 +42,8 @@ private:
     QCheckBox* mUsePressureBox   = nullptr;
     QCheckBox* mMakeInvisibleBox = nullptr;
     QCheckBox* mPreserveAlphaBox = nullptr;
-    QSpinBox* mBrushSpinBox          = nullptr;
-    QSpinBox* mFeatherSpinBox        = nullptr;
+    QSpinBox* mBrushSpinBox      = nullptr;
+    QSpinBox* mFeatherSpinBox    = nullptr;
     SpinSlider* mSizeSlider      = nullptr;
     SpinSlider* mFeatherSlider   = nullptr;
 };


### PR DESCRIPTION
This should make it much easier to select precise values.

~~ideally i want to remove the smaller brush number and update the spinBox simultaneously instead. Right now it's only updating when you let go of the slider and of course when you insert a value or use the arrows or use the shortcuts to change size.~~
fixed it! now, as there is no need for the brush number to be shown twice anymore, i have removed the smaller text showing its value and instead made it so the SpinBox updates simultaneously with the slider.

the new UI looks like so:
![Visual representation]
(http://i.imgbox.com/4mDuOTZv.png)