### PR TITLE
Centered color wheel and square, set contrains for widget #430

### DIFF
--- a/app/colorbox.cpp
+++ b/app/colorbox.cpp
@@ -10,6 +10,7 @@ ColorBox::ColorBox( const QString& strTitle, QWidget* parent ) : BaseDockWidget(
     m_colorWheel = new ColorWheel(this);
     m_colorInspector = new ColorInspector(this);
 
+    layout->setContentsMargins(5,5,5,5);
     layout->addWidget(m_colorWheel);
     layout->addWidget(m_colorInspector);
 
@@ -24,6 +25,9 @@ ColorBox::ColorBox( const QString& strTitle, QWidget* parent ) : BaseDockWidget(
 
     m_colorWheel->setColor(Qt::black);
     m_colorInspector->setColor(Qt::black);
+    m_colorWheel->setMinimumSize(100,100);
+
+
 }
 
 ColorBox::~ColorBox()

--- a/app/colorinspector.cpp
+++ b/app/colorinspector.cpp
@@ -11,6 +11,9 @@ ColorInspector::ColorInspector(QWidget *parent) :
 {
     ui->setupUi(this);
 
+    //We constrain the widget, as the layout should have a stretch limit.
+    parent->setMaximumSize(500,height());
+
     connect(ui->RedspinBox, SIGNAL(valueChanged(int)),
         this, SLOT(onColorChanged()));
     connect(ui->GreenspinBox, SIGNAL(valueChanged(int)),
@@ -52,9 +55,10 @@ void ColorInspector::setColor(const QColor &newColor)
     }
     m_color = newColor;
 
-    QPalette p = ui->label->palette();
+    QPalette p = ui->color->palette();
     p.setColor(QPalette::Background, m_color);
-    ui->label->setPalette(p);
+    ui->color->setPalette(p);
+    //ui->color->setFixedSize(30,30);
     noColorUpdate = false;
 }
 

--- a/app/colorwheel.cpp
+++ b/app/colorwheel.cpp
@@ -261,10 +261,6 @@ void ColorWheel::drawWheelImage(const QSize &newSize)
 
 void ColorWheel::drawSquareImage(const int &hue)
 {
-
-    QPainter painter(&m_wheelPixmap);
-    painter.setRenderHint(QPainter::Antialiasing);
-
     // region of the widget
     int w = qMin(width(), height());
     // radius of outer circle

--- a/app/colorwheel.h
+++ b/app/colorwheel.h
@@ -48,7 +48,7 @@ private:
     QImage m_squareImage;
     QPixmap m_wheelPixmap;
    
-    int m_wheelWidth;
+    int m_wheelThickness;
     QRegion m_wheelRegion;
     QRegion m_squareRegion;
     QColor m_currentColor;

--- a/app/ui/colorinspector.ui
+++ b/app/ui/colorinspector.ui
@@ -8,7 +8,7 @@
     <x>0</x>
     <y>0</y>
     <width>114</width>
-    <height>141</height>
+    <height>152</height>
    </rect>
   </property>
   <property name="baseSize">
@@ -118,20 +118,20 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="2" rowspan="3">
-      <widget class="QLabel" name="label">
-       <property name="autoFillBackground">
-        <bool>true</bool>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::Box</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Raised</enum>
-       </property>
-      </widget>
-     </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="color">
+     <property name="autoFillBackground">
+      <bool>true</bool>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Color wheel and color square has been centred to the widget and is resizable to a certain extend. 
Fixed the region focus when resizing the window, now it is possible to resize and still
use the colorwheel hue indicator.
m_wheelWidth has been renamed to m_wheelThickness. 
color label has been positioned below inspector instead of next to.
constrained the widget to not be able to resize to fill the whole application window.
#430 

