### PR TITLE
Added the ability to see the current zoom level and disable feathering

### DIFF
--- a/app/displayoptionwidget.cpp
+++ b/app/displayoptionwidget.cpp
@@ -30,6 +30,15 @@ void DisplayOptionWidget::initUI()
     updateUI();
 }
 
+void DisplayOptionWidget::updateZoomLabel()
+{
+    ViewManager * viewmanager = editor()->view();
+
+    float zoom = (viewmanager->scaling())*100.0f;
+
+    ui->zoomLabel->setText(QString("Zoom: ")+QString("").setNum(zoom)+QString("%"));
+}
+
 void DisplayOptionWidget::makeConnectionToEditor( Editor* editor )
 {
     PreferenceManager* prefs = editor->preference();
@@ -46,6 +55,8 @@ void DisplayOptionWidget::makeConnectionToEditor( Editor* editor )
     connect( ui->cameraBorderButton, &QToolButton::clicked, pScriArea, &ScribbleArea::toggleCameraBorder);
 
     connect( prefs, &PreferenceManager::optionChanged, this, &DisplayOptionWidget::updateUI );
+
+    connect( editor->view(), &ViewManager::viewChanged, this, &DisplayOptionWidget::updateZoomLabel );
 
     updateUI();
 

--- a/app/displayoptionwidget.h
+++ b/app/displayoptionwidget.h
@@ -9,7 +9,7 @@ namespace Ui
 }
 class Editor;
 class QToolButton;
-
+class ViewManager;
 
 class DisplayOptionWidget : public BaseDockWidget
 {
@@ -20,6 +20,8 @@ public:
 
     void initUI() override;
     void updateUI() override;
+
+    void updateZoomLabel();
 
     void makeConnectionToEditor(Editor* editor);
 

--- a/app/ui/displayoption.ui
+++ b/app/ui/displayoption.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>156</width>
-    <height>128</height>
+    <height>210</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -54,6 +54,49 @@ border:1px solid #555555;
      <property name="icon">
       <iconset resource="../resource/app.qrc">
        <normaloff>:/app/icons/mirrorV.png</normaloff>:/app/icons/mirrorV.png</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>21</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QToolButton" name="thinLinesButton">
+     <property name="mouseTracking">
+      <bool>false</bool>
+     </property>
+     <property name="acceptDrops">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Show invisible lines</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QToolButton { 
+background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.0851364, y2:0.278, stop:0 rgba(216, 216, 216, 255), stop:1 rgba(250, 250, 250, 255));
+
+/*border:1px solid #555555;*/
+
+border-radius:5px;
+}
+
+QToolButton:pressed, QToolButton:checked { 
+background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.085, y2:0.0791364, stop:0 rgba(246, 252, 255, 255), stop:1 rgba(204, 217, 250, 255));
+border:1px solid #555555;
+}</string>
+     </property>
+     <property name="text">
+      <string>...</string>
+     </property>
+     <property name="icon">
+      <iconset resource="../resource/app.qrc">
+       <normaloff>:/app/icons/thinlines5.png</normaloff>:/app/icons/thinlines5.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -118,16 +161,13 @@ border:1px solid #555555;
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QToolButton" name="thinLinesButton">
-     <property name="mouseTracking">
-      <bool>false</bool>
-     </property>
-     <property name="acceptDrops">
-      <bool>true</bool>
-     </property>
+   <item row="0" column="3">
+    <widget class="QToolButton" name="onionRedButton">
      <property name="toolTip">
-      <string>Show invisible lines</string>
+      <string>Onion skin color: red</string>
+     </property>
+     <property name="statusTip">
+      <string>Onion skin color: red</string>
      </property>
      <property name="styleSheet">
       <string notr="true">QToolButton { 
@@ -148,7 +188,7 @@ border:1px solid #555555;
      </property>
      <property name="icon">
       <iconset resource="../resource/app.qrc">
-       <normaloff>:/app/icons/thinlines5.png</normaloff>:/app/icons/thinlines5.png</iconset>
+       <normaloff>:/app/icons/onion-red.png</normaloff>:/app/icons/onion-red.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -161,16 +201,10 @@ border:1px solid #555555;
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
-    <widget class="QToolButton" name="onionPrevButton">
+   <item row="1" column="1">
+    <widget class="QToolButton" name="outLinesButton">
      <property name="toolTip">
-      <string>Onion skin previous frame</string>
-     </property>
-     <property name="statusTip">
-      <string>Onion skin previous frame</string>
-     </property>
-     <property name="autoFillBackground">
-      <bool>false</bool>
+      <string>Show outlines only</string>
      </property>
      <property name="styleSheet">
       <string notr="true">QToolButton { 
@@ -191,7 +225,7 @@ border:1px solid #555555;
      </property>
      <property name="icon">
       <iconset resource="../resource/app.qrc">
-       <normaloff>:/app/icons/onionPrev.png</normaloff>:/app/icons/onionPrev.png</iconset>
+       <normaloff>:/app/icons/outlines5.png</normaloff>:/app/icons/outlines5.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -293,13 +327,16 @@ border:1px solid #555555;
      </property>
     </widget>
    </item>
-   <item row="0" column="3">
-    <widget class="QToolButton" name="onionRedButton">
+   <item row="0" column="2">
+    <widget class="QToolButton" name="onionPrevButton">
      <property name="toolTip">
-      <string>Onion skin color: red</string>
+      <string>Onion skin previous frame</string>
      </property>
      <property name="statusTip">
-      <string>Onion skin color: red</string>
+      <string>Onion skin previous frame</string>
+     </property>
+     <property name="autoFillBackground">
+      <bool>false</bool>
      </property>
      <property name="styleSheet">
       <string notr="true">QToolButton { 
@@ -320,44 +357,7 @@ border:1px solid #555555;
      </property>
      <property name="icon">
       <iconset resource="../resource/app.qrc">
-       <normaloff>:/app/icons/onion-red.png</normaloff>:/app/icons/onion-red.png</iconset>
-     </property>
-     <property name="iconSize">
-      <size>
-       <width>21</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QToolButton" name="outLinesButton">
-     <property name="toolTip">
-      <string>Show outlines only</string>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">QToolButton { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.0851364, y2:0.278, stop:0 rgba(216, 216, 216, 255), stop:1 rgba(250, 250, 250, 255));
-
-/*border:1px solid #555555;*/
-
-border-radius:5px;
-}
-
-QToolButton:pressed, QToolButton:checked { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.085, y2:0.0791364, stop:0 rgba(246, 252, 255, 255), stop:1 rgba(204, 217, 250, 255));
-border:1px solid #555555;
-}</string>
-     </property>
-     <property name="text">
-      <string>...</string>
-     </property>
-     <property name="icon">
-      <iconset resource="../resource/app.qrc">
-       <normaloff>:/app/icons/outlines5.png</normaloff>:/app/icons/outlines5.png</iconset>
+       <normaloff>:/app/icons/onionPrev.png</normaloff>:/app/icons/onionPrev.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -404,6 +404,13 @@ border:1px solid #555555;
      </property>
      <property name="checkable">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="4">
+    <widget class="QLabel" name="zoomLabel">
+     <property name="text">
+      <string>Zoom: ???%</string>
      </property>
     </widget>
    </item>

--- a/core_lib/canvasrenderer.cpp
+++ b/core_lib/canvasrenderer.cpp
@@ -395,7 +395,7 @@ int round100( double f, int gridSize )
 
 void CanvasRenderer::paintGrid( QPainter& painter )
 {
-    const int gridSize = 50;
+    int gridSize = mOptions.nGridSize;
 
     QRectF rect = painter.viewport();
     QRectF boundingRect = mViewTransform.inverted().mapRect( rect );
@@ -415,7 +415,8 @@ void CanvasRenderer::paintGrid( QPainter& painter )
     painter.setPen( pen );
     painter.setWorldMatrixEnabled( true );
     painter.setBrush( Qt::NoBrush );
-
+    QPainter::RenderHints previous_renderhints = painter.renderHints();
+    painter.setRenderHint(QPainter::QPainter::Antialiasing, false);
     for ( int x = left; x < right; x += gridSize )
     {
         painter.drawLine( x, top, x, bottom );
@@ -425,4 +426,5 @@ void CanvasRenderer::paintGrid( QPainter& painter )
     {
         painter.drawLine( left, y, right, y );
     }
+    painter.setRenderHints(previous_renderhints);
 }

--- a/core_lib/canvasrenderer.h
+++ b/core_lib/canvasrenderer.h
@@ -41,6 +41,7 @@ struct RenderOptions
     bool  bColorizeNextOnion = false;
     bool  bAntiAlias = false;
     bool  bGrid = false;
+    int   nGridSize = 50; /* This is the grid size IN PIXELS. The grid will scale with the image, though! - Nick */
     bool  bAxis = false;
     bool  bThinLines = false;
     bool  bOutlines = false;

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1035,17 +1035,24 @@ void ScribbleArea::drawPencil( QPointF thePoint, qreal brushWidth, QColor fillCo
     drawBrush(thePoint, brushWidth, 50, fillColour, opacity / 5);
 }
 
-void ScribbleArea::drawBrush( QPointF thePoint, qreal brushWidth, qreal mOffset, QColor fillColour, qreal opacity )
+void ScribbleArea::drawBrush( QPointF thePoint, qreal brushWidth, qreal mOffset, QColor fillColour, qreal opacity, bool usingFeather )
 {
-    QRadialGradient radialGrad( thePoint, 0.5 * brushWidth );
-    setGaussianGradient( radialGrad, fillColour, opacity, mOffset );
-
     QRectF rectangle( thePoint.x() - 0.5 * brushWidth, thePoint.y() - 0.5 * brushWidth, brushWidth, brushWidth );
 
     BitmapImage* tempBitmapImage = new BitmapImage;
-    tempBitmapImage->drawEllipse( rectangle, Qt::NoPen, radialGrad,
-                               QPainter::CompositionMode_Source, mPrefs->isOn( SETTING::ANTIALIAS ) );
+    if (usingFeather==true)
+    {
+        QRadialGradient radialGrad( thePoint, 0.5 * brushWidth );
+        setGaussianGradient( radialGrad, fillColour, opacity, mOffset );
 
+        tempBitmapImage->drawEllipse( rectangle, Qt::NoPen, radialGrad,
+                                   QPainter::CompositionMode_Source, mPrefs->isOn( SETTING::ANTIALIAS ) );
+    }
+    else
+    {
+        tempBitmapImage->drawEllipse( rectangle, Qt::NoPen, QBrush(fillColour, Qt::SolidPattern),
+                                   QPainter::CompositionMode_Source, mPrefs->isOn( SETTING::ANTIALIAS ) );
+    }
     mBufferImg->paste( tempBitmapImage );
     delete tempBitmapImage;
 }

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -175,7 +175,7 @@ public:
     void drawPath( QPainterPath path, QPen pen, QBrush brush, QPainter::CompositionMode cm );
     void drawPen( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity );
     void drawPencil( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity );
-    void drawBrush( QPointF thePoint, qreal brushWidth, qreal offset, QColor fillColour, qreal opacity );
+    void drawBrush( QPointF thePoint, qreal brushWidth, qreal offset, QColor fillColour, qreal opacity, bool usingFeather = true );
     void drawEraser( QPointF thePoint, qreal brushWidth, qreal offset, QColor fillColour, qreal opacity );
     void blurBrush( BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal offset_, qreal opacity_ );
     void liquifyBrush( BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal offset_, qreal opacity_ );

--- a/core_lib/interface/tooloptiondockwidget.cpp
+++ b/core_lib/interface/tooloptiondockwidget.cpp
@@ -34,6 +34,7 @@ void ToolOptionWidget::updateUI()
     mSizeSlider->setVisible( currentTool->isPropertyEnabled( WIDTH ) );
     mBrushSpinBox->setVisible( currentTool->isPropertyEnabled( WIDTH) );
     mFeatherSlider->setVisible( currentTool->isPropertyEnabled( FEATHER ) );
+    mUseFeatherBox->setVisible( currentTool->isPropertyEnabled( FEATHER ) );
     mFeatherSpinBox->setVisible( currentTool->isPropertyEnabled( FEATHER) );
     mUseBezierBox->setVisible( currentTool->isPropertyEnabled( BEZIER ) );
     mUsePressureBox->setVisible( currentTool->isPropertyEnabled( PRESSURE ) );
@@ -76,6 +77,11 @@ void ToolOptionWidget::createUI()
     mFeatherSpinBox->setRange(2,64);
     mFeatherSpinBox->setValue(settings.value( "brushFeather" ).toDouble() );
 
+    mUseFeatherBox = new QCheckBox( tr( "Use Feather?" ) );
+    mUseFeatherBox->setToolTip( tr( "Enable or disable feathering" ) );
+    mUseFeatherBox->setFont( QFont( "Helvetica", 10 ) );
+    mUseFeatherBox->setChecked( settings.value( "brushUseFeather" ).toBool() );
+
     mUseBezierBox = new QCheckBox( tr( "Bezier" ) );
     mUseBezierBox->setToolTip( tr( "Bezier curve fitting" ) );
     mUseBezierBox->setFont( QFont( "Helvetica", 10 ) );
@@ -103,6 +109,7 @@ void ToolOptionWidget::createUI()
     pLayout->addWidget( mUseBezierBox, 10, 0, 1, 2 );
     pLayout->addWidget( mUsePressureBox, 11, 0, 1, 2 );
     pLayout->addWidget( mPreserveAlphaBox, 12, 0, 1, 2 );
+    pLayout->addWidget( mUseFeatherBox, 13, 0, 1, 2 );
     pLayout->addWidget( mMakeInvisibleBox, 14, 0, 1, 2 );
 
     pLayout->setRowStretch( 15, 1 );
@@ -126,6 +133,8 @@ void ToolOptionWidget::makeConnectionToEditor( Editor* editor )
 
     connect( mBrushSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), toolManager, &ToolManager::setWidth );
     connect( mFeatherSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), toolManager, &ToolManager::setFeather );
+
+    connect( mUseFeatherBox, &QCheckBox::clicked, toolManager, &ToolManager::setUseFeather );
 
     connect( toolManager, &ToolManager::toolChanged, this, &ToolOptionWidget::onToolChanged );
     connect( toolManager, &ToolManager::toolPropertyChanged, this, &ToolOptionWidget::onToolPropertyChanged );
@@ -211,6 +220,7 @@ void ToolOptionWidget::disableAllOptions()
     mBrushSpinBox->hide();
     mFeatherSlider->hide();
     mFeatherSpinBox->hide();
+    mUseFeatherBox->hide();
     mUseBezierBox->hide();
     mUsePressureBox->hide();
     mMakeInvisibleBox->hide();

--- a/core_lib/interface/tooloptiondockwidget.h
+++ b/core_lib/interface/tooloptiondockwidget.h
@@ -40,6 +40,7 @@ private:
 
     QCheckBox* mUseBezierBox     = nullptr;
     QCheckBox* mUsePressureBox   = nullptr;
+    QCheckBox* mUseFeatherBox    = nullptr;
     QCheckBox* mMakeInvisibleBox = nullptr;
     QCheckBox* mPreserveAlphaBox = nullptr;
     QSpinBox* mBrushSpinBox      = nullptr;

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -128,6 +128,12 @@ void ToolManager::setFeather( float newFeather )
     Q_EMIT toolPropertyChanged( currentTool()->type(), FEATHER );
 }
 
+void ToolManager::setUseFeather( bool usingFeather )
+{
+    currentTool()->setUseFeather( usingFeather );
+    Q_EMIT toolPropertyChanged( currentTool()->type(), USEFEATHER );
+}
+
 void ToolManager::setInvisibility( bool isInvisible )
 {
     currentTool()->setInvisibility(isInvisible);

--- a/core_lib/managers/toolmanager.h
+++ b/core_lib/managers/toolmanager.h
@@ -39,6 +39,7 @@ public slots:
 
     void setWidth( float );
     void setFeather( float );
+    void setUseFeather( bool );
     void setInvisibility( bool );
     void setPreserveAlpha( bool );
     void setBezier( bool );

--- a/core_lib/tool/basetool.cpp
+++ b/core_lib/tool/basetool.cpp
@@ -295,6 +295,11 @@ void BaseTool::setFeather( const qreal feather )
     properties.feather = feather;
 }
 
+void BaseTool::setUseFeather( const bool usingFeather )
+{
+    properties.useFeather = usingFeather;
+}
+
 void BaseTool::setInvisibility( const bool invisibility )
 {
     properties.invisibility = invisibility;

--- a/core_lib/tool/basetool.h
+++ b/core_lib/tool/basetool.h
@@ -25,6 +25,7 @@ public:
     int invisibility  = 0;
     int preserveAlpha = 0;
     bool bezier_state = false;
+    bool useFeather   = true;
 };
 
 const int ON = 1;
@@ -77,6 +78,7 @@ public:
     virtual void setInvisibility( const bool invisibility );
     virtual void setBezier( const bool bezier_state );
     virtual void setPressure( const bool pressure );
+    virtual void setUseFeather( const bool usingFeather );
     virtual void setPreserveAlpha( const bool preserveAlpha );
     virtual void leavingThisTool(){}
     virtual void switchingLayers(){}

--- a/core_lib/tool/brushtool.cpp
+++ b/core_lib/tool/brushtool.cpp
@@ -38,7 +38,7 @@ void BrushTool::loadSettings()
 
     properties.width = settings.value( "brushWidth" ).toDouble();
     properties.feather = settings.value( "brushFeather", 15.0 ).toDouble();
-
+    properties.useFeather = settings.value( "brushUseFeather", true ).toBool();
     properties.pressure = settings.value( "brushPressure", true ).toBool();
     properties.invisibility = DISABLED;
     properties.preserveAlpha = OFF;
@@ -64,6 +64,17 @@ void BrushTool::setWidth(const qreal width)
     // Update settings
     QSettings settings( PENCIL2D, PENCIL2D );
     settings.setValue("brushWidth", width);
+    settings.sync();
+}
+
+void BrushTool::setUseFeather( const bool usingFeather )
+{
+    // Set current property
+    properties.useFeather = usingFeather;
+
+    // Update settings
+    QSettings settings( PENCIL2D, PENCIL2D );
+    settings.setValue("brushUseFeather", usingFeather);
     settings.sync();
 }
 
@@ -243,7 +254,8 @@ void BrushTool::drawStroke()
                                       brushWidth,
                                       properties.feather,
                                       mEditor->color()->frontColor(),
-                                      opacity );
+                                      opacity,
+                                      properties.useFeather );
 
             if ( i == ( steps - 1 ) )
             {

--- a/core_lib/tool/brushtool.h
+++ b/core_lib/tool/brushtool.h
@@ -24,6 +24,7 @@ public:
 
     void setWidth( const qreal width ) override;
     void setFeather( const qreal feather ) override;
+    void setUseFeather( const bool usingFeather ) override;
     void setPressure( const bool pressure ) override;
 
 protected:

--- a/core_lib/tool/eyedroppertool.cpp
+++ b/core_lib/tool/eyedroppertool.cpp
@@ -24,6 +24,7 @@ void EyedropperTool::loadSettings()
 {
     properties.width = -1;
     properties.feather = -1;
+    properties.useFeather = -1;
 }
 
 QCursor EyedropperTool::cursor()

--- a/core_lib/tool/handtool.cpp
+++ b/core_lib/tool/handtool.cpp
@@ -17,6 +17,7 @@ void HandTool::loadSettings()
 {
     properties.width = -1;
     properties.feather = -1;
+    properties.useFeather = -1;
 }
 
 QCursor HandTool::cursor()

--- a/core_lib/tool/movetool.cpp
+++ b/core_lib/tool/movetool.cpp
@@ -21,6 +21,7 @@ void MoveTool::loadSettings()
 {
     properties.width = -1;
     properties.feather = -1;
+    properties.useFeather = -1;
 }
 
 QCursor MoveTool::cursor()

--- a/core_lib/util/pencildef.h
+++ b/core_lib/util/pencildef.h
@@ -34,7 +34,8 @@ enum ToolPropertyType
     PRESSURE,
     INVISIBILITY,
     PRESERVEALPHA,
-    BEZIER
+    BEZIER,
+    USEFEATHER
 };
 
 enum BackgroundStyle


### PR DESCRIPTION
Brush feathering can be disabled and reenabled through a simple
checkbox, no harm done.
Zoom level is seen on the display options widget. It's not pretty but it
works.