### PR TITLE
Fixed layers rendering order

### DIFF
--- a/core_lib/canvasrenderer.cpp
+++ b/core_lib/canvasrenderer.cpp
@@ -337,23 +337,21 @@ void CanvasRenderer::paintTransformedSelection( QPainter& painter )
 
 void CanvasRenderer::paintCurrentFrame( QPainter& painter )
 {
-    if (mOptions.nShowAllLayers > 0) {
 
-        if (mOptions.nShowAllLayers == 1) {
-            painter.setOpacity( 0.8 );
-        }
-        else {
+    for ( int i = 0; i < mObject->getLayerCount(); ++i )
+    {
+        Layer* layer = mObject->getLayer( i );
+
+        if ( i == mLayerIndex || mOptions.nShowAllLayers != 1 )
+        {
             painter.setOpacity( 1.0 );
         }
+        else {
+            painter.setOpacity( 0.8 );
+        }
 
-        for ( int i = 0; i < mObject->getLayerCount(); ++i )
-        {
-            Layer* layer = mObject->getLayer( i );
-            if ( i == mLayerIndex )
-            {
-                continue; // current layer should be paint at last.
-            }
 
+        if ( i == mLayerIndex || mOptions.nShowAllLayers > 0 ) {
             switch ( layer->type() )
             {
                 case Layer::BITMAP: { paintBitmapFrame( painter, layer, mFrameNumber ); break; }
@@ -363,19 +361,6 @@ void CanvasRenderer::paintCurrentFrame( QPainter& painter )
                 default: Q_ASSERT( false ); break;
             }
         }
-    }
-
-
-    painter.setOpacity( 1.0 );
-
-    Layer* currentLayer = mObject->getLayer( mLayerIndex );
-    switch ( currentLayer->type() )
-    {
-        case Layer::BITMAP: { paintBitmapFrame( painter, currentLayer, mFrameNumber ); break; }
-        case Layer::VECTOR: { paintVectorFrame( painter, currentLayer, mFrameNumber ); break; }
-        case Layer::CAMERA: break;
-        case Layer::SOUND: break;
-        default: Q_ASSERT( false ); break;
     }
 }
 


### PR DESCRIPTION
Fixes bug : https://github.com/pencil2d/pencil/issues/386

The current selected layer was always rendered on top of the others. This broke the "paint on a different layer" feature because as soon as we were working on the colour layer for adjustments, we were overlapping the strokes.