### PR TITLE
Single-point brush strokes, grid customization, zoom info, optional pixel brush

### DIFF
--- a/app/displayoptionwidget.cpp
+++ b/app/displayoptionwidget.cpp
@@ -30,6 +30,15 @@ void DisplayOptionWidget::initUI()
     updateUI();
 }
 
+void DisplayOptionWidget::updateZoomLabel()
+{
+    ViewManager * viewmanager = editor()->view();
+
+    float zoom = (viewmanager->scaling())*100.0f;
+
+    ui->zoomLabel->setText(QString("Zoom: ")+QString("").setNum(zoom)+QString("%"));
+}
+
 void DisplayOptionWidget::makeConnectionToEditor( Editor* editor )
 {
     PreferenceManager* prefs = editor->preference();
@@ -46,6 +55,8 @@ void DisplayOptionWidget::makeConnectionToEditor( Editor* editor )
     connect( ui->cameraBorderButton, &QToolButton::clicked, pScriArea, &ScribbleArea::toggleCameraBorder);
 
     connect( prefs, &PreferenceManager::optionChanged, this, &DisplayOptionWidget::updateUI );
+
+    connect( editor->view(), &ViewManager::viewChanged, this, &DisplayOptionWidget::updateZoomLabel );
 
     updateUI();
 

--- a/app/displayoptionwidget.h
+++ b/app/displayoptionwidget.h
@@ -9,7 +9,7 @@ namespace Ui
 }
 class Editor;
 class QToolButton;
-
+class ViewManager;
 
 class DisplayOptionWidget : public BaseDockWidget
 {
@@ -20,6 +20,8 @@ public:
 
     void initUI() override;
     void updateUI() override;
+
+    void updateZoomLabel();
 
     void makeConnectionToEditor(Editor* editor);
 

--- a/app/preferencesdialog.cpp
+++ b/app/preferencesdialog.cpp
@@ -43,10 +43,14 @@ void PreferencesDialog::init( PreferenceManager* m )
     general->updateValues();
     //connect(mPrefManager, &PreferenceManager::effectChanged, general, &GeneralPage::updateValues);
     
+    GridPage* grid = new GridPage( this );
+    grid->setManager( mPrefManager );
+    grid->updateValues();
+
     FilesPage* file = new FilesPage( this );
     file->setManager( mPrefManager );
     file->updateValues();
-    
+
     TimelinePage* timeline = new TimelinePage( this );
     timeline->setManager( mPrefManager );
     timeline->updateValues();
@@ -60,6 +64,7 @@ void PreferencesDialog::init( PreferenceManager* m )
 
     pagesWidget = new QStackedWidget;
     pagesWidget->addWidget( general );
+    pagesWidget->addWidget( grid );
     pagesWidget->addWidget( file );
     pagesWidget->addWidget( timeline );
     pagesWidget->addWidget( tools );
@@ -101,6 +106,12 @@ void PreferencesDialog::createIcons()
     generalButton->setText(tr("General"));
     generalButton->setTextAlignment(Qt::AlignHCenter);
     generalButton->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+
+    QListWidgetItem* gridButton = new QListWidgetItem(contentsWidget);
+    gridButton->setIcon(QIcon(":icons/prefspencil.png")); /* this needs its own icon sometime! */
+    gridButton->setText(tr("Grid"));
+    gridButton->setTextAlignment(Qt::AlignHCenter);
+    gridButton->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 
     QListWidgetItem* filesButton = new QListWidgetItem(contentsWidget);
     filesButton->setIcon(QIcon(":icons/prefs-files.png"));
@@ -263,7 +274,6 @@ GeneralPage::GeneralPage(QWidget* parent) : QWidget(parent)
 }
 
 
-
 void GeneralPage::updateValues()
 {
     mCurveSmoothingLevel->setValue(mManager->getInt(SETTING::CURVE_SMOOTHING));
@@ -348,6 +358,42 @@ void GeneralPage::dottedCursorCheckboxStateChanged(bool b)
     mManager->set( SETTING::DOTTED_CURSOR, b );
 }
 
+
+GridPage::GridPage(QWidget* parent) : QWidget(parent)
+{
+    QSettings settings( PENCIL2D, PENCIL2D );
+    QVBoxLayout* lay = new QVBoxLayout();
+
+    QGroupBox* gridSizeBox = new QGroupBox(tr("Grid Size"));
+
+    mGridSizeInput = new QSpinBox();
+    mGridSizeInput->setMinimum(1);
+    mGridSizeInput->setMaximum(512);
+    mGridSizeInput->setFixedWidth(80);
+    int gridSize = settings.value("gridSize").toInt();
+    mGridSizeInput->setValue( gridSize );
+
+    connect( mGridSizeInput, SIGNAL(valueChanged(int)), this, SLOT(gridSizeChange(int)));
+
+    QGridLayout* gridSizeLayout = new QGridLayout();
+    gridSizeBox->setLayout(gridSizeLayout);
+    gridSizeLayout->addWidget(mGridSizeInput, 0, 0);
+
+    lay->addWidget(gridSizeBox);
+
+
+    setLayout(lay);
+}
+
+void GridPage::updateValues()
+{
+    mGridSizeInput->setValue(mManager->getInt(SETTING::GRID_SIZE));
+}
+
+void GridPage::gridSizeChange(int value)
+{
+    mManager->set(SETTING::GRID_SIZE, value);
+}
 
 TimelinePage::TimelinePage(QWidget* parent) : QWidget(parent)
 {

--- a/app/preferencesdialog.h
+++ b/app/preferencesdialog.h
@@ -105,6 +105,27 @@ private:
 
 };
 
+class GridPage : public QWidget
+{
+    Q_OBJECT
+public:
+    GridPage(QWidget* parent = 0);
+    void setManager( PreferenceManager* p ) { mManager = p; }
+
+
+public slots:
+    void updateValues();
+    void gridSizeChange(int value);
+
+private:
+
+    PreferenceManager* mManager = nullptr;
+
+    QSpinBox* mGridSizeInput;
+
+};
+
+
 class TimelinePage : public QWidget
 {
     Q_OBJECT

--- a/app/ui/displayoption.ui
+++ b/app/ui/displayoption.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>156</width>
-    <height>128</height>
+    <height>210</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -54,6 +54,49 @@ border:1px solid #555555;
      <property name="icon">
       <iconset resource="../resource/app.qrc">
        <normaloff>:/app/icons/mirrorV.png</normaloff>:/app/icons/mirrorV.png</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>21</width>
+       <height>21</height>
+      </size>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QToolButton" name="thinLinesButton">
+     <property name="mouseTracking">
+      <bool>false</bool>
+     </property>
+     <property name="acceptDrops">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Show invisible lines</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QToolButton { 
+background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.0851364, y2:0.278, stop:0 rgba(216, 216, 216, 255), stop:1 rgba(250, 250, 250, 255));
+
+/*border:1px solid #555555;*/
+
+border-radius:5px;
+}
+
+QToolButton:pressed, QToolButton:checked { 
+background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.085, y2:0.0791364, stop:0 rgba(246, 252, 255, 255), stop:1 rgba(204, 217, 250, 255));
+border:1px solid #555555;
+}</string>
+     </property>
+     <property name="text">
+      <string>...</string>
+     </property>
+     <property name="icon">
+      <iconset resource="../resource/app.qrc">
+       <normaloff>:/app/icons/thinlines5.png</normaloff>:/app/icons/thinlines5.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -118,16 +161,13 @@ border:1px solid #555555;
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QToolButton" name="thinLinesButton">
-     <property name="mouseTracking">
-      <bool>false</bool>
-     </property>
-     <property name="acceptDrops">
-      <bool>true</bool>
-     </property>
+   <item row="0" column="3">
+    <widget class="QToolButton" name="onionRedButton">
      <property name="toolTip">
-      <string>Show invisible lines</string>
+      <string>Onion skin color: red</string>
+     </property>
+     <property name="statusTip">
+      <string>Onion skin color: red</string>
      </property>
      <property name="styleSheet">
       <string notr="true">QToolButton { 
@@ -148,7 +188,7 @@ border:1px solid #555555;
      </property>
      <property name="icon">
       <iconset resource="../resource/app.qrc">
-       <normaloff>:/app/icons/thinlines5.png</normaloff>:/app/icons/thinlines5.png</iconset>
+       <normaloff>:/app/icons/onion-red.png</normaloff>:/app/icons/onion-red.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -161,16 +201,10 @@ border:1px solid #555555;
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
-    <widget class="QToolButton" name="onionPrevButton">
+   <item row="1" column="1">
+    <widget class="QToolButton" name="outLinesButton">
      <property name="toolTip">
-      <string>Onion skin previous frame</string>
-     </property>
-     <property name="statusTip">
-      <string>Onion skin previous frame</string>
-     </property>
-     <property name="autoFillBackground">
-      <bool>false</bool>
+      <string>Show outlines only</string>
      </property>
      <property name="styleSheet">
       <string notr="true">QToolButton { 
@@ -191,7 +225,7 @@ border:1px solid #555555;
      </property>
      <property name="icon">
       <iconset resource="../resource/app.qrc">
-       <normaloff>:/app/icons/onionPrev.png</normaloff>:/app/icons/onionPrev.png</iconset>
+       <normaloff>:/app/icons/outlines5.png</normaloff>:/app/icons/outlines5.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -293,13 +327,16 @@ border:1px solid #555555;
      </property>
     </widget>
    </item>
-   <item row="0" column="3">
-    <widget class="QToolButton" name="onionRedButton">
+   <item row="0" column="2">
+    <widget class="QToolButton" name="onionPrevButton">
      <property name="toolTip">
-      <string>Onion skin color: red</string>
+      <string>Onion skin previous frame</string>
      </property>
      <property name="statusTip">
-      <string>Onion skin color: red</string>
+      <string>Onion skin previous frame</string>
+     </property>
+     <property name="autoFillBackground">
+      <bool>false</bool>
      </property>
      <property name="styleSheet">
       <string notr="true">QToolButton { 
@@ -320,44 +357,7 @@ border:1px solid #555555;
      </property>
      <property name="icon">
       <iconset resource="../resource/app.qrc">
-       <normaloff>:/app/icons/onion-red.png</normaloff>:/app/icons/onion-red.png</iconset>
-     </property>
-     <property name="iconSize">
-      <size>
-       <width>21</width>
-       <height>21</height>
-      </size>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QToolButton" name="outLinesButton">
-     <property name="toolTip">
-      <string>Show outlines only</string>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">QToolButton { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.0851364, y2:0.278, stop:0 rgba(216, 216, 216, 255), stop:1 rgba(250, 250, 250, 255));
-
-/*border:1px solid #555555;*/
-
-border-radius:5px;
-}
-
-QToolButton:pressed, QToolButton:checked { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.085, y2:0.0791364, stop:0 rgba(246, 252, 255, 255), stop:1 rgba(204, 217, 250, 255));
-border:1px solid #555555;
-}</string>
-     </property>
-     <property name="text">
-      <string>...</string>
-     </property>
-     <property name="icon">
-      <iconset resource="../resource/app.qrc">
-       <normaloff>:/app/icons/outlines5.png</normaloff>:/app/icons/outlines5.png</iconset>
+       <normaloff>:/app/icons/onionPrev.png</normaloff>:/app/icons/onionPrev.png</iconset>
      </property>
      <property name="iconSize">
       <size>
@@ -404,6 +404,13 @@ border:1px solid #555555;
      </property>
      <property name="checkable">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="4">
+    <widget class="QLabel" name="zoomLabel">
+     <property name="text">
+      <string>Zoom: ???%</string>
      </property>
     </widget>
    </item>

--- a/core_lib/canvasrenderer.cpp
+++ b/core_lib/canvasrenderer.cpp
@@ -395,7 +395,7 @@ int round100( double f, int gridSize )
 
 void CanvasRenderer::paintGrid( QPainter& painter )
 {
-    const int gridSize = 50;
+    int gridSize = mOptions.nGridSize;
 
     QRectF rect = painter.viewport();
     QRectF boundingRect = mViewTransform.inverted().mapRect( rect );
@@ -415,7 +415,8 @@ void CanvasRenderer::paintGrid( QPainter& painter )
     painter.setPen( pen );
     painter.setWorldMatrixEnabled( true );
     painter.setBrush( Qt::NoBrush );
-
+    QPainter::RenderHints previous_renderhints = painter.renderHints();
+    painter.setRenderHint(QPainter::QPainter::Antialiasing, false);
     for ( int x = left; x < right; x += gridSize )
     {
         painter.drawLine( x, top, x, bottom );
@@ -425,4 +426,5 @@ void CanvasRenderer::paintGrid( QPainter& painter )
     {
         painter.drawLine( left, y, right, y );
     }
+    painter.setRenderHints(previous_renderhints);
 }

--- a/core_lib/canvasrenderer.h
+++ b/core_lib/canvasrenderer.h
@@ -41,6 +41,7 @@ struct RenderOptions
     bool  bColorizeNextOnion = false;
     bool  bAntiAlias = false;
     bool  bGrid = false;
+    int   nGridSize = 50; /* This is the grid size IN PIXELS. The grid will scale with the image, though! - Nick */
     bool  bAxis = false;
     bool  bThinLines = false;
     bool  bOutlines = false;

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1035,17 +1035,24 @@ void ScribbleArea::drawPencil( QPointF thePoint, qreal brushWidth, QColor fillCo
     drawBrush(thePoint, brushWidth, 50, fillColour, opacity / 5);
 }
 
-void ScribbleArea::drawBrush( QPointF thePoint, qreal brushWidth, qreal mOffset, QColor fillColour, qreal opacity )
+void ScribbleArea::drawBrush( QPointF thePoint, qreal brushWidth, qreal mOffset, QColor fillColour, qreal opacity, bool usingFeather )
 {
-    QRadialGradient radialGrad( thePoint, 0.5 * brushWidth );
-    setGaussianGradient( radialGrad, fillColour, opacity, mOffset );
-
     QRectF rectangle( thePoint.x() - 0.5 * brushWidth, thePoint.y() - 0.5 * brushWidth, brushWidth, brushWidth );
 
     BitmapImage* tempBitmapImage = new BitmapImage;
-    tempBitmapImage->drawEllipse( rectangle, Qt::NoPen, radialGrad,
-                               QPainter::CompositionMode_Source, mPrefs->isOn( SETTING::ANTIALIAS ) );
+    if (usingFeather==true)
+    {
+        QRadialGradient radialGrad( thePoint, 0.5 * brushWidth );
+        setGaussianGradient( radialGrad, fillColour, opacity, mOffset );
 
+        tempBitmapImage->drawEllipse( rectangle, Qt::NoPen, radialGrad,
+                                   QPainter::CompositionMode_Source, mPrefs->isOn( SETTING::ANTIALIAS ) );
+    }
+    else
+    {
+        tempBitmapImage->drawEllipse( rectangle, Qt::NoPen, QBrush(fillColour, Qt::SolidPattern),
+                                   QPainter::CompositionMode_Source, mPrefs->isOn( SETTING::ANTIALIAS ) );
+    }
     mBufferImg->paste( tempBitmapImage );
     delete tempBitmapImage;
 }

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -134,6 +134,9 @@ void ScribbleArea::settingUpdated(SETTING setting)
     case SETTING::GRID:
         updateAllFrames();
         break;
+    case SETTING::GRID_SIZE:
+        updateAllFrames();
+        break;
     default:
         break;
     }
@@ -976,6 +979,7 @@ void ScribbleArea::drawCanvas( int frame, QRect rect )
     options.fOnionSkinMinOpacity = mPrefs->getInt(SETTING::ONION_MIN_OPACITY);
     options.bAntiAlias = mPrefs->isOn( SETTING::ANTIALIAS );
     options.bGrid = mPrefs->isOn( SETTING::GRID );
+    options.nGridSize = mPrefs->getInt( SETTING::GRID_SIZE );
     options.bAxis = mPrefs->isOn( SETTING::AXIS );
     options.bThinLines = mPrefs->isOn( SETTING::INVISIBLE_LINES );
     options.bOutlines = mPrefs->isOn( SETTING::OUTLINES );

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -175,7 +175,7 @@ public:
     void drawPath( QPainterPath path, QPen pen, QBrush brush, QPainter::CompositionMode cm );
     void drawPen( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity );
     void drawPencil( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity );
-    void drawBrush( QPointF thePoint, qreal brushWidth, qreal offset, QColor fillColour, qreal opacity );
+    void drawBrush( QPointF thePoint, qreal brushWidth, qreal offset, QColor fillColour, qreal opacity, bool usingFeather = true );
     void drawEraser( QPointF thePoint, qreal brushWidth, qreal offset, QColor fillColour, qreal opacity );
     void blurBrush( BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal offset_, qreal opacity_ );
     void liquifyBrush( BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal offset_, qreal opacity_ );

--- a/core_lib/interface/tooloptiondockwidget.cpp
+++ b/core_lib/interface/tooloptiondockwidget.cpp
@@ -34,6 +34,7 @@ void ToolOptionWidget::updateUI()
     mSizeSlider->setVisible( currentTool->isPropertyEnabled( WIDTH ) );
     mBrushSpinBox->setVisible( currentTool->isPropertyEnabled( WIDTH) );
     mFeatherSlider->setVisible( currentTool->isPropertyEnabled( FEATHER ) );
+    mUseFeatherBox->setVisible( currentTool->isPropertyEnabled( FEATHER ) );
     mFeatherSpinBox->setVisible( currentTool->isPropertyEnabled( FEATHER) );
     mUseBezierBox->setVisible( currentTool->isPropertyEnabled( BEZIER ) );
     mUsePressureBox->setVisible( currentTool->isPropertyEnabled( PRESSURE ) );
@@ -76,6 +77,11 @@ void ToolOptionWidget::createUI()
     mFeatherSpinBox->setRange(2,64);
     mFeatherSpinBox->setValue(settings.value( "brushFeather" ).toDouble() );
 
+    mUseFeatherBox = new QCheckBox( tr( "Use Feather?" ) );
+    mUseFeatherBox->setToolTip( tr( "Enable or disable feathering" ) );
+    mUseFeatherBox->setFont( QFont( "Helvetica", 10 ) );
+    mUseFeatherBox->setChecked( settings.value( "brushUseFeather" ).toBool() );
+
     mUseBezierBox = new QCheckBox( tr( "Bezier" ) );
     mUseBezierBox->setToolTip( tr( "Bezier curve fitting" ) );
     mUseBezierBox->setFont( QFont( "Helvetica", 10 ) );
@@ -103,6 +109,7 @@ void ToolOptionWidget::createUI()
     pLayout->addWidget( mUseBezierBox, 10, 0, 1, 2 );
     pLayout->addWidget( mUsePressureBox, 11, 0, 1, 2 );
     pLayout->addWidget( mPreserveAlphaBox, 12, 0, 1, 2 );
+    pLayout->addWidget( mUseFeatherBox, 13, 0, 1, 2 );
     pLayout->addWidget( mMakeInvisibleBox, 14, 0, 1, 2 );
 
     pLayout->setRowStretch( 15, 1 );
@@ -126,6 +133,8 @@ void ToolOptionWidget::makeConnectionToEditor( Editor* editor )
 
     connect( mBrushSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), toolManager, &ToolManager::setWidth );
     connect( mFeatherSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), toolManager, &ToolManager::setFeather );
+
+    connect( mUseFeatherBox, &QCheckBox::clicked, toolManager, &ToolManager::setUseFeather );
 
     connect( toolManager, &ToolManager::toolChanged, this, &ToolOptionWidget::onToolChanged );
     connect( toolManager, &ToolManager::toolPropertyChanged, this, &ToolOptionWidget::onToolPropertyChanged );
@@ -211,6 +220,7 @@ void ToolOptionWidget::disableAllOptions()
     mBrushSpinBox->hide();
     mFeatherSlider->hide();
     mFeatherSpinBox->hide();
+    mUseFeatherBox->hide();
     mUseBezierBox->hide();
     mUsePressureBox->hide();
     mMakeInvisibleBox->hide();

--- a/core_lib/interface/tooloptiondockwidget.h
+++ b/core_lib/interface/tooloptiondockwidget.h
@@ -40,6 +40,7 @@ private:
 
     QCheckBox* mUseBezierBox     = nullptr;
     QCheckBox* mUsePressureBox   = nullptr;
+    QCheckBox* mUseFeatherBox    = nullptr;
     QCheckBox* mMakeInvisibleBox = nullptr;
     QCheckBox* mPreserveAlphaBox = nullptr;
     QSpinBox* mBrushSpinBox      = nullptr;

--- a/core_lib/managers/preferencemanager.cpp
+++ b/core_lib/managers/preferencemanager.cpp
@@ -36,6 +36,9 @@ void PreferenceManager::loadPrefs()
     set( SETTING::MIRROR_H,                 false ); // Always off by default
     set( SETTING::MIRROR_V,                 false ); // Always off by default
 
+    // Grid
+    set( SETTING::GRID_SIZE,                settings.value( SETTING_GRID_SIZE,               50 ).toInt() );
+
     // General
     //
     set( SETTING::ANTIALIAS,                settings.value( SETTING_ANTIALIAS,              true ).toBool() );
@@ -194,6 +197,9 @@ void PreferenceManager::set( SETTING option, int value )
         break;
     case SETTING::ONION_NEXT_FRAMES_NUM:
         settings.setValue ( SETTING_ONION_NEXT_FRAMES_NUM, value );
+        break;
+    case SETTING::GRID_SIZE:
+        settings.setValue ( SETTING_GRID_SIZE, value );
         break;
     default:
         break;

--- a/core_lib/managers/preferencemanager.h
+++ b/core_lib/managers/preferencemanager.h
@@ -39,7 +39,8 @@ enum class SETTING
     ONION_MIN_OPACITY,
     ONION_PREV_FRAMES_NUM,
     ONION_NEXT_FRAMES_NUM,
-    ONION_TYPE
+    ONION_TYPE,
+    GRID_SIZE
 };
 
 class PreferenceManager : public BaseManager

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -128,6 +128,12 @@ void ToolManager::setFeather( float newFeather )
     Q_EMIT toolPropertyChanged( currentTool()->type(), FEATHER );
 }
 
+void ToolManager::setUseFeather( bool usingFeather )
+{
+    currentTool()->setUseFeather( usingFeather );
+    Q_EMIT toolPropertyChanged( currentTool()->type(), USEFEATHER );
+}
+
 void ToolManager::setInvisibility( bool isInvisible )
 {
     currentTool()->setInvisibility(isInvisible);

--- a/core_lib/managers/toolmanager.h
+++ b/core_lib/managers/toolmanager.h
@@ -39,6 +39,7 @@ public slots:
 
     void setWidth( float );
     void setFeather( float );
+    void setUseFeather( bool );
     void setInvisibility( bool );
     void setPreserveAlpha( bool );
     void setBezier( bool );

--- a/core_lib/tool/basetool.cpp
+++ b/core_lib/tool/basetool.cpp
@@ -295,6 +295,11 @@ void BaseTool::setFeather( const qreal feather )
     properties.feather = feather;
 }
 
+void BaseTool::setUseFeather( const bool usingFeather )
+{
+    properties.useFeather = usingFeather;
+}
+
 void BaseTool::setInvisibility( const bool invisibility )
 {
     properties.invisibility = invisibility;

--- a/core_lib/tool/basetool.h
+++ b/core_lib/tool/basetool.h
@@ -25,6 +25,7 @@ public:
     int invisibility  = 0;
     int preserveAlpha = 0;
     bool bezier_state = false;
+    bool useFeather   = true;
 };
 
 const int ON = 1;
@@ -77,6 +78,7 @@ public:
     virtual void setInvisibility( const bool invisibility );
     virtual void setBezier( const bool bezier_state );
     virtual void setPressure( const bool pressure );
+    virtual void setUseFeather( const bool usingFeather );
     virtual void setPreserveAlpha( const bool preserveAlpha );
     virtual void leavingThisTool(){}
     virtual void switchingLayers(){}

--- a/core_lib/tool/brushtool.cpp
+++ b/core_lib/tool/brushtool.cpp
@@ -38,7 +38,7 @@ void BrushTool::loadSettings()
 
     properties.width = settings.value( "brushWidth" ).toDouble();
     properties.feather = settings.value( "brushFeather", 15.0 ).toDouble();
-
+    properties.useFeather = settings.value( "brushUseFeather", true ).toBool();
     properties.pressure = settings.value( "brushPressure", true ).toBool();
     properties.invisibility = DISABLED;
     properties.preserveAlpha = OFF;
@@ -64,6 +64,17 @@ void BrushTool::setWidth(const qreal width)
     // Update settings
     QSettings settings( PENCIL2D, PENCIL2D );
     settings.setValue("brushWidth", width);
+    settings.sync();
+}
+
+void BrushTool::setUseFeather( const bool usingFeather )
+{
+    // Set current property
+    properties.useFeather = usingFeather;
+
+    // Update settings
+    QSettings settings( PENCIL2D, PENCIL2D );
+    settings.setValue("brushUseFeather", usingFeather);
     settings.sync();
 }
 
@@ -243,7 +254,8 @@ void BrushTool::drawStroke()
                                       brushWidth,
                                       properties.feather,
                                       mEditor->color()->frontColor(),
-                                      opacity );
+                                      opacity,
+                                      properties.useFeather );
 
             if ( i == ( steps - 1 ) )
             {

--- a/core_lib/tool/brushtool.h
+++ b/core_lib/tool/brushtool.h
@@ -24,6 +24,7 @@ public:
 
     void setWidth( const qreal width ) override;
     void setFeather( const qreal feather ) override;
+    void setUseFeather( const bool usingFeather ) override;
     void setPressure( const bool pressure ) override;
 
 protected:

--- a/core_lib/tool/brushtool.h
+++ b/core_lib/tool/brushtool.h
@@ -30,6 +30,8 @@ public:
 protected:
     QPointF lastBrushPoint;
 
+    QPointF mouseDownPoint;
+
     BitmapImage img;
     QColor currentPressuredColor;
     qreal mOpacity;

--- a/core_lib/tool/eyedroppertool.cpp
+++ b/core_lib/tool/eyedroppertool.cpp
@@ -24,6 +24,7 @@ void EyedropperTool::loadSettings()
 {
     properties.width = -1;
     properties.feather = -1;
+    properties.useFeather = -1;
 }
 
 QCursor EyedropperTool::cursor()

--- a/core_lib/tool/handtool.cpp
+++ b/core_lib/tool/handtool.cpp
@@ -17,6 +17,7 @@ void HandTool::loadSettings()
 {
     properties.width = -1;
     properties.feather = -1;
+    properties.useFeather = -1;
 }
 
 QCursor HandTool::cursor()

--- a/core_lib/tool/movetool.cpp
+++ b/core_lib/tool/movetool.cpp
@@ -21,6 +21,7 @@ void MoveTool::loadSettings()
 {
     properties.width = -1;
     properties.feather = -1;
+    properties.useFeather = -1;
 }
 
 QCursor MoveTool::cursor()

--- a/core_lib/util/pencildef.h
+++ b/core_lib/util/pencildef.h
@@ -34,7 +34,8 @@ enum ToolPropertyType
     PRESSURE,
     INVISIBILITY,
     PRESERVEALPHA,
-    BEZIER
+    BEZIER,
+    USEFEATHER
 };
 
 enum BackgroundStyle

--- a/core_lib/util/pencildef.h
+++ b/core_lib/util/pencildef.h
@@ -158,6 +158,8 @@ enum BackgroundStyle
 #define SETTING_MIRROR_H        "MirrorH"
 #define SETTING_MIRROR_V        "MirrorV"
 
+#define SETTING_GRID_SIZE       "GridSize"
+
 #define SETTING_ONION_MAX_OPACITY       "OnionMaxOpacity"
 #define SETTING_ONION_MIN_OPACITY       "OnionMinOpacity"
 #define SETTING_ONION_PREV_FRAMES_NUM   "OnionPrevFramesNum"


### PR DESCRIPTION
This fork adds the ability to customize grid size in preferences, to make a single point brush stroke, to see the current zoom level, and to disable brush feathering for a "pixel brush" effect. I got the OK from Matt so I figured I'd go ahead and submit a pull request now.