### PR TITLE
#468 Added ctrl/shift quick sizing toggle

### DIFF
--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -65,6 +65,8 @@ bool ScribbleArea::init()
     int curveSmoothingLevel = mPrefs->getInt(SETTING::CURVE_SMOOTHING);
     mCurveSmoothingLevel = curveSmoothingLevel / 20.0; // default value is 1.0
 
+    mQuickSizing = mPrefs->isOn( SETTING::QUICK_SIZING );
+
     mMakeInvisible = false;
     somethingSelected = false;
 
@@ -136,6 +138,8 @@ void ScribbleArea::settingUpdated(SETTING setting)
         break;
     case SETTING::GRID_SIZE:
         updateAllFrames();
+    case SETTING::QUICK_SIZING:
+        mQuickSizing = mPrefs->isOn( SETTING::QUICK_SIZING );
         break;
     default:
         break;
@@ -478,9 +482,9 @@ void ScribbleArea::mousePressEvent( QMouseEvent* event )
     }
 
     // ----- assisted tool adjusment -- todo: simplify this
-    if ( event->button() == Qt::LeftButton )
+    if ( event->button() == Qt::LeftButton && mQuickSizing)
     {
-        if ( ( event->modifiers() == Qt::ShiftModifier ) && ( currentTool()->properties.width > -1 ) )
+        if ( ( event->modifiers() == Qt::ShiftModifier ) && ( currentTool()->properties.width > -1 )  )
         {
             //adjust width if not locked
             currentTool()->startAdjusting( WIDTH, 1 );
@@ -570,6 +574,7 @@ void ScribbleArea::mouseMoveEvent( QMouseEvent *event )
     if ( event->buttons() & Qt::LeftButton || event->buttons() & Qt::RightButton )
     {
         mOffset = mCurrentPoint - mLastPoint;
+
         // --- use SHIFT + drag to resize WIDTH / use CTRL + drag to resize FEATHER ---
         if ( currentTool()->isAdjusting )
         {

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -66,7 +66,6 @@ bool ScribbleArea::init()
     mCurveSmoothingLevel = curveSmoothingLevel / 20.0; // default value is 1.0
 
     mQuickSizing = mPrefs->isOn( SETTING::QUICK_SIZING );
-
     mMakeInvisible = false;
     somethingSelected = false;
 
@@ -484,7 +483,7 @@ void ScribbleArea::mousePressEvent( QMouseEvent* event )
     // ----- assisted tool adjusment -- todo: simplify this
     if ( event->button() == Qt::LeftButton && mQuickSizing)
     {
-        if ( ( event->modifiers() == Qt::ShiftModifier ) && ( currentTool()->properties.width > -1 )  )
+        if ( ( event->modifiers() == Qt::ShiftModifier ) && ( currentTool()->properties.width > -1 ) )
         {
             //adjust width if not locked
             currentTool()->startAdjusting( WIDTH, 1 );
@@ -574,7 +573,6 @@ void ScribbleArea::mouseMoveEvent( QMouseEvent *event )
     if ( event->buttons() & Qt::LeftButton || event->buttons() & Qt::RightButton )
     {
         mOffset = mCurrentPoint - mLastPoint;
-
         // --- use SHIFT + drag to resize WIDTH / use CTRL + drag to resize FEATHER ---
         if ( currentTool()->isAdjusting )
         {

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -211,6 +211,7 @@ private:
 
     bool mIsSimplified  = false;
     bool mShowThinLines = false;
+    bool mQuickSizing = true;
     int  mShowAllLayers;
     bool mUsePressure   = true;
     bool mMakeInvisible = false;

--- a/core_lib/managers/preferencemanager.cpp
+++ b/core_lib/managers/preferencemanager.cpp
@@ -45,6 +45,7 @@ void PreferenceManager::loadPrefs()
     set( SETTING::TOOL_CURSOR,              settings.value( SETTING_TOOL_CURSOR,            true ).toBool() );
     set( SETTING::HIGH_RESOLUTION,          settings.value( SETTING_HIGH_RESOLUTION,        true ).toBool() );
     set( SETTING::SHADOW,                   settings.value( SETTING_SHADOW,                 false ).toBool() );
+    set( SETTING::QUICK_SIZING,             settings.value( SETTING_QUICK_SIZING,           true ).toBool() );
 
     set( SETTING::WINDOW_OPACITY,           settings.value( SETTING_WINDOW_OPACITY,         0 ).toInt() );
     set( SETTING::CURVE_SMOOTHING,          settings.value( SETTING_CURVE_SMOOTHING,        20 ).toInt() );
@@ -273,6 +274,8 @@ void PreferenceManager::set( SETTING option, bool value )
         break;
     case SETTING::DRAW_LABEL:
         settings.setValue ( SETTING_DRAW_LABEL, value );
+    case SETTING::QUICK_SIZING:
+        settings.setValue ( SETTING_QUICK_SIZING, value );
         break;
     default:
         break;

--- a/core_lib/managers/preferencemanager.h
+++ b/core_lib/managers/preferencemanager.h
@@ -40,7 +40,8 @@ enum class SETTING
     ONION_PREV_FRAMES_NUM,
     ONION_NEXT_FRAMES_NUM,
     ONION_TYPE,
-    GRID_SIZE
+    GRID_SIZE,
+    QUICK_SIZING
 };
 
 class PreferenceManager : public BaseManager

--- a/core_lib/tool/basetool.cpp
+++ b/core_lib/tool/basetool.cpp
@@ -3,7 +3,7 @@
 #include "toolmanager.h"
 #include "scribblearea.h"
 #include "strokemanager.h"
-
+#include <QDebug>
 
 // ---- shared static variables ---- ( only one instance for all the tools )
 ToolPropertyType BaseTool::assistedSettingType; // setting beeing changed
@@ -211,8 +211,11 @@ void BaseTool::stopAdjusting()
 
 void BaseTool::adjustCursor( qreal argOffsetX, ToolPropertyType type ) //offsetx x-lastx ...
 {
+
+
     qreal inc = pow( OriginalSettingValue * 100, 0.5 );
     qreal newValue = inc + argOffsetX;
+
     int max = type == FEATHER ? 64 : 200;
     int min = type == FEATHER ? 2 : 1;
 
@@ -225,7 +228,9 @@ void BaseTool::adjustCursor( qreal argOffsetX, ToolPropertyType type ) //offsetx
     if ( adjustmentStep > 0 )
     {
         int tempValue = ( int )( newValue / adjustmentStep ); // + 0.5 ?
+
         newValue = tempValue * adjustmentStep;
+
     }
     if ( newValue < min ) // can be optimized for size: min(200,max(0.2,newValueX))
     {

--- a/core_lib/tool/basetool.cpp
+++ b/core_lib/tool/basetool.cpp
@@ -3,7 +3,7 @@
 #include "toolmanager.h"
 #include "scribblearea.h"
 #include "strokemanager.h"
-#include <QDebug>
+
 
 // ---- shared static variables ---- ( only one instance for all the tools )
 ToolPropertyType BaseTool::assistedSettingType; // setting beeing changed
@@ -211,11 +211,8 @@ void BaseTool::stopAdjusting()
 
 void BaseTool::adjustCursor( qreal argOffsetX, ToolPropertyType type ) //offsetx x-lastx ...
 {
-
-
     qreal inc = pow( OriginalSettingValue * 100, 0.5 );
     qreal newValue = inc + argOffsetX;
-
     int max = type == FEATHER ? 64 : 200;
     int min = type == FEATHER ? 2 : 1;
 
@@ -228,9 +225,7 @@ void BaseTool::adjustCursor( qreal argOffsetX, ToolPropertyType type ) //offsetx
     if ( adjustmentStep > 0 )
     {
         int tempValue = ( int )( newValue / adjustmentStep ); // + 0.5 ?
-
         newValue = tempValue * adjustmentStep;
-
     }
     if ( newValue < min ) // can be optimized for size: min(200,max(0.2,newValueX))
     {

--- a/core_lib/util/pencildef.h
+++ b/core_lib/util/pencildef.h
@@ -142,6 +142,7 @@ enum BackgroundStyle
 #define SETTING_TIMELINE_SIZE       "TimelineSize"
 #define SETTING_LABEL_FONT_SIZE     "LabelFontSize"
 #define SETTING_DRAW_LABEL          "DrawLabel"
+#define SETTING_QUICK_SIZING        "QuickSizing"
 
 #define SETTING_ANTIALIAS       "Antialiasing"
 #define SETTING_SHOW_GRID       "ShowGrid"


### PR DESCRIPTION
Added a toggle in the General -> Editing section of the Preferences menu to turn on and off Quick feather/width resizing using CTRL+SHIFT. 
