### PR TITLE
Bug fixing

### DIFF
--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -272,11 +272,7 @@ void ScribbleArea::keyPressEvent( QKeyEvent *event )
     // --- fixed control key shortcuts ---
     if ( event->modifiers() == ( Qt::ControlModifier | Qt::ShiftModifier ) )
     {
-        qreal width = currentTool()->properties.width;
-        qreal feather = currentTool()->properties.feather;
         setTemporaryTool( ERASER );
-        mEditor->tools()->setWidth( width + ( 200 - width ) / 41 ); // minimum size: 0.2 + 4.8 = 5 units. maximum size 200 + 0.
-        mEditor->tools()->setFeather( feather ); //anticipates future implementation of feather (not used yet).
         return;
     }
 

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -254,6 +254,7 @@ void ScribbleArea::keyPressEvent( QKeyEvent *event )
 
     if ( mMouseInUse ){ return; } // prevents shortcuts calls while drawing
 
+
     if ( currentTool()->keyPressEvent( event ) )
     {
         // has been handled by tool
@@ -263,6 +264,11 @@ void ScribbleArea::keyPressEvent( QKeyEvent *event )
     // --- fixed control key shortcuts ---
     if ( event->modifiers() == ( Qt::ControlModifier | Qt::ShiftModifier ) )
     {
+        // Don't set temporary tool if it is already the current tool.
+        if (currentTool()->type() == ERASER) {
+            return;
+        }
+
         qreal width = currentTool()->properties.width;
         qreal feather = currentTool()->properties.feather;
         setTemporaryTool( ERASER );
@@ -1610,9 +1616,13 @@ void ScribbleArea::setCurrentTool( ToolType eToolMode )
 
 void ScribbleArea::setTemporaryTool( ToolType eToolMode )
 {
-    instantTool = true; // used to return to previous tool when finished (keyRelease).
-    mPrevTemporalToolType = currentTool()->type();
-    editor()->tools()->setCurrentTool( eToolMode );
+    // Only switch to remporary tool if not already in this state.
+    //
+    if (!instantTool) {
+        instantTool = true; // used to return to previous tool when finished (keyRelease).
+        mPrevTemporalToolType = currentTool()->type();
+        editor()->tools()->setCurrentTool( eToolMode );
+    }
 }
 
 void ScribbleArea::deleteSelection()

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -260,6 +260,8 @@ void ScribbleArea::keyPressEvent( QKeyEvent *event )
 
     if ( mMouseInUse ){ return; } // prevents shortcuts calls while drawing
 
+    if ( instantTool ){ return; } // prevents shortcuts calls while using instant tool
+
 
     if ( currentTool()->keyPressEvent( event ) )
     {

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -145,6 +145,7 @@ void ScribbleArea::settingUpdated(SETTING setting)
 
 void ScribbleArea::updateToolCursor()
 {
+    this->setFocus();
     setCursor( currentTool()->cursor() );
     updateAllFrames();
 }

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -250,6 +250,12 @@ void ScribbleArea::escape()
 
 void ScribbleArea::keyPressEvent( QKeyEvent *event )
 {
+    // Don't handle this event on auto repeat
+    //
+    if (event->isAutoRepeat()) {
+        return;
+    }
+
     mKeyboardInUse = true;
 
     if ( mMouseInUse ){ return; } // prevents shortcuts calls while drawing
@@ -264,11 +270,6 @@ void ScribbleArea::keyPressEvent( QKeyEvent *event )
     // --- fixed control key shortcuts ---
     if ( event->modifiers() == ( Qt::ControlModifier | Qt::ShiftModifier ) )
     {
-        // Don't set temporary tool if it is already the current tool.
-        if (currentTool()->type() == ERASER) {
-            return;
-        }
-
         qreal width = currentTool()->properties.width;
         qreal feather = currentTool()->properties.feather;
         setTemporaryTool( ERASER );
@@ -369,8 +370,16 @@ void ScribbleArea::keyPressEvent( QKeyEvent *event )
 
 void ScribbleArea::keyReleaseEvent( QKeyEvent *event )
 {
+    // Don't handle this event on auto repeat
+    //
+    if (event->isAutoRepeat()) {
+        return;
+    }
+
     mKeyboardInUse = false;
-    if ( mMouseInUse ) { return; }
+
+    if ( mMouseInUse  ) { return; }
+
     if ( instantTool ) // temporary tool
     {
         currentTool()->keyReleaseEvent( event );
@@ -1616,9 +1625,11 @@ void ScribbleArea::setCurrentTool( ToolType eToolMode )
 
 void ScribbleArea::setTemporaryTool( ToolType eToolMode )
 {
-    // Only switch to remporary tool if not already in this state.
+    // Only switch to remporary tool if not already in this state
+    // and temporary tool is not already the current tool.
     //
-    if (!instantTool) {
+    if (!instantTool && currentTool()->type() != eToolMode) {
+
         instantTool = true; // used to return to previous tool when finished (keyRelease).
         mPrevTemporalToolType = currentTool()->type();
         editor()->tools()->setCurrentTool( eToolMode );

--- a/core_lib/structure/layer.cpp
+++ b/core_lib/structure/layer.cpp
@@ -635,6 +635,11 @@ bool Layer::moveSelectedFrames(int offset)
                     }
                 }
 
+                // If the first frame is moving, we need to create a new first frame
+                if (fromPos == 1) {
+                    addNewEmptyKeyAt(1);
+                }
+
                 // Update the position of the selected frame
                 selectedFrame->setPos(toPos);
                 mKeyFrames.insert( std::make_pair( toPos, selectedFrame ) );


### PR DESCRIPTION
- Fixed eraser behavior when using it through the SHIFT + CTRL keyboard shortcut.
- Fixed crash when moving the first frame in the timeline (re-create a new first frame)