### PR TITLE
Clamped view scale (zoom) to [1%-10000%]

### DIFF
--- a/core_lib/managers/viewmanager.cpp
+++ b/core_lib/managers/viewmanager.cpp
@@ -96,13 +96,16 @@ void ViewManager::rotate(float degree)
 
 void ViewManager::scale(float scaleValue)
 {
-    if(scaleValue < mMinScale){
+    if( scaleValue < mMinScale )
+    {
         scaleValue = mMinScale;
     }
-    else if(scaleValue > mMaxScale){
+    else if( scaleValue > mMaxScale)
+    {
         scaleValue = mMaxScale;
     }
-    else if(scaleValue == mMinScale || scaleValue == mMaxScale){
+    else if( scaleValue == mMinScale || scaleValue == mMaxScale  )
+    {
         return;
     }
     mScale = scaleValue;

--- a/core_lib/managers/viewmanager.cpp
+++ b/core_lib/managers/viewmanager.cpp
@@ -96,6 +96,15 @@ void ViewManager::rotate(float degree)
 
 void ViewManager::scale(float scaleValue)
 {
+    if(scaleValue < mMinScale){
+        scaleValue = mMinScale;
+    }
+    else if(scaleValue > mMaxScale){
+        scaleValue = mMaxScale;
+    }
+    else if(scaleValue == mMinScale || scaleValue == mMaxScale){
+        return;
+    }
     mScale = scaleValue;
     mView = createViewTransform();
     Q_EMIT viewChanged();

--- a/core_lib/managers/viewmanager.h
+++ b/core_lib/managers/viewmanager.h
@@ -48,6 +48,9 @@ public:
     Q_SIGNAL void viewChanged();
 
 private:
+    const float mMinScale = 0.01;
+    const float mMaxScale = 100;
+
     QTransform createViewTransform();
 
     QTransform mView;


### PR DESCRIPTION
You can currently zoom out to infinity or float overflow which is probably an issue.  All this does is clamp the zoom to 1-10000%.