### PR TITLE
Fixed Export as Image Sequence without selecting the camera.

### DIFF
--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -712,7 +712,7 @@ void MainWindow2::exportImageSequence()
     int projectLength = mEditor->layers()->projectLength();
     mEditor->object()->exportFrames( 1,
                                      projectLength,
-                                     mEditor->layers()->currentLayer(),
+                                     cameraLayer,
                                      exportSize,
                                      strFilePath,
                                      exportFormat.toStdString().c_str(),

--- a/core_lib/soundplayer.cpp
+++ b/core_lib/soundplayer.cpp
@@ -60,6 +60,9 @@ void SoundPlayer::makeConnections()
 {   
     QObject::connect( mMediaPlayer, &QMediaPlayer::mediaStatusChanged, this, [ this ]( QMediaPlayer::MediaStatus s )
     {
+        // WARNING :
+        // This call is not supported in QT 5.3. Is it necessary?
+        //
         QMediaPlayer* mediaPlayer = ( QMediaPlayer* )QObject::sender();
         qDebug() << "MediaStatus: " << s;
         qDebug() << "Duration:" << mediaPlayer->duration();


### PR DESCRIPTION
Quick fix for image sequences export.

It is not necessary to select the camera when there is only one. If there are several cameras, the last created or selected one will be used for the export.