### PR TITLE
do not install quazip headers

### DIFF
--- a/3rdlib/quazip/quazip.pro
+++ b/3rdlib/quazip/quazip.pro
@@ -14,10 +14,8 @@ INCLUDEPATH += ../zlib
 include(quazip.pri)
 
 unix:!symbian {
-    headers.path=$$PREFIX/include/quazip
-    headers.files=$$HEADERS
     target.path=$$PREFIX/lib
-    INSTALLS += headers target
+    INSTALLS += target
 
     OBJECTS_DIR=.obj
     MOC_DIR=.moc


### PR DESCRIPTION
quazip headers are not needed by pencil2d, so do not bother to install them at all