### PR TITLE
Added transparency checkerboard to color inspector preview box

### DIFF
--- a/app/colorinspector.cpp
+++ b/app/colorinspector.cpp
@@ -55,9 +55,11 @@ void ColorInspector::setColor(const QColor &newColor)
     }
     m_color = newColor;
 
-    QPalette p = ui->color->palette();
-    p.setColor(QPalette::Background, m_color);
-    ui->color->setPalette(p);
+    QPalette p1 = ui->colorWrapper->palette(), p2 = ui->color->palette();
+    p1.setBrush(QPalette::Background, QBrush(QImage(":/background/checkerboard.png")));
+    p2.setColor(QPalette::Background, m_color);
+    ui->colorWrapper->setPalette(p1);
+    ui->color->setPalette(p2);
     //ui->color->setFixedSize(30,30);
     noColorUpdate = false;
 }

--- a/app/ui/colorinspector.ui
+++ b/app/ui/colorinspector.ui
@@ -121,16 +121,43 @@
     </layout>
    </item>
    <item>
-    <widget class="QLabel" name="color">
+    <widget class="QFrame" name="colorWrapper">
      <property name="autoFillBackground">
       <bool>true</bool>
      </property>
      <property name="frameShape">
-      <enum>QFrame::Box</enum>
+      <enum>QFrame::StyledPanel</enum>
      </property>
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="color">
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Box</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
This adds a checkerboard background underneath the color preview box in the color inspector to make it easy to see when a color is transparent. Here's what the end result looks like:
![Color Inspector Preview](https://cloud.githubusercontent.com/assets/3461051/15449520/7617b974-1f3d-11e6-9ada-68ac60c952c0.png)
