### PR TITLE
SpinSlider improvements

### DIFF
--- a/core_lib/interface/spinslider.h
+++ b/core_lib/interface/spinslider.h
@@ -15,6 +15,7 @@ public:
     {
         LINEAR,
         LOG,
+        EXPONENT,
     };
 
     enum VALUE_TYPE
@@ -25,6 +26,7 @@ public:
 
     SpinSlider( QString text, GROWTH_TYPE, VALUE_TYPE, qreal min, qreal max, QWidget* parent = 0 );
     void setValue( qreal );
+    void setExponent( const qreal );
     
 signals:
     void valueChanged(qreal);
@@ -40,6 +42,7 @@ private:
     qreal mValue = 50.0;
     qreal mMin   = 0.1;
     qreal mMax   = 100.0;
+    qreal mExp   = 2.0;
 
     GROWTH_TYPE mGrowthType = LINEAR;
     VALUE_TYPE  mValueType  = INTEGER;

--- a/core_lib/interface/tooloptiondockwidget.cpp
+++ b/core_lib/interface/tooloptiondockwidget.cpp
@@ -61,7 +61,7 @@ void ToolOptionWidget::createUI()
 
     QSettings settings( "Pencil", "Pencil" );
 
-    mSizeSlider = new SpinSlider( tr( "Brush" ), SpinSlider::LOG, SpinSlider::INTEGER, 1, 200, this );
+    mSizeSlider = new SpinSlider( tr( "Brush" ), SpinSlider::EXPONENT, SpinSlider::INTEGER, 1, 200, this );
     mSizeSlider->setValue( settings.value( "brushWidth" ).toDouble() );
     mSizeSlider->setToolTip( tr( "Set Pen Width <br><b>[SHIFT]+drag</b><br>for quick adjustment" ) );
 


### PR DESCRIPTION
Improved the following things in the spinslider class:
- Fixed bug where moving the slider by clicking without dragging failed to emit valueChanged
- Fixed bug where logarithmic growth rates weren't taking effect
- Added support for exponential growth rates (and setting the exponent to fine-tune the result)

I also changed the brush size spinslider to use the new exponential growth rate because logarithmic felt a bit to sharp (with log it's about 20 at the halfway out of 200, whereas with exponential with exponent 2 it's 50 at the halfway).