### PR TITLE
CLI Overhaul

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -54,6 +54,96 @@ void installTranslator( PencilApplication& app )
     qDebug() << "Install translation = " << b;
 }
 
+bool parseArguments( QStringList args, QString & inputPath, QStringList & outputPaths )
+{
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 2, 0 )
+#import <QCommandLineParser>
+#import <QCommandLineOption>
+    QCommandLineParser parser;
+
+    parser.setApplicationDescription( PencilApplication::tr("Pencil2D is an animation/drawing software for Mac OS X, Windows, and Linux. It lets you create traditional hand-drawn animation (cartoon) using both bitmap and vector graphics.") );
+    parser.addHelpOption();
+    parser.addVersionOption();
+    parser.addPositionalArgument( "input", PencilApplication::tr( "Path to the input pencil file." ) );
+
+    QCommandLineOption exportSeqOption( QStringList() << "o" << "export-sequence",
+                                        PencilApplication::tr( "Render the file to <output_path>" ),
+                                        PencilApplication::tr( "output_path" ) );
+    parser.addOption( exportSeqOption );
+
+    parser.process( args );
+
+    QStringList posArgs = parser.positionalArguments();
+    if ( !posArgs.isEmpty() )
+    {
+        inputPath = posArgs.at(0);
+    }
+
+    outputPaths = parser.values( exportSeqOption );
+    return true;
+#else
+    // Extracting options
+    bool error = false, help = false;
+    for ( int i = 1; i < args.length(); i++ ) // TODO: use iterator instead
+    {
+        if ( args[i] == "-NSDocumentRevisionsDebugMode")
+        {
+            // Ignore the next option
+            i++;
+        }
+        else if ( args[i] == "-o" || args[i] == "--export-sequence" )
+        {
+            if( ++i < args.length() )
+            {
+                // Output path is at args[i]
+                outputPaths.append(args[i]);
+            }
+            else
+            {
+                // Error, no output path specified
+                qDebug() << PencilApplication::tr( "Error: no output path specified" );
+                error = true;
+            }
+        }
+        else if ( args[i] == "-h" || args[i] == "--help" )
+        {
+            help = true;
+        }
+        else if ( args[i] == "-v" || args[i] == "--version" )
+        {
+            return false;
+        }
+        else if ( args[i].startsWith( "-" ) )
+        {
+            qDebug() << "Error: Unknown option '" << args[i] << "'";
+            error = true;
+        }
+        else if ( inputPath.isEmpty() )
+        {
+            // Positional argument: input file path
+            inputPath = args[i];
+        }
+    }
+
+    if (error || help) {
+        qDebug() << "Usage: ./Pencil2D [options] input" << std::endl
+                 << "Pencil2D is an animation/drawing software for Mac OS X, Windows, and Linux. It lets you create traditional hand-drawn animation (cartoon) using both bitmap and vector graphics." << std::endl
+                 << std::endl
+                 << "Options:" << std::endl
+                 << "  -h, --help                            Displays this help." << std::endl
+                 << "  -v, --version                        Displays version information." << std::endl
+                 << "  -o, --export-sequence <output_path>  Render the file to <output_path>" << std::endl
+                 << std::endl
+                 << "Arguments:" << std::endl
+                 << "  input                                Path to the input pencil file.";
+        return help;
+    }
+
+    return true;
+#endif
+}
+
+
 int main(int argc, char* argv[])
 {
     PencilApplication app( argc, argv );
@@ -66,105 +156,68 @@ int main(int argc, char* argv[])
     QObject::connect(&app, &PencilApplication::openFileRequested, &mainWindow, &MainWindow2::openDocument);
     //QObject::connect(&app, SIGNAL(openFileRequested(QString)), &mainWindow, SLOT(openDocument(QString)));
     app.emitOpenFileRequest();
-    
-    if ( argc == 1 || (argc > 1 && strcmp( argv[1], "-NSDocumentRevisionsDebugMode" ) == 0)  )
+
+    if ( argc == 1 || ( ( argc == 2 || argc == 3 ) && QString(argv[1]) == "-NSDocumentRevisionsDebugMode" ) )
     {
         mainWindow.show();
         return app.exec();
     }
 
-    QString inputFile;
+    QString inputPath;
+    QStringList outputPaths;
 
-    bool jobExportSequence = false;
-    QString jobExportSequenceOutput = "";
-
-    // Extracting options
-    int i;
-    for ( i = 1; i < argc; ++i )
+    if ( !parseArguments( app.arguments(), inputPath, outputPaths ) )
     {
-        if (jobExportSequence && jobExportSequenceOutput == "")
-        {
-            jobExportSequenceOutput = argv[i];
-            continue;
-        }
-        if ( QString(argv[i]) == "--export-sequence" )
-        {
-            jobExportSequence = true;
-            continue;
-        }
-        if (inputFile == "")
-        {
-            inputFile = QString(argv[i]);
-        }
-    }
-
-    bool error = false;
-    if ( jobExportSequence )
-    {
-        std::cout << "Exporting image sequence..." << std::endl;
-        if (inputFile.isEmpty())
-        {
-            qDebug() << "Error: No input file specified.";
-            error = true;
-        }
-        // TODO: Check if input file exists
-        if ( jobExportSequenceOutput.isEmpty())
-        {
-            qDebug() << "Error: No output file specified.";
-            error = true;
-        }
-        // TODO: Check if output path exists
-
-        if ( !error )
-        {
-            mainWindow.openFile( inputFile );
-            // Detecting format
-            QString format = "";
-            if (jobExportSequenceOutput.endsWith(".png"))
-            {
-                format = "PNG";
-            }
-            else if (jobExportSequenceOutput.endsWith(".jpg"))
-            {
-                format = "JPG";
-            }
-            else if (jobExportSequenceOutput.endsWith(".tif"))
-            {
-                format = "TIF";
-            }
-            else if (jobExportSequenceOutput.endsWith(".bmp"))
-            {
-                format = "BMP";
-            }
-            else
-            {
-                qDebug() << "Warning: Output format is not specified or unsupported.";
-                qDebug() << "         Using PNG.";
-                format = "PNG";
-            }
-            mainWindow.mEditor->exportSeqCLI(jobExportSequenceOutput, format);
-            qDebug() << "Done.";
-        }
-    }
-    else if ( !inputFile.isEmpty() )
-    {
-        mainWindow.show();
-        mainWindow.openFile(inputFile);
-        return app.exec();
-    }
-    else
-    {
-        qDebug() << "Error: Invalid commandline options.";
-        error = true;
-    }
-
-    if (error)
-    {
-        qDebug() << "Syntax:";
-        qDebug() << "   " << argv[0] << "FILENAME --export-sequence PATH";
-        qDebug() << "Example:";
-        qDebug() << "   " << argv[0] << "/path/to/your/file.pcl --export-sequence /path/to/export/file.png";
         return 1;
     }
+
+    // If there are no output paths, open up the GUI (to the input path if there is one)
+    if ( outputPaths.isEmpty() )
+    {
+        mainWindow.show();
+        if( !inputPath.isEmpty() )
+        {
+            mainWindow.openFile(inputPath);
+        }
+        return app.exec();
+    }
+    else if ( inputPath.isEmpty() )
+    {
+        // Error if there are output paths without an input path
+        qDebug() << PencilApplication::tr( "Error: No input file specified." );
+        return 1;
+    }
+
+    std::cout << "Exporting image sequence..." << std::endl;
+    // TODO: Check if input file exists
+    for ( int i = 0; i < outputPaths.length(); i++ )
+    {
+        // TODO: Check if output path exists
+        mainWindow.openFile( inputPath );
+
+        // Detect format
+        QString format;
+        QMap<QString, QString> extensionMapping;
+        extensionMapping[ "png" ] = "PNG";
+        extensionMapping[ "jpg" ] = "JPG";
+        extensionMapping[ "jpeg" ] = "JPG";
+        extensionMapping[ "tif" ] = "TIF";
+        extensionMapping[ "tiff" ] = "TIF";
+        extensionMapping[ "bmp" ] = "BMP";
+        QString extension = outputPaths[i].mid( outputPaths[i].lastIndexOf( "." ) + 1 ).toLower();
+        //qDebug() << "Ext: " << outputPaths[i].lastIndexOf(".") << " " << extension << " " << outputPaths[i];
+        if ( inputPath.contains(".") && extensionMapping.contains( extension ) )
+        {
+            format = extensionMapping[extension];
+        }
+        else {
+            qDebug() << "Warning: Output format is not specified or unsupported. Using PNG.";
+            format = "PNG";
+        }
+
+        mainWindow.mEditor->exportSeqCLI(outputPaths[i], format);
+    }
+    qDebug() << "Done.";
+
     return 0;
 }

--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -493,9 +493,12 @@ void MainWindow2::openFile( QString filename )
 bool MainWindow2::openObject( QString strFilePath )
 {
     QProgressDialog progress( tr("Opening document..."), tr("Abort"), 0, 100, this );
-
-    progress.setWindowModality( Qt::WindowModal );
-    progress.show();
+    // Don't show progress bar if running without a GUI (aka. when rendering from command line)
+    if ( this->isVisible() )
+    {
+        progress.setWindowModality( Qt::WindowModal );
+        progress.show();
+    }
 
     mEditor->setCurrentLayer( 0 );
 

--- a/core_lib/interface/editor.cpp
+++ b/core_lib/interface/editor.cpp
@@ -562,23 +562,39 @@ void Editor::createExportMovieDialog()
 
 
 
-bool Editor::exportSeqCLI( QString filePath = "", QString format = "PNG" )
+bool Editor::exportSeqCLI( QString filePath, QString format, int width, int height, bool transparency, bool antialias )
 {
-	int width = mScribbleArea->getViewRect().toRect().width();
-	int height = mScribbleArea->getViewRect().toRect().height();
+    // Get the camera layer
+    int cameraLayerId = mLayerManager->getLastCameraLayer();
+    LayerCamera *cameraLayer = dynamic_cast< LayerCamera* >(mObject->getLayer(cameraLayerId));
+
+    if(width < 0) {
+        width = cameraLayer->getViewRect().width();
+    }
+    if(height < 0) {
+        height = cameraLayer->getViewRect().height();
+    }
 
 	QSize exportSize = QSize( width, height );
 	QByteArray exportFormat( format.toLatin1() );
 
 	QTransform view = RectMapTransform( mScribbleArea->getViewRect(), QRectF( QPointF( 0, 0 ), exportSize ) );
-	view = mScribbleArea->getView() * view;
+    //view = mScribbleArea->getView() * view;
 
-	int projectLength = layers()->projectLength();
+    int projectLength = mLayerManager->projectLength();
 
-	mObject->exportFrames( 1, projectLength, layers()->currentLayer(),
+    mObject->exportFrames( 1,
+                           projectLength,
+                           cameraLayer,
 						   exportSize,
 						   filePath,
-						   exportFormat, -1, false, true, NULL, 0 );
+                           exportFormat,
+                           -1,
+                           transparency,
+                           antialias,
+                           NULL,
+                           0 );
+
 	return true;
 }
 

--- a/core_lib/interface/editor.h
+++ b/core_lib/interface/editor.h
@@ -83,7 +83,7 @@ public:
     void scrubTo( int frameNumber );
 
     int  allLayers();
-    bool exportSeqCLI( QString, QString );
+    bool exportSeqCLI( QString filePath, QString format = "PNG", int width = -1, int height = -1, bool transparency = false, bool antialias = true );
     
     QString workingDir() const;
 


### PR DESCRIPTION
This is a mixture of bug fixes and enhancements for the command line interface. I have made a lot of changes, but they _should_ be backwards-compatible with the latest stable release.

A list significant changes:
- Fixed camera layer size being ignored
- Prevented GUI from opening when rendering from command line
- Added support for exporting multiple sequences
- Created `-o` alias for `--export-sequence`
- Added `-h`/`--help` and `-v`/`--version` flags
- Added optional arguments for rendering: `--width`, `--height`, and `--transparency`