### PR TITLE
Improve unsaved changes behavior

### DIFF
--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -200,12 +200,12 @@ void MainWindow2::createDockWidgets()
     addDockWidget( Qt::RightDockWidgetArea, mPreview );
     */
 
+    makeConnections( mEditor );
     makeConnections( mEditor, mTimeLine );
     makeConnections( mEditor, mColorWheel );
     makeConnections( mEditor, mColorPalette );
     makeConnections( mEditor, mDisplayOptionWidget );
     makeConnections( mEditor, mToolOptions );
-    makeConnections( mScribbleArea );
 
     for ( BaseDockWidget* w : mDockWidgets )
     {
@@ -372,6 +372,24 @@ void MainWindow2::markTitleUnsaved()
 {
     if (!isTitleMarkedUnsaved())
         setWindowTitle( QString("* ") + QApplication::activeWindow()->windowTitle() );
+}
+
+void MainWindow2::markTitleSaved()
+{
+    if (isTitleMarkedUnsaved())
+        setWindowTitle( QApplication::activeWindow()->windowTitle().remove(0, 2) );
+}
+
+void MainWindow2::updateTitleSaveState()
+{
+    qDebug() << "updateTitleSaveState";
+    if( mEditor->currentBackup() == mBackupAtSave )
+    {
+        markTitleSaved();
+    }
+    else {
+        markTitleUnsaved();
+    }
 }
 
 void MainWindow2::closeEvent( QCloseEvent* event )
@@ -555,6 +573,7 @@ bool MainWindow2::saveObject( QString strSavedFileName )
     mTimeLine->updateContent();
 
     setWindowTitle( strSavedFileName );
+    mBackupAtSave = mEditor->currentBackup();
 
     return true;
 }
@@ -1076,6 +1095,11 @@ void MainWindow2::helpBox()
     QDesktopServices::openUrl( QUrl(url) );
 }
 
+void MainWindow2::makeConnections( Editor* editor )
+{
+    connect( editor, &Editor::updateBackup, this, &MainWindow2::updateTitleSaveState );
+}
+
 void MainWindow2::makeConnections( Editor* editor, ColorBox* colorBox )
 {
     connect( colorBox, &ColorBox::colorChanged, editor->color(), &ColorManager::setColor );
@@ -1149,11 +1173,6 @@ void MainWindow2::makeConnections( Editor* pEditor, ColorPaletteWidget* pColorPa
 
     connect( pColorManager, &ColorManager::colorChanged, pColorPalette, &ColorPaletteWidget::setColor );
     connect( pColorManager, &ColorManager::colorNumberChanged, pColorPalette, &ColorPaletteWidget::selectColorNumber );
-}
-
-void MainWindow2::makeConnections( ScribbleArea* pScribbleArea )
-{
-    connect( pScribbleArea, static_cast<void (ScribbleArea::*)(void)>(&ScribbleArea::modification), this, &MainWindow2::markTitleUnsaved );
 }
 
 void MainWindow2::bindActionWithSetting( QAction* action, SETTING setting )

--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -592,7 +592,7 @@ void MainWindow2::saveDocument()
 
 bool MainWindow2::maybeSave()
 {
-    if ( mEditor->object()->isModified() )
+    if ( isTitleMarkedUnsaved() )
     {
         int ret = QMessageBox::warning( this, tr( "Warning" ),
                                         tr( "This animation has been modified.\n Do you want to save your changes?" ),

--- a/app/mainwindow2.h
+++ b/app/mainwindow2.h
@@ -59,7 +59,7 @@ public slots:
     void undoActSetText(void);
     void undoActSetEnabled(void);
     void openDocument(const QString &fileName);
-    void markTitleUnsaved(void);
+    void updateTitleSaveState(void);
 
 public:
     void setOpacity(int opacity);
@@ -108,18 +108,19 @@ private:
     void readSettings();
     void writeSettings();
 
+    void makeConnections( Editor* );
     void makeConnections( Editor*, ColorBox* );
     void makeConnections( Editor*, ScribbleArea* );
     void makeConnections( Editor*, ColorPaletteWidget* );
     void makeConnections( Editor*, TimeLine* );
     void makeConnections( Editor*, DisplayOptionWidget* );
     void makeConnections( Editor*, ToolOptionWidget*);
-    void makeConnections( ScribbleArea* );
 
     void bindActionWithSetting( QAction*, SETTING );
 
     bool isTitleMarkedUnsaved();
     void markTitleSaved();
+    void markTitleUnsaved();
 
     // UI: central Drawing Area
     ScribbleArea* mScribbleArea                = nullptr;
@@ -134,6 +135,9 @@ private:
     RecentFileMenu*       mRecentFileMenu      = nullptr;
     //PreviewWidget*      mPreview = nullptr;
     TimeLine*             mTimeLine; // be public temporary
+
+    // backup
+    BackupElement* mBackupAtSave = nullptr;
 
 private:
     ActionCommands* mCommands              = nullptr;

--- a/core_lib/interface/editor.cpp
+++ b/core_lib/interface/editor.cpp
@@ -175,6 +175,19 @@ void Editor::settingUpdated(SETTING setting)
     }
 }
 
+BackupElement* Editor::currentBackup()
+{
+    qDebug() << mBackupIndex << mBackupList.length();
+    if ( mBackupIndex >= 0 )
+    {
+        return mBackupList[ mBackupIndex ];
+    }
+    else
+    {
+        return nullptr;
+    }
+}
+
 void Editor::backup( QString undoText )
 {
 	if ( lastModifiedLayer > -1 && lastModifiedFrame > 0 )
@@ -216,7 +229,7 @@ void Editor::backup( int backupLayer, int backupFrame, QString undoText )
 			{
 				element->bitmapImage = bitmapImage->copy();  // copy the image
 				mBackupList.append( element );
-				mBackupIndex++;
+                mBackupIndex++;
 			}
 		}
 		if ( layer->type() == Layer::VECTOR )
@@ -234,10 +247,11 @@ void Editor::backup( int backupLayer, int backupFrame, QString undoText )
 			{
 				element->vectorImage = *vectorImage;  // copy the image (that works but I should also provide a copy() method)
 				mBackupList.append( element );
-				mBackupIndex++;
+                mBackupIndex++;
 			}
 		}
 	}
+    emit updateBackup();
 }
 
 void BackupBitmapElement::restore( Editor* editor )
@@ -305,6 +319,7 @@ void Editor::undo()
 		mBackupIndex--;
         mScribbleArea->cancelTransformedSelection();
         mScribbleArea->calculateSelectionRect(); // really ugly -- to improve
+        emit updateBackup();
 	}
 }
 
@@ -314,6 +329,7 @@ void Editor::redo()
 	{
 		mBackupIndex++;
 		mBackupList[ mBackupIndex + 1 ]->restore( this );
+        emit updateBackup();
 	}
 }
 

--- a/core_lib/interface/editor.h
+++ b/core_lib/interface/editor.h
@@ -91,11 +91,13 @@ public:
 
     // backup
     int mBackupIndex;
+    BackupElement* currentBackup();
     QList<BackupElement*> mBackupList;
 
 Q_SIGNALS:
     void updateTimeLine();
     void updateLayerCount();
+    void updateBackup();
 
     void selectAll();
     void changeThinLinesButton( bool );


### PR DESCRIPTION
This fixes the bug where users would not be warned when closing a modified document. Additionally it removes the modification marker (*) from the title if changes are undone/redone to the save point (making it effectively unmodified).

Fixes #387
See also #282 and #527