### PR TITLE
Fix memory leaks at importing images

### DIFF
--- a/core_lib/graphics/vector/vectorimage.cpp
+++ b/core_lib/graphics/vector/vectorimage.cpp
@@ -38,15 +38,15 @@ bool VectorImage::read(QString filePath)
 		return false;
 	}
 
-    QFile* file = new QFile(filePath);
-    if (!file->open(QFile::ReadOnly))
+    QFile file{filePath};
+    if (!file.open(QFile::ReadOnly))
     {
         //QMessageBox::warning(this, "Warning", "Cannot read file");
         return false;
     }
 
     QDomDocument doc;
-    if (!doc.setContent(file)) return false; // this is not a XML file
+    if (!doc.setContent(&file)) return false; // this is not a XML file
     QDomDocumentType type = doc.doctype();
     if (type.name() != "PencilVectorImage") return false; // this is not a Pencil document
 
@@ -64,15 +64,15 @@ bool VectorImage::read(QString filePath)
 
 bool VectorImage::write(QString filePath, QString format)
 {
-    QFile* file = new QFile(filePath);
-    bool result = file->open(QIODevice::WriteOnly);
+    QFile file{filePath};
+    bool result = file.open(QIODevice::WriteOnly);
     if (!result)
     {
         //QMessageBox::warning(this, "Warning", "Cannot write file");
-        qDebug() << "VectorImage - Cannot write file" << filePath << file->error();
+        qDebug() << "VectorImage - Cannot write file" << filePath << file.error();
         return false;
     }
-    QTextStream out(file);
+    QTextStream out(&file);
 
     if (format == "VEC")
     {
@@ -87,12 +87,10 @@ bool VectorImage::write(QString filePath, QString format)
         qDebug() << "--- Starting to write XML file...";
         doc.save(out, IndentSize);
         qDebug() << "--- Writing XML file done.";
-        file->close();
         return true;
     }
     else
     {
-        file->close();
         qDebug() << "--- Not the VEC format!";
         return false;
     }

--- a/core_lib/interface/editor.cpp
+++ b/core_lib/interface/editor.cpp
@@ -689,8 +689,8 @@ bool Editor::importBitmapImage( QString filePath )
 		QRect boundaries = img.rect();
 		boundaries.moveTopLeft( mScribbleArea->getCentralPoint().toPoint() - QPoint( boundaries.width() / 2, boundaries.height() / 2 ) );
 
-		BitmapImage* importedBitmapImage = new BitmapImage( boundaries, img );
-		bitmapImage->paste( importedBitmapImage );
+        BitmapImage importedBitmapImage{boundaries, img};
+        bitmapImage->paste(&importedBitmapImage);
 
 		scrubTo( currentFrame() + 1 );
 	}
@@ -712,12 +712,12 @@ bool Editor::importVectorImage( QString filePath )
 		addNewKey();
 		vectorImage = ( (LayerVector*)layer )->getVectorImageAtFrame( currentFrame() );
 	}
-	VectorImage* importedVectorImage = new VectorImage;
-	bool ok = importedVectorImage->read( filePath );
+    VectorImage importedVectorImage;
+    bool ok = importedVectorImage.read( filePath );
 	if ( ok )
 	{
-		importedVectorImage->selectAll();
-		vectorImage->paste( *importedVectorImage );
+        importedVectorImage.selectAll();
+        vectorImage->paste(importedVectorImage);
 	}
 	/*
 	else


### PR DESCRIPTION
Several object allocation without calling deleting it after.

Due object are used in the same scope, heap allocation is not needed, intead using stack allocation for better resource management (auto delete and file close).