### PR TITLE
Spinbox focus loss bug fix

### DIFF
--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -142,7 +142,6 @@ void ScribbleArea::settingUpdated(SETTING setting)
 
 void ScribbleArea::updateToolCursor()
 {
-    this->setFocus();
     setCursor( currentTool()->cursor() );
     updateAllFrames();
 }


### PR DESCRIPTION
Here's a tiny baby commit.

This modifies the program so spin boxes in the tool options widget don't lose focus when typing values in with the keyboard. 
ex. You can now input 34 as the brush size without needing to click back into the spin box to type the second digit.