### PR TITLE
Improve import import and export dialogs

### DIFF
--- a/app/filedialogex.cpp
+++ b/app/filedialogex.cpp
@@ -71,8 +71,8 @@ QString FileDialog::fileFilters( EFile fileType )
 {
     switch ( fileType )
     {
-        case EFile::SOUND: return tr( "Sounds(*.wav *.mp3);;WAV(*.wav);;MP3(*.mp3)" );
-		case EFile::MOVIE_EXPORT: return tr( "MP4(*.mp4);;AVI(*.avi);;GIF(*.gif)" );
+        case EFile::SOUND: return tr( "Sounds (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)" );
+        case EFile::MOVIE_EXPORT: return tr( "MP4 (*.mp4);;AVI (*.avi);;GIF (*.gif)" );
         default: Q_ASSERT( false );
     }
     return "";

--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -684,13 +684,15 @@ void MainWindow2::importImageSequence()
     QStringList files = w.getOpenFileNames( this,
                                             "Select one or more files to open",
                                             initialPath,
-                                            "Images (*.png *.jpg *.jpeg *.bmp)" );
+                                            "Images (*.png *.jpg *.jpeg *.tif *.tiff *.bmp)" );
 
     for ( QString strImgFile : files )
     {
         if ( strImgFile.endsWith( ".png" ) ||
              strImgFile.endsWith( ".jpg" ) ||
              strImgFile.endsWith( ".jpeg" ) ||
+             strImgFile.endsWith(".tif") ||
+             strImgFile.endsWith(".tiff") ||
              strImgFile.endsWith( ".bmp" ) )
         {
             mEditor->importImage( strImgFile );

--- a/core_lib/util/pencildef.h
+++ b/core_lib/util/pencildef.h
@@ -8,7 +8,7 @@
     QObject::tr( "AVI (*.avi);;MPEG(*.mpg);;MOV(*.mov);;MP4(*.mp4);;SWF(*.swf);;FLV(*.flv);;WMV(*.wmv)" )
 
 #define PENCIL_IMAGE_FILTER \
-   QObject::tr( "PNG (*.png);;JPG(*.jpg *.jpeg);;TIFF(*.tiff);;TIF(*.tif);;BMP(*.bmp);;GIF(*.gif)" )
+   QObject::tr( "Images (*.png *.jpg *.jpeg *.tiff *.tif *.bmp *.gif);;PNG (*.png);;JPG(*.jpg *.jpeg);;TIFF(*.tif *.tiff);;BMP(*.bmp);;GIF(*.gif)" )
 
 
 enum ToolType


### PR DESCRIPTION
Some very minor changes to the file type filters for importing and exporting. Changes:
- Modified formatting of export option labels to match import option formatting
- Added support for importing TIFF sequences
- Set the default import option to all image types. This is especially important for Mac, since the file type option is hidden by default, potentially leading people to think that only PNGs can be imported.