### PR TITLE
Working ffmpeg call on Linux systems (patch)

### DIFF
--- a/core_lib/movieexporter.cpp
+++ b/core_lib/movieexporter.cpp
@@ -89,7 +89,7 @@ QString ffmpegLocation()
 #elif __APPLE__
     return QApplication::applicationDirPath() + "/plugins/ffmpeg";
 #else
-    return "";// TODO: linux
+    return "/usr/bin/ffmpeg"; // ffmpeg is a standalone project.
 #endif
 }
 


### PR DESCRIPTION
This patch is working on my linux system without any problem.

You must/may add ffmpeg as dependency or as a recommended package for Pencil2D's .deb and .rpm packages.

ffmpeg is a standalone project/package so if you install Pencil2D on a Linux system (normally with a package manager) then you can not use it in a plugin-like directory structure (as you do it on windows or apple systems).

The windows/apple way may work if Pencil2D is installed in user's home directory (/home/auser/Pencil2D) then ffmpeg can be placed in a subdirectory (/home/auser/Pencil2D/plugins), but this way each user on the system must install a new copy of Pencil2D and ffmpeg.

In my oppinion the best solution on all systems would be to search ffmpeg on the PATH and then (if not found) ask the user to select the ffmpeg executable manually.