### PR TITLE
Added yes-no option for vector merge

### DIFF
--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -1153,6 +1153,7 @@ void MainWindow2::makeConnections( Editor* pEditor, TimeLine* pTimeline )
     connect( pEditor->sound(), &SoundManager::soundClipDurationChanged, pTimeline, &TimeLine::updateUI );
     connect( pEditor, &Editor::updateTimeLine,   pTimeline, &TimeLine::updateUI );
 
+    connect( pEditor->layers(), &LayerManager::currentLayerChanged, mToolOptions, &ToolOptionWidget::updateUI);
 }
 
 void MainWindow2::makeConnections(Editor* editor, DisplayOptionWidget* display)

--- a/core_lib/interface/tooloptiondockwidget.h
+++ b/core_lib/interface/tooloptiondockwidget.h
@@ -34,6 +34,7 @@ private:
     void setPenInvisibility( int );
     void setPressure( int );
     void setPreserveAlpha( int );
+    void setVectorMergeEnabled( int );
 
     void disableAllOptions();
     void createUI();
@@ -43,6 +44,7 @@ private:
     QCheckBox* mUseFeatherBox    = nullptr;
     QCheckBox* mMakeInvisibleBox = nullptr;
     QCheckBox* mPreserveAlphaBox = nullptr;
+    QCheckBox* mVectorMergeBox   = nullptr;
     QSpinBox* mBrushSpinBox      = nullptr;
     QSpinBox* mFeatherSpinBox    = nullptr;
     SpinSlider* mSizeSlider      = nullptr;

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -151,6 +151,12 @@ void ToolManager::setPreserveAlpha( bool isPreserveAlpha )
     Q_EMIT toolPropertyChanged( currentTool()->type(), PRESERVEALPHA );
 }
 
+void ToolManager::setVectorMergeEnabled(bool isVectorMergeEnabled)
+{
+    currentTool()->setVectorMergeEnabled(isVectorMergeEnabled);
+    Q_EMIT toolPropertyChanged( currentTool()->type(), VECTORMERGE );
+}
+
 void ToolManager::setBezier( bool isBezierOn )
 {
     currentTool()->setBezier( isBezierOn );

--- a/core_lib/managers/toolmanager.h
+++ b/core_lib/managers/toolmanager.h
@@ -43,6 +43,7 @@ public slots:
     void setUseFeather( bool );
     void setInvisibility( bool );
     void setPreserveAlpha( bool );
+    void setVectorMergeEnabled( bool );
     void setBezier( bool );
     void setPressure( bool );
 

--- a/core_lib/tool/basetool.cpp
+++ b/core_lib/tool/basetool.cpp
@@ -322,3 +322,7 @@ void BaseTool::setPreserveAlpha( const bool preserveAlpha )
     properties.preserveAlpha = preserveAlpha;
 }
 
+void BaseTool::setVectorMergeEnabled(const bool vectorMergeEnabled)
+{
+    properties.vectorMergeEnabled = vectorMergeEnabled;
+}

--- a/core_lib/tool/basetool.h
+++ b/core_lib/tool/basetool.h
@@ -21,6 +21,7 @@ public:
     bool pressure      = 1;
     int invisibility  = 0;
     int preserveAlpha = 0;
+    bool vectorMergeEnabled = false;
     bool bezier_state = false;
     bool useFeather   = true;
 };
@@ -77,6 +78,7 @@ public:
     virtual void setPressure( const bool pressure );
     virtual void setUseFeather( const bool usingFeather );
     virtual void setPreserveAlpha( const bool preserveAlpha );
+    virtual void setVectorMergeEnabled( const bool vectorMergeEnabled );
     virtual void leavingThisTool(){}
     virtual void switchingLayers(){}
     Properties properties;

--- a/core_lib/tool/penciltool.cpp
+++ b/core_lib/tool/penciltool.cpp
@@ -24,6 +24,7 @@ void PencilTool::loadSettings()
 {
     m_enabledProperties[WIDTH] = true;
     m_enabledProperties[PRESSURE] = true;
+    m_enabledProperties[VECTORMERGE] = true;
 
     QSettings settings( PENCIL2D, PENCIL2D );
     properties.width = settings.value( "pencilWidth" ).toDouble();
@@ -169,7 +170,7 @@ void PencilTool::mouseReleaseEvent( QMouseEvent *event )
             curve.setColourNumber( mEditor->color()->frontColorNumber() );
             VectorImage* vectorImage = ( ( LayerVector * )layer )->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 );
 
-            vectorImage->addCurve( curve, qAbs( mEditor->view()->scaling() ) );
+            vectorImage->addCurve( curve, qAbs( mEditor->view()->scaling() ), properties.vectorMergeEnabled );
             mScribbleArea->setModified( mEditor->layers()->currentLayerIndex(), mEditor->currentFrame() );
             mScribbleArea->setAllDirty();
         }

--- a/core_lib/tool/pentool.cpp
+++ b/core_lib/tool/pentool.cpp
@@ -20,6 +20,7 @@ void PenTool::loadSettings()
 {
     m_enabledProperties[WIDTH] = true;
     m_enabledProperties[PRESSURE] = true;
+    m_enabledProperties[VECTORMERGE] = true;
 
     QSettings settings( PENCIL2D, PENCIL2D );
 
@@ -141,7 +142,7 @@ void PenTool::mouseReleaseEvent( QMouseEvent *event )
 
             auto pLayerVector = static_cast< LayerVector* >( layer );
             VectorImage* vectorImage = pLayerVector->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 );
-            vectorImage->addCurve( curve, mEditor->view()->scaling() );
+            vectorImage->addCurve( curve, mEditor->view()->scaling(), properties.vectorMergeEnabled );
 
             mScribbleArea->setModified( mEditor->layers()->currentLayerIndex(), mEditor->currentFrame() );
             mScribbleArea->setAllDirty();

--- a/core_lib/util/pencildef.h
+++ b/core_lib/util/pencildef.h
@@ -33,7 +33,8 @@ enum ToolPropertyType
     INVISIBILITY,
     PRESERVEALPHA,
     BEZIER,
-    USEFEATHER
+    USEFEATHER,
+    VECTORMERGE
 };
 
 enum BackgroundStyle


### PR DESCRIPTION
A fix for #244. I added a checkbox called "Merge" to the Tool Options panel. When it is checked, new vector lines are merged with existing ones. If unchecked, this merging does not happen.

By default it is un-checked.

This checkbox is only visible when both 1) a vector layer is selected and 2) either the pencil or pen tool are selected. (The pencil and pen tool are the only ones which can do vector merging).

Below is a screenshot:

![bug_244_new_checkbox](https://cloud.githubusercontent.com/assets/24422213/21975496/c9f34c6e-dc31-11e6-9bad-50baf2c07840.png)

Below is a video demo (zipped):

[Bug_244_Fix_Demo.zip](https://github.com/pencil2d/pencil/files/707642/Bug_244_Fix_Demo.zip)

What do you think?
