### PR TITLE
Fix for #565. ESC key now clears polyline.

### DIFF
--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1216,6 +1216,13 @@ void ScribbleArea::drawPolyline( QList<QPointF> points, QPointF endPoint )
     }
 }
 
+void ScribbleArea::cancelPolyline(QList<QPointF> points)
+{
+    // Clear the in-progress polyline from the bitmap buffer.
+    clearBitmapBuffer();
+    updateCurrentFrame();
+}
+
 void ScribbleArea::endPolyline( QList<QPointF> points )
 {
     if ( !areLayersSane() )

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -162,6 +162,7 @@ protected:
 public:
     void drawPolyline( QList<QPointF> points, QPointF lastPoint );
     void endPolyline( QList<QPointF> points );
+    void cancelPolyline( QList<QPointF> points );
 
     void drawLine( QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm );
     void drawPath( QPainterPath path, QPen pen, QBrush brush, QPainter::CompositionMode cm );

--- a/core_lib/tool/polylinetool.cpp
+++ b/core_lib/tool/polylinetool.cpp
@@ -137,6 +137,7 @@ bool PolylineTool::keyPressEvent( QKeyEvent *event )
 
     case Qt::Key_Escape:
         if ( mPoints.size() > 0 ) {
+            mScribbleArea->cancelPolyline( mPoints );
             clear();
             return true;
         }


### PR DESCRIPTION
Fix for #565. Pressing the ESC key now clears the in-progress polyline.