### PR TITLE
Removed division from opacity and set feather to 1

### DIFF
--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1066,7 +1066,7 @@ void ScribbleArea::drawPen( QPointF thePoint, qreal brushWidth, QColor fillColou
     qreal offset = 64;
 
     QRadialGradient radialGrad( thePoint, 0.5 * brushWidth );
-    setGaussianGradient( radialGrad, fillColour, opacity/2, offset );
+    setGaussianGradient( radialGrad, fillColour, opacity, offset );
 
     QRectF rectangle( thePoint.x() - 0.5 * brushWidth, thePoint.y() - 0.5 * brushWidth, brushWidth, brushWidth );
 
@@ -1076,7 +1076,7 @@ void ScribbleArea::drawPen( QPointF thePoint, qreal brushWidth, QColor fillColou
 
 void ScribbleArea::drawPencil( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity )
 {
-    drawBrush(thePoint, brushWidth, 50, fillColour, opacity / 5);
+    drawBrush(thePoint, brushWidth, 50, fillColour, opacity);
 }
 
 void ScribbleArea::drawBrush( QPointF thePoint, qreal brushWidth, qreal mOffset, QColor fillColour, qreal opacity, bool usingFeather )

--- a/core_lib/tool/penciltool.cpp
+++ b/core_lib/tool/penciltool.cpp
@@ -28,7 +28,7 @@ void PencilTool::loadSettings()
 
     QSettings settings( PENCIL2D, PENCIL2D );
     properties.width = settings.value( "pencilWidth" ).toDouble();
-    properties.feather = 50;
+    properties.feather = 1;
     properties.pressure = settings.value( "pencilPressure" ).toBool();
     properties.invisibility = 1;
     properties.preserveAlpha = 0;
@@ -202,7 +202,11 @@ void PencilTool::drawStroke()
 
     if ( layer->type() == Layer::BITMAP )
     {
-        qreal opacity = mCurrentPressure * mCurrentPressure;
+        qreal opacity = 1.0f;
+        if (properties.pressure == true)
+        {
+            opacity = mCurrentPressure / 2;
+        }
 
         mCurrentWidth = properties.width * mCurrentPressure;
         qreal brushWidth = mCurrentWidth;


### PR DESCRIPTION
This should fix #596 and maybe also solve #595

![test3](https://cloud.githubusercontent.com/assets/1045397/22697789/db40a322-ed52-11e6-9e7a-f480769f1756.gif)

## Changes:
* Removed division from opacity in ScribbleArea
* feather has also been set to 1 in PencilTool, as it seemed to have no influence on the look, except the cursor radius.
* The opacity pressure has been modified to be consistent with how it works in brushTool. I see no reason why the Pencil should act differently.

Is there a a reason as to why the opacity was being divided before drawing the stroke? 