### PR TITLE
Fix for #547. Can play and delete sound from any frame in its length.

### DIFF
--- a/core_lib/managers/playbackmanager.cpp
+++ b/core_lib/managers/playbackmanager.cpp
@@ -64,6 +64,10 @@ void PlaybackManager::play()
 
     mTimer->setInterval( 1000.0f / mFps );
     mTimer->start();
+
+    // Check for any sounds we should start playing part-way through.
+    mCheckForSoundsHalfway = true;
+
     emit playStateChanged(true);
 }
 
@@ -97,7 +101,22 @@ void PlaybackManager::playSounds( int frame )
 
     for ( LayerSound* layer : kSoundLayers )
     {
-        if ( layer->keyExists( frame ) )
+        if (mCheckForSoundsHalfway)
+        {
+            // Check for sounds which we should start playing from part-way through.
+            if ( layer->keyExistsWhichCovers( frame ) )
+            {
+                KeyFrame* key = layer->getKeyFrameWhichCovers( frame );
+                SoundClip* clip = static_cast< SoundClip* >( key );
+
+                clip->playFromPosition(frame, mFps);
+            }
+
+            // Set flag to false, since this check should only be done when
+            // starting play-back.
+            mCheckForSoundsHalfway = false;
+        }
+        else if ( layer->keyExists( frame ) )
         {
             KeyFrame* key = layer->getKeyFrameAt( frame );
             SoundClip* clip = static_cast< SoundClip* >( key );

--- a/core_lib/managers/playbackmanager.h
+++ b/core_lib/managers/playbackmanager.h
@@ -61,6 +61,8 @@ private:
     int mFps = 12;
 
     QTimer* mTimer = nullptr;
+
+    bool mCheckForSoundsHalfway = false;
 };
 
 #endif // PLAYBACKMANAGER_H

--- a/core_lib/soundplayer.cpp
+++ b/core_lib/soundplayer.cpp
@@ -64,6 +64,14 @@ int64_t SoundPlayer::duration()
     return 0;
 }
 
+void SoundPlayer::setMediaPlayerPosition(qint64 pos)
+{
+    if( mMediaPlayer )
+    {
+        mMediaPlayer->setPosition(pos);
+    }
+}
+
 void SoundPlayer::makeConnections()
 {   
     auto errorSignal = static_cast< void ( QMediaPlayer::* )( QMediaPlayer::Error ) >( &QMediaPlayer::error );

--- a/core_lib/soundplayer.h
+++ b/core_lib/soundplayer.h
@@ -26,6 +26,8 @@ public:
     int64_t duration();
     SoundClip* clip() { return mSoundClip; }
 
+    void setMediaPlayerPosition( qint64 pos );
+
 Q_SIGNALS:
     void corruptedSoundFile( SoundClip* );
     void durationChanged( SoundPlayer*, int64_t duration );

--- a/core_lib/structure/layer.cpp
+++ b/core_lib/structure/layer.cpp
@@ -209,11 +209,11 @@ bool Layer::addKeyFrame( int position, KeyFrame* pKeyFrame )
 
 bool Layer::removeKeyFrame( int position )
 {
-    auto it = mKeyFrames.find( position );
-    if ( it != mKeyFrames.end() )
+    auto frame = getKeyFrameWhichCovers(position);
+    if(frame)
     {
-        delete it->second;
-        mKeyFrames.erase( it );
+        mKeyFrames.erase(frame->pos());
+        delete frame;
     }
 
     return true;
@@ -502,19 +502,29 @@ void Layer::setModified( int position, bool )
 
 bool Layer::isFrameSelected(int position)
 {
-    return mSelectedFrames_byLast.contains(position);
+    KeyFrame *keyFrame = getKeyFrameWhichCovers(position);
+    if(keyFrame)
+    {
+        return mSelectedFrames_byLast.contains(keyFrame->pos());
+    }
+    else
+    {
+        return false;
+    }
 }
 
 void Layer::setFrameSelected(int position, bool isSelected)
 {
-    KeyFrame *keyFrame = getKeyFrameAt(position);
+    KeyFrame *keyFrame = getKeyFrameWhichCovers(position);
     if (keyFrame != nullptr) {
-        if (isSelected && !mSelectedFrames_byLast.contains(position)) {
+        int startPosition = keyFrame->pos();
+
+        if (isSelected && !mSelectedFrames_byLast.contains(startPosition)) {
 
             // Add the selected frame to the lists
             //
-            mSelectedFrames_byLast.insert(0, position);
-            mSelectedFrames_byPosition.append(position);
+            mSelectedFrames_byLast.insert(0, startPosition);
+            mSelectedFrames_byPosition.append(startPosition);
 
             // We need to keep the list of selected frames sorted
             // in order to easily handle their movement
@@ -526,10 +536,10 @@ void Layer::setFrameSelected(int position, bool isSelected)
 
             // Remove the selected frame from the lists
             //
-            int iLast = mSelectedFrames_byLast.indexOf(position);
+            int iLast = mSelectedFrames_byLast.indexOf(startPosition);
             mSelectedFrames_byLast.removeAt(iLast);
 
-            int iPos = mSelectedFrames_byPosition.indexOf(position);
+            int iPos = mSelectedFrames_byPosition.indexOf(startPosition);
             mSelectedFrames_byPosition.removeAt(iPos);
         }
         keyFrame->setSelected(isSelected);
@@ -704,4 +714,24 @@ bool isLayerPaintable( Layer* layer )
             break;
     }
     return false;
+}
+
+bool Layer::keyExistsWhichCovers(int frameNumber)
+{
+    return getKeyFrameWhichCovers(frameNumber) != nullptr;
+}
+
+KeyFrame *Layer::getKeyFrameWhichCovers(int frameNumber)
+{
+    auto keyFrame = getLastKeyFrameAtPosition(frameNumber);
+
+    if( keyFrame != nullptr )
+    {
+        if(keyFrame->pos() + keyFrame->length() > frameNumber)
+        {
+            return keyFrame;
+        }
+    }
+
+    return nullptr;
 }

--- a/core_lib/structure/layer.h
+++ b/core_lib/structure/layer.h
@@ -88,6 +88,8 @@ public:
     bool loadKey( KeyFrame* );
     KeyFrame* getKeyFrameAt( int position );
     KeyFrame* getLastKeyFrameAtPosition( int position );
+    bool keyExistsWhichCovers(int frameNumber);
+    KeyFrame *getKeyFrameWhichCovers(int frameNumber);
 
     void foreachKeyFrame( std::function<void( KeyFrame* )> );
 

--- a/core_lib/structure/soundclip.cpp
+++ b/core_lib/structure/soundclip.cpp
@@ -59,6 +59,19 @@ void SoundClip::play()
     }
 }
 
+void SoundClip::playFromPosition(int frameNumber, int fps)
+{
+    int framesIntoSound = frameNumber - pos();
+    int msPerFrame = 1000/fps;
+    int msIntoSound = framesIntoSound * msPerFrame;
+
+    if ( mPlayer )
+    {
+        mPlayer->setMediaPlayerPosition(msIntoSound);
+        mPlayer->play();
+    }
+}
+
 void SoundClip::stop()
 {
     if ( mPlayer )

--- a/core_lib/structure/soundclip.h
+++ b/core_lib/structure/soundclip.h
@@ -21,6 +21,7 @@ public:
     SoundPlayer* player() { return mPlayer.get(); }
 
     void play();
+    void playFromPosition(int frameNumber, int fps);
     void stop();
 
 private:


### PR DESCRIPTION
Fix for #547. You can now play a sound from any frame in its duration, not just its starting frame.
	
You can also delete and move the sound from any frame.

**Code Changes:**

- Added "mCheckForSoundsHalfway" flag to PlaybackManager. Set to true when starting playback - to check whether to play any sound from part-way through.
- Added "getKeyFrameWhichCovers(pos)" to Layer. This returns the keyframe which covers pos. E.g. a sound clip starting at frame 1 and ending at frame 6 covers frames 1, 2, 3, 4, 5, 6. 
- Updated Layer methods "isFrameSelected(pos)" and "setFrameSelected(pos)" to use "getKeyFrameWhichCovers". I could possibly move this logic change to the LayerSound class and keep Layer as is.
- Added "playFromPosition()" to SoundClip to play sound from part-way through.
