### PR TITLE
Improve compatibility with older Mac OS X systems

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -101,6 +101,8 @@ macx {
     FILE_ICONS.files = ../icons/mac_pcl_icon.icns ../icons/mac_pclx_icon.icns
     FILE_ICONS.path = Contents/Resources
     QMAKE_BUNDLE_DATA += FILE_ICONS
+
+    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.3
 }
 
 win32 {


### PR DESCRIPTION
Setting `QMAKE_MACOSX_DEPLOYMENT_TARGET` will enable weak linking, which will improve support for older Mac versions (10.4+ probably). [Qt documentation on the subject](https://doc.qt.io/qt-5/osx-deployment.html#macos-version-dependencies).