### PR TITLE
Some tablets are not recognized

### DIFF
--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -427,8 +427,14 @@ void ScribbleArea::tabletEvent( QTabletEvent *event )
     //qDebug() << "Device" << event->device() << "Pointer type" << event->pointerType();
     mStrokeManager->tabletEvent( event );
 
-    currentTool()->adjustPressureSensitiveProperties( pow( ( float )mStrokeManager->getPressure(), 2.0f ),
+    // Some tablets return "NoDevice" and Cursor.
+    if (event->device() == QTabletEvent::NoDevice) {
+        currentTool()->adjustPressureSensitiveProperties( pow( ( float )mStrokeManager->getPressure(), 2.0f ),
+                                                      false );
+    } else {
+        currentTool()->adjustPressureSensitiveProperties( pow( ( float )mStrokeManager->getPressure(), 2.0f ),
                                                       event->pointerType() == QTabletEvent::Cursor );
+    }
 
     if ( event->pointerType() == QTabletEvent::Eraser )
     {


### PR DESCRIPTION
Some tablets are not recognized because TabletEvent only expects a pointerType. This PR adds a NoDevice condition for tablets that are not recognized as a Stylus, likewise PointerType: Cursor is not fail proof either, my tablet was recognized as a Cursor even if it was a pen.

My non Wacom tablet works now, so this should definitely increase compatibility for those who use other tablet brands.