### PR TITLE
Brush/Tools changes, AA Brush setting and more..

### DIFF
--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1190,6 +1190,10 @@ void ScribbleArea::drawPolyline( QList<QPointF> points, QPointF endPoint )
         }
         tempPath.lineTo( endPoint );
 
+        QRectF updateRect = mEditor->view()->mapCanvasToScreen( tempPath.boundingRect().toRect() ).adjusted( -1, -1, 1, 1);
+
+        // Update region outside updateRect
+        QRectF boundingRect = updateRect.adjusted(-width(),-height(), width(),height());
         if ( mEditor->layers()->currentLayer()->type() == Layer::VECTOR )
         {
             tempPath = mEditor->view()->mapCanvasToScreen( tempPath );
@@ -1204,6 +1208,8 @@ void ScribbleArea::drawPolyline( QList<QPointF> points, QPointF endPoint )
             }
         }
         mBufferImg->clear();
+        mBufferImg->drawPath( tempPath, pen2, Qt::NoBrush, QPainter::CompositionMode_SourceOver, getTool( POLYLINE )->properties.useAA);
+        update( boundingRect.toRect());
     }
 }
 

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1190,7 +1190,6 @@ void ScribbleArea::drawPolyline( QList<QPointF> points, QPointF endPoint )
         }
         tempPath.lineTo( endPoint );
 
-        QRectF updateRect = mEditor->view()->mapCanvasToScreen( tempPath.boundingRect().toRect() ).adjusted( -10, -10, 10, 10 );
         if ( mEditor->layers()->currentLayer()->type() == Layer::VECTOR )
         {
             tempPath = mEditor->view()->mapCanvasToScreen( tempPath );
@@ -1205,9 +1204,6 @@ void ScribbleArea::drawPolyline( QList<QPointF> points, QPointF endPoint )
             }
         }
         mBufferImg->clear();
-        mBufferImg->drawPath( tempPath, pen2, Qt::NoBrush, QPainter::CompositionMode_SourceOver, mPrefs->isOn( SETTING::ANTIALIAS ) );
-
-        update( updateRect.toRect() );
     }
 }
 

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1061,22 +1061,17 @@ void ScribbleArea::setGaussianGradient( QGradient &gradient, QColor colour, qrea
     gradient.setColorAt( 1.0 - (mOffset/100.0), QColor( r, g, b, mainColorAlpha - alphaAdded ) );
 }
 
-void ScribbleArea::drawPen( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity )
+void ScribbleArea::drawPen( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity, bool useAA )
 {
-    qreal offset = 64;
-
-    QRadialGradient radialGrad( thePoint, 0.5 * brushWidth );
-    setGaussianGradient( radialGrad, fillColour, opacity, offset );
-
     QRectF rectangle( thePoint.x() - 0.5 * brushWidth, thePoint.y() - 0.5 * brushWidth, brushWidth, brushWidth );
 
-    mBufferImg->drawEllipse( rectangle, Qt::NoPen, radialGrad,
-                             QPainter::CompositionMode_SourceOver, mPrefs->isOn( SETTING::ANTIALIAS ) );
+    mBufferImg->drawEllipse( rectangle, Qt::NoPen, QBrush(fillColour, Qt::SolidPattern),
+                               QPainter::CompositionMode_Source, useAA );
 }
 
 void ScribbleArea::drawPencil( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity )
 {
-    drawBrush(thePoint, brushWidth, 50, fillColour, opacity);
+    drawBrush(thePoint, brushWidth, 50, fillColour, opacity, true);
 }
 
 void ScribbleArea::drawBrush( QPointF thePoint, qreal brushWidth, qreal mOffset, QColor fillColour, qreal opacity, bool usingFeather )
@@ -1090,12 +1085,12 @@ void ScribbleArea::drawBrush( QPointF thePoint, qreal brushWidth, qreal mOffset,
         setGaussianGradient( radialGrad, fillColour, opacity, mOffset );
 
         tempBitmapImage.drawEllipse( rectangle, Qt::NoPen, radialGrad,
-                                   QPainter::CompositionMode_Source, mPrefs->isOn( SETTING::ANTIALIAS ) );
+                                   QPainter::CompositionMode_Source, false );
     }
     else
     {
-        tempBitmapImage.drawEllipse( rectangle, Qt::NoPen, QBrush(fillColour, Qt::SolidPattern),
-                                   QPainter::CompositionMode_Source, mPrefs->isOn( SETTING::ANTIALIAS ) );
+        mBufferImg->drawEllipse( rectangle, Qt::NoPen, QBrush(fillColour, Qt::SolidPattern),
+                                   QPainter::CompositionMode_Source, true );
     }
     mBufferImg->paste( &tempBitmapImage );
 }

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -166,7 +166,7 @@ public:
 
     void drawLine( QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm );
     void drawPath( QPainterPath path, QPen pen, QBrush brush, QPainter::CompositionMode cm );
-    void drawPen( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity );
+    void drawPen( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity, bool useAA = true );
     void drawPencil( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity );
     void drawBrush( QPointF thePoint, qreal brushWidth, qreal offset, QColor fillColour, qreal opacity, bool usingFeather = true );
     void blurBrush( BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal offset_, qreal opacity_ );

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -160,10 +160,7 @@ protected:
     void resizeEvent( QResizeEvent* ) override;
 
 public:
-    void drawPolyline( QList<QPointF> points, QPointF lastPoint );
-    void endPolyline( QList<QPointF> points );
-    void cancelPolyline( QList<QPointF> points );
-
+    void drawPolyline(QPainterPath path, QPen pen, bool useAA );
     void drawLine( QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm );
     void drawPath( QPainterPath path, QPen pen, QBrush brush, QPainter::CompositionMode cm );
     void drawPen( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity, bool useAA = true );

--- a/core_lib/interface/tooloptiondockwidget.cpp
+++ b/core_lib/interface/tooloptiondockwidget.cpp
@@ -43,6 +43,7 @@ void ToolOptionWidget::updateUI()
     mUsePressureBox->setVisible( currentTool->isPropertyEnabled( PRESSURE ) );
     mMakeInvisibleBox->setVisible( currentTool->isPropertyEnabled( INVISIBILITY ) );
     mPreserveAlphaBox->setVisible( currentTool->isPropertyEnabled( PRESERVEALPHA ) );
+    mUseAABox->setVisible(currentTool->isPropertyEnabled(ANTI_ALIASING ) );
 
     auto currentLayerType = editor()->layers()->currentLayer()->type();
 
@@ -59,6 +60,7 @@ void ToolOptionWidget::updateUI()
     setPenInvisibility( p.invisibility );
     setPreserveAlpha( p.preserveAlpha );
     setVectorMergeEnabled( p.vectorMergeEnabled );
+    setAA(p.useAA);
 }
 
 void ToolOptionWidget::createUI()
@@ -88,7 +90,7 @@ void ToolOptionWidget::createUI()
     mFeatherSpinBox->setRange(2,64);
     mFeatherSpinBox->setValue(settings.value( "brushFeather" ).toDouble() );
 
-    mUseFeatherBox = new QCheckBox( tr( "Use Feather?" ) );
+    mUseFeatherBox = new QCheckBox( tr( "Use Feather" ) );
     mUseFeatherBox->setToolTip( tr( "Enable or disable feathering" ) );
     mUseFeatherBox->setFont( QFont( "Helvetica", 10 ) );
     mUseFeatherBox->setChecked( settings.value( "brushUseFeather" ).toBool() );
@@ -102,6 +104,11 @@ void ToolOptionWidget::createUI()
     mUsePressureBox->setToolTip( tr( "Size with pressure" ) );
     mUsePressureBox->setFont( QFont( "Helvetica", 10 ) );
     mUsePressureBox->setChecked( true );
+
+    mUseAABox = new QCheckBox( tr( "Anti-Aliasing" ) );
+    mUseAABox->setToolTip( tr( "Enable Anti-Aliasing" ) );
+    mUseAABox->setFont( QFont( "Helvetica", 10 ) );
+    mUseAABox->setChecked( true );
 
     mMakeInvisibleBox = new QCheckBox( tr( "Invisible" ) );
     mMakeInvisibleBox->setToolTip( tr( "Make invisible" ) );
@@ -124,10 +131,11 @@ void ToolOptionWidget::createUI()
     pLayout->addWidget( mFeatherSpinBox, 9, 10, 1, 2 );
     pLayout->addWidget( mUseBezierBox, 10, 0, 1, 2 );
     pLayout->addWidget( mUsePressureBox, 11, 0, 1, 2 );
-    pLayout->addWidget( mPreserveAlphaBox, 12, 0, 1, 2 );
-    pLayout->addWidget( mUseFeatherBox, 13, 0, 1, 2 );
-    pLayout->addWidget( mMakeInvisibleBox, 14, 0, 1, 2 );
-    pLayout->addWidget( mVectorMergeBox, 15, 0, 1, 2 );
+    pLayout->addWidget( mUseAABox, 14, 0, 1, 2);
+    pLayout->addWidget( mPreserveAlphaBox, 13, 0, 1, 2 );
+    pLayout->addWidget( mUseFeatherBox, 12, 0, 1, 2 );
+    pLayout->addWidget( mMakeInvisibleBox, 15, 0, 1, 2 );
+    pLayout->addWidget( mVectorMergeBox, 16, 0, 1, 2 );
 
     pLayout->setRowStretch( 16, 1 );
 
@@ -154,6 +162,7 @@ void ToolOptionWidget::makeConnectionToEditor( Editor* editor )
     connect( mUseFeatherBox, &QCheckBox::clicked, toolManager, &ToolManager::setUseFeather );
 
     connect( mVectorMergeBox, &QCheckBox::clicked, toolManager, &ToolManager::setVectorMergeEnabled );
+    connect( mUseAABox, &QCheckBox::clicked, toolManager, &ToolManager::setAA );
 
     connect( toolManager, &ToolManager::toolChanged, this, &ToolOptionWidget::onToolChanged );
     connect( toolManager, &ToolManager::toolPropertyChanged, this, &ToolOptionWidget::onToolPropertyChanged );
@@ -182,6 +191,9 @@ void ToolOptionWidget::onToolPropertyChanged( ToolType, ToolPropertyType eProper
             break;
         case VECTORMERGE:
             setVectorMergeEnabled(p.vectorMergeEnabled);
+            break;
+        case ANTI_ALIASING:
+            setAA(p.useAA);
             break;
     }
 }
@@ -245,6 +257,15 @@ void ToolOptionWidget::setVectorMergeEnabled(int x)
     mVectorMergeBox->setChecked( x > 0 );
 }
 
+void ToolOptionWidget::setAA(int x)
+{
+    qDebug() << "Setting - Pen AA Enabled=" << x;
+
+    SignalBlocker b( mUseAABox );
+    mUseAABox->setEnabled( true );
+    mUseAABox->setChecked( x > 0 );
+}
+
 void ToolOptionWidget::disableAllOptions()
 {
     mSizeSlider->hide();
@@ -257,4 +278,5 @@ void ToolOptionWidget::disableAllOptions()
     mMakeInvisibleBox->hide();
     mPreserveAlphaBox->hide();
     mVectorMergeBox->hide();
+    mUseAABox->hide();
 }

--- a/core_lib/interface/tooloptiondockwidget.cpp
+++ b/core_lib/interface/tooloptiondockwidget.cpp
@@ -131,11 +131,11 @@ void ToolOptionWidget::createUI()
     pLayout->addWidget( mFeatherSpinBox, 9, 10, 1, 2 );
     pLayout->addWidget( mUseBezierBox, 10, 0, 1, 2 );
     pLayout->addWidget( mUsePressureBox, 11, 0, 1, 2 );
-    pLayout->addWidget( mUseAABox, 14, 0, 1, 2);
+    pLayout->addWidget( mUseAABox, 12, 0, 1, 2);
     pLayout->addWidget( mPreserveAlphaBox, 13, 0, 1, 2 );
-    pLayout->addWidget( mUseFeatherBox, 12, 0, 1, 2 );
-    pLayout->addWidget( mMakeInvisibleBox, 15, 0, 1, 2 );
-    pLayout->addWidget( mVectorMergeBox, 16, 0, 1, 2 );
+    pLayout->addWidget( mUseFeatherBox, 13, 0, 1, 2 );
+    pLayout->addWidget( mMakeInvisibleBox, 14, 0, 1, 2 );
+    pLayout->addWidget( mVectorMergeBox, 15, 0, 1, 2 );
 
     pLayout->setRowStretch( 16, 1 );
 

--- a/core_lib/interface/tooloptiondockwidget.h
+++ b/core_lib/interface/tooloptiondockwidget.h
@@ -35,6 +35,7 @@ private:
     void setPressure( int );
     void setPreserveAlpha( int );
     void setVectorMergeEnabled( int );
+    void setAA( int );
 
     void disableAllOptions();
     void createUI();
@@ -49,6 +50,7 @@ private:
     QSpinBox* mFeatherSpinBox    = nullptr;
     SpinSlider* mSizeSlider      = nullptr;
     SpinSlider* mFeatherSlider   = nullptr;
+    QCheckBox* mUseAABox         = nullptr;
 };
 
 #endif // TOOLOPTIONDOCKWIDGET_H

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -169,6 +169,12 @@ void ToolManager::setPressure( bool isPressureOn )
     Q_EMIT toolPropertyChanged( currentTool()->type(), PRESSURE );
 }
 
+void ToolManager::setAA( bool usingAA )
+{
+    currentTool()->setAA( usingAA );
+    Q_EMIT toolPropertyChanged( currentTool()->type(), ANTI_ALIASING );
+}
+
 void ToolManager::tabletSwitchToEraser()
 {
     if (!mIsSwitchedToEraser)

--- a/core_lib/managers/toolmanager.h
+++ b/core_lib/managers/toolmanager.h
@@ -46,6 +46,7 @@ public slots:
     void setVectorMergeEnabled( bool );
     void setBezier( bool );
     void setPressure( bool );
+    void setAA( bool );
 
 private:
     BaseTool* mCurrentTool       = nullptr;

--- a/core_lib/tool/basetool.cpp
+++ b/core_lib/tool/basetool.cpp
@@ -43,6 +43,7 @@ BaseTool::BaseTool( QObject *parent ) : QObject( parent )
     m_enabledProperties.insert( INVISIBILITY,   false  );
     m_enabledProperties.insert( PRESERVEALPHA,  false  );
     m_enabledProperties.insert( BEZIER,         false  );
+    m_enabledProperties.insert( ANTI_ALIASING,  false  );
 }
 
 QCursor BaseTool::cursor()
@@ -326,3 +327,9 @@ void BaseTool::setVectorMergeEnabled(const bool vectorMergeEnabled)
 {
     properties.vectorMergeEnabled = vectorMergeEnabled;
 }
+
+void BaseTool::setAA(const bool useAA)
+{
+    properties.useAA = useAA;
+}
+

--- a/core_lib/tool/basetool.h
+++ b/core_lib/tool/basetool.h
@@ -18,12 +18,13 @@ class Properties
 public:
     qreal width       = 1.f;
     qreal feather     = 1.f;
-    bool pressure      = 1;
+    bool pressure     = 1;
     int invisibility  = 0;
     int preserveAlpha = 0;
     bool vectorMergeEnabled = false;
     bool bezier_state = false;
     bool useFeather   = true;
+    bool useAA        = true;
 };
 
 const int ON = 1;
@@ -79,6 +80,7 @@ public:
     virtual void setUseFeather( const bool usingFeather );
     virtual void setPreserveAlpha( const bool preserveAlpha );
     virtual void setVectorMergeEnabled( const bool vectorMergeEnabled );
+    virtual void setAA ( const bool useAA );
     virtual void leavingThisTool(){}
     virtual void switchingLayers(){}
     Properties properties;

--- a/core_lib/tool/brushtool.cpp
+++ b/core_lib/tool/brushtool.cpp
@@ -301,7 +301,7 @@ void BrushTool::drawStroke()
         }
 
         int rad = qRound( brushWidth ) / 2 + 2;
-        mScribbleArea->paintBitmapBufferRect(rect);
+
         mScribbleArea->refreshBitmap( rect, rad );
     }
     else if ( layer->type() == Layer::VECTOR )

--- a/core_lib/tool/penciltool.h
+++ b/core_lib/tool/penciltool.h
@@ -16,6 +16,7 @@ public:
     void mousePressEvent( QMouseEvent* ) override;
     void mouseMoveEvent( QMouseEvent* ) override;
     void mouseReleaseEvent( QMouseEvent* ) override;
+    void paintAt( QPointF point );
 
     void drawStroke();
 
@@ -31,6 +32,7 @@ private:
     QColor mCurrentPressuredColor { 0, 0, 0, 255 };
     QPointF mLastBrushPoint { 0, 0 };
     qreal mOpacity = 1.0f;
+    QPointF mMouseDownPoint;
 };
 
 #endif // PENCILTOOL_H

--- a/core_lib/tool/pentool.h
+++ b/core_lib/tool/pentool.h
@@ -17,15 +17,17 @@ public:
     void mouseReleaseEvent( QMouseEvent* ) override;
 
     void drawStroke();
+    void paintAt( QPointF point );
 
     void adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice ) override;
 
     void setWidth( const qreal width ) override;
-    void setFeather( const qreal feather ) override;
     void setPressure( const bool pressure ) override;
+    void setAA( const bool AA ) override;
 
 private:
     QPointF mLastBrushPoint;
+    QPointF mMouseDownPoint;
 };
 
 #endif // PENTOOL_H

--- a/core_lib/tool/polylinetool.cpp
+++ b/core_lib/tool/polylinetool.cpp
@@ -122,7 +122,7 @@ void PolylineTool::mouseMoveEvent( QMouseEvent *event )
 
     if ( layer->type() == Layer::BITMAP || layer->type() == Layer::VECTOR )
     {
-        mScribbleArea->drawPolyline( mPoints, getCurrentPoint() );
+       drawPolyline( mPoints, getCurrentPoint() );
     }
 }
 
@@ -131,7 +131,7 @@ void PolylineTool::mouseDoubleClickEvent( QMouseEvent *event )
     // XXX highres position ??
     if ( BezierCurve::eLength( m_pStrokeManager->getLastPressPixel() - event->pos() ) < 2.0 )
     {
-        mScribbleArea->endPolyline( mPoints );
+        endPolyline( mPoints );
         clear();
     }
 }
@@ -142,7 +142,7 @@ bool PolylineTool::keyPressEvent( QKeyEvent *event )
     case Qt::Key_Return:
         if ( mPoints.size() > 0 )
         {
-            mScribbleArea->endPolyline( mPoints );
+            endPolyline( mPoints );
             clear();
             return true;
         }
@@ -150,7 +150,7 @@ bool PolylineTool::keyPressEvent( QKeyEvent *event )
 
     case Qt::Key_Escape:
         if ( mPoints.size() > 0 ) {
-            mScribbleArea->cancelPolyline( mPoints );
+            cancelPolyline( );
             clear();
             return true;
         }
@@ -161,4 +161,98 @@ bool PolylineTool::keyPressEvent( QKeyEvent *event )
     }
 
     return false;
+}
+
+void PolylineTool::drawPolyline(QList<QPointF> points, QPointF endPoint)
+{
+    if ( !mScribbleArea->areLayersSane() )
+    {
+        return;
+    }
+
+    if ( points.size() > 0 )
+    {
+        QPen pen( mEditor->color()->frontColor(),
+                   properties.width,
+                   Qt::SolidLine,
+                   Qt::RoundCap,
+                   Qt::RoundJoin );
+        Layer* layer = mEditor->layers()->currentLayer();
+
+        // Bitmap by default
+        QPainterPath tempPath;
+        if ( properties.bezier_state )
+        {
+            tempPath = BezierCurve( points ).getSimplePath();
+        }
+        else
+        {
+            tempPath = BezierCurve( points ).getStraightPath();
+        }
+        tempPath.lineTo( endPoint );
+
+        // Vector otherwise
+        if ( layer->type() == Layer::VECTOR )
+        {
+            if ( mEditor->layers()->currentLayer()->type() == Layer::VECTOR )
+            {
+                tempPath = mEditor->view()->mapCanvasToScreen( tempPath );
+                if ( mScribbleArea->makeInvisible() == true )
+                {
+                    pen.setWidth( 0 );
+                    pen.setStyle( Qt::DotLine );
+                }
+                else
+                {
+                    pen.setWidth(properties.width * mEditor->view()->scaling() );
+                }
+            }
+        }
+
+        mScribbleArea->drawPolyline(tempPath, pen, properties.useAA);
+    }
+}
+
+
+void PolylineTool::cancelPolyline()
+{
+    // Clear the in-progress polyline from the bitmap buffer.
+    mScribbleArea->clearBitmapBuffer();
+    mScribbleArea->updateCurrentFrame();
+}
+
+void PolylineTool::endPolyline( QList<QPointF> points )
+{
+    if ( !mScribbleArea->areLayersSane() )
+    {
+        return;
+    }
+
+    Layer* layer = mEditor->layers()->currentLayer();
+
+    if ( layer->type() == Layer::VECTOR )
+    {
+        BezierCurve curve = BezierCurve( points );
+        if ( mScribbleArea->makeInvisible() == true )
+        {
+            curve.setWidth( 0 );
+        }
+        else
+        {
+            curve.setWidth( properties.width );
+        }
+        curve.setColourNumber( mEditor->color()->frontColorNumber() );
+        curve.setVariableWidth( false );
+        curve.setInvisibility( mScribbleArea->makeInvisible() );
+        //curve.setSelected(true);
+        ( ( LayerVector * )layer )->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 )->addCurve( curve, mEditor->view()->scaling() );
+    }
+    if ( layer->type() == Layer::BITMAP )
+    {
+        drawPolyline( points, points.last() );
+        BitmapImage *bitmapImage = ( ( LayerBitmap * )layer )->getLastBitmapImageAtFrame( mEditor->currentFrame(), 0 );
+        bitmapImage->paste( mScribbleArea->mBufferImg );
+    }
+    mScribbleArea->mBufferImg->clear();
+    mScribbleArea->setModified( mEditor->layers()->currentLayerIndex(), mEditor->currentFrame() );
 }

--- a/core_lib/tool/polylinetool.cpp
+++ b/core_lib/tool/polylinetool.cpp
@@ -24,6 +24,7 @@ void PolylineTool::loadSettings()
 {
     m_enabledProperties[WIDTH] = true;
     m_enabledProperties[BEZIER] = true;
+    m_enabledProperties[ANTI_ALIASING] = true;
 
     QSettings settings( PENCIL2D, PENCIL2D );
 
@@ -32,6 +33,7 @@ void PolylineTool::loadSettings()
     properties.pressure = 0;
     properties.invisibility = OFF;
     properties.preserveAlpha = OFF;
+    properties.useAA = settings.value( "brushAA").toBool();
 
     // First run
     if ( properties.width <= 0 )
@@ -54,6 +56,17 @@ void PolylineTool::setWidth(const qreal width)
 void PolylineTool::setFeather( const qreal feather )
 {
     properties.feather = -1;
+}
+
+void PolylineTool::setAA( const bool AA )
+{
+    // Set current property
+    properties.useAA = AA;
+
+    // Update settings
+    QSettings settings( PENCIL2D, PENCIL2D );
+    settings.setValue("brushAA", AA);
+    settings.sync();
 }
 
 QCursor PolylineTool::cursor() //Not working this one, any guru to fix it?

--- a/core_lib/tool/polylinetool.h
+++ b/core_lib/tool/polylinetool.h
@@ -24,6 +24,7 @@ public:
 
     void setWidth( const qreal width ) override;
     void setFeather( const qreal feather ) override;
+    void setAA( const bool AA ) override;
 
 private:
     QList<QPointF> mPoints;

--- a/core_lib/tool/polylinetool.h
+++ b/core_lib/tool/polylinetool.h
@@ -28,6 +28,10 @@ public:
 
 private:
     QList<QPointF> mPoints;
+
+    void drawPolyline(QList<QPointF> points, QPointF endPoint);
+    void cancelPolyline();
+    void endPolyline( QList<QPointF> points );
 };
 
 #endif // POLYLINETOOL_H

--- a/core_lib/tool/strokemanager.cpp
+++ b/core_lib/tool/strokemanager.cpp
@@ -114,10 +114,10 @@ void StrokeManager::tabletEvent(QTabletEvent* event)
 void StrokeManager::mouseMoveEvent(QMouseEvent* event)
 {
     QPointF pos = getEventPosition(event);
-    QPointF smoothPos = QPointF( ( pos.x() + mLastPixel.x() ) / 2.0, ( pos.y() + mLastPixel.y() ) / 2.0 );
+    QPointF newPos = QPointF( ( pos.x()), ( pos.y() ));
 
     mLastPixel = mCurrentPixel;
-    mCurrentPixel = smoothPos;
+    mCurrentPixel = newPos;
 
 	if ( !mStrokeStarted )
 	{
@@ -135,7 +135,7 @@ void StrokeManager::mouseMoveEvent(QMouseEvent* event)
         strokeQueue.pop_front();
     }
 
-    strokeQueue.push_back( smoothPos );
+    strokeQueue.push_back( newPos );
 
 }
 
@@ -162,7 +162,7 @@ QList<QPointF> StrokeManager::interpolateStroke()
         //qDebug() << "previous tangent" << m_previousTangent;
         QLineF _line(QPointF(0,0), m_previousTangent);
         // don't bother for small tangents, as they can induce single pixel wobbliness
-        if (_line.length() < 2) 
+        if (_line.length() < 2)
 		{
             m_previousTangent = QPointF(0,0);
         }

--- a/core_lib/tool/strokemanager.cpp
+++ b/core_lib/tool/strokemanager.cpp
@@ -114,7 +114,7 @@ void StrokeManager::tabletEvent(QTabletEvent* event)
 void StrokeManager::mouseMoveEvent(QMouseEvent* event)
 {
     QPointF pos = getEventPosition(event);
-    QPointF newPos = QPointF( ( pos.x()), ( pos.y() ));
+    QPointF newPos = QPointF( pos.x(), pos.y() );
 
     mLastPixel = mCurrentPixel;
     mCurrentPixel = newPos;

--- a/core_lib/util/pencildef.h
+++ b/core_lib/util/pencildef.h
@@ -34,7 +34,8 @@ enum ToolPropertyType
     PRESERVEALPHA,
     BEZIER,
     USEFEATHER,
-    VECTORMERGE
+    VECTORMERGE,
+    ANTI_ALIASING
 };
 
 enum BackgroundStyle


### PR DESCRIPTION
## What's fixed/changed:

- Opacity strokes being drawn on top of each other instead of being continuous
for Pen and Brush.
- Separated painting/brush Anti-Aliasing from the Preferences
Anti-aliasing setting.
- Set fixed step size for pen. In the future I want to control this via a slider, but it should be hidden in a popup window, so for now it's fixed instead of relying on the feather value.

## What's removed:
- Feather from Pen

## What's added:
- Checkbox to enable AA for brushes, this is used for Pen only. AA is
redundant for Brush and Pencil when feather is enabled and is otherwise
enabled.
- Consistent dap ability across Pencil, Brush and Pen. Before this was only possible with brush.
- Dotted Cursor for Pen tool.

![brush](https://cloud.githubusercontent.com/assets/1045397/23142657/61c9a154-f7bd-11e6-8223-0f702d0709d5.gif)
