### PR TITLE
You can now export images without a camera layer

### DIFF
--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -740,7 +740,14 @@ void MainWindow2::exportImageSequence()
     auto dialog =  new ExportImageSeqDialog( this );
     OnScopeExit( dialog->deleteLater() );
 
-    dialog->setExportSize( cameraLayer->getViewRect().size() );
+    if(cameraLayer != nullptr)
+    {
+        dialog->setExportSize( cameraLayer->getViewRect().size() );
+    }
+    else
+    {
+        dialog->setExportSize( QSize(640,480) );
+    }
     dialog->exec();
 
     QSize exportSize = dialog->getExportSize();
@@ -803,7 +810,14 @@ void MainWindow2::exportImage()
     auto dialog =  new ExportImageSeqDialog( this );
     OnScopeExit( dialog->deleteLater() );
 
-    dialog->setExportSize( cameraLayer->getViewRect().size() );
+    if(cameraLayer != nullptr)
+    {
+        dialog->setExportSize(cameraLayer->getViewRect().size());
+    }
+    else
+    {
+        dialog->setExportSize(QSize(640, 480));
+    }
     dialog->exec();
 
     QSize exportSize = dialog->getExportSize();

--- a/core_lib/structure/object.cpp
+++ b/core_lib/structure/object.cpp
@@ -561,7 +561,18 @@ bool Object::exportFrames( int frameStart, int frameEnd,
 
         QPainter painter( &imageToExport );
 
-        QRect viewRect = ( ( LayerCamera* )currentLayer )->getViewRect();
+        QRect viewRect;
+        if(currentLayer != nullptr)
+        {
+            viewRect = ( ( LayerCamera* )currentLayer )->getViewRect();
+        }
+        else
+        {
+            // Some old .PCL files may not have a camera layer.
+            // In that case, use a default size.
+            viewRect = QRect( QPoint(-320,-240), QSize(640,480) );
+        }
+
         QTransform mapView = RectMapTransform( viewRect, QRectF( QPointF( 0, 0 ), exportSize ) );
 //        mapView = ( ( LayerCamera* )currentLayer )->getViewAtFrame( currentFrame ) * mapView;
         painter.setWorldTransform( mapView );


### PR DESCRIPTION
Fix fox #612. You can now export images and image sequences even when there is no camera layer. In that case the export dialog will have a default size setting of 640 by 480 pixels.