### PR TITLE
Added progress dialog (with cancel option) for exporting image sequences

### DIFF
--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -782,6 +782,13 @@ void MainWindow2::exportImageSequence()
 
 
     int projectLength = mEditor->layers()->projectLength();
+
+    // Show a progress dialog, as this can take a while if you have lots of frames.
+    QProgressDialog progress( tr( "Exporting image sequence..." ), tr( "Abort" ), 0, 100, this );
+    hideQuestionMark(progress);
+    progress.setWindowModality( Qt::WindowModal );
+    progress.show();
+
     mEditor->object()->exportFrames( 1,
                                      projectLength,
                                      cameraLayer,
@@ -791,8 +798,11 @@ void MainWindow2::exportImageSequence()
                                      -1,
                                      useTranparency,
                                      true,
-                                     NULL,
-                                     0 );
+                                     &progress,
+                                     100 );
+
+    progress.close();
+
     //return true;
 }
 

--- a/core_lib/structure/object.cpp
+++ b/core_lib/structure/object.cpp
@@ -19,6 +19,7 @@ GNU General Public License for more details.
 #include <QTextStream>
 #include <QMessageBox>
 #include <QProgressDialog>
+#include <QApplication>
 
 #include "object.h"
 #include "layer.h"
@@ -551,7 +552,21 @@ bool Object::exportFrames( int frameStart, int frameEnd,
 
     for ( int currentFrame = frameStart; currentFrame <= frameEnd; currentFrame++ )
     {
-        if ( progress != NULL ) progress->setValue( ( currentFrame - frameStart )*progressMax / ( frameEnd - frameStart ) );
+        if ( progress != NULL )
+        {
+            int totalFramesToExport = ( frameEnd - frameStart ) + 1;
+            if ( totalFramesToExport != 0 ) // Avoid dividing by zero.
+            {
+                progress->setValue( ( currentFrame - frameStart + 1 )*progressMax / totalFramesToExport );
+                QApplication::processEvents();  // Required to make progress bar update on-screen.
+            }
+
+            if(progress->wasCanceled())
+            {
+                break;
+            }
+        }
+
         QImage imageToExport( exportSize, QImage::Format_ARGB32_Premultiplied );
         QColor bgColor = Qt::white;
         if (transparency) {


### PR DESCRIPTION
Added a progress dialog for exporting image sequences. Shows how far through the export is, and you can stop the export by clicking "Abort".  Below is a video demo:

[Progressbar Demo.zip](https://github.com/pencil2d/pencil/files/805477/Progressbar.Demo.zip)

The reason for this is:
1. When exporting image sequences, I couldn't tell how far Pencil was through, so I just had to wait till it became responsive again. This sometimes took a few minutes for very long animations.
2. There was no way to cancel the export, so I would either have to kill the application or just wait till the export eventually finished.