### PR TITLE
Interpolation levels and refactoring

### DIFF
--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1080,7 +1080,7 @@ void ScribbleArea::drawPencil( QPointF thePoint, qreal brushWidth, QColor fillCo
     drawBrush(thePoint, brushWidth, 50, fillColour, opacity, true);
 }
 
-void ScribbleArea::drawBrush( QPointF thePoint, qreal brushWidth, qreal mOffset, QColor fillColour, qreal opacity, bool usingFeather )
+void ScribbleArea::drawBrush( QPointF thePoint, qreal brushWidth, qreal mOffset, QColor fillColour, qreal opacity, bool usingFeather, int useAA )
 {
     QRectF rectangle( thePoint.x() - 0.5 * brushWidth, thePoint.y() - 0.5 * brushWidth, brushWidth, brushWidth );
 
@@ -1096,7 +1096,7 @@ void ScribbleArea::drawBrush( QPointF thePoint, qreal brushWidth, qreal mOffset,
     else
     {
         mBufferImg->drawEllipse( rectangle, Qt::NoPen, QBrush(fillColour, Qt::SolidPattern),
-                                   QPainter::CompositionMode_Source, true );
+                                   QPainter::CompositionMode_Source, useAA );
     }
     mBufferImg->paste( &tempBitmapImage );
 }

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -165,7 +165,7 @@ public:
     void drawPath( QPainterPath path, QPen pen, QBrush brush, QPainter::CompositionMode cm );
     void drawPen( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity, bool useAA = true );
     void drawPencil( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity );
-    void drawBrush( QPointF thePoint, qreal brushWidth, qreal offset, QColor fillColour, qreal opacity, bool usingFeather = true );
+    void drawBrush( QPointF thePoint, qreal brushWidth, qreal offset, QColor fillColour, qreal opacity, bool usingFeather = true, int useAA = 0 );
     void blurBrush( BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal offset_, qreal opacity_ );
     void liquifyBrush( BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal offset_, qreal opacity_ );
 

--- a/core_lib/interface/spinslider.cpp
+++ b/core_lib/interface/spinslider.cpp
@@ -28,7 +28,7 @@ SpinSlider::SpinSlider( QString text, GROWTH_TYPE type, VALUE_TYPE dataType, qre
     mSlider = new QSlider(Qt::Horizontal, this);
     mSlider->setMinimum( 0 );
     mSlider->setMaximum( 100 );
-    mSlider->setMaximumWidth( 70 );
+    mSlider->setMaximumWidth( 500 );
 
     QGridLayout* layout = new QGridLayout();
     layout->setMargin( 2 );

--- a/core_lib/interface/tooloptiondockwidget.cpp
+++ b/core_lib/interface/tooloptiondockwidget.cpp
@@ -319,12 +319,23 @@ void ToolOptionWidget::setAA(int x)
 
     SignalBlocker b( mUseAABox );
     mUseAABox->setEnabled( true );
+
+    if (x == -1) {
+        mUseAABox->setEnabled(false);
+        mUseAABox->hide();
+    } else {
+        mUseAABox->show();
+    }
     mUseAABox->setChecked( x > 0 );
 }
 
 void ToolOptionWidget::setInpolLevel(int x)
 {
     qDebug() << "Setting - Interpolation level:" << x;
+
+    SignalBlocker b( mNoInpol );
+    SignalBlocker c( mSimpleInpol );
+    SignalBlocker d( mStrongInpol );
     if (x == 0) {
         mNoInpol->setChecked(true);
     }

--- a/core_lib/interface/tooloptiondockwidget.cpp
+++ b/core_lib/interface/tooloptiondockwidget.cpp
@@ -3,6 +3,8 @@
 #include <QCheckBox>
 #include <QSpinBox>
 #include <QGridLayout>
+#include <QGroupBox>
+#include <QRadioButton>
 #include <QSettings>
 #include <QDebug>
 #include "spinslider.h"
@@ -43,7 +45,8 @@ void ToolOptionWidget::updateUI()
     mUsePressureBox->setVisible( currentTool->isPropertyEnabled( PRESSURE ) );
     mMakeInvisibleBox->setVisible( currentTool->isPropertyEnabled( INVISIBILITY ) );
     mPreserveAlphaBox->setVisible( currentTool->isPropertyEnabled( PRESERVEALPHA ) );
-    mUseAABox->setVisible(currentTool->isPropertyEnabled(ANTI_ALIASING ) );
+    mUseAABox->setVisible(currentTool->isPropertyEnabled( ANTI_ALIASING ) );
+    mInpolLevelsBox->setVisible(currentTool->isPropertyEnabled( INTERPOLATION ) );
 
     auto currentLayerType = editor()->layers()->currentLayer()->type();
 
@@ -61,11 +64,13 @@ void ToolOptionWidget::updateUI()
     setPreserveAlpha( p.preserveAlpha );
     setVectorMergeEnabled( p.vectorMergeEnabled );
     setAA(p.useAA);
+    setInpolLevel(p.inpolLevel);
 }
 
 void ToolOptionWidget::createUI()
 {
     setMinimumWidth( 115 );
+    setMaximumWidth(300);
 
     QFrame* optionGroup = new QFrame();
     QGridLayout* pLayout = new QGridLayout();
@@ -110,6 +115,47 @@ void ToolOptionWidget::createUI()
     mUseAABox->setFont( QFont( "Helvetica", 10 ) );
     mUseAABox->setChecked( true );
 
+    mInpolLevelsBox = new QGroupBox ( tr( "Stabilization level" ) );
+    mInpolLevelsBox->setFlat(true);
+    mInpolLevelsBox->setFont(QFont( "Helvetica", 10 ) );
+    mInpolLevelsBox->setStyleSheet(
+                                    "QGroupBox"
+                                    "{"
+                                        "margin-top: 1.0em"
+                                    "}"
+                                    "QGroupBox::title"
+                                    "{"
+                                        "subcontrol-origin: margin;"
+                                        "left: 5px;"
+                                        "padding: 0.7em 3px 0 3px;"
+                                    "}");
+
+    mNoInpol = new QRadioButton ( tr( "" ) );
+    mNoInpol->setToolTip( tr( "No line interpolation" ) );
+    mNoInpol->setFont( QFont( "Helvetica", 10) );
+    mNoInpol->setChecked ( true );
+
+    mSimpleInpol = new QRadioButton (tr( "" ) );
+    mSimpleInpol->setToolTip( tr( "Simple line interpolation" ) );
+    mSimpleInpol->setChecked ( false );
+
+    mStrongInpol = new QRadioButton (tr( "" ) );
+    mStrongInpol->setToolTip( tr( "Strong line interpolation" ) );
+    mStrongInpol->setChecked ( false );
+
+//    mExtremeInpol = new QRadioButton (tr( "" ) );
+//    mExtremeInpol->setToolTip( tr( "Extreme line interpolation" ) );
+//    mExtremeInpol->setFont( QFont( "Helvetica", 10) );
+//    mExtremeInpol->setChecked ( false );
+
+    QGridLayout* inpolLayout = new QGridLayout();
+    inpolLayout->addWidget( mNoInpol, 16, 0, 2, 1 );
+    inpolLayout->addWidget( mSimpleInpol, 16, 1, 2, 1 );
+    inpolLayout->addWidget( mStrongInpol, 16, 2, 2, 1 );
+//    inpolLayout->addWidget( mExtremeInpol, 16, 3, 2, 1 );
+    mInpolLevelsBox->setLayout(inpolLayout);
+    inpolLayout->setSpacing(2);
+
     mMakeInvisibleBox = new QCheckBox( tr( "Invisible" ) );
     mMakeInvisibleBox->setToolTip( tr( "Make invisible" ) );
     mMakeInvisibleBox->setFont( QFont( "Helvetica", 10 ) );
@@ -125,19 +171,20 @@ void ToolOptionWidget::createUI()
     mVectorMergeBox->setFont( QFont( "Helvetica", 10 ) );
     mVectorMergeBox->setChecked( false );
 
-    pLayout->addWidget( mSizeSlider, 8, 0, 1, 2 );
-    pLayout->addWidget( mBrushSpinBox, 8, 10, 1, 2);
-    pLayout->addWidget( mFeatherSlider, 9, 0, 1, 2 );
-    pLayout->addWidget( mFeatherSpinBox, 9, 10, 1, 2 );
-    pLayout->addWidget( mUseBezierBox, 10, 0, 1, 2 );
-    pLayout->addWidget( mUsePressureBox, 11, 0, 1, 2 );
-    pLayout->addWidget( mUseAABox, 12, 0, 1, 2);
-    pLayout->addWidget( mPreserveAlphaBox, 13, 0, 1, 2 );
-    pLayout->addWidget( mUseFeatherBox, 13, 0, 1, 2 );
-    pLayout->addWidget( mMakeInvisibleBox, 14, 0, 1, 2 );
-    pLayout->addWidget( mVectorMergeBox, 15, 0, 1, 2 );
+    pLayout->addWidget( mSizeSlider, 1, 0, 1, 2 );
+    pLayout->addWidget( mBrushSpinBox, 1, 2, 1, 2);
+    pLayout->addWidget( mFeatherSlider, 2, 0, 1, 2 );
+    pLayout->addWidget( mFeatherSpinBox, 2, 2, 1, 2 );
+    pLayout->addWidget( mUseFeatherBox, 3, 0, 1, 2 );
+    pLayout->addWidget( mUseBezierBox, 4, 0, 1, 2 );
+    pLayout->addWidget( mUsePressureBox, 5, 0, 1, 2 );
+    pLayout->addWidget( mUseAABox, 6, 0, 1, 2);
+    pLayout->addWidget( mPreserveAlphaBox, 7, 0, 1, 2 );
+    pLayout->addWidget( mMakeInvisibleBox, 8, 0, 1, 2 );
+    pLayout->addWidget( mVectorMergeBox, 9, 0, 1, 2 );
+    pLayout->addWidget( mInpolLevelsBox, 10, 0, 1, 4);
 
-    pLayout->setRowStretch( 16, 1 );
+    pLayout->setRowStretch( 17, 1 );
 
     optionGroup->setLayout( pLayout );
 
@@ -163,6 +210,12 @@ void ToolOptionWidget::makeConnectionToEditor( Editor* editor )
 
     connect( mVectorMergeBox, &QCheckBox::clicked, toolManager, &ToolManager::setVectorMergeEnabled );
     connect( mUseAABox, &QCheckBox::clicked, toolManager, &ToolManager::setAA );
+
+    connect( mNoInpol, &QRadioButton::clicked, toolManager, &ToolManager::noInpolSelected);
+    connect( mSimpleInpol, &QRadioButton::clicked, toolManager, &ToolManager::SimplepolSelected);
+    connect( mStrongInpol, &QRadioButton::clicked, toolManager, &ToolManager::StrongpolSelected);
+    connect( mExtremeInpol, &QRadioButton::clicked, toolManager, &ToolManager::ExtremepolSelected);
+
 
     connect( toolManager, &ToolManager::toolChanged, this, &ToolOptionWidget::onToolChanged );
     connect( toolManager, &ToolManager::toolPropertyChanged, this, &ToolOptionWidget::onToolPropertyChanged );
@@ -194,6 +247,9 @@ void ToolOptionWidget::onToolPropertyChanged( ToolType, ToolPropertyType eProper
             break;
         case ANTI_ALIASING:
             setAA(p.useAA);
+            break;
+        case INTERPOLATION:
+            setInpolLevel(p.inpolLevel);
             break;
     }
 }
@@ -266,6 +322,23 @@ void ToolOptionWidget::setAA(int x)
     mUseAABox->setChecked( x > 0 );
 }
 
+void ToolOptionWidget::setInpolLevel(int x)
+{
+    qDebug() << "Setting - Interpolation level:" << x;
+    if (x == 0) {
+        mNoInpol->setChecked(true);
+    }
+    else if (x == 1) {
+        mSimpleInpol->setChecked(true);
+    } else if (x == 2) {
+        mStrongInpol->setChecked(true);
+    } else if (x == 3) {
+        mExtremeInpol->setChecked(true);
+    } else if (x == -1) {
+        mNoInpol->setChecked(true);
+    }
+}
+
 void ToolOptionWidget::disableAllOptions()
 {
     mSizeSlider->hide();
@@ -279,4 +352,5 @@ void ToolOptionWidget::disableAllOptions()
     mPreserveAlphaBox->hide();
     mVectorMergeBox->hide();
     mUseAABox->hide();
+    mInpolLevelsBox->hide();
 }

--- a/core_lib/interface/tooloptiondockwidget.h
+++ b/core_lib/interface/tooloptiondockwidget.h
@@ -6,7 +6,9 @@
 class QToolButton;
 class SpinSlider;
 class QCheckBox;
+class QRadioButton;
 class QSpinBox;
+class QGroupBox;
 class Editor;
 class BaseTool;
 
@@ -36,6 +38,7 @@ private:
     void setPreserveAlpha( int );
     void setVectorMergeEnabled( int );
     void setAA( int );
+    void setInpolLevel( int );
 
     void disableAllOptions();
     void createUI();
@@ -51,6 +54,12 @@ private:
     SpinSlider* mSizeSlider      = nullptr;
     SpinSlider* mFeatherSlider   = nullptr;
     QCheckBox* mUseAABox         = nullptr;
+    QRadioButton* mNoInpol       = nullptr;
+    QRadioButton* mSimpleInpol   = nullptr;
+    QRadioButton* mStrongInpol   = nullptr;
+    QRadioButton* mExtremeInpol  = nullptr;
+    QGroupBox* mInpolLevelsBox   = nullptr;
+
 };
 
 #endif // TOOLOPTIONDOCKWIDGET_H

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -94,16 +94,18 @@ void ToolManager::resetAllTools()
     // Betatesters should be recommended to reset before sending tool related issues.
     // This can prevent from users to stop working on their project.
     getTool( PEN )->properties.width = 1.5; // not supposed to use feather
+    getTool( PEN )->properties.inpolLevel = -1;
     getTool( POLYLINE )->properties.width = 1.5; // PEN dependent
     getTool( PENCIL )->properties.width = 1.0;
     getTool( PENCIL )->properties.feather = -1.0; // locks feather usage (can be changed)
+    getTool( PENCIL )->properties.inpolLevel = -1;
     getTool( ERASER )->properties.width = 25.0;
     getTool( ERASER )->properties.feather = 50.0;
     getTool( BRUSH )->properties.width = 15.0;
     getTool( BRUSH )->properties.feather = 200.0;
+    getTool( BRUSH )->properties.inpolLevel = -1;
     getTool( SMUDGE )->properties.width = 25.0;
     getTool( SMUDGE )->properties.feather = 200.0;
-    getTool( BRUSH )->properties.inpolLevel = -1;
 
     // todo: add all the default settings
 

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -103,6 +103,7 @@ void ToolManager::resetAllTools()
     getTool( BRUSH )->properties.feather = 200.0;
     getTool( SMUDGE )->properties.width = 25.0;
     getTool( SMUDGE )->properties.feather = 200.0;
+    getTool( BRUSH )->properties.inpolLevel = -1;
 
     // todo: add all the default settings
 
@@ -173,6 +174,12 @@ void ToolManager::setAA( bool usingAA )
 {
     currentTool()->setAA( usingAA );
     Q_EMIT toolPropertyChanged( currentTool()->type(), ANTI_ALIASING );
+}
+
+void ToolManager::setInpolLevel(int level)
+{
+    currentTool()->setInpolLevel( level );
+    Q_EMIT toolPropertyChanged(currentTool()->type(), INTERPOLATION );
 }
 
 void ToolManager::tabletSwitchToEraser()

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -136,8 +136,13 @@ void ToolManager::setFeather( float newFeather )
 
 void ToolManager::setUseFeather( bool usingFeather )
 {
+    int usingAA = currentTool()->properties.useAA;
+    int value = propertySwitch(usingFeather, usingAA);
+
+    currentTool()->setAA(value);
     currentTool()->setUseFeather( usingFeather );
     Q_EMIT toolPropertyChanged( currentTool()->type(), USEFEATHER );
+    Q_EMIT toolPropertyChanged( currentTool()->type(), ANTI_ALIASING );
 }
 
 void ToolManager::setInvisibility( bool isInvisible )
@@ -170,7 +175,7 @@ void ToolManager::setPressure( bool isPressureOn )
     Q_EMIT toolPropertyChanged( currentTool()->type(), PRESSURE );
 }
 
-void ToolManager::setAA( bool usingAA )
+void ToolManager::setAA( int usingAA )
 {
     currentTool()->setAA( usingAA );
     Q_EMIT toolPropertyChanged( currentTool()->type(), ANTI_ALIASING );
@@ -180,6 +185,30 @@ void ToolManager::setInpolLevel(int level)
 {
     currentTool()->setInpolLevel( level );
     Q_EMIT toolPropertyChanged(currentTool()->type(), INTERPOLATION );
+}
+
+
+// Switches on/off two actions
+// eg. if x = true, then y = false
+int ToolManager::propertySwitch(bool condition, int tool)
+{
+    int value = 0;
+    int newValue = 0;
+
+    if (condition == true){
+        value = -1;
+        newValue = oldValue;
+        oldValue = tool;
+    }
+
+    if (condition == false) {
+        if (newValue == 1) {
+            value = 1;
+        } else {
+            value = oldValue;
+        }
+    }
+    return value;
 }
 
 void ToolManager::tabletSwitchToEraser()

--- a/core_lib/managers/toolmanager.h
+++ b/core_lib/managers/toolmanager.h
@@ -38,6 +38,11 @@ Q_SIGNALS:
 public slots:
     void resetAllTools();
 
+    void noInpolSelected() { setInpolLevel( 0 ); }
+    void SimplepolSelected() { setInpolLevel( 1 ); }
+    void StrongpolSelected() { setInpolLevel( 2 ); }
+    void ExtremepolSelected() { setInpolLevel( 3 ); }
+
     void setWidth( float );
     void setFeather( float );
     void setUseFeather( bool );
@@ -47,6 +52,7 @@ public slots:
     void setBezier( bool );
     void setPressure( bool );
     void setAA( bool );
+    void setInpolLevel (int );
 
 private:
     BaseTool* mCurrentTool       = nullptr;

--- a/core_lib/managers/toolmanager.h
+++ b/core_lib/managers/toolmanager.h
@@ -8,7 +8,6 @@
 
 class ScribbleArea;
 
-
 class ToolManager : public BaseManager
 {
     Q_OBJECT
@@ -27,6 +26,7 @@ public:
 
     void      tabletSwitchToEraser();
     void      tabletRestorePrevTool();
+    int propertySwitch( bool condition, int property );
 
 Q_SIGNALS:
     void penWidthValueChanged( float );
@@ -51,7 +51,7 @@ public slots:
     void setVectorMergeEnabled( bool );
     void setBezier( bool );
     void setPressure( bool );
-    void setAA( bool );
+    void setAA(int );
     void setInpolLevel (int );
 
 private:
@@ -59,6 +59,8 @@ private:
     ToolType  meTabletBackupTool = PENCIL;
     bool mIsSwitchedToEraser     = false;
     QHash<ToolType, BaseTool*> mToolSetHash;
+
+    int oldValue = 0;
 
 };
 

--- a/core_lib/tool/basetool.cpp
+++ b/core_lib/tool/basetool.cpp
@@ -329,7 +329,7 @@ void BaseTool::setVectorMergeEnabled(const bool vectorMergeEnabled)
     properties.vectorMergeEnabled = vectorMergeEnabled;
 }
 
-void BaseTool::setAA(const bool useAA)
+void BaseTool::setAA(const int useAA)
 {
     properties.useAA = useAA;
 }

--- a/core_lib/tool/basetool.cpp
+++ b/core_lib/tool/basetool.cpp
@@ -44,6 +44,7 @@ BaseTool::BaseTool( QObject *parent ) : QObject( parent )
     m_enabledProperties.insert( PRESERVEALPHA,  false  );
     m_enabledProperties.insert( BEZIER,         false  );
     m_enabledProperties.insert( ANTI_ALIASING,  false  );
+    m_enabledProperties.insert( INTERPOLATION,  false  );
 }
 
 QCursor BaseTool::cursor()
@@ -333,3 +334,7 @@ void BaseTool::setAA(const bool useAA)
     properties.useAA = useAA;
 }
 
+void BaseTool::setInpolLevel (const int level)
+{
+    properties.inpolLevel = level;
+}

--- a/core_lib/tool/basetool.h
+++ b/core_lib/tool/basetool.h
@@ -24,7 +24,7 @@ public:
     bool vectorMergeEnabled = false;
     bool bezier_state = false;
     bool useFeather   = true;
-    bool useAA        = true;
+    int useAA        = 0;
     int inpolLevel    = 0;
 };
 
@@ -81,10 +81,11 @@ public:
     virtual void setUseFeather( const bool usingFeather );
     virtual void setPreserveAlpha( const bool preserveAlpha );
     virtual void setVectorMergeEnabled( const bool vectorMergeEnabled );
-    virtual void setAA( const bool useAA );
+    virtual void setAA(const int useAA );
     virtual void setInpolLevel( const int level );
     virtual void leavingThisTool(){}
     virtual void switchingLayers(){}
+
     Properties properties;
 
     QPointF getCurrentPixel();

--- a/core_lib/tool/basetool.h
+++ b/core_lib/tool/basetool.h
@@ -25,6 +25,7 @@ public:
     bool bezier_state = false;
     bool useFeather   = true;
     bool useAA        = true;
+    int inpolLevel    = 0;
 };
 
 const int ON = 1;
@@ -80,7 +81,8 @@ public:
     virtual void setUseFeather( const bool usingFeather );
     virtual void setPreserveAlpha( const bool preserveAlpha );
     virtual void setVectorMergeEnabled( const bool vectorMergeEnabled );
-    virtual void setAA ( const bool useAA );
+    virtual void setAA( const bool useAA );
+    virtual void setInpolLevel( const int level );
     virtual void leavingThisTool(){}
     virtual void switchingLayers(){}
     Properties properties;

--- a/core_lib/tool/brushtool.cpp
+++ b/core_lib/tool/brushtool.cpp
@@ -35,6 +35,7 @@ void BrushTool::loadSettings()
     m_enabledProperties[PRESSURE] = true;
     m_enabledProperties[INVISIBILITY] = true;
     m_enabledProperties[INTERPOLATION] = true;
+    m_enabledProperties[ANTI_ALIASING] = true;
 
     QSettings settings( PENCIL2D, PENCIL2D );
 
@@ -45,6 +46,11 @@ void BrushTool::loadSettings()
     properties.invisibility = settings.value("brushInvisibility", true).toBool();
     properties.preserveAlpha = OFF;
     properties.inpolLevel = 0;
+    properties.useAA = 1;
+
+    if (properties.useFeather == true) {
+        properties.useAA = -1;
+    }
 
     // First run
     //
@@ -122,6 +128,16 @@ void BrushTool::setInpolLevel(const int level)
     settings.sync();
 }
 
+void BrushTool::setAA( const int AA )
+{
+    // Set current property
+    properties.useAA = AA;
+
+    // Update settings
+    QSettings settings( PENCIL2D, PENCIL2D );
+    settings.setValue("brushAA", AA);
+    settings.sync();
+}
 
 QCursor BrushTool::cursor()
 {
@@ -271,7 +287,7 @@ void BrushTool::drawStroke()
 
         qreal opacity = 1.0f;
         if (properties.pressure == true) {
-            opacity = m_pStrokeManager->getPressure() / 2;
+            opacity = mCurrentPressure / 2;
         }
 
         mCurrentWidth = properties.width;
@@ -298,7 +314,8 @@ void BrushTool::drawStroke()
                                       properties.feather,
                                       mEditor->color()->frontColor(),
                                       opacity,
-                                      properties.useFeather );
+                                      properties.useFeather,
+                                      properties.useAA );
 
             if ( i == ( steps - 1 ) )
             {

--- a/core_lib/tool/brushtool.cpp
+++ b/core_lib/tool/brushtool.cpp
@@ -33,6 +33,8 @@ void BrushTool::loadSettings()
     m_enabledProperties[WIDTH] = true;
     m_enabledProperties[FEATHER] = true;
     m_enabledProperties[PRESSURE] = true;
+    m_enabledProperties[INVISIBILITY] = true;
+    m_enabledProperties[INTERPOLATION] = true;
 
     QSettings settings( PENCIL2D, PENCIL2D );
 
@@ -40,8 +42,9 @@ void BrushTool::loadSettings()
     properties.feather = settings.value( "brushFeather", 15.0 ).toDouble();
     properties.useFeather = settings.value( "brushUseFeather", true ).toBool();
     properties.pressure = settings.value( "brushPressure", true ).toBool();
-    properties.invisibility = DISABLED;
+    properties.invisibility = settings.value("brushInvisibility", true).toBool();
     properties.preserveAlpha = OFF;
+    properties.inpolLevel = 0;
 
     // First run
     //
@@ -89,6 +92,16 @@ void BrushTool::setFeather( const qreal feather )
     settings.sync();
 }
 
+void BrushTool::setInvisibility( const bool invisibility )
+{
+    // force value
+    properties.invisibility = invisibility;
+
+    QSettings settings ( PENCIL2D, PENCIL2D );
+    settings.setValue("brushInvisibility",invisibility);
+    settings.sync();
+}
+
 void BrushTool::setPressure( const bool pressure )
 {
     // Set current property
@@ -97,6 +110,15 @@ void BrushTool::setPressure( const bool pressure )
     // Update settings
     QSettings settings( PENCIL2D, PENCIL2D );
     settings.setValue("brushPressure", pressure);
+    settings.sync();
+}
+
+void BrushTool::setInpolLevel(const int level)
+{
+    properties.inpolLevel = level;
+
+    QSettings settings( PENCIL2D, PENCIL2D);
+    settings.setValue("lineInpol", level);
     settings.sync();
 }
 
@@ -158,17 +180,20 @@ void BrushTool::mousePressEvent( QMouseEvent *event )
     mLastBrushPoint = getCurrentPoint();
     startStroke();
 
+    if ( !mEditor->preference()->isOn(SETTING::INVISIBLE_LINES) )
+    {
+        mScribbleArea->toggleThinLines();
+    }
+
 }
 
 void BrushTool::mouseReleaseEvent( QMouseEvent *event )
 {
-    Layer* layer = mEditor->layers()->currentLayer();
-
     if ( event->button() == Qt::LeftButton )
     {
         if ( mScribbleArea->isLayerPaintable() )
         {
-            if (getCurrentPoint()==mMouseDownPoint)
+            if (getCurrentPoint() == mMouseDownPoint)
             {
                 paintAt(mMouseDownPoint);
             }
@@ -178,31 +203,7 @@ void BrushTool::mouseReleaseEvent( QMouseEvent *event )
             }
         }
 
-        if ( layer->type() == Layer::BITMAP )
-        {
-            mScribbleArea->paintBitmapBuffer();
-            mScribbleArea->setAllDirty();
-            mScribbleArea->clearBitmapBuffer();
-        }
-        else if ( layer->type() == Layer::VECTOR && mStrokePoints.size() > -1 )
-        {
-            // Clear the temporary pixel path
-            mScribbleArea->clearBitmapBuffer();
-            qreal tol = mScribbleArea->getCurveSmoothing() / mEditor->view()->scaling();
-            BezierCurve curve( mStrokePoints, mStrokePressures, tol );
-            curve.setWidth( properties.width );
-            curve.setFeather( properties.feather );
-            curve.setInvisibility( false );
-            curve.setVariableWidth( properties.pressure );
-            curve.setColourNumber( mEditor->color()->frontColorNumber() );
-
-            auto pLayerVector = static_cast< LayerVector* >( layer );
-            VectorImage* vectorImage = pLayerVector->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 );
-            vectorImage->insertCurve( 0, curve, mEditor->view()->scaling(), false );
-
-            mScribbleArea->setModified( mEditor->layers()->currentLayerIndex(), mEditor->currentFrame() );
-            mScribbleArea->setAllDirty();
-        }
+        paintVectorStroke();
     }
 
     endStroke();
@@ -217,6 +218,9 @@ void BrushTool::mouseMoveEvent( QMouseEvent *event )
         if ( event->buttons() & Qt::LeftButton )
         {
             drawStroke();
+            if (properties.inpolLevel != m_pStrokeManager->getInpolLevel()) {
+                m_pStrokeManager->setInpolLevel(properties.inpolLevel);
+            }
         }
     }
 }
@@ -264,11 +268,12 @@ void BrushTool::drawStroke()
         {
             p[ i ] = mEditor->view()->mapScreenToCanvas( p[ i ] );
         }
+
         qreal opacity = 1.0f;
-        if (properties.pressure == true)
-        {
-        opacity = mCurrentPressure / 2;
+        if (properties.pressure == true) {
+            opacity = m_pStrokeManager->getPressure() / 2;
         }
+
         mCurrentWidth = properties.width;
         qreal brushWidth = mCurrentWidth;
 
@@ -285,7 +290,8 @@ void BrushTool::drawStroke()
 
         for ( int i = 0; i < steps; i++ )
         {
-            QPointF point = mLastBrushPoint + ( i + 1 ) * ( brushStep )* ( b - mLastBrushPoint ) / distance;
+            QPointF point = mLastBrushPoint + ( i + 1 ) * ( brushStep ) * ( b - mLastBrushPoint ) / distance;
+
             rect.extend( point.toPoint() );
             mScribbleArea->drawBrush( point,
                                       brushWidth,
@@ -303,10 +309,32 @@ void BrushTool::drawStroke()
         int rad = qRound( brushWidth ) / 2 + 2;
 
         mScribbleArea->refreshBitmap( rect, rad );
+
+          // Line visualizer
+          // for debugging
+//        QPainterPath tempPath;
+
+//        QPointF mappedMousePos = mEditor->view()->mapScreenToCanvas(m_pStrokeManager->getMousePos());
+//        tempPath.moveTo(getCurrentPoint());
+//        tempPath.lineTo(mappedMousePos);
+
+//        QPen pen( Qt::black,
+//                   1,
+//                   Qt::SolidLine,
+//                   Qt::RoundCap,
+//                   Qt::RoundJoin );
+//        mScribbleArea->drawPolyline(tempPath, pen, true);
+
     }
     else if ( layer->type() == Layer::VECTOR )
     {
-        qreal brushWidth = properties.width * mCurrentPressure;
+        qreal brushWidth = 0;
+        if (properties.pressure ) {
+            brushWidth = properties.width * m_pStrokeManager->getPressure();
+        }
+        else {
+            brushWidth = properties.width;
+        }
 
         int rad = qRound( ( brushWidth / 2 + 2 ) * mEditor->view()->scaling() );
 
@@ -322,8 +350,46 @@ void BrushTool::drawStroke()
             path.cubicTo( p[ 1 ],
                           p[ 2 ],
                           p[ 3 ] );
+
             mScribbleArea->drawPath( path, pen, Qt::NoBrush, QPainter::CompositionMode_Source );
             mScribbleArea->refreshVector( path.boundingRect().toRect(), rad );
         }
+    }
+}
+
+// This function uses the points from DrawStroke
+// and turns them into vector lines.
+void BrushTool::paintVectorStroke()
+{
+    Layer* layer = mEditor->layers()->currentLayer();
+
+    if ( layer->type() == Layer::BITMAP )
+    {
+        mScribbleArea->paintBitmapBuffer();
+        mScribbleArea->setAllDirty();
+        mScribbleArea->clearBitmapBuffer();
+    }
+    else if ( layer->type() == Layer::VECTOR && mStrokePoints.size() > -1 )
+    {
+
+        // Clear the temporary pixel path
+        mScribbleArea->clearBitmapBuffer();
+        qreal tol = mScribbleArea->getCurveSmoothing() / mEditor->view()->scaling();
+
+        mStrokePressures.append(0.01);
+
+        BezierCurve curve( mStrokePoints, mStrokePressures, tol );
+                    curve.setWidth( properties.width );
+                    curve.setFeather( properties.feather );
+                    curve.setInvisibility( properties.invisibility );
+                    curve.setVariableWidth( properties.pressure );
+                    curve.setColourNumber( mEditor->color()->frontColorNumber() );
+
+        auto pLayerVector = static_cast< LayerVector* >( layer );
+        VectorImage* vectorImage = pLayerVector->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 );
+        vectorImage->insertCurve( 0, curve, mEditor->view()->scaling(), false );
+
+        mScribbleArea->setModified( mEditor->layers()->currentLayerIndex(), mEditor->currentFrame() );
+        mScribbleArea->setAllDirty();
     }
 }

--- a/core_lib/tool/brushtool.h
+++ b/core_lib/tool/brushtool.h
@@ -20,12 +20,15 @@ public:
     void adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice ) override;
 
     void drawStroke();
+    void paintVectorStroke();
     void paintAt( QPointF point );
 
     void setWidth( const qreal width ) override;
     void setFeather( const qreal feather ) override;
     void setUseFeather( const bool usingFeather ) override;
     void setPressure( const bool pressure ) override;
+    void setInvisibility(const bool invisibility) override;
+    void setInpolLevel( const int level ) override;
 
 protected:
     QPointF mLastBrushPoint;

--- a/core_lib/tool/brushtool.h
+++ b/core_lib/tool/brushtool.h
@@ -27,7 +27,8 @@ public:
     void setFeather( const qreal feather ) override;
     void setUseFeather( const bool usingFeather ) override;
     void setPressure( const bool pressure ) override;
-    void setInvisibility(const bool invisibility) override;
+    void setInvisibility( const bool invisibility) override;
+    void setAA( const int useAA ) override;
     void setInpolLevel( const int level ) override;
 
 protected:

--- a/core_lib/tool/buckettool.cpp
+++ b/core_lib/tool/buckettool.cpp
@@ -31,6 +31,7 @@ void BucketTool::loadSettings()
     properties.width = 4;
     properties.feather = 10;
     properties.inpolLevel = -1;
+    properties.useAA = -1;
 }
 
 QCursor BucketTool::cursor()

--- a/core_lib/tool/buckettool.cpp
+++ b/core_lib/tool/buckettool.cpp
@@ -30,6 +30,7 @@ void BucketTool::loadSettings()
 {
     properties.width = 4;
     properties.feather = 10;
+    properties.inpolLevel = -1;
 }
 
 QCursor BucketTool::cursor()

--- a/core_lib/tool/erasertool.cpp
+++ b/core_lib/tool/erasertool.cpp
@@ -28,6 +28,7 @@ void EraserTool::loadSettings()
     m_enabledProperties[WIDTH] = true;
     m_enabledProperties[FEATHER] = true;
     m_enabledProperties[PRESSURE] = true;
+    m_enabledProperties[INTERPOLATION] = true;
 
 
     QSettings settings( PENCIL2D, PENCIL2D );
@@ -38,6 +39,7 @@ void EraserTool::loadSettings()
     properties.pressure = settings.value( "eraserPressure" ).toBool();
     properties.invisibility = DISABLED;
     properties.preserveAlpha = OFF;
+    properties.inpolLevel = 0;
 
     // First run
     if ( properties.width <= 0 )
@@ -80,6 +82,16 @@ void EraserTool::setPressure( const bool pressure )
     settings.setValue("eraserPressure", pressure);
     settings.sync();
 }
+
+void EraserTool::setInpolLevel(const int level)
+{
+    properties.inpolLevel = level;
+
+    QSettings settings( PENCIL2D, PENCIL2D);
+    settings.setValue("lineInpol", level);
+    settings.sync();
+}
+
 
 QCursor EraserTool::cursor()
 {
@@ -124,7 +136,6 @@ void EraserTool::mousePressEvent( QMouseEvent *event )
 
 void EraserTool::mouseReleaseEvent( QMouseEvent *event )
 {
-    Layer* layer = mEditor->layers()->currentLayer();
 
     if ( event->button() == Qt::LeftButton )
     {
@@ -133,24 +144,7 @@ void EraserTool::mouseReleaseEvent( QMouseEvent *event )
             drawStroke();
         }
 
-        if ( layer->type() == Layer::BITMAP )
-        {
-            mScribbleArea->paintBitmapBuffer();
-            mScribbleArea->setAllDirty();
-            mScribbleArea->clearBitmapBuffer();
-        }
-        else if ( layer->type() == Layer::VECTOR )
-        {
-            VectorImage *vectorImage = ( ( LayerVector * )layer )->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 );
-            // Clear the area containing the last point
-            //vectorImage->removeArea(lastPoint);
-            // Clear the temporary pixel path
-            mScribbleArea->clearBitmapBuffer();
-            vectorImage->deleteSelectedPoints();
-            //update();
-            mScribbleArea->setModified( mEditor->layers()->currentLayerIndex(), mEditor->currentFrame() );
-            mScribbleArea->setAllDirty();
-        }
+        removeVectorPaint();
     }
 
     endStroke();
@@ -158,25 +152,15 @@ void EraserTool::mouseReleaseEvent( QMouseEvent *event )
 
 void EraserTool::mouseMoveEvent( QMouseEvent *event )
 {
-    Layer* layer = mEditor->layers()->currentLayer();
 
     if ( event->buttons() & Qt::LeftButton )
     {
-        if ( layer->type() == Layer::BITMAP || layer->type() == Layer::VECTOR )
+        if ( mScribbleArea->isLayerPaintable() )
         {
-            drawStroke();
-        }
-        if ( layer->type() == Layer::VECTOR )
-        {
-            qreal radius = ( properties.width / 2 ) / mEditor->view()->scaling();
-            QList<VertexRef> nearbyVertices = ( ( LayerVector * )layer )->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 )
-                ->getVerticesCloseTo( getCurrentPoint(), radius );
-            for ( int i = 0; i < nearbyVertices.size(); i++ )
-            {
-                ( ( LayerVector * )layer )->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 )->setSelected( nearbyVertices.at( i ), true );
+            updateStrokes();
+            if (properties.inpolLevel != m_pStrokeManager->getInpolLevel()) {
+                m_pStrokeManager->setInpolLevel(properties.inpolLevel);
             }
-            //update();
-            mScribbleArea->setAllDirty();
         }
     }
 }
@@ -200,9 +184,10 @@ void EraserTool::drawStroke()
             p[ i ] = mEditor->view()->mapScreenToCanvas( p[ i ] );
         }
 
-        qreal opacity = mCurrentPressure;
+        qreal opacity = m_pStrokeManager->getPressure();
         mCurrentWidth = properties.width;
-        qreal brushWidth = (mCurrentWidth + (mCurrentPressure * mCurrentWidth)) * 0.5;
+
+        qreal brushWidth = (mCurrentWidth + ( m_pStrokeManager->getPressure() * mCurrentWidth)) * 0.5;
         qreal brushStep = (0.5 * brushWidth) - ((properties.feather/100.0) * brushWidth * 0.5);
         brushStep = qMax( 1.0, brushStep );
 
@@ -235,8 +220,16 @@ void EraserTool::drawStroke()
     }
     else if ( layer->type() == Layer::VECTOR )
     {
-        QPen pen( Qt::white, mCurrentWidth, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin );
-        int rad = qRound( ( mCurrentWidth / 2 + 2 ) * mEditor->view()->scaling() );
+        qreal brushWidth = 0;
+        if (properties.pressure ) {
+            brushWidth = properties.width * m_pStrokeManager->getPressure();
+        }
+        else {
+            brushWidth = properties.width;
+        }
+
+        QPen pen( Qt::white, brushWidth, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin );
+        int rad = qRound( ( brushWidth / 2 + 2 ) * mEditor->view()->scaling() );
 
         if ( p.size() == 4 ) {
             QSizeF size( 2, 2 );
@@ -244,8 +237,54 @@ void EraserTool::drawStroke()
             path.cubicTo( p[ 1 ],
                           p[ 2 ],
                           p[ 3 ] );
+            qDebug() << path;
             mScribbleArea->drawPath( path, pen, Qt::NoBrush, QPainter::CompositionMode_Source );
             mScribbleArea->refreshVector( path.boundingRect().toRect(), rad );
         }
+    }
+}
+
+void EraserTool::removeVectorPaint()
+{
+    Layer* layer = mEditor->layers()->currentLayer();
+    if ( layer->type() == Layer::BITMAP )
+    {
+        mScribbleArea->paintBitmapBuffer();
+        mScribbleArea->setAllDirty();
+        mScribbleArea->clearBitmapBuffer();
+    }
+    else if ( layer->type() == Layer::VECTOR )
+    {
+        VectorImage *vectorImage = ( ( LayerVector * )layer )->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 );
+        // Clear the area containing the last point
+        //vectorImage->removeArea(lastPoint);
+        // Clear the temporary pixel path
+        mScribbleArea->clearBitmapBuffer();
+        vectorImage->deleteSelectedPoints();
+        //update();
+        mScribbleArea->setModified( mEditor->layers()->currentLayerIndex(), mEditor->currentFrame() );
+        mScribbleArea->setAllDirty();
+    }
+}
+
+void EraserTool::updateStrokes()
+{
+    Layer* layer = mEditor->layers()->currentLayer();
+    if ( layer->type() == Layer::BITMAP || layer->type() == Layer::VECTOR )
+    {
+        drawStroke();
+    }
+
+    if ( layer->type() == Layer::VECTOR )
+    {
+        qreal radius = ( properties.width / 2 ) / mEditor->view()->scaling();
+        QList<VertexRef> nearbyVertices = ( ( LayerVector * )layer )->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 )
+            ->getVerticesCloseTo( getCurrentPoint(), radius );
+        for ( int i = 0; i < nearbyVertices.size(); i++ )
+        {
+            ( ( LayerVector * )layer )->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 )->setSelected( nearbyVertices.at( i ), true );
+        }
+        //update();
+        mScribbleArea->setAllDirty();
     }
 }

--- a/core_lib/tool/erasertool.h
+++ b/core_lib/tool/erasertool.h
@@ -20,12 +20,14 @@ public:
     void adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice ) override;
 
     void drawStroke();
-
     void paintAt( QPointF point );
+    void removeVectorPaint();
+    void updateStrokes();
 
     void setWidth( const qreal width ) override;
     void setFeather( const qreal feather ) override;
     void setPressure( const bool pressure ) override;
+    void setInpolLevel(const int level) override;
 
 protected:
     QPointF mLastBrushPoint;

--- a/core_lib/tool/eyedroppertool.cpp
+++ b/core_lib/tool/eyedroppertool.cpp
@@ -25,6 +25,7 @@ void EyedropperTool::loadSettings()
     properties.width = -1;
     properties.feather = -1;
     properties.useFeather = -1;
+    properties.useAA = -1;
 }
 
 QCursor EyedropperTool::cursor()

--- a/core_lib/tool/handtool.cpp
+++ b/core_lib/tool/handtool.cpp
@@ -20,6 +20,7 @@ void HandTool::loadSettings()
     properties.feather = -1;
     properties.useFeather = -1;
     properties.inpolLevel = -1;
+    properties.useAA = -1;
 }
 
 QCursor HandTool::cursor()

--- a/core_lib/tool/handtool.cpp
+++ b/core_lib/tool/handtool.cpp
@@ -19,6 +19,7 @@ void HandTool::loadSettings()
     properties.width = -1;
     properties.feather = -1;
     properties.useFeather = -1;
+    properties.inpolLevel = -1;
 }
 
 QCursor HandTool::cursor()

--- a/core_lib/tool/movetool.cpp
+++ b/core_lib/tool/movetool.cpp
@@ -23,6 +23,7 @@ void MoveTool::loadSettings()
     properties.width = -1;
     properties.feather = -1;
     properties.useFeather = -1;
+    properties.inpolLevel = -1;
 }
 
 QCursor MoveTool::cursor()

--- a/core_lib/tool/movetool.cpp
+++ b/core_lib/tool/movetool.cpp
@@ -24,6 +24,7 @@ void MoveTool::loadSettings()
     properties.feather = -1;
     properties.useFeather = -1;
     properties.inpolLevel = -1;
+    properties.useAA = -1;
 }
 
 QCursor MoveTool::cursor()

--- a/core_lib/tool/penciltool.cpp
+++ b/core_lib/tool/penciltool.cpp
@@ -230,7 +230,7 @@ void PencilTool::drawStroke()
     {
         qreal opacity = 1.0f;
         if (properties.pressure == true) {
-            opacity = m_pStrokeManager->getPressure() / 2;
+            opacity = mCurrentPressure / 2;
         }
 
         mCurrentWidth = properties.width * m_pStrokeManager->getPressure();

--- a/core_lib/tool/penciltool.h
+++ b/core_lib/tool/penciltool.h
@@ -16,9 +16,10 @@ public:
     void mousePressEvent( QMouseEvent* ) override;
     void mouseMoveEvent( QMouseEvent* ) override;
     void mouseReleaseEvent( QMouseEvent* ) override;
-    void paintAt( QPointF point );
 
     void drawStroke();
+    void paintAt( QPointF point );
+    void paintVectorStroke();
 
     void adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice ) override;
 
@@ -27,6 +28,7 @@ public:
     void setInvisibility( const bool invisibility ) override;
     void setPressure( const bool pressure ) override;
     void setPreserveAlpha( const bool preserveAlpha ) override;
+    void setInpolLevel(const int level) override;
 
 private:
     QColor mCurrentPressuredColor { 0, 0, 0, 255 };

--- a/core_lib/tool/pentool.cpp
+++ b/core_lib/tool/pentool.cpp
@@ -65,7 +65,7 @@ void PenTool::setPressure( const bool pressure )
     settings.sync();
 }
 
-void PenTool::setAA( const bool AA )
+void PenTool::setAA(const int AA )
 {
     // Set current property
     properties.useAA = AA;

--- a/core_lib/tool/pentool.h
+++ b/core_lib/tool/pentool.h
@@ -24,7 +24,7 @@ public:
 
     void setWidth( const qreal width ) override;
     void setPressure( const bool pressure ) override;
-    void setAA( const bool AA ) override;
+    void setAA( const int AA ) override;
     void setInpolLevel(const int level) override;
 
 private:

--- a/core_lib/tool/pentool.h
+++ b/core_lib/tool/pentool.h
@@ -18,12 +18,14 @@ public:
 
     void drawStroke();
     void paintAt( QPointF point );
+    void paintVectorStroke();
 
     void adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice ) override;
 
     void setWidth( const qreal width ) override;
     void setPressure( const bool pressure ) override;
     void setAA( const bool AA ) override;
+    void setInpolLevel(const int level) override;
 
 private:
     QPointF mLastBrushPoint;

--- a/core_lib/tool/polylinetool.cpp
+++ b/core_lib/tool/polylinetool.cpp
@@ -59,7 +59,7 @@ void PolylineTool::setFeather( const qreal feather )
     properties.feather = -1;
 }
 
-void PolylineTool::setAA( const bool AA )
+void PolylineTool::setAA( const int AA )
 {
     // Set current property
     properties.useAA = AA;

--- a/core_lib/tool/polylinetool.cpp
+++ b/core_lib/tool/polylinetool.cpp
@@ -34,6 +34,7 @@ void PolylineTool::loadSettings()
     properties.invisibility = OFF;
     properties.preserveAlpha = OFF;
     properties.useAA = settings.value( "brushAA").toBool();
+    properties.inpolLevel = -1;
 
     // First run
     if ( properties.width <= 0 )
@@ -93,7 +94,7 @@ void PolylineTool::mousePressEvent( QMouseEvent *event )
         {
             if ( mPoints.size() == 0 )
             {
-                mEditor->backup( tr( "Polyline" ) );
+                mEditor->backup( tr( "Line" ) );
             }
 
             if ( layer->type() == Layer::VECTOR )

--- a/core_lib/tool/polylinetool.h
+++ b/core_lib/tool/polylinetool.h
@@ -24,7 +24,7 @@ public:
 
     void setWidth( const qreal width ) override;
     void setFeather( const qreal feather ) override;
-    void setAA( const bool AA ) override;
+    void setAA( const int AA ) override;
 
 private:
     QList<QPointF> mPoints;

--- a/core_lib/tool/selecttool.cpp
+++ b/core_lib/tool/selecttool.cpp
@@ -19,6 +19,7 @@ void SelectTool::loadSettings()
     properties.width = -1;
     properties.feather = -1;
     properties.inpolLevel = -1;
+    properties.useAA = -1;
 }
 
 QCursor SelectTool::cursor()

--- a/core_lib/tool/selecttool.cpp
+++ b/core_lib/tool/selecttool.cpp
@@ -18,6 +18,7 @@ void SelectTool::loadSettings()
 {
     properties.width = -1;
     properties.feather = -1;
+    properties.inpolLevel = -1;
 }
 
 QCursor SelectTool::cursor()

--- a/core_lib/tool/smudgetool.cpp
+++ b/core_lib/tool/smudgetool.cpp
@@ -32,6 +32,7 @@ void SmudgeTool::loadSettings()
     properties.width = settings.value("smudgeWidth").toDouble();
     properties.feather = settings.value("smudgeFeather").toDouble();
     properties.pressure = 0;
+    properties.inpolLevel = -1;
 
     // First run
     if (properties.width <= 0)

--- a/core_lib/tool/strokemanager.cpp
+++ b/core_lib/tool/strokemanager.cpp
@@ -25,7 +25,7 @@
 #include <QLineF>
 #include <QPainterPath>
 #include "strokemanager.h"
-
+#include "object.h"
 
 
 StrokeManager::StrokeManager()
@@ -34,16 +34,21 @@ StrokeManager::StrokeManager()
 
     mTabletInUse = false;
     mTabletPressure = 0;
+    mMeanPressure = 0;
 
     reset();
+    connect(&timer, &QTimer::timeout, this, &StrokeManager::interpolatePollAndPaint);
 }
 
 void StrokeManager::reset()
 {
     mStrokeStarted = false;
+    pressureQueue.clear();
     strokeQueue.clear();
     pressure = 0.0f;
     hasTangent = false;
+    timer.stop();
+    mInpolLevel = -1;
 }
 
 void StrokeManager::setPressure(float pressure)
@@ -60,7 +65,7 @@ QPointF StrokeManager::getEventPosition(QMouseEvent* event)
         // QT BUG (Wacom Tablets): updates are not synchronised in Windows giving different coordinates.
         // Clue: Not a Microsoft nor Wacom problem because other windows apps are working fine in the same tablet mode.
         // Solved: Qt bug in Wacom coding -> a lot of patches but no real solutions.
-        QPointF pos2 = event->pos() + mTabletPosition - event->globalPos();
+        // QPointF pos2 = event->pos() + mTabletPosition - event->globalPos();
         // Patch: next line skips the coordinate problem and it seems safe .
         pos = event->pos() + mTabletPosition - mTabletPosition.toPoint();
         //pos = event->pos();
@@ -80,14 +85,11 @@ void StrokeManager::mousePressEvent(QMouseEvent* event)
     if ( !(event->button() == Qt::NoButton) ) // if the user is pressing the left/right button
     {
         mLastPressPixel = getEventPosition(event);
-        qDebug() << mLastPressPixel;
     }
     mLastPixel = getEventPosition( event );
     mCurrentPixel = getEventPosition( event );
 
     mStrokeStarted = true;
-    mSingleshotTime.start();
-    previousTime = mSingleshotTime.elapsed();
 
 }
 
@@ -111,38 +113,183 @@ void StrokeManager::tabletEvent(QTabletEvent* event)
     setPressure(event->pressure());
 }
 
+void StrokeManager::setInpolLevel(int level)
+{
+    mInpolLevel = level;
+}
+
 void StrokeManager::mouseMoveEvent(QMouseEvent* event)
 {
     QPointF pos = getEventPosition(event);
-    QPointF newPos = QPointF( pos.x(), pos.y() );
 
-    mLastPixel = mCurrentPixel;
-    mCurrentPixel = newPos;
+    // only applied to drawing tools.
+    if (mInpolLevel != -1){
+        smoothMousePos(pos);
+    } else {
+        // No smoothing
+        mLastPixel = mCurrentPixel;
+        mCurrentPixel = pos;
+        mLastInterpolated = mCurrentPixel;
 
-	if ( !mStrokeStarted )
-	{
-		return;
-	}
+    }
+}
+
+void StrokeManager::smoothMousePos(QPointF pos)
+{
+
+    // Smooth mouse position before drawing
+    QPointF smoothPos;
+
+    if (mInpolLevel == 0) {
+
+        mLastPixel = mCurrentPixel;
+        mCurrentPixel = pos;
+        mLastInterpolated = mCurrentPixel;
+    }
+    else if (mInpolLevel == 1) {
+
+        // simple interpolation
+        smoothPos = QPointF( ( pos.x() + mCurrentPixel.x() ) / 2.0, ( pos.y() + mCurrentPixel.y() ) / 2.0 );
+        mLastPixel = mCurrentPixel;
+        mCurrentPixel = smoothPos;
+        mLastInterpolated = mCurrentPixel;
+
+        // shift queue
+        while ( strokeQueue.size()  >= STROKE_QUEUE_LENGTH )
+        {
+            strokeQueue.pop_front();
+        }
+
+        strokeQueue.push_back( smoothPos );
+    } else if (mInpolLevel == 2 ) {
+
+        smoothPos = QPointF( ( pos.x() + mLastInterpolated.x() ) / 2.0, ( pos.y() + mLastInterpolated.y() ) / 2.0 );
+
+        mLastInterpolated = mCurrentPixel;
+        mCurrentPixel = smoothPos;
+        mLastPixel = mLastInterpolated;
+    }
+
+    mousePos = pos;
+
+    if ( !mStrokeStarted )
+    {
+        return;
+    }
 
     if (!mTabletInUse)   // a mouse is used instead of a tablet
     {
         setPressure(1.0);
     }
+}
 
-    // shift queue
-    while ( strokeQueue.size()  >= STROKE_QUEUE_LENGTH )
+
+QPointF StrokeManager::interpolateStart(QPointF firstPoint)
+{
+        if (mInpolLevel == 1) {
+            // Clear queue
+            strokeQueue.clear();
+            pressureQueue.clear();
+
+            mSingleshotTime.start();
+            previousTime = mSingleshotTime.elapsed();
+
+            mLastPixel = firstPoint;
+        }
+        else if (mInpolLevel == 2){
+
+            mSingleshotTime.start();
+            previousTime = mSingleshotTime.elapsed();
+
+            int sampleSize = 5;
+
+            // Clear queue
+            strokeQueue.clear();
+            pressureQueue.clear();
+
+            assert(sampleSize > 0);
+
+            // fill strokeQueue with firstPoint x times
+            for ( int i = sampleSize; i > 0; i--) {
+                strokeQueue.enqueue(firstPoint);
+            }
+
+            // last interpolated stroke should always be firstPoint
+            mLastInterpolated = firstPoint;
+
+            // draw and poll each millisecond
+            timer.setInterval(sampleSize);
+            timer.start();
+        } else if (mInpolLevel == 0) {
+            // Clear queue
+            strokeQueue.clear();
+            pressureQueue.clear();
+
+            mLastPixel = firstPoint;
+        }
+    return firstPoint;
+}
+
+void StrokeManager::interpolatePoll()
+{
+    // remove oldest stroke
+    strokeQueue.dequeue();
+
+    // add new stroke with the last interpolated pixel position
+    strokeQueue.enqueue(mLastInterpolated);
+}
+
+void StrokeManager::interpolatePollAndPaint()
+{
+    //qDebug() <<"inpol:" << mInpolLevel << "strokes"<< strokeQueue;
+    if (!strokeQueue.isEmpty())
     {
-        strokeQueue.pop_front();
+        interpolatePoll();
+        interpolateStroke();
     }
-
-    strokeQueue.push_back( newPos );
-
 }
 
 QList<QPointF> StrokeManager::interpolateStroke()
 {
+    // is nan initially
     QList<QPointF> result;
 
+    qreal x = 0,
+          y = 0,
+          pressure = 0;
+
+    if (mInpolLevel == 1) {
+
+        result = tangentInpolOp(result,pressure);
+
+    }
+    else if (mInpolLevel == 2){
+
+        result = meanInpolOp(result, x, y, pressure);
+
+    } else if (mInpolLevel == 0) {
+
+        result = noInpolOp(result);
+
+    }
+    return result;
+}
+
+QList<QPointF> StrokeManager::noInpolOp(QList<QPointF> points)
+{
+    setPressure(getPressure());
+
+    points << mLastPixel << mLastPixel << mCurrentPixel << mCurrentPixel;
+
+    // Set lastPixel non CurrentPixel
+    // new interpolated pixel
+    mLastPixel = mCurrentPixel;
+
+    return points;
+}
+
+QList<QPointF> StrokeManager::tangentInpolOp(QList<QPointF> points, qreal pressure)
+{
     int time = mSingleshotTime.elapsed();
     static const qreal smoothness = 1.f;
     QLineF line( mLastPixel, mCurrentPixel);
@@ -163,7 +310,7 @@ QList<QPointF> StrokeManager::interpolateStroke()
         QLineF _line(QPointF(0,0), m_previousTangent);
         // don't bother for small tangents, as they can induce single pixel wobbliness
         if (_line.length() < 2)
-		{
+        {
             m_previousTangent = QPointF(0,0);
         }
     }
@@ -187,7 +334,7 @@ QList<QPointF> StrokeManager::interpolateStroke()
         QPointF c2 = mCurrentPixel - newTangent * scaleFactor;
         //c1 = mLastPixel;
         //c2 = mCurrentPixel;
-        result << mLastPixel << c1 << c2 << mCurrentPixel;
+        points << mLastPixel << c1 << c2 << mCurrentPixel;
         /*
         qDebug() << mLastPixel
                  << c1
@@ -197,8 +344,61 @@ QList<QPointF> StrokeManager::interpolateStroke()
         m_previousTangent = newTangent;
     }
 
+    return points;
     previousTime = time;
 
-    return result;
 }
 
+// Mean sampling interpolation operation
+QList<QPointF> StrokeManager::meanInpolOp(QList<QPointF> points, qreal x, qreal y, qreal pressure)
+{
+    for (int i = 0; i < strokeQueue.size(); i++) {
+           x += strokeQueue[i].x();
+           y += strokeQueue[i].y();
+           pressure += getPressure();
+    }
+
+    // get arichmic mean of x, y and pressure
+    x /= strokeQueue.size();
+    y /= strokeQueue.size();
+    pressure /= strokeQueue.size();
+
+    // Use our interpolated points
+    QPointF mNewInterpolated = mLastInterpolated;
+    mNewInterpolated = QPointF(x,y);
+
+    //save our new pressure value
+    setPressure(pressure);
+
+    points << mLastPixel << mLastInterpolated << mNewInterpolated << mCurrentPixel;
+
+    // Set lastPixel non interpolated pixel to our
+    // new interpolated pixel
+    mLastPixel = mNewInterpolated;
+
+    return points;
+}
+
+void StrokeManager::interpolateEnd()
+{
+    // Stop timer
+    timer.stop();
+    if (mInpolLevel == 2) {
+        if (!strokeQueue.isEmpty())
+        {
+
+            // How many samples should we get point from?
+            // TODO: Qt slider.
+            int sampleSize = 5;
+
+            assert(sampleSize > 0);
+            for (int i = sampleSize; i > 0; i--)
+            {
+                interpolatePoll();
+                interpolateStroke();
+            }
+        } else {
+            // Do nothing
+        }
+    }
+}

--- a/core_lib/tool/strokemanager.cpp
+++ b/core_lib/tool/strokemanager.cpp
@@ -260,7 +260,7 @@ QList<QPointF> StrokeManager::interpolateStroke()
 
     if (mInpolLevel == 1) {
 
-        result = tangentInpolOp(result,pressure);
+        result = tangentInpolOp(result);
 
     }
     else if (mInpolLevel == 2){
@@ -288,7 +288,7 @@ QList<QPointF> StrokeManager::noInpolOp(QList<QPointF> points)
     return points;
 }
 
-QList<QPointF> StrokeManager::tangentInpolOp(QList<QPointF> points, qreal pressure)
+QList<QPointF> StrokeManager::tangentInpolOp(QList<QPointF> points)
 {
     int time = mSingleshotTime.elapsed();
     static const qreal smoothness = 1.f;

--- a/core_lib/tool/strokemanager.h
+++ b/core_lib/tool/strokemanager.h
@@ -36,7 +36,7 @@ public:
     void smoothMousePos(QPointF pos);
     QList<QPointF> meanInpolOp( QList<QPointF> points, qreal x, qreal y, qreal pressure );
     QList<QPointF> noInpolOp(QList<QPointF> points);
-    QList<QPointF> tangentInpolOp(QList<QPointF> points, qreal pressure);
+    QList<QPointF> tangentInpolOp(QList<QPointF> points);
 
     QPointF getLastPressPixel() const { return mLastPressPixel; }
     QPointF getCurrentPixel() const { return mCurrentPixel; }

--- a/core_lib/tool/stroketool.cpp
+++ b/core_lib/tool/stroketool.cpp
@@ -29,8 +29,11 @@ void StrokeTool::startStroke()
     mFirstDraw = true;
     mLastPixel = getCurrentPixel();
     
-	mStrokePoints.clear();
-    mStrokePoints << mEditor->view()->mapScreenToCanvas( mLastPixel );
+    mStrokePoints.clear();
+
+    //Experimental
+    QPointF startStrokes =  m_pStrokeManager->interpolateStart(mLastPixel);
+    mStrokePoints << mEditor->view()->mapScreenToCanvas( startStrokes );
 
     mStrokePressures.clear();
     mStrokePressures << m_pStrokeManager->getPressure();
@@ -56,9 +59,10 @@ bool StrokeTool::keyReleaseEvent(QKeyEvent *event)
     return true;
 }
 
-
 void StrokeTool::endStroke()
 {
+    m_pStrokeManager->interpolateEnd();
+    mStrokePressures << m_pStrokeManager->getPressure();
     mStrokePoints.clear();
     mStrokePressures.clear();
 
@@ -70,9 +74,12 @@ void StrokeTool::drawStroke()
     QPointF pixel = getCurrentPixel();
     if ( pixel != mLastPixel || !mFirstDraw )
     {
-        mLastPixel = pixel;
-        mStrokePoints << mEditor->view()->mapScreenToCanvas( pixel );
+
+        // get last pixel before interpolation initializes
+        QPointF startStrokes =  m_pStrokeManager->interpolateStart(getLastPixel());
+        mStrokePoints << mEditor->view()->mapScreenToCanvas( startStrokes );
         mStrokePressures << m_pStrokeManager->getPressure();
+
     }
     else
     {

--- a/core_lib/util/pencildef.h
+++ b/core_lib/util/pencildef.h
@@ -35,7 +35,8 @@ enum ToolPropertyType
     BEZIER,
     USEFEATHER,
     VECTORMERGE,
-    ANTI_ALIASING
+    ANTI_ALIASING,
+    INTERPOLATION
 };
 
 enum BackgroundStyle


### PR DESCRIPTION
## What's added:
- interpolation levels:
  Non -- Simple -- Strong
 Interpolatino can be applied to:
Pen, Brush, Pencil and Eraser.

The mean interpolation operation is ported from Krita. 
The smooth operation that was removed in my last PR has been added again too.
![image](https://i.imgbox.com/zD1Pwcgb.gif)


------ 

- Invisibility checkbox for brush

## What's changed:
- All drawing tools have gone through code refactoring.
- Spinslider maximum width changed

## What's fixed:
- Temporary raster preview of vector drawing is much closer to the final output now.
  Prior to this, the line would become thicker after the vector path had been generated.

## To be improved:
At some point I want to make a list widget class for small items with icons that can be used for various settings.
For example the interpolation levels should look likes squares that are filled with a color, brighter color means lighter interpolation, darker color means stronger interpolation. Atm. though they're just radio buttons.

## Bugs?

The InterpolatePollAndPaint should trigger as long as the you're drawing, but for some reason Qt doesn't seem to understand that when using a tablet. it works fine with mouse though.
If you want to test this, add a qDebug() << strokeQueue; inside the function, draw using your tablet and check if there's constant feedback. Please state your tablet brand.

I'll probably make a separate issue of this, so I can report to QT, if it's a bug.