### PR TITLE
Refactor title save indicator and add file icon to main window title

### DIFF
--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -524,7 +524,7 @@ bool MainWindow2::openObject( QString strFilePath )
     mRecentFileMenu->addRecentFile( object->filePath() );
     mRecentFileMenu->saveToDisk();
 
-    setWindowTitle( object->filePath() );
+    setWindowTitle( object->filePath().append("[*]") );
     setWindowModified( false );
     setWindowIcon( QFileIconProvider().icon(strFilePath) );
 
@@ -582,7 +582,7 @@ bool MainWindow2::saveObject( QString strSavedFileName )
 
     mTimeLine->updateContent();
 
-    setWindowTitle( strSavedFileName );
+    setWindowTitle( strSavedFileName.append("[*]") );
     mBackupAtSave = mEditor->currentBackup();
 
     return true;

--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -524,7 +524,7 @@ bool MainWindow2::openObject( QString strFilePath )
     mRecentFileMenu->addRecentFile( object->filePath() );
     mRecentFileMenu->saveToDisk();
 
-    setWindowTitle( object->filePath().append("[*]") );
+    setWindowTitle( object->filePath().prepend("[*]") );
     setWindowModified( false );
     setWindowIcon( QFileIconProvider().icon(strFilePath) );
 
@@ -582,7 +582,7 @@ bool MainWindow2::saveObject( QString strSavedFileName )
 
     mTimeLine->updateContent();
 
-    setWindowTitle( strSavedFileName.append("[*]") );
+    setWindowTitle( strSavedFileName.prepend("[*]") );
     mBackupAtSave = mEditor->currentBackup();
 
     return true;

--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -415,6 +415,7 @@ void MainWindow2::newDocument()
         mEditor->color()->setColorNumber(0);
 
         setWindowTitle( PENCIL_WINDOW_TITLE );
+        updateSaveState();
     }
 }
 
@@ -584,6 +585,7 @@ bool MainWindow2::saveObject( QString strSavedFileName )
 
     setWindowTitle( strSavedFileName.prepend("[*]") );
     mBackupAtSave = mEditor->currentBackup();
+    updateSaveState();
 
     return true;
 }

--- a/app/mainwindow2.h
+++ b/app/mainwindow2.h
@@ -41,7 +41,7 @@ class Timeline2;
 class ActionCommands;
 class ImageSeqDialog;
 
-#define PENCIL_WINDOW_TITLE QString("Pencil2D - Nightly Build %1").arg( __DATE__ )
+#define PENCIL_WINDOW_TITLE QString("[*]Pencil2D - Nightly Build %1").arg( __DATE__ )
 
 
 namespace Ui

--- a/app/mainwindow2.h
+++ b/app/mainwindow2.h
@@ -62,7 +62,7 @@ public:
 public slots:
     void undoActSetText();
     void undoActSetEnabled();
-	void updateTitleSaveState();
+    void updateSaveState();
 
 public:
     void setOpacity(int opacity);
@@ -121,10 +121,6 @@ private:
     void makeConnections( Editor*, ToolOptionWidget*);
 
     void bindActionWithSetting( QAction*, SETTING );
-
-    bool isTitleMarkedUnsaved();
-    void markTitleSaved();
-    void markTitleUnsaved();
 
     // UI: central Drawing Area
     ScribbleArea* mScribbleArea                = nullptr;


### PR DESCRIPTION
Instead of manually prepending the asterisk to the window title to indicate file changes, this lets QT handle it. On Window and Linux I don't think there will be any noticeable difference from this change, but on Mac, the close button will change when the current file has unsaved changes. I have also added a file icon to the window title (again probably mac only), which will be greyed out slightly when there are unsaved changes, as is typical of Mac applications.