### PR TITLE
Fix syntax

### DIFF
--- a/pencil.pro
+++ b/pencil.pro
@@ -28,7 +28,7 @@ core_lib.depends = quazip
 app.depends      = core_lib
 tests.depends    = core_lib
 
-TRANSLATIONS += translations/pencil.ts
+TRANSLATIONS += translations/pencil.ts \
                 translations/Language.cs.ts \
                 translations/Language.da.ts \
                 translations/Language.de.ts \


### PR DESCRIPTION
a379816fefaa5bb9ecd7e313b701d19bb2d4e3e2 added pencil.ts to TRANSLATIONS, but doing so it broke the syntax of the list.