### PR TITLE
Fix Linux upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ after_success:
       wget -P Pencil2D.app/Contents/MacOS/plugins https://evermeet.cx/ffmpeg/ffmpeg-3.2.4.7z;
       7z x Pencil2D.app/Contents/MacOS/plugins/ffmpeg-3.2.4.7z -o"Pencil2D.app/Contents/MacOS/plugins";
       rm Pencil2D.app/Contents/MacOs/plugins/ffmpeg-3.2.4.7z;
-      
+
       echo "Copying necessary Qt frameworks";
       macdeployqt Pencil2D.app;
       echo "Removing Makefile";
@@ -110,7 +110,7 @@ after_success:
   - cd "$TRAVIS_BUILD_DIR/util"
 
   - 'if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    python nightly-build-upload.py 0BxdcdOiOmg-CcU1WOFpCOFBvVXc "$TRAVIS_BUILD_DIR/build/pencil2d-linux-$(date +"%Y-%m-%d").zip";
+    python nightly-build-upload.py 0BxdcdOiOmg-CcU1WOFpCOFBvVXc "$TRAVIS_BUILD_DIR/build/pencil2d-linux-$(date +"%Y-%m-%d").tar.gz";
   fi'
   - 'if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     python nightly-build-upload.py 0BxdcdOiOmg-CeVpTY294cXdLZ2c "$TRAVIS_BUILD_DIR/build/pencil2d-mac-$(date +"%Y-%m-%d").zip";


### PR DESCRIPTION
In the recent CI build I noticed that right now the Travis script still tries to upload the ZIP file on Linux even though we switched to tar.gz.