### PR TITLE
Remove custom styling

### DIFF
--- a/app/ui/displayoption.ui
+++ b/app/ui/displayoption.ui
@@ -34,20 +34,6 @@
      <property name="toolTip">
       <string>Horizontal flip</string>
      </property>
-     <property name="styleSheet">
-      <string notr="true">QToolButton { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.0851364, y2:0.278, stop:0 rgba(216, 216, 216, 255), stop:1 rgba(250, 250, 250, 255));
-
-/*border:1px solid #555555;*/
-
-border-radius:5px;
-}
-
-QToolButton:pressed, QToolButton:checked { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.085, y2:0.0791364, stop:0 rgba(246, 252, 255, 255), stop:1 rgba(204, 217, 250, 255));
-border:1px solid #555555;
-}</string>
-     </property>
      <property name="text">
       <string>...</string>
      </property>
@@ -77,20 +63,6 @@ border:1px solid #555555;
      <property name="autoFillBackground">
       <bool>false</bool>
      </property>
-     <property name="styleSheet">
-      <string notr="true">QToolButton { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.0851364, y2:0.278, stop:0 rgba(216, 216, 216, 255), stop:1 rgba(250, 250, 250, 255));
-
-/*border:1px solid #555555;*/
-
-border-radius:5px;
-}
-
-QToolButton:pressed, QToolButton:checked { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.085, y2:0.0791364, stop:0 rgba(246, 252, 255, 255), stop:1 rgba(204, 217, 250, 255));
-border:1px solid #555555;
-}</string>
-     </property>
      <property name="text">
       <string>...</string>
      </property>
@@ -119,20 +91,6 @@ border:1px solid #555555;
      </property>
      <property name="toolTip">
       <string>Show invisible lines</string>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">QToolButton { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.0851364, y2:0.278, stop:0 rgba(216, 216, 216, 255), stop:1 rgba(250, 250, 250, 255));
-
-/*border:1px solid #555555;*/
-
-border-radius:5px;
-}
-
-QToolButton:pressed, QToolButton:checked { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.085, y2:0.0791364, stop:0 rgba(246, 252, 255, 255), stop:1 rgba(204, 217, 250, 255));
-border:1px solid #555555;
-}</string>
      </property>
      <property name="text">
       <string>...</string>
@@ -169,20 +127,6 @@ border:1px solid #555555;
      <property name="autoFillBackground">
       <bool>false</bool>
      </property>
-     <property name="styleSheet">
-      <string notr="true">QToolButton { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.0851364, y2:0.278, stop:0 rgba(216, 216, 216, 255), stop:1 rgba(250, 250, 250, 255));
-
-/*border:1px solid #555555;*/
-
-border-radius:5px;
-}
-
-QToolButton:pressed, QToolButton:checked { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.085, y2:0.0791364, stop:0 rgba(246, 252, 255, 255), stop:1 rgba(204, 217, 250, 255));
-border:1px solid #555555;
-}</string>
-     </property>
      <property name="text">
       <string>...</string>
      </property>
@@ -208,20 +152,6 @@ border:1px solid #555555;
      </property>
      <property name="statusTip">
       <string>Onion skin next frame</string>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">QToolButton { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.0851364, y2:0.278, stop:0 rgba(216, 216, 216, 255), stop:1 rgba(250, 250, 250, 255));
-
-/*border:1px solid #555555;*/
-
-border-radius:5px;
-}
-
-QToolButton:pressed, QToolButton:checked { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.085, y2:0.0791364, stop:0 rgba(246, 252, 255, 255), stop:1 rgba(204, 217, 250, 255));
-border:1px solid #555555;
-}</string>
      </property>
      <property name="text">
       <string>...</string>
@@ -249,20 +179,6 @@ border:1px solid #555555;
      <property name="statusTip">
       <string>Onion skin color: red</string>
      </property>
-     <property name="styleSheet">
-      <string notr="true">QToolButton { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.0851364, y2:0.278, stop:0 rgba(216, 216, 216, 255), stop:1 rgba(250, 250, 250, 255));
-
-/*border:1px solid #555555;*/
-
-border-radius:5px;
-}
-
-QToolButton:pressed, QToolButton:checked { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.085, y2:0.0791364, stop:0 rgba(246, 252, 255, 255), stop:1 rgba(204, 217, 250, 255));
-border:1px solid #555555;
-}</string>
-     </property>
      <property name="text">
       <string>...</string>
      </property>
@@ -286,20 +202,6 @@ border:1px solid #555555;
      <property name="toolTip">
       <string>Show outlines only</string>
      </property>
-     <property name="styleSheet">
-      <string notr="true">QToolButton { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.0851364, y2:0.278, stop:0 rgba(216, 216, 216, 255), stop:1 rgba(250, 250, 250, 255));
-
-/*border:1px solid #555555;*/
-
-border-radius:5px;
-}
-
-QToolButton:pressed, QToolButton:checked { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.085, y2:0.0791364, stop:0 rgba(246, 252, 255, 255), stop:1 rgba(204, 217, 250, 255));
-border:1px solid #555555;
-}</string>
-     </property>
      <property name="text">
       <string>...</string>
      </property>
@@ -322,20 +224,6 @@ border:1px solid #555555;
     <widget class="QToolButton" name="mirrorVButton">
      <property name="toolTip">
       <string>Vertical flip</string>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">QToolButton { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.0851364, y2:0.278, stop:0 rgba(216, 216, 216, 255), stop:1 rgba(250, 250, 250, 255));
-
-/*border:1px solid #555555;*/
-
-border-radius:5px;
-}
-
-QToolButton:pressed, QToolButton:checked { 
-background-color: qlineargradient(spread:pad, x1:0.187818, y1:0.949, x2:0.085, y2:0.0791364, stop:0 rgba(246, 252, 255, 255), stop:1 rgba(204, 217, 250, 255));
-border:1px solid #555555;
-}</string>
      </property>
      <property name="text">
       <string>...</string>

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -25,37 +25,7 @@
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
   <widget class="QMenuBar" name="menubar">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>800</width>
-     <height>26</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <family>Trebuchet MS</family>
-    </font>
-   </property>
-   <property name="styleSheet">
-    <string notr="true">QMenuBar {
-background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 rgba(245, 245, 245, 255), stop:1 rgba(233, 233, 233, 255));
-border-bottom:1px solid #cccccc;
-}
-
-QMenuBar::item {
-background: transparent;
-}
-
-QMenuBar::item:selected {
-background: #B6DBEA;
-}</string>
-   </property>
    <widget class="QMenu" name="menuFile">
-    <property name="styleSheet">
-     <string notr="true"/>
-    </property>
     <property name="title">
      <string>File</string>
     </property>
@@ -97,9 +67,6 @@ background: #B6DBEA;
     <addaction name="actionExit"/>
    </widget>
    <widget class="QMenu" name="menuEdit">
-    <property name="styleSheet">
-     <string notr="true">b</string>
-    </property>
     <property name="title">
      <string>Edit</string>
     </property>


### PR DESCRIPTION
This removes custom styling of the menu bar and the display option buttons, which makes Pencil play along much more nicely with system themes (i.e. #550). Before:

![Before](https://cloud.githubusercontent.com/assets/2063777/24813961/499e61be-1bd0-11e7-8c8d-166d91da14ce.png)

After:

![After](https://cloud.githubusercontent.com/assets/2063777/24813980/55c81b7e-1bd0-11e7-9767-32e265aad400.png)