### PR TITLE
fix ffmpeg path on MacOS

### DIFF
--- a/core_lib/movieexporter.cpp
+++ b/core_lib/movieexporter.cpp
@@ -88,7 +88,7 @@ QString ffmpegLocation()
 #ifdef _WIN32
     return QApplication::applicationDirPath() + "/plugins/ffmpeg.exe";
 #elif __APPLE__
-    return QApplication::applicationDirPath() + "/ffmpeg";
+    return QApplication::applicationDirPath() + "/plugins/ffmpeg";
 #else
     return QStandardPaths::findExecutable( "ffmpeg" ); // ffmpeg is a standalone project.
 #endif
@@ -112,7 +112,13 @@ Status MovieExporter::run(const Object* obj,
 	qDebug() << ffmpegPath;
 	if ( !QFile::exists( ffmpegPath ) )
 	{
+    #ifdef _WIN32
 		qDebug() << "Please place ffmpeg.exe in " << ffmpegPath << " directory";
+    #elif __APPLE__
+        qDebug() << "Please place ffmpeg in " << ffmpegPath << " directory";
+    #else
+        qDebug() << "Please place ffmpeg in " << ffmpegPath << " directory";
+    #endif
 		return Status::ERROR_FFMPEG_NOT_FOUND;
 	}
 	


### PR DESCRIPTION
I just tested movie export on mac in the newest nightly build and noticed that it didn't work, because the ffmpeg path was wrong. i'm curious as to how it knew where to find the executable in the builds you provided @chchwy because the source code didn't look for a plugins folder inside MacOs/, so it shouldn't work. 

I've added more specific debug too.