### PR TITLE
macdeployqt fix for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,14 @@ after_success:
 
       echo "Copying necessary Qt frameworks";
       macdeployqt Pencil2D.app;
-      echo "Removing Makefile";
+
+      echo "applying macdeployqt fix";
+      wget https://github.com/aurelien-rainone/macdeployqtfix/archive/master.zip;
+      unzip -x master.zip;
+      python $TRAVIS_BUILD_DIR/build/Pencil2D/macdeployqtfix-master/macdeployqtfix.py $TRAVIS_BUILD_DIR/build/Pencil2D/Pencil2D.app/Contents/MacOS/Pencil2D /usr/local/Cellar/qt@5.7/5.7.1/;
+      echo "Removing files";
+      rm -rf macdeployqtfix-master;
+      rm master.zip;
       rm Makefile;
       cd ..;
       echo "Zipping...";


### PR DESCRIPTION
After investigating this, I discovered that it wasn't a problem on my end after all, macdeployqt is just broken, even more so than what I initially had observed. 

It fails to link the qt libraries correctly which makes pencil crash if you have qt installed already. I've tested this fix locally and works for me.

There's also another issue where the bundle takes up additionally 30-50mb more than what it should, but i'm not sure whether this fixes that as well.