### PR TITLE
Hand tool improvements

### DIFF
--- a/core_lib/tool/handtool.cpp
+++ b/core_lib/tool/handtool.cpp
@@ -25,13 +25,15 @@ void HandTool::loadSettings()
 
 QCursor HandTool::cursor()
 {
-    return QPixmap( ":icons/hand.png" );
+    return buttonsDown > 0 ? Qt::ClosedHandCursor : Qt::OpenHandCursor;
 }
 
 void HandTool::mousePressEvent( QMouseEvent* )
 {
     mLastPixel = getLastPressPixel();
     mCurrentRotation = 0;
+    ++buttonsDown;
+    mScribbleArea->updateToolCursor();
 }
 
 void HandTool::mouseReleaseEvent( QMouseEvent* event )
@@ -42,6 +44,8 @@ void HandTool::mouseReleaseEvent( QMouseEvent* event )
         qDebug( "[HandTool] Stop Hand Tool" );
         mScribbleArea->setPrevTool();
     }
+    --buttonsDown;
+    mScribbleArea->updateToolCursor();
 }
 
 void HandTool::mouseMoveEvent( QMouseEvent* evt )

--- a/core_lib/tool/handtool.cpp
+++ b/core_lib/tool/handtool.cpp
@@ -31,6 +31,7 @@ QCursor HandTool::cursor()
 void HandTool::mousePressEvent( QMouseEvent* )
 {
     mLastPixel = getLastPressPixel();
+    mCurrentRotation = 0;
 }
 
 void HandTool::mouseReleaseEvent( QMouseEvent* event )
@@ -64,13 +65,15 @@ void HandTool::mouseMoveEvent( QMouseEvent* evt )
     else if ( isRotate )
     {
         QPoint centralPixel( mScribbleArea->width() / 2, mScribbleArea->height() / 2 );
-        QVector2D v1( getLastPressPixel() - centralPixel );
-        QVector2D v2( getCurrentPixel() - centralPixel );
+        QVector2D startV( getLastPressPixel() - centralPixel );
+        QVector2D curV( getCurrentPixel() - centralPixel );
 
-        float angle = acos( QVector2D::dotProduct( v1, v2 ) / ( v1.length() * v2.length() ) );
-        //angle = angle * 180.0 / M_PI;
-
-        mEditor->view()->rotate( angle );
+        float angle = ( atan2( curV.y(), curV.x() ) - atan2( startV.y(), startV.x() ) ) * 180.0 / M_PI;
+        if ( angle != mCurrentRotation )
+        {
+            mEditor->view()->rotate( angle - mCurrentRotation );
+            mCurrentRotation = angle;
+        }
     }
     else if ( isScale )
     {

--- a/core_lib/tool/handtool.h
+++ b/core_lib/tool/handtool.h
@@ -20,6 +20,7 @@ public:
 
 private:
     QPointF mLastPixel;
+    float mCurrentRotation;
 };
 
 #endif

--- a/core_lib/tool/handtool.h
+++ b/core_lib/tool/handtool.h
@@ -21,6 +21,7 @@ public:
 private:
     QPointF mLastPixel;
     float mCurrentRotation;
+    int buttonsDown = 0;
 };
 
 #endif


### PR DESCRIPTION
Just a couple of improvements for the hand tool. It now uses the native Qt::OpenHandCursor, and changes to Qt::ClosedHandCursor while dragging. Rotation behavior with alt click has been basically rewritten. I honestly am not even sure if it was functioning before, because it just more or less seemed to go wherever. I think you will agree that the new behavior is much more intuitive when you try it.