### PR TITLE
Fixed removing first frame would crash application #639

### DIFF
--- a/core_lib/structure/keyframe.cpp
+++ b/core_lib/structure/keyframe.cpp
@@ -30,10 +30,3 @@ void KeyFrame::removeEventListner( KeyFrameEventListener* listener )
         mEventListeners.erase( it );
     }
 }
-
-NullKeyFrame* NullKeyFrame::get()
-{
-    static NullKeyFrame* pTheOnlyOne = new NullKeyFrame;
-
-    return pTheOnlyOne;
-}

--- a/core_lib/structure/keyframe.h
+++ b/core_lib/structure/keyframe.h
@@ -48,27 +48,10 @@ private:
 
 typedef std::shared_ptr< KeyFrame > KeyFramePtr;
 
-
-
 class KeyFrameEventListener
 {
 public:
     virtual void onKeyFrameDestroy( KeyFrame* ) = 0;
-};
-
-
-
-class NullKeyFrame : public KeyFrame
-{
-public:
-    static NullKeyFrame* get();
-
-	bool isNull() override { return true; }
-
-private:
-    NullKeyFrame() {}
-    NullKeyFrame( const NullKeyFrame& ) {}
-    void operator=( const NullKeyFrame& ) {}
 };
 
 #endif // KeyFrame_H

--- a/core_lib/structure/layer.cpp
+++ b/core_lib/structure/layer.cpp
@@ -74,7 +74,6 @@ KeyFrame* Layer::getKeyFrameAt( int position )
     auto it = mKeyFrames.find( position );
     if ( it == mKeyFrames.end() )
     {
-        //return NullKeyFrame::get();
         return nullptr;
     }
     return it->second;
@@ -89,7 +88,7 @@ KeyFrame* Layer::getLastKeyFrameAtPosition( int position )
     auto it = mKeyFrames.lower_bound( position );
     if ( it == mKeyFrames.end() )
     {
-        return NullKeyFrame::get();
+        return nullptr;
     }
     return it->second;
 }


### PR DESCRIPTION
+ Fixed an instance where removing the first frame would sometimes lead
to a crash. See #639 
- Removed unused keyframe header stuff.