### PR TITLE
Specify Nightly target directories as env vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,10 +110,10 @@ after_success:
   - cd "$TRAVIS_BUILD_DIR/util"
 
   - 'if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    python nightly-build-upload.py 0BxdcdOiOmg-CcU1WOFpCOFBvVXc "$TRAVIS_BUILD_DIR/build/pencil2d-linux-$(date +"%Y-%m-%d").tar.gz";
+    python nightly-build-upload.py "$LINUX_NIGHTLY_PARENT" "$TRAVIS_BUILD_DIR/build/pencil2d-linux-$(date +"%Y-%m-%d").tar.gz";
   fi'
   - 'if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    python nightly-build-upload.py 0BxdcdOiOmg-CeVpTY294cXdLZ2c "$TRAVIS_BUILD_DIR/build/pencil2d-mac-$(date +"%Y-%m-%d").zip";
+    python nightly-build-upload.py "$OSX_NIGHTLY_PARENT" "$TRAVIS_BUILD_DIR/build/pencil2d-mac-$(date +"%Y-%m-%d").zip";
   fi'
   - echo "Operation done"
 


### PR DESCRIPTION
Since I’m playing with CI again, this makes it possible for me to have my own nightly builds, so I can check if everything works as intended. To keep the upload for this repo working as well, you’ll need to set two env vars in travis: 
- `LINUX_NIGHTLY_PARENT` = `0BxdcdOiOmg-CcU1WOFpCOFBvVXc`
- `OSX_NIGHTLY_PARENT` = `0BxdcdOiOmg-CeVpTY294cXdLZ2c`