### PR TITLE
fix #555 replace special characters with '?'

### DIFF
--- a/core_lib/structure/filemanager.cpp
+++ b/core_lib/structure/filemanager.cpp
@@ -299,6 +299,8 @@ Status FileManager::save( Object* object, QString strFileName )
 
     QDomDocument xmlDoc( "PencilDocument" );
     QDomElement root = xmlDoc.createElement( "document" );
+    QDomProcessingInstruction encoding = xmlDoc.createProcessingInstruction("xml", "version=\"1.0\" encoding=\"UTF-8\"");
+    xmlDoc.appendChild( encoding );
     xmlDoc.appendChild( root );
 
     // save editor information

--- a/core_lib/structure/layer.cpp
+++ b/core_lib/structure/layer.cpp
@@ -474,11 +474,23 @@ void Layer::mouseRelease( QMouseEvent* event, int frameNumber )
 void Layer::editProperties()
 {
     bool ok;
+    QString replace;
     QString text = QInputDialog::getText( NULL, tr( "Layer Properties" ),
                                           tr( "Layer name:" ), QLineEdit::Normal,
                                           mName, &ok );
     if ( ok && !text.isEmpty() )
     {
+        for (int i = 0; i < text.size(); ++i)
+        {
+            QChar check = text.at(i);
+            unsigned char c = *(unsigned char*)(&check);
+            if (c >= 127) {
+                replace.append("?");
+            } else if (QChar(check).isPrint()) {
+                replace.append(QChar(c));
+            }
+        }
+        text = replace;
         mName = text;
         setUpdated();
     }

--- a/core_lib/structure/layer.cpp
+++ b/core_lib/structure/layer.cpp
@@ -473,10 +473,6 @@ void Layer::mouseRelease( QMouseEvent* event, int frameNumber )
 
 void Layer::editProperties()
 {
-    QStringList illegalChars;
-    illegalChars << "\uFFFE" << "\uFFFF" << "\uFFFD" << "\uFFFC" << "\uFFFB"
-                 << "\uFFFA" << "\uFFF9" << "\uFFF8" << "\uFFF7" << "\uFFF6" << "\uFFF5"
-                 << "\uFFF4" << "\uFFF3" << "\uFFF2" << "\uFFF1" << "\uFFF0" << "\uFFEF";
     QRegExp regex("([\uFFEF-\uFFFF])+");
 
     bool ok;
@@ -485,13 +481,7 @@ void Layer::editProperties()
                                           mName, &ok );
     if ( ok && !text.isEmpty() )
     {
-        if (text.contains(regex))
-        {
-            for (int i = 0; i < illegalChars.size(); i++)
-            {
-                text.replace(illegalChars[i], "");
-            }
-        }
+        text.replace(regex, "");
         mName = text;
         setUpdated();
     }

--- a/core_lib/structure/layer.cpp
+++ b/core_lib/structure/layer.cpp
@@ -473,24 +473,25 @@ void Layer::mouseRelease( QMouseEvent* event, int frameNumber )
 
 void Layer::editProperties()
 {
+    QStringList illegalChars;
+    illegalChars << "\uFFFE" << "\uFFFF" << "\uFFFD" << "\uFFFC" << "\uFFFB"
+                 << "\uFFFA" << "\uFFF9" << "\uFFF8" << "\uFFF7" << "\uFFF6" << "\uFFF5"
+                 << "\uFFF4" << "\uFFF3" << "\uFFF2" << "\uFFF1" << "\uFFF0" << "\uFFEF";
+    QRegExp regex("([\uFFEF-\uFFFF])+");
+
     bool ok;
-    QString replace;
     QString text = QInputDialog::getText( NULL, tr( "Layer Properties" ),
                                           tr( "Layer name:" ), QLineEdit::Normal,
                                           mName, &ok );
     if ( ok && !text.isEmpty() )
     {
-        for (int i = 0; i < text.size(); ++i)
+        if (text.contains(regex))
         {
-            QChar check = text.at(i);
-            unsigned char c = *(unsigned char*)(&check);
-            if (c >= 127) {
-                replace.append("?");
-            } else if (QChar(check).isPrint()) {
-                replace.append(QChar(c));
+            for (int i = 0; i < illegalChars.size(); i++)
+            {
+                text.replace(illegalChars[i], "");
             }
         }
-        text = replace;
         mName = text;
         setUpdated();
     }

--- a/core_lib/structure/layer.h
+++ b/core_lib/structure/layer.h
@@ -19,6 +19,7 @@ GNU General Public License for more details.
 #include <map>
 #include <functional>
 #include <QString>
+#include <QStringList>
 #include <QPainter>
 #include <QtXml>
 
@@ -129,6 +130,7 @@ private:
     LAYER_TYPE meType = UNDEFINED;
     Object* mObject   = nullptr;
     int mId           = 0;
+    static QStringList illegalChars;
 
     std::map<int, KeyFrame*, std::greater<int>> mKeyFrames;
 

--- a/core_lib/structure/layer.h
+++ b/core_lib/structure/layer.h
@@ -19,7 +19,6 @@ GNU General Public License for more details.
 #include <map>
 #include <functional>
 #include <QString>
-#include <QStringList>
 #include <QPainter>
 #include <QtXml>
 
@@ -130,7 +129,6 @@ private:
     LAYER_TYPE meType = UNDEFINED;
     Object* mObject   = nullptr;
     int mId           = 0;
-    static QStringList illegalChars;
 
     std::map<int, KeyFrame*, std::greater<int>> mKeyFrames;
 


### PR DESCRIPTION
This PR fixes #555 which occurred when special characters were inserted into layer labels, causing your save to become corrupted.

It looks through all ascii characters, if the inserted character is above, then replace with '?'