### PR TITLE
Apply STRINGIFY to window title TIMESTAMP

### DIFF
--- a/app/mainwindow2.h
+++ b/app/mainwindow2.h
@@ -41,8 +41,13 @@ class Timeline2;
 class ActionCommands;
 class ImageSeqDialog;
 
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define S__GIT_TIMESTAMP__ TOSTRING(GIT_TIMESTAMP)
+
 #ifdef GIT_TIMESTAMP
-#define PENCIL_WINDOW_TITLE QString("[*]Pencil2D - Nightly Build %1").arg( GIT_TIMESTAMP )
+#define PENCIL_WINDOW_TITLE QString("[*]Pencil2D - Nightly Build %1").arg( S__GIT_TIMESTAMP__ )
 #else
 #define PENCIL_WINDOW_TITLE QString("[*]Pencil2D - Nightly Build %1").arg( __DATE__ )
 #endif


### PR DESCRIPTION
The window title timestamp should be stringified too, otherwise compilation fails.