### PR TITLE
#129 fix delete current layer shortcut not working

### DIFF
--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -1021,6 +1021,7 @@ void MainWindow2::setupKeyboardShortcuts()
     ui->actionNew_Vector_Layer->setShortcut( cmdKeySeq( CMD_NEW_VECTOR_LAYER ) );
     ui->actionNew_Camera_Layer->setShortcut( cmdKeySeq( CMD_NEW_CAMERA_LAYER ) );
     ui->actionNew_Sound_Layer->setShortcut( cmdKeySeq( CMD_NEW_SOUND_LAYER ) );
+    ui->actionDelete_Current_Layer->setShortcut(cmdKeySeq(CMD_DELETE_CUR_LAYER));
 
     mToolBox->toggleViewAction()->setShortcut( cmdKeySeq( CMD_TOGGLE_TOOLBOX ) );
     mToolOptions->toggleViewAction()->setShortcut( cmdKeySeq( CMD_TOGGLE_TOOL_OPTIONS ) );


### PR DESCRIPTION
FIxed deleting current layer shortcut not working, related to #129