### PR TITLE
fixed an issue that would render layers translucent on a camera layer

### DIFF
--- a/core_lib/canvasrenderer.cpp
+++ b/core_lib/canvasrenderer.cpp
@@ -360,20 +360,14 @@ void CanvasRenderer::paintTransformedSelection( QPainter& painter )
 
 void CanvasRenderer::paintCurrentFrame( QPainter& painter )
 {
-
-    bool isCamera = false;
-    if (mObject->getLayer(mLayerIndex)->type() == Layer::CAMERA) { isCamera = true;}
-    else {
-        isCamera = false;
-    }
-
+    bool isCamera = mObject->getLayer(mLayerIndex)->type() == Layer::CAMERA;
     for ( int i = 0; i < mObject->getLayerCount(); ++i )
     {
         Layer* layer = mObject->getLayer( i );
         if ( i == mLayerIndex || mOptions.nShowAllLayers != 1 )
         {
             painter.setOpacity( 1.0 );
-        } else if (isCamera != true) {
+        } else if ( isCamera != true ) {
 
             painter.setOpacity( 0.8 );
         }

--- a/core_lib/canvasrenderer.cpp
+++ b/core_lib/canvasrenderer.cpp
@@ -361,18 +361,22 @@ void CanvasRenderer::paintTransformedSelection( QPainter& painter )
 void CanvasRenderer::paintCurrentFrame( QPainter& painter )
 {
 
+    bool isCamera = false;
+    if (mObject->getLayer(mLayerIndex)->type() == Layer::CAMERA) { isCamera = true;}
+    else {
+        isCamera = false;
+    }
+
     for ( int i = 0; i < mObject->getLayerCount(); ++i )
     {
         Layer* layer = mObject->getLayer( i );
-
         if ( i == mLayerIndex || mOptions.nShowAllLayers != 1 )
         {
             painter.setOpacity( 1.0 );
-        }
-        else {
+        } else if (isCamera != true) {
+
             painter.setOpacity( 0.8 );
         }
-
 
         if ( i == mLayerIndex || mOptions.nShowAllLayers > 0 ) {
             switch ( layer->type() )


### PR DESCRIPTION
It was mentioned in #552 that some time ago, whenever you selected a camera layer, everything would be shown "as if rendered" 

Prior to this PR only the selected layer would be shown fully opaque.

demonstration of the PR:
![opacity](https://cloud.githubusercontent.com/assets/1045397/25533101/d0846c22-2c2f-11e7-9498-0755d7310a20.gif)