### PR TITLE
Fix packaging on Travis after binary target dir changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ addons:
     - libqt5xmlpatterns5-dev
     - bsdtar
 
-
 before_install:
   - 'if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     brew update;
@@ -80,16 +79,12 @@ after_success:
   - echo "cleaning..."
   - make clean
   - 'if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      mv app Pencil2D;
-      cd Pencil2D;
-      echo "Removing Makefile";
-      rm Makefile;
-      cd ..;
+      mv bin Pencil2D;
       echo "Archiving...";
       bsdtar cvzfs "pencil2d-linux-$(date +"%Y-%m-%d").tar.gz" "/Pencil2D/pencil2d-linux-$(date +"%Y-%m-%d")/" Pencil2D;
      fi'
   - 'if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      mv app Pencil2D;
+      mv bin Pencil2D;
       echo "Fixing info.plist";
       cd Pencil2D;
       plutil -replace CFBundleExecutable -string Pencil2D Pencil2D.app/Contents/Info.plist;
@@ -103,8 +98,6 @@ after_success:
 
       echo "Copying necessary Qt frameworks";
       macdeployqt Pencil2D.app;
-      echo "Removing Makefile";
-      rm Makefile;
       cd ..;
       echo "Zipping...";
       zip -r "pencil2d-mac-$(date +"%Y-%m-%d").zip" Pencil2D/;


### PR DESCRIPTION
In 685a0d7729543834db607ee63957eef5aaa4b9c0, the output directory of the Pencil binary was changed from app/ to bin/, but the Travis build script was not updated accordingly, causing Linux and macOS nightlies to be generated without the binaries as mentioned in https://github.com/pencil2d/pencil/pull/633#issuecomment-299073279 – This PR makes up for that. The change also means that removing the Makefile is no longer necessary.