### PR TITLE
Always use FileDialog instead of QFileDialog

### DIFF
--- a/app/actioncommands.cpp
+++ b/app/actioncommands.cpp
@@ -2,7 +2,6 @@
 
 #include <QInputDialog>
 #include <QMessageBox>
-#include <QFileDialog>
 #include <QProgressDialog>
 #include <QApplication>
 #include <QDesktopServices>
@@ -33,7 +32,7 @@
 
 ActionCommands::ActionCommands( QWidget* parent ) : QObject( parent )
 {
-	mParent = parent;
+    mParent = parent;
 }
 
 ActionCommands::~ActionCommands() {}
@@ -50,7 +49,7 @@ Status ActionCommands::importSound()
         msg.setText( tr( "No sound layer exists as a destination for your import. Create a new sound layer?" ) );
         msg.addButton( tr( "Create sound layer" ), QMessageBox::AcceptRole );
         msg.addButton( tr( "Don't create layer" ), QMessageBox::RejectRole );
-        
+
         int buttonClicked = msg.exec();
         if ( buttonClicked != QMessageBox::AcceptRole )
         {
@@ -78,7 +77,7 @@ Status ActionCommands::importSound()
 
     if ( layer->keyExists( mEditor->currentFrame() ) )
     {
-        QMessageBox::warning( nullptr, 
+        QMessageBox::warning( nullptr,
                               "",
                               tr( "A sound clip already exists on this frame! Please select another frame or layer." ) );
         return Status::SAFE;
@@ -94,85 +93,85 @@ Status ActionCommands::importSound()
 
 Status ActionCommands::exportMovie()
 {
-	FileDialog fileDialog( mParent );
-	QString strMoviePath = fileDialog.saveFile( FileType::MOVIE );
-	if ( strMoviePath.isEmpty() )
-	{
-		return Status::SAFE;
-	}
+    FileDialog fileDialog( mParent );
+    QString strMoviePath = fileDialog.saveFile( FileType::MOVIE );
+    if ( strMoviePath.isEmpty() )
+    {
+        return Status::SAFE;
+    }
 
-	ExportMovieDialog exportDialog( mParent );
+    ExportMovieDialog exportDialog( mParent );
 
-	std::vector< std::pair<QString, QSize > > camerasInfo;
-	auto cameraLayers = mEditor->object()->getLayersByType< LayerCamera >();
-	for ( LayerCamera* i : cameraLayers )
-	{
-		camerasInfo.push_back( std::make_pair( i->name(), i->getViewSize() ) );
-	}
+    std::vector< std::pair<QString, QSize > > camerasInfo;
+    auto cameraLayers = mEditor->object()->getLayersByType< LayerCamera >();
+    for ( LayerCamera* i : cameraLayers )
+    {
+        camerasInfo.push_back( std::make_pair( i->name(), i->getViewSize() ) );
+    }
 
-	auto currLayer = mEditor->layers()->currentLayer();
-	if ( currLayer->type() == Layer::CAMERA )
-	{
-		QString strName = currLayer->name();
-		auto it = std::find_if( camerasInfo.begin(), camerasInfo.end(), 
-			[strName] ( std::pair<QString, QSize> p )
-		{
-			return p.first == strName;
-		} );
+    auto currLayer = mEditor->layers()->currentLayer();
+    if ( currLayer->type() == Layer::CAMERA )
+    {
+        QString strName = currLayer->name();
+        auto it = std::find_if( camerasInfo.begin(), camerasInfo.end(),
+            [strName] ( std::pair<QString, QSize> p )
+        {
+            return p.first == strName;
+        } );
 
         Q_ASSERT(it != camerasInfo.end());
 
-		std::swap( camerasInfo[ 0 ], *it );
-	}
+        std::swap( camerasInfo[ 0 ], *it );
+    }
 
-	exportDialog.setCamerasInfo( camerasInfo );
-	exportDialog.setDefaultRange( 1, mEditor->layers()->projectLength() );
-	exportDialog.exec();
-	if ( exportDialog.result() == QDialog::Rejected )
-	{
-		return Status::SAFE;
-	}
+    exportDialog.setCamerasInfo( camerasInfo );
+    exportDialog.setDefaultRange( 1, mEditor->layers()->projectLength() );
+    exportDialog.exec();
+    if ( exportDialog.result() == QDialog::Rejected )
+    {
+        return Status::SAFE;
+    }
 
-	ExportMovieDesc desc;
-	desc.strFileName   = strMoviePath;
-	desc.startFrame    = exportDialog.getStartFrame();
-	desc.endFrame      = exportDialog.getEndFrame();
-	desc.fps           = mEditor->playback()->fps();
-	desc.exportSize    = exportDialog.getExportSize();
-	desc.strCameraName = exportDialog.getSelectedCameraName();
+    ExportMovieDesc desc;
+    desc.strFileName   = strMoviePath;
+    desc.startFrame    = exportDialog.getStartFrame();
+    desc.endFrame      = exportDialog.getEndFrame();
+    desc.fps           = mEditor->playback()->fps();
+    desc.exportSize    = exportDialog.getExportSize();
+    desc.strCameraName = exportDialog.getSelectedCameraName();
 
-	QProgressDialog progressDlg;
-	progressDlg.setWindowModality( Qt::WindowModal );
-	progressDlg.setLabelText( tr("Exporting movie...") );
-	Qt::WindowFlags eFlags = Qt::Dialog | Qt::WindowTitleHint;
-	progressDlg.setWindowFlags( eFlags );
-	progressDlg.show();
+    QProgressDialog progressDlg;
+    progressDlg.setWindowModality( Qt::WindowModal );
+    progressDlg.setLabelText( tr("Exporting movie...") );
+    Qt::WindowFlags eFlags = Qt::Dialog | Qt::WindowTitleHint;
+    progressDlg.setWindowFlags( eFlags );
+    progressDlg.show();
 
-	MovieExporter ex;
+    MovieExporter ex;
 
-	connect( &progressDlg, &QProgressDialog::canceled, [&ex]
-	{
-		ex.cancel();
-	} );
+    connect( &progressDlg, &QProgressDialog::canceled, [&ex]
+    {
+        ex.cancel();
+    } );
 
-	Status st = ex.run( mEditor->object(), desc, [ &progressDlg ]( float f )
-	{
-		progressDlg.setValue( (int)(f * 100.f) );
-		QApplication::processEvents( QEventLoop::ExcludeUserInputEvents );
-	} );
+    Status st = ex.run( mEditor->object(), desc, [ &progressDlg ]( float f )
+    {
+        progressDlg.setValue( (int)(f * 100.f) );
+        QApplication::processEvents( QEventLoop::ExcludeUserInputEvents );
+    } );
 
-	if ( st.ok() && QFile::exists( strMoviePath ) )
-	{
-		auto btn = QMessageBox::question( mParent, 
-                                          "Pencil2D", 
-	                                      tr( "Finished. Open movie now?" ) );
-		if ( btn == QMessageBox::Yes )
-		{
+    if ( st.ok() && QFile::exists( strMoviePath ) )
+    {
+        auto btn = QMessageBox::question( mParent,
+                                          "Pencil2D",
+                                          tr( "Finished. Open movie now?" ) );
+        if ( btn == QMessageBox::Yes )
+        {
             QDesktopServices::openUrl( QUrl::fromLocalFile( strMoviePath ) );
-		}
-	}
+        }
+    }
 
-	return Status::OK; 
+    return Status::OK;
 }
 
 void ActionCommands::ZoomIn()
@@ -330,7 +329,7 @@ Status ActionCommands::addNewCameraLayer()
     {
         mEditor->layers()->createCameraLayer( text );
     }
-    
+
     return Status::OK;
 
 }

--- a/app/actioncommands.cpp
+++ b/app/actioncommands.cpp
@@ -85,7 +85,7 @@ Status ActionCommands::importSound()
     }
 
     FileDialog fileDialog( mParent );
-    QString strSoundFile = fileDialog.openFile( EFile::SOUND );
+    QString strSoundFile = fileDialog.openFile( FileType::SOUND );
 
     Status st = mEditor->sound()->loadSound( layer, mEditor->currentFrame(), strSoundFile );
 
@@ -95,7 +95,7 @@ Status ActionCommands::importSound()
 Status ActionCommands::exportMovie()
 {
 	FileDialog fileDialog( mParent );
-	QString strMoviePath = fileDialog.saveFile( EFile::MOVIE_EXPORT );
+	QString strMoviePath = fileDialog.saveFile( FileType::MOVIE );
 	if ( strMoviePath.isEmpty() )
 	{
 		return Status::SAFE;
@@ -263,7 +263,7 @@ void ActionCommands::addNewKey()
     if ( clip )
     {
         FileDialog fileDialog( mParent );
-        QString strSoundFile = fileDialog.openFile( EFile::SOUND );
+        QString strSoundFile = fileDialog.openFile( FileType::SOUND );
 
         if ( strSoundFile.isEmpty() )
         {

--- a/app/filedialogex.cpp
+++ b/app/filedialogex.cpp
@@ -105,7 +105,7 @@ QString FileDialog::openDialogTitle( FileType fileType )
 {
     switch ( fileType )
     {
-        case FileType::DOCUMENT: return tr( "Open document" );
+        case FileType::ANIMATION: return tr( "Open animation" );
         case FileType::IMAGE: return tr( "Import image" );
         case FileType::IMAGE_SEQUENCE: return tr( "Import image sequence" );
         case FileType::MOVIE: return tr( "Import movie" );
@@ -120,7 +120,7 @@ QString FileDialog::saveDialogTitle( FileType fileType )
 {
     switch ( fileType )
     {
-        case FileType::DOCUMENT: return tr( "Save document" );
+        case FileType::ANIMATION: return tr( "Save animation" );
         case FileType::IMAGE: return tr( "Export image" );
         case FileType::IMAGE_SEQUENCE: return tr( "Export image sequence" );
         case FileType::MOVIE: return tr( "Export movie" );
@@ -135,7 +135,7 @@ QString FileDialog::openFileFilters( FileType fileType )
 {
     switch ( fileType )
     {
-        case FileType::DOCUMENT: return tr( PFF_OPEN_ALL_FILE_FILTER );
+        case FileType::ANIMATION: return tr( PFF_OPEN_ALL_FILE_FILTER );
         case FileType::IMAGE: return PENCIL_IMAGE_FILTER;
         case FileType::IMAGE_SEQUENCE: return PENCIL_IMAGE_FILTER;
         case FileType::MOVIE: return PENCIL_MOVIE_EXT;
@@ -150,7 +150,7 @@ QString FileDialog::saveFileFilters( FileType fileType )
 {
     switch ( fileType )
     {
-        case FileType::DOCUMENT: return tr( PFF_SAVE_ALL_FILE_FILTER );
+        case FileType::ANIMATION: return tr( PFF_SAVE_ALL_FILE_FILTER );
         case FileType::IMAGE: return QString();
         case FileType::IMAGE_SEQUENCE: return QString();
         case FileType::MOVIE: return tr( "MP4 (*.mp4);;AVI (*.avi);;GIF (*.gif)" );
@@ -166,7 +166,7 @@ QString FileDialog::defaultFileName( FileType fileType )
 
     switch ( fileType )
     {
-        case FileType::DOCUMENT: return tr( PFF_DEFAULT_FILENAME );
+        case FileType::ANIMATION: return tr( PFF_DEFAULT_FILENAME );
         case FileType::IMAGE: return tr( "untitled.png" );
         case FileType::IMAGE_SEQUENCE: return tr( "untitled.png" );
         case FileType::MOVIE: return tr( "untitled.mp4" );
@@ -181,7 +181,7 @@ QString FileDialog::toSettingKey( FileType fileType )
 {
     switch ( fileType )
     {
-        case FileType::DOCUMENT: return "Document";
+        case FileType::ANIMATION: return "Animation";
         case FileType::IMAGE: return "Image";
         case FileType::IMAGE_SEQUENCE: return "ImageSequence";
         case FileType::MOVIE: return "Movie";

--- a/app/filedialogex.cpp
+++ b/app/filedialogex.cpp
@@ -18,7 +18,7 @@ QString FileDialog::openFile(FileType fileType)
 {
     QString strTitle = openDialogTitle( fileType );
     QString strInitialFilePath = getLastOpenPath( fileType );
-    QString strFilter = saveFileFilters( fileType );
+    QString strFilter = openFileFilters( fileType );
 
     QString filePath = QFileDialog::getOpenFileName( mRoot,
                                                      strTitle,
@@ -30,6 +30,24 @@ QString FileDialog::openFile(FileType fileType)
     }
 
     return filePath;
+}
+
+QStringList FileDialog::openFiles(FileType fileType)
+{
+    QString strTitle = openDialogTitle( fileType );
+    QString strInitialFilePath = getLastOpenPath( fileType );
+    QString strFilter = openFileFilters( fileType );
+
+    QStringList filePaths = QFileDialog::getOpenFileNames( mRoot,
+                                                           strTitle,
+                                                           strInitialFilePath,
+                                                           strFilter );
+    if ( !filePaths.isEmpty() && !filePaths.first().isEmpty() )
+    {
+        setLastOpenPath( fileType, filePaths.first() );
+    }
+
+    return filePaths;
 }
 
 QString FileDialog::saveFile( FileType fileType )
@@ -118,7 +136,7 @@ QString FileDialog::openFileFilters( FileType fileType )
     {
         case FileType::DOCUMENT: return tr( PFF_OPEN_ALL_FILE_FILTER );
         case FileType::IMAGE: return PENCIL_IMAGE_FILTER;
-        case FileType::IMAGE_SEQUENCE: return tr( "Images (*.png *.jpg *.jpeg *.tif *.tiff *.bmp)" );
+        case FileType::IMAGE_SEQUENCE: return PENCIL_IMAGE_FILTER;
         case FileType::MOVIE: return PENCIL_MOVIE_EXT;
         case FileType::SOUND: return tr( "Sounds (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)" );
         case FileType::PALETTE: return QString();

--- a/app/filedialogex.cpp
+++ b/app/filedialogex.cpp
@@ -2,26 +2,23 @@
 
 #include <QSettings>
 #include <QFileDialog>
-
+#include "fileformat.h"
 #include "pencildef.h"
 
 FileDialog::FileDialog( QWidget* parent ) : QObject( parent )
 {
-	mRoot = parent;
+    mRoot = parent;
 }
 
 FileDialog::~FileDialog()
 {
 }
 
-QString FileDialog::openFile(EFile fileType)
+QString FileDialog::openFile(FileType fileType)
 {
-    QSettings setting( PENCIL2D, PENCIL2D );
-    setting.beginGroup( "LastFilePath" );
-
-    QString strTitle = dialogTitle( fileType );
-    QString strInitialFilePath = setting.value( toSettingKey( fileType ), QDir::homePath() ).toString();
-    QString strFilter = fileFilters( fileType );
+    QString strTitle = openDialogTitle( fileType );
+    QString strInitialFilePath = getLastOpenPath( fileType );
+    QString strFilter = saveFileFilters( fileType );
 
     QString filePath = QFileDialog::getOpenFileName( mRoot,
                                                      strTitle,
@@ -29,20 +26,17 @@ QString FileDialog::openFile(EFile fileType)
                                                      strFilter );
     if ( !filePath.isEmpty() )
     {
-        setting.setValue( toSettingKey( fileType ), filePath );
+        setLastOpenPath( fileType, filePath );
     }
 
     return filePath;
 }
 
-QString FileDialog::saveFile( EFile fileType )
+QString FileDialog::saveFile( FileType fileType )
 {
-    QSettings setting( PENCIL2D, PENCIL2D );
-    setting.beginGroup( "LastFilePath" );
-
-    QString strTitle = dialogTitle( fileType );
-    QString strInitialFilePath = setting.value( toSettingKey( fileType ), QDir::homePath() ).toString();
-    QString strFilter = fileFilters( fileType );
+    QString strTitle = saveDialogTitle( fileType );
+    QString strInitialFilePath = getLastSavePath( fileType );
+    QString strFilter = saveFileFilters( fileType );
 
     QString filePath = QFileDialog::getSaveFileName( mRoot,
                                                      strTitle,
@@ -50,40 +44,114 @@ QString FileDialog::saveFile( EFile fileType )
                                                      strFilter );
     if ( !filePath.isEmpty() )
     {
-        setting.setValue( toSettingKey( fileType ), filePath );
+        setLastSavePath( fileType, filePath );
     }
 
     return filePath;
 }
 
-QString FileDialog::dialogTitle( EFile fileType )
+QString FileDialog::getLastOpenPath( FileType fileType )
+{
+    QSettings setting( PENCIL2D, PENCIL2D );
+    setting.beginGroup( "LastOpenPath" );
+
+    return setting.value( toSettingKey( fileType ), QDir::homePath() ).toString();
+}
+
+void FileDialog::setLastOpenPath( FileType fileType, QString openPath )
+{
+    QSettings setting( PENCIL2D, PENCIL2D );
+    setting.beginGroup( "LastOpenPath" );
+
+    setting.setValue( toSettingKey( fileType ), openPath );
+}
+
+QString FileDialog::getLastSavePath( FileType fileType )
+{
+    QSettings setting( PENCIL2D, PENCIL2D );
+    setting.beginGroup( "LastSavePath" );
+
+    return setting.value( toSettingKey( fileType ), QDir::homePath() ).toString();
+}
+
+void FileDialog::setLastSavePath( FileType fileType, QString savePath )
+{
+    QSettings setting( PENCIL2D, PENCIL2D );
+    setting.beginGroup( "LastSavePath" );
+
+    setting.setValue( toSettingKey( fileType ), savePath );
+}
+
+QString FileDialog::openDialogTitle( FileType fileType )
 {
     switch ( fileType )
     {
-        case EFile::SOUND: return tr( "Import sound..." );
-        case EFile::MOVIE_EXPORT: return tr( "Export movie as ..." );
+        case FileType::DOCUMENT: return tr( "Open document" );
+        case FileType::IMAGE: return tr( "Import image" );
+        case FileType::IMAGE_SEQUENCE: return tr( "Import image sequence" );
+        case FileType::MOVIE: return tr( "Import movie" );
+        case FileType::SOUND: return tr( "Import sound" );
+        case FileType::PALETTE: return tr( "Import palette" );
         default: Q_ASSERT( false );
     }
     return "";
 }
 
-QString FileDialog::fileFilters( EFile fileType )
+QString FileDialog::saveDialogTitle( FileType fileType )
 {
     switch ( fileType )
     {
-        case EFile::SOUND: return tr( "Sounds (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)" );
-        case EFile::MOVIE_EXPORT: return tr( "MP4 (*.mp4);;AVI (*.avi);;GIF (*.gif)" );
+        case FileType::DOCUMENT: return tr( "Save document" );
+        case FileType::IMAGE: return tr( "Export image" );
+        case FileType::IMAGE_SEQUENCE: return tr( "Export image sequence" );
+        case FileType::MOVIE: return tr( "Export movie" );
+        case FileType::SOUND: return tr( "Export sound" );
+        case FileType::PALETTE: return tr( "Export palette" );
         default: Q_ASSERT( false );
     }
     return "";
 }
 
-QString FileDialog::toSettingKey( EFile fileType )
+QString FileDialog::openFileFilters( FileType fileType )
 {
     switch ( fileType )
     {
-        case EFile::SOUND: return "Sound";
-        case EFile::MOVIE_EXPORT: return "MovExport";
+        case FileType::DOCUMENT: return tr( PFF_OPEN_ALL_FILE_FILTER );
+        case FileType::IMAGE: return PENCIL_IMAGE_FILTER;
+        case FileType::IMAGE_SEQUENCE: return tr( "Images (*.png *.jpg *.jpeg *.tif *.tiff *.bmp)" );
+        case FileType::MOVIE: return PENCIL_MOVIE_EXT;
+        case FileType::SOUND: return tr( "Sounds (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)" );
+        case FileType::PALETTE: return QString();
+        default: Q_ASSERT( false );
+    }
+    return "";
+}
+
+QString FileDialog::saveFileFilters( FileType fileType )
+{
+    switch ( fileType )
+    {
+        case FileType::DOCUMENT: return tr( PFF_SAVE_ALL_FILE_FILTER );
+        case FileType::IMAGE: return QString();
+        case FileType::IMAGE_SEQUENCE: return QString();
+        case FileType::MOVIE: return tr( "MP4 (*.mp4);;AVI (*.avi);;GIF (*.gif)" );
+        case FileType::SOUND: return QString();
+        case FileType::PALETTE: return QString();
+        default: Q_ASSERT( false );
+    }
+    return "";
+}
+
+QString FileDialog::toSettingKey( FileType fileType )
+{
+    switch ( fileType )
+    {
+        case FileType::DOCUMENT: return "Document";
+        case FileType::IMAGE: return "Image";
+        case FileType::IMAGE_SEQUENCE: return "ImageSequence";
+        case FileType::MOVIE: return "Movie";
+        case FileType::SOUND: return "Sound";
+        case FileType::PALETTE: return "Palette";
         default: Q_ASSERT( false );
     }
     return "";

--- a/app/filedialogex.cpp
+++ b/app/filedialogex.cpp
@@ -89,7 +89,8 @@ QString FileDialog::getLastSavePath( FileType fileType )
     QSettings setting( PENCIL2D, PENCIL2D );
     setting.beginGroup( "LastSavePath" );
 
-    return setting.value( toSettingKey( fileType ), QDir::homePath() ).toString();
+    return setting.value( toSettingKey( fileType ),
+                          QDir::homePath() + "/" + defaultFileName( fileType) ).toString();
 }
 
 void FileDialog::setLastSavePath( FileType fileType, QString savePath )
@@ -139,7 +140,7 @@ QString FileDialog::openFileFilters( FileType fileType )
         case FileType::IMAGE_SEQUENCE: return PENCIL_IMAGE_FILTER;
         case FileType::MOVIE: return PENCIL_MOVIE_EXT;
         case FileType::SOUND: return tr( "Sounds (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)" );
-        case FileType::PALETTE: return QString();
+        case FileType::PALETTE: return tr( "Palette (*.xml)" );
         default: Q_ASSERT( false );
     }
     return "";
@@ -154,7 +155,23 @@ QString FileDialog::saveFileFilters( FileType fileType )
         case FileType::IMAGE_SEQUENCE: return QString();
         case FileType::MOVIE: return tr( "MP4 (*.mp4);;AVI (*.avi);;GIF (*.gif)" );
         case FileType::SOUND: return QString();
-        case FileType::PALETTE: return QString();
+        case FileType::PALETTE: return tr( "Palette (*.xml)" );
+        default: Q_ASSERT( false );
+    }
+    return "";
+}
+
+QString FileDialog::defaultFileName( FileType fileType )
+{
+
+    switch ( fileType )
+    {
+        case FileType::DOCUMENT: return tr( PFF_DEFAULT_FILENAME );
+        case FileType::IMAGE: return tr( "untitled.png" );
+        case FileType::IMAGE_SEQUENCE: return tr( "untitled.png" );
+        case FileType::MOVIE: return tr( "untitled.mp4" );
+        case FileType::SOUND: return tr( "untitled.wav" );
+        case FileType::PALETTE: return tr( "untitled.xml" );
         default: Q_ASSERT( false );
     }
     return "";

--- a/app/filedialogex.h
+++ b/app/filedialogex.h
@@ -21,6 +21,7 @@ public:
     ~FileDialog();
 
     QString openFile( FileType fileType );
+    QStringList openFiles( FileType fileType );
     QString saveFile( FileType fileType );
 
     QString getLastOpenPath( FileType fileType );

--- a/app/filedialogex.h
+++ b/app/filedialogex.h
@@ -3,12 +3,14 @@
 
 #include <QObject>
 
-class QWidget;
-
-enum class EFile
+enum class FileType
 {
+    DOCUMENT,
+    IMAGE,
+    IMAGE_SEQUENCE,
+    MOVIE,
     SOUND,
-    MOVIE_EXPORT
+    PALETTE
 };
 
 class FileDialog : public QObject
@@ -18,13 +20,21 @@ public:
     FileDialog( QWidget* parent );
     ~FileDialog();
 
-    QString openFile( EFile fileType );
-    QString saveFile( EFile fileType );
+    QString openFile( FileType fileType );
+    QString saveFile( FileType fileType );
+
+    QString getLastOpenPath( FileType fileType );
+    void setLastOpenPath( FileType fileType, QString openPath );
+    QString getLastSavePath( FileType fileType );
+    void setLastSavePath( FileType fileType, QString savePath );
 
 private:
-    QString dialogTitle( EFile fileType );
-    QString fileFilters( EFile fileType );
-    QString toSettingKey( EFile fileType );
+    QString openDialogTitle( FileType fileType );
+    QString saveDialogTitle( FileType fileType );
+    QString openFileFilters( FileType fileType );
+    QString saveFileFilters( FileType fileType );
+
+    QString toSettingKey( FileType fileType);
 
     QWidget* mRoot = nullptr;
 };

--- a/app/filedialogex.h
+++ b/app/filedialogex.h
@@ -5,7 +5,7 @@
 
 enum class FileType
 {
-    DOCUMENT,
+    ANIMATION,
     IMAGE,
     IMAGE_SEQUENCE,
     MOVIE,

--- a/app/filedialogex.h
+++ b/app/filedialogex.h
@@ -34,6 +34,7 @@ private:
     QString saveDialogTitle( FileType fileType );
     QString openFileFilters( FileType fileType );
     QString saveFileFilters( FileType fileType );
+    QString defaultFileName( FileType fileType );
 
     QString toSettingKey( FileType fileType);
 

--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -703,14 +703,14 @@ void MainWindow2::exportImageSequence()
     }
 
     // Path
+    FileDialog fileDialog( this );
     /* TODO: adapt this to filedialogex
-    QString strInitPath = settings.value( "lastExportPath", QDir::homePath() + "/untitled.png" ).toString();
+    QString strInitPath = fileDialog.getLastSavePath( FileType::IMAGE_SEQUENCE );
 
     QFileInfo info( strInitPath );
     strInitPath = info.path() + "/" + info.baseName() + "." + exportFormat.toLower();
     */
 
-    FileDialog fileDialog( this );
     QString strFilePath = fileDialog.saveFile( FileType::IMAGE_SEQUENCE );
     if ( strFilePath.isEmpty() )
     {
@@ -784,16 +784,16 @@ void MainWindow2::exportImage()
 
 
     // Path
+    FileDialog fileDialog( this );
     /* TODO: adapt this part to filedialogex
-    QString initPath = settings.value( "lastExportPath", QDir::homePath() + "/untitled.png" ).toString();
+    QString initPath = fileDialog.getLastSavePath( FileType::IMAGE );
 
     QFileInfo info( initPath );
     initPath = info.path() + "/" + info.baseName() + "." + exportFormat.toLower();
     */
 
 
-    FileDialog FileDialog( this );
-    QString filePath = FileDialog.saveFile( FileType::IMAGE );
+    QString filePath = fileDialog.saveFile( FileType::IMAGE );
     if ( filePath.isEmpty() )
     {
         qDebug() << "empty file";

--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -422,7 +422,7 @@ void MainWindow2::openDocument()
     if ( maybeSave() )
     {
         FileDialog fileDialog( this );
-        QString fileName = fileDialog.openFile( FileType::DOCUMENT );
+        QString fileName = fileDialog.openFile( FileType::ANIMATION );
         if ( fileName.isEmpty() )
         {
             return;
@@ -445,7 +445,7 @@ void MainWindow2::openDocument()
 bool MainWindow2::saveAsNewDocument()
 {
     FileDialog fileDialog( this );
-    QString fileName = fileDialog.saveFile( FileType::DOCUMENT );
+    QString fileName = fileDialog.saveFile( FileType::ANIMATION );
     if ( fileName.isEmpty() )
     {
         return false;

--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -28,7 +28,6 @@ GNU General Public License for more details.
 #include <QFile>
 #include <QScopedPointer>
 #include <QMessageBox>
-#include <QFileDialog>
 #include <QProgressDialog>
 #include <QDesktopWidget>
 #include <QDesktopServices>
@@ -136,7 +135,7 @@ MainWindow2::MainWindow2( QWidget *parent ) : QMainWindow( parent )
 
     mEditor->updateObject();
     mEditor->color()->setColorNumber(0);
-    
+
     connect( mEditor->view(), &ViewManager::viewChanged, this, &MainWindow2::updateZoomLabel );
 }
 
@@ -422,13 +421,8 @@ void MainWindow2::openDocument()
 {
     if ( maybeSave() )
     {
-        QSettings settings( PENCIL2D, PENCIL2D );
-
-        QString strLastOpenPath = settings.value( LAST_PCLX_PATH, QDir::homePath() ).toString();
-        QString fileName = QFileDialog::getOpenFileName( this,
-                                                         tr( "Open File..." ),
-                                                         strLastOpenPath,
-                                                         tr( PFF_OPEN_ALL_FILE_FILTER ) );
+        FileDialog fileDialog( this );
+        QString fileName = fileDialog.openFile( FileType::DOCUMENT );
         if ( fileName.isEmpty() )
         {
             return;
@@ -450,18 +444,8 @@ void MainWindow2::openDocument()
 
 bool MainWindow2::saveAsNewDocument()
 {
-    QSettings settings( PENCIL2D, PENCIL2D );
-
-    QString strLastFolder = settings.value( LAST_PCLX_PATH, QDir::homePath() ).toString();
-    if ( strLastFolder.isEmpty() || !QDir(strLastFolder).exists() )
-    {
-        strLastFolder = QDir( QDir::homePath() ).filePath( PFF_DEFAULT_FILENAME );
-    }
-
-    QString fileName = QFileDialog::getSaveFileName( this,
-                                                     tr( "Save As..." ),
-                                                     strLastFolder,
-                                                     tr( PFF_SAVE_ALL_FILE_FILTER ) );
+    FileDialog fileDialog( this );
+    QString fileName = fileDialog.saveFile( FileType::DOCUMENT );
     if ( fileName.isEmpty() )
     {
         return false;
@@ -471,7 +455,6 @@ bool MainWindow2::saveAsNewDocument()
     {
         fileName = fileName + PFF_EXTENSION;
     }
-    settings.setValue( LAST_PCLX_PATH, QVariant( fileName ) );
 
     return saveObject( fileName );
 
@@ -490,11 +473,11 @@ void MainWindow2::openFile( QString filename )
 bool MainWindow2::openObject( QString strFilePath )
 {
     QProgressDialog progress( tr("Opening document..."), tr("Abort"), 0, 100, this );
-    
-	// Don't show progress bar if running without a GUI (aka. when rendering from command line)
+
+    // Don't show progress bar if running without a GUI (aka. when rendering from command line)
     if ( this->isVisible() )
     {
-		hideQuestionMark( progress );
+        hideQuestionMark( progress );
         progress.setWindowModality( Qt::WindowModal );
         progress.show();
     }
@@ -502,12 +485,12 @@ bool MainWindow2::openObject( QString strFilePath )
     mEditor->setCurrentLayer( 0 );
 
     FileManager fm( this );
-	connect( &fm, &FileManager::progressUpdated, [&progress]( float f )
-	{
-		progress.setValue( (int)( f * 100.f ) );
-		QApplication::processEvents( QEventLoop::ExcludeUserInputEvents );
-		
-	} );
+    connect( &fm, &FileManager::progressUpdated, [&progress]( float f )
+    {
+        progress.setValue( (int)( f * 100.f ) );
+        QApplication::processEvents( QEventLoop::ExcludeUserInputEvents );
+
+    } );
 
     Object* object = fm.load( strFilePath );
 
@@ -550,7 +533,7 @@ bool MainWindow2::saveObject( QString strSavedFileName )
     Status st = fm->save( mEditor->object(), strSavedFileName );
 
     progress.setValue( 100 );
-    
+
     if ( !st.ok() )
     {
         QDateTime dt = QDateTime::currentDateTime();
@@ -625,13 +608,8 @@ bool MainWindow2::maybeSave()
 
 void MainWindow2::importImage()
 {
-    QSettings settings( PENCIL2D, PENCIL2D );
-    QString initPath = settings.value( "lastImportPath", QDir::homePath() ).toString();
-
-    QString strFilePath = QFileDialog::getOpenFileName( this,
-                                                        tr( "Import image..." ),
-                                                        initPath,
-                                                        PENCIL_IMAGE_FILTER );
+    FileDialog fileDialog( this );
+    QString strFilePath = fileDialog.openFile( FileType::IMAGE );
     if ( strFilePath.isEmpty() )
     {
         return;
@@ -653,27 +631,14 @@ void MainWindow2::importImage()
         return;
     }
 
-    settings.setValue( "lastImportPath", strFilePath );
-
     mScribbleArea->updateCurrentFrame();
     mTimeLine->updateContent();
 }
 
 void MainWindow2::importImageSequence()
 {
-    QFileDialog w;
-    w.setFileMode( QFileDialog::AnyFile );
-
-    QSettings settings( PENCIL2D, PENCIL2D );
-    QString initialPath = settings.value( "lastImportPath", QVariant( QDir::homePath() ) ).toString();
-    if ( initialPath.isEmpty() )
-    {
-        initialPath = QDir::homePath();
-    }
-    QStringList files = w.getOpenFileNames( this,
-                                            tr("Select one or more files to open"),
-                                            initialPath,
-                                            tr("Images (*.png *.jpg *.jpeg *.tif *.tiff *.bmp)") );
+    FileDialog fileDialog( this );
+    QStringList files = fileDialog.openFiles( FileType::IMAGE_SEQUENCE );
 
     ImageSeqDialog* imageSeqDialog = new ImageSeqDialog( this );
 
@@ -696,20 +661,13 @@ void MainWindow2::importImageSequence()
 
 void MainWindow2::importMovie()
 {
-    QSettings settings( PENCIL2D, PENCIL2D );
-
-    QString initialPath = settings.value( "lastExportPath", QDir::homePath() ).toString();
-    QString filePath = QFileDialog::getOpenFileName( this,
-                                                     tr( "Import movie" ),
-                                                     initialPath,
-                                                     PENCIL_MOVIE_EXT );
+    FileDialog fileDialog( this );
+    QString filePath = fileDialog.openFile( FileType::MOVIE );
     if ( filePath.isEmpty() )
     {
         return;
     }
     mEditor->importMovie( filePath, mEditor->playback()->fps() );
-
-    settings.setValue( "lastExportPath", filePath );
 }
 
 void MainWindow2::exportImageSequence()
@@ -745,20 +703,20 @@ void MainWindow2::exportImageSequence()
     }
 
     // Path
+    /* TODO: adapt this to filedialogex
     QString strInitPath = settings.value( "lastExportPath", QDir::homePath() + "/untitled.png" ).toString();
 
     QFileInfo info( strInitPath );
     strInitPath = info.path() + "/" + info.baseName() + "." + exportFormat.toLower();
+    */
 
-    QString strFilePath = QFileDialog::getSaveFileName( this,
-                                                        tr( "Save Image Sequence" ),
-                                                        strInitPath);
+    FileDialog fileDialog( this );
+    QString strFilePath = fileDialog.saveFile( FileType::IMAGE_SEQUENCE );
     if ( strFilePath.isEmpty() )
     {
         // TODO:
         return; // false;
     }
-    settings.setValue( "lastExportPath", strFilePath );
 
 
     // Export
@@ -826,21 +784,21 @@ void MainWindow2::exportImage()
 
 
     // Path
+    /* TODO: adapt this part to filedialogex
     QString initPath = settings.value( "lastExportPath", QDir::homePath() + "/untitled.png" ).toString();
 
     QFileInfo info( initPath );
     initPath = info.path() + "/" + info.baseName() + "." + exportFormat.toLower();
+    */
 
 
-    QString filePath = QFileDialog::getSaveFileName( this,
-                                                     tr( "Save Image" ),
-                                                     initPath);
+    FileDialog FileDialog( this );
+    QString filePath = FileDialog.saveFile( FileType::IMAGE );
     if ( filePath.isEmpty() )
     {
         qDebug() << "empty file";
         return;// false;
     }
-    settings.setValue( "lastExportPath", QVariant( filePath ) );
 
 
     // Export
@@ -875,12 +833,12 @@ void MainWindow2::preferences()
 
     connect( prefDialog, &PreferencesDialog::windowOpacityChange, this, &MainWindow2::setOpacity );
     connect( prefDialog, &PreferencesDialog::finished, [ &]
-    { 
+    {
         //qDebug() << "Preference dialog closed!";
         clearKeyboardShortcuts();
         setupKeyboardShortcuts();
     } );
-    
+
     prefDialog->show();
 }
 
@@ -1073,35 +1031,23 @@ void MainWindow2::undoActSetEnabled( void )
 
 void MainWindow2::exportPalette()
 {
-    QSettings settings( PENCIL2D, PENCIL2D );
-    QString initialPath = settings.value( "lastPalettePath", QVariant( QDir::homePath() ) ).toString();
-    if ( initialPath.isEmpty() )
-    {
-        initialPath = QDir::homePath() + "/untitled.xml";
-    }
-    QString filePath = QFileDialog::getSaveFileName( this, tr( "Export As" ), initialPath );
+    FileDialog FileDialog( this );
+    QString filePath = FileDialog.saveFile( FileType::PALETTE );
     if ( !filePath.isEmpty() )
     {
         mEditor->object()->exportPalette( filePath );
-        settings.setValue( "lastPalettePath", QVariant( filePath ) );
     }
 }
 
 void MainWindow2::importPalette()
 {
-    QSettings settings( PENCIL2D, PENCIL2D );
-    QString initialPath = settings.value( "lastPalettePath", QVariant( QDir::homePath() ) ).toString();
-    if ( initialPath.isEmpty() )
-    {
-        initialPath = QDir::homePath() + "/untitled.xml";
-    }
-    QString filePath = QFileDialog::getOpenFileName( this, tr( "Import" ), initialPath );
+    FileDialog fileDialog( this );
+    QString filePath = fileDialog.openFile( FileType::PALETTE );
     if ( !filePath.isEmpty() )
     {
         mEditor->object()->importPalette( filePath );
         mColorPalette->refreshColorList();
         mEditor->color()->setColorNumber(0);
-        settings.setValue( "lastPalettePath", QVariant( filePath ) );
     }
 }
 
@@ -1158,7 +1104,7 @@ void MainWindow2::makeConnections( Editor* pEditor, TimeLine* pTimeline )
 
     connect( pTimeline, &TimeLine::addKeyClick, mCommands, &ActionCommands::addNewKey );
     connect( pTimeline, &TimeLine::removeKeyClick, mCommands, &ActionCommands::removeKey );
-    
+
     connect( pTimeline, &TimeLine::newBitmapLayer, mCommands, &ActionCommands::addNewBitmapLayer );
     connect( pTimeline, &TimeLine::newVectorLayer, mCommands, &ActionCommands::addNewVectorLayer );
     connect( pTimeline, &TimeLine::newSoundLayer, mCommands, &ActionCommands::addNewSoundLayer );


### PR DESCRIPTION
While working on #673 I noticed that sound import and movie export used the file dialog from filedialogex.(h|cpp) while all the other import/export/open/save procedures each did their very own thing. Therefore I adapted FileDialog accordingly and replaced the remaining QFileDialogs with it. This will make #673 much easier for me and it improves consistency. Also, translatable default file names!

Right now there are still two todos left in the code, I’ll resolve them as part of #673 because it’s easier that way.