### PR TITLE
fixed brush dap artifact and pressure toggle

### DIFF
--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -418,10 +418,10 @@ void ScribbleArea::tabletEvent( QTabletEvent *event )
 
     // Some tablets return "NoDevice" and Cursor.
     if (event->device() == QTabletEvent::NoDevice) {
-        currentTool()->adjustPressureSensitiveProperties( pow( ( float )mStrokeManager->getPressure(), 2.0f ),
+        currentTool()->adjustPressureSensitiveProperties( mStrokeManager->getPressure(),
                                                       false );
     } else {
-        currentTool()->adjustPressureSensitiveProperties( pow( ( float )mStrokeManager->getPressure(), 2.0f ),
+        currentTool()->adjustPressureSensitiveProperties( mStrokeManager->getPressure(),
                                                       event->pointerType() == QTabletEvent::Cursor );
     }
 

--- a/core_lib/tool/brushtool.cpp
+++ b/core_lib/tool/brushtool.cpp
@@ -350,7 +350,7 @@ void BrushTool::drawStroke()
     {
         qreal brushWidth = 0;
         if (properties.pressure ) {
-            brushWidth = properties.width * m_pStrokeManager->getPressure();
+            brushWidth = properties.width * mCurrentPressure;
         }
         else {
             brushWidth = properties.width;
@@ -395,8 +395,6 @@ void BrushTool::paintVectorStroke()
         // Clear the temporary pixel path
         mScribbleArea->clearBitmapBuffer();
         qreal tol = mScribbleArea->getCurveSmoothing() / mEditor->view()->scaling();
-
-        mStrokePressures.append(0.01);
 
         BezierCurve curve( mStrokePoints, mStrokePressures, tol );
                     curve.setWidth( properties.width );

--- a/core_lib/tool/brushtool.cpp
+++ b/core_lib/tool/brushtool.cpp
@@ -209,7 +209,8 @@ void BrushTool::mouseReleaseEvent( QMouseEvent *event )
     {
         if ( mScribbleArea->isLayerPaintable() )
         {
-            if (getCurrentPoint() == mMouseDownPoint)
+            qreal distance = QLineF( getCurrentPoint(), mMouseDownPoint ).length();
+            if (distance < 1)
             {
                 paintAt(mMouseDownPoint);
             }
@@ -249,10 +250,6 @@ void BrushTool::paintAt( QPointF point )
     if ( layer->type() == Layer::BITMAP )
     {
         qreal opacity = 1.0f;
-        if (properties.pressure == true)
-        {
-            opacity = mCurrentPressure / 2;
-        }
         mCurrentWidth = properties.width;
         qreal brushWidth = mCurrentWidth;
 
@@ -264,7 +261,8 @@ void BrushTool::paintAt( QPointF point )
                                   properties.feather,
                                   mEditor->color()->frontColor(),
                                   opacity,
-                                  properties.useFeather );
+                                  properties.useFeather,
+                                  properties.useAA );
 
         int rad = qRound( brushWidth ) / 2 + 2;
         mScribbleArea->refreshBitmap( rect, rad );

--- a/core_lib/tool/penciltool.cpp
+++ b/core_lib/tool/penciltool.cpp
@@ -201,6 +201,7 @@ void PencilTool::paintAt( QPointF point )
         if (properties.pressure == true)
         {
             opacity = mCurrentPressure / 2;
+            mCurrentWidth = properties.width * mCurrentPressure;
         }
         mCurrentWidth = properties.width;
         qreal brushWidth = mCurrentWidth;
@@ -229,11 +230,11 @@ void PencilTool::drawStroke()
     if ( layer->type() == Layer::BITMAP )
     {
         qreal opacity = 1.0f;
+        mCurrentWidth = properties.width;
         if (properties.pressure == true) {
             opacity = mCurrentPressure / 2;
+            mCurrentWidth = properties.width * mCurrentPressure;
         }
-
-        mCurrentWidth = properties.width * m_pStrokeManager->getPressure();
         qreal brushWidth = mCurrentWidth;
 
         qreal brushStep = (0.5 * brushWidth) - ((properties.feather/100.0) * brushWidth * 0.5);

--- a/core_lib/tool/penciltool.cpp
+++ b/core_lib/tool/penciltool.cpp
@@ -161,7 +161,8 @@ void PencilTool::mouseReleaseEvent( QMouseEvent *event )
     {
         if ( mScribbleArea->isLayerPaintable() )
         {
-            if (getCurrentPoint()==mMouseDownPoint)
+            qreal distance = QLineF( getCurrentPoint(), mMouseDownPoint ).length();
+            if (distance < 1)
             {
                 paintAt(mMouseDownPoint);
             }
@@ -198,11 +199,6 @@ void PencilTool::paintAt( QPointF point )
     if ( layer->type() == Layer::BITMAP )
     {
         qreal opacity = 1.0f;
-        if (properties.pressure == true)
-        {
-            opacity = mCurrentPressure / 2;
-            mCurrentWidth = properties.width * mCurrentPressure;
-        }
         mCurrentWidth = properties.width;
         qreal brushWidth = mCurrentWidth;
 

--- a/core_lib/tool/pentool.cpp
+++ b/core_lib/tool/pentool.cpp
@@ -136,7 +136,8 @@ void PenTool::mouseReleaseEvent( QMouseEvent *event )
     {
         if ( mScribbleArea->isLayerPaintable() )
         {
-            if (getCurrentPoint()==mMouseDownPoint)
+            qreal distance = QLineF( getCurrentPoint(), mMouseDownPoint ).length();
+            if (distance < 1)
             {
                 paintAt(mMouseDownPoint);
             }
@@ -179,7 +180,7 @@ void PenTool::paintAt( QPointF point )
         mCurrentWidth = properties.width;
         if (properties.pressure == true)
         {
-            mCurrentWidth = properties.width * mCurrentPressure;
+            mCurrentWidth = properties.width;
         }
         qreal brushWidth = mCurrentWidth;
 

--- a/core_lib/tool/pentool.cpp
+++ b/core_lib/tool/pentool.cpp
@@ -176,11 +176,11 @@ void PenTool::paintAt( QPointF point )
     if ( layer->type() == Layer::BITMAP )
     {
         qreal opacity = 1.0f;
+        mCurrentWidth = properties.width;
         if (properties.pressure == true)
         {
-            opacity = m_pStrokeManager->getPressure() / 2;
+            mCurrentWidth = properties.width * mCurrentPressure;
         }
-        mCurrentWidth = properties.width;
         qreal brushWidth = mCurrentWidth;
 
         BlitRect rect;
@@ -212,7 +212,12 @@ void PenTool::drawStroke()
         }
 
         qreal opacity = 1.0;
-        qreal brushWidth = m_pStrokeManager->getPressure() * mCurrentWidth;
+        mCurrentWidth = properties.width;
+        if (properties.pressure == true)
+        {
+            mCurrentWidth = properties.width * mCurrentPressure;
+        }
+        qreal brushWidth = mCurrentWidth;
 
         // TODO: Make popup widget for less important properties,
         // Eg. stepsize should be a slider.. will have fixed (0.3) value for now.
@@ -253,11 +258,9 @@ void PenTool::drawStroke()
     else if ( layer->type() == Layer::VECTOR )
     {
         qreal brushWidth = 0;
-        if (properties.pressure ) {
-            brushWidth = properties.width * m_pStrokeManager->getPressure();
-        }
-        else {
-            brushWidth = properties.width;
+        brushWidth = properties.width;
+        if (properties.pressure == true) {
+            brushWidth = properties.width * mCurrentPressure;
         }
 
         int rad = qRound( ( brushWidth / 2 + 2 ) * mEditor->view()->scaling() );
@@ -296,8 +299,6 @@ void PenTool::paintVectorStroke()
         // Clear the temporary pixel path
         mScribbleArea->clearBitmapBuffer();
         qreal tol = mScribbleArea->getCurveSmoothing() / mEditor->view()->scaling();
-
-        mStrokePressures.append(0.01);
 
         BezierCurve curve( mStrokePoints, mStrokePressures, tol );
                     curve.setWidth( properties.width );

--- a/core_lib/tool/strokemanager.cpp
+++ b/core_lib/tool/strokemanager.cpp
@@ -281,7 +281,7 @@ QList<QPointF> StrokeManager::noInpolOp(QList<QPointF> points)
 
     points << mLastPixel << mLastPixel << mCurrentPixel << mCurrentPixel;
 
-    // Set lastPixel non CurrentPixel
+    // Set lastPixel to CurrentPixel
     // new interpolated pixel
     mLastPixel = mCurrentPixel;
 
@@ -293,7 +293,6 @@ QList<QPointF> StrokeManager::tangentInpolOp(QList<QPointF> points)
     int time = mSingleshotTime.elapsed();
     static const qreal smoothness = 1.f;
     QLineF line( mLastPixel, mCurrentPixel);
-
 
     qreal scaleFactor = line.length() * 3.f;
 
@@ -344,8 +343,8 @@ QList<QPointF> StrokeManager::tangentInpolOp(QList<QPointF> points)
         m_previousTangent = newTangent;
     }
 
-    return points;
     previousTime = time;
+    return points;
 
 }
 
@@ -366,9 +365,6 @@ QList<QPointF> StrokeManager::meanInpolOp(QList<QPointF> points, qreal x, qreal 
     // Use our interpolated points
     QPointF mNewInterpolated = mLastInterpolated;
     mNewInterpolated = QPointF(x,y);
-
-    //save our new pressure value
-    setPressure(pressure);
 
     points << mLastPixel << mLastInterpolated << mNewInterpolated << mCurrentPixel;
 


### PR DESCRIPTION
This fixes #677 #678

Notice though that pressure still won't do anything for brush unless feather is on. I recall it was discussed whether Brush should have size pressure or not and I believe that it concluded that pressure should only affect feather at the time.

Because of that and the fact that there's no constant control for feather blending, it feels a bit broken. Therefore whenever you need feather, set pressure on too, otherwise it won't work. I want to add more customisation for the tools but I don't want to implement anything yet if we intend to integrate mypaint.