### PR TITLE
Make GitHub exclude code in 3rdlib/ from language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,13 +10,16 @@
 *.dbproj merge=union
 
 # Standard to msysgit
-*.doc	 diff=astextplain
-*.DOC	 diff=astextplain
+*.doc  diff=astextplain
+*.DOC  diff=astextplain
 *.docx diff=astextplain
 *.DOCX diff=astextplain
 *.dot  diff=astextplain
 *.DOT  diff=astextplain
 *.pdf  diff=astextplain
-*.PDF	 diff=astextplain
-*.rtf	 diff=astextplain
-*.RTF	 diff=astextplain
+*.PDF  diff=astextplain
+*.rtf  diff=astextplain
+*.RTF  diff=astextplain
+
+# Code in 3rdlib/ is not part of Pencil itself
+3rdlib/** linguist-vendored


### PR DESCRIPTION
What it says in the title; pretty trivial. See <https://github.com/github/linguist#vendored-code> for documentation of this feature.