### PR TITLE
Fix compilation with MSVC 12.0

### DIFF
--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -193,9 +193,9 @@ void ToolManager::setInpolLevel(int level)
 
 void ToolManager::setTolerance( int newTolerance )
 {
-    if ( std::isnan( newTolerance ) || newTolerance < 0 )
+    if ( newTolerance < 0 )
     {
-        newTolerance = 1.f;
+        newTolerance = 1;
     }
 
     currentTool()->setTolerance( newTolerance );


### PR DESCRIPTION
I caught another compiler error that I originally missed because it appears to be specific to MSVC. The parameter type of ToolManager::setTolerance was changed from qreal to int, but the isnan check on the parameter was not removed, so the compiler didn’t know whether it should cast the parameter to float, double or long double. Since int can never be NaN to begin with, I removed the check.