### PR TITLE
About dialog links to GPLv3, should actually be GPLv2

### DIFF
--- a/app/aboutdialog.cpp
+++ b/app/aboutdialog.cpp
@@ -50,7 +50,7 @@ void AboutDialog::init()
     aboutText->setText(tr("Official site: <a href=\"http://pencil2d.org\">pencil2d.org</a>"
                                                         "<br>Developed by: <b>Pascal Naidon, Patrick Corrieri, Matt Chang, Cirus</b></>"
                                                         "<br>Thanks to: Qt Framework <a href=\"http://qt-project.org\">qt-project.org</a></>"
-                                                        "<br>Distributed under the <a href=\"http://www.gnu.org/copyleft/gpl.html\">GPL License</a></>"));
+                                                        "<br>Distributed under the <a href=\"http://www.gnu.org/licenses/gpl-2.0.html\">GNU General Public License, version 2</a></>"));
 
     connect(okButton, &QAbstractButton::clicked, this, &QDialog::accept);
 


### PR DESCRIPTION
Just something that I happened to run across due to https://github.com/pencil2d/pencil/issues/622#issuecomment-311619489. Better ~safe~ correct than sorry