### PR TITLE
Added preference for color palette background

### DIFF
--- a/app/colorpalettewidget.cpp
+++ b/app/colorpalettewidget.cpp
@@ -29,6 +29,7 @@ GNU General Public License for more details.
 #include "colormanager.h"
 #include "colorpalettewidget.h"
 #include "ui_colorpalette.h"
+#include "preferencemanager.h"
 
 
 ColorPaletteWidget::ColorPaletteWidget( QWidget* pParent ) : BaseDockWidget( pParent, Qt::Tool )
@@ -54,6 +55,14 @@ ColorPaletteWidget::ColorPaletteWidget( QWidget* pParent ) : BaseDockWidget( pPa
     connect( ui->palettePref, &QToolButton::clicked, this, &ColorPaletteWidget::palettePreferences );
 
     ui->colorListWidget->setStyleSheet(QString("QListWidget { background-image: url(:/background/checkerboard.png); } "));
+}
+
+void ColorPaletteWidget::init(PreferenceManager *prefs)
+{
+    mPrefs = prefs;
+    connect(mPrefs, &PreferenceManager::optionChanged, this, &ColorPaletteWidget::settingUpdated);
+    loadBackgroundStyle();
+    update();
 }
 
 void ColorPaletteWidget::initUI()
@@ -286,6 +295,34 @@ void ColorPaletteWidget::updateGridUI()
         ui->colorListWidget->setGridSize(QSize(-1,-1));
     }
     ui->colorListWidget->setIconSize(iconSize);
+}
+
+void ColorPaletteWidget::settingUpdated(SETTING setting)
+{
+    switch ( setting )
+    {
+    case SETTING::COLOR_PALETTE_BACKGROUND_STYLE:
+        loadBackgroundStyle();
+        update();
+        break;
+
+    default:
+        break;
+    }
+}
+
+void ColorPaletteWidget::loadBackgroundStyle()
+{
+    QString bgName = mPrefs->getString(SETTING::COLOR_PALETTE_BACKGROUND_STYLE);
+
+    if ( bgName == "white" )
+    {
+        ui->colorListWidget->setStyleSheet(QString("QListWidget { background-color:white; } "));
+    }
+    else if ( bgName == "checkerboard" )
+    {
+        ui->colorListWidget->setStyleSheet(QString("QListWidget { background-image: url(:/background/checkerboard.png); } "));
+    }
 }
 
 void ColorPaletteWidget::clickAddColorButton()

--- a/app/colorpalettewidget.h
+++ b/app/colorpalettewidget.h
@@ -33,6 +33,8 @@ namespace Ui
 class ColorPalette;
 }
 
+class PreferenceManager;
+enum class SETTING;
 
 class ColorPaletteWidget : public BaseDockWidget
 {
@@ -41,6 +43,7 @@ class ColorPaletteWidget : public BaseDockWidget
 public:
     explicit ColorPaletteWidget( QWidget* pParent );
 
+    void init(PreferenceManager * prefs);
     void initUI() override;
     void updateUI() override;
 
@@ -72,6 +75,7 @@ private slots:
     void setSwatchSizeMedium();
     void setSwatchSizeLarge();
     void updateGridUI();
+    void settingUpdated(SETTING setting);
 
 private:
     Ui::ColorPalette* ui = nullptr;
@@ -87,7 +91,9 @@ private:
     QPixmap colourSwatch;
     QMenu *toolMenu;
     int stepper;
+    PreferenceManager * mPrefs = nullptr;
 
+    void loadBackgroundStyle();
 };
 
 #endif

--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -158,6 +158,7 @@ void MainWindow2::createDockWidgets()
 
     mColorPalette = new ColorPaletteWidget( this );
     mColorPalette->setObjectName( "ColorPalette" );
+    mColorPalette->init( mEditor->preference() );
 
     mDisplayOptionWidget = new DisplayOptionWidget( this );
     mDisplayOptionWidget->setObjectName( "DisplayOption" );

--- a/app/preferencesdialog.cpp
+++ b/app/preferencesdialog.cpp
@@ -641,9 +641,39 @@ ToolsPage::ToolsPage(QWidget* parent) : QWidget(parent)
     brushBox->setLayout(brushBoxLayout);
 
 
+    QGroupBox* colorPaletteBackgroundBox = new QGroupBox( tr( "Color Palette Background", "GroupBox title in Preference" ) );
+
+    mColorPaletteBackgroundButtons = new QButtonGroup();
+    QRadioButton* checkerBackgroundButton = new QRadioButton();
+    QRadioButton* whiteBackgroundButton = new QRadioButton();
+
+    QPixmap previewCheckerboard( ":background/checkerboard.png" );
+    QPixmap previewWhite(32,32);
+
+    previewWhite.fill( Qt::white );
+
+    checkerBackgroundButton->setIcon( previewCheckerboard.scaled(32, 32) );
+    whiteBackgroundButton->setIcon( previewWhite );
+
+    mColorPaletteBackgroundButtons->addButton(checkerBackgroundButton);
+    mColorPaletteBackgroundButtons->addButton(whiteBackgroundButton);
+
+    mColorPaletteBackgroundButtons->setId(checkerBackgroundButton, 1);
+    mColorPaletteBackgroundButtons->setId(whiteBackgroundButton, 2);
+
+    auto kButtonClicked = static_cast< void (QButtonGroup::* )( int ) >( &QButtonGroup::buttonClicked );
+    connect( mColorPaletteBackgroundButtons, kButtonClicked, this, &ToolsPage::colorPaletteBackgroundChange );
+
+    QHBoxLayout* colorPaletteBackgroundLayout = new QHBoxLayout();
+    colorPaletteBackgroundBox->setLayout(colorPaletteBackgroundLayout);
+    colorPaletteBackgroundLayout->addWidget(checkerBackgroundButton);
+    colorPaletteBackgroundLayout->addWidget(whiteBackgroundButton);
+
+
     QVBoxLayout* lay2 = new QVBoxLayout();
     lay2->addWidget(onionSkinBox);
     lay2->addWidget(brushBox);
+    lay2->addWidget(colorPaletteBackgroundBox);
     lay2->addStretch(1);
     setLayout(lay2);
 }
@@ -655,6 +685,14 @@ void ToolsPage::updateValues()
     mOnionPrevFramesNumBox->setValue(mManager->getInt(SETTING::ONION_PREV_FRAMES_NUM));
     mOnionNextFramesNumBox->setValue(mManager->getInt(SETTING::ONION_NEXT_FRAMES_NUM));
     mUseQuickSizingBox->setChecked(mManager->isOn(SETTING::QUICK_SIZING));
+
+    QString bgName = mManager->getString(SETTING::COLOR_PALETTE_BACKGROUND_STYLE);
+    if (bgName == "checkerboard") {
+        mColorPaletteBackgroundButtons->button(1)->setChecked(true);
+    }
+    if (bgName == "white") {
+        mColorPaletteBackgroundButtons->button(2)->setChecked(true);
+    }
 }
 
 void ToolsPage::onionMaxOpacityChange(int value)
@@ -665,6 +703,22 @@ void ToolsPage::onionMaxOpacityChange(int value)
 void ToolsPage::quickSizingChange( bool b )
 {
     mManager->set(SETTING::QUICK_SIZING, b);
+}
+
+void ToolsPage::colorPaletteBackgroundChange(int value)
+{
+    QString brushName = "white";
+    switch (value) {
+    case 1:
+        brushName = "checkerboard";
+        break;
+    case 2:
+        brushName = "white";
+        break;
+    default:
+        break;
+    }
+    mManager->set(SETTING::COLOR_PALETTE_BACKGROUND_STYLE, brushName);
 }
 
 void ToolsPage::onionMinOpacityChange(int value)

--- a/app/preferencesdialog.h
+++ b/app/preferencesdialog.h
@@ -181,6 +181,7 @@ public slots:
     void onionPrevFramesNumChange(int);
     void onionNextFramesNumChange(int);
     void quickSizingChange(bool);
+    void colorPaletteBackgroundChange(int value);
 private:
     PreferenceManager* mManager = nullptr;
     QSpinBox* mOnionMaxOpacityBox;
@@ -188,6 +189,7 @@ private:
     QSpinBox* mOnionPrevFramesNumBox;
     QSpinBox* mOnionNextFramesNumBox;
     QCheckBox * mUseQuickSizingBox;
+    QButtonGroup *mColorPaletteBackgroundButtons;
 };
 
 #endif

--- a/core_lib/managers/preferencemanager.cpp
+++ b/core_lib/managers/preferencemanager.cpp
@@ -89,6 +89,10 @@ void PreferenceManager::loadPrefs()
 #ifdef DRAW_AXIS
     set( SETTING::AXIS, true );
 #endif
+
+    // Color Palette
+    //
+    set( SETTING::COLOR_PALETTE_BACKGROUND_STYLE,   settings.value( SETTING_COLOR_PALETTE_BACKGROUND_STYLE,"white" ).toString() );
 }
 
 void PreferenceManager::turnOn( SETTING option )
@@ -150,6 +154,9 @@ void PreferenceManager::set(SETTING option, QString value)
         break;
     case SETTING::LANGUAGE:
         settings.setValue( SETTING_LANGUAGE, value );
+        break;
+    case SETTING::COLOR_PALETTE_BACKGROUND_STYLE:
+        settings.setValue( SETTING_COLOR_PALETTE_BACKGROUND_STYLE, value );
         break;
     default:
         break;

--- a/core_lib/managers/preferencemanager.h
+++ b/core_lib/managers/preferencemanager.h
@@ -42,6 +42,7 @@ enum class SETTING
     QUICK_SIZING,
     MULTILAYER_ONION,
     LANGUAGE,
+    COLOR_PALETTE_BACKGROUND_STYLE,
     COUNT, // COUNT must always be the last one.
 };
 

--- a/core_lib/util/pencildef.h
+++ b/core_lib/util/pencildef.h
@@ -172,4 +172,6 @@ enum BackgroundStyle
 
 #define SETTING_LANGUAGE        "Language"
 
+#define SETTING_COLOR_PALETTE_BACKGROUND_STYLE  "ColorPaletteBackground"
+
 #endif // PENCILDEF_H


### PR DESCRIPTION
The checkered background makes the color labels hard to read on my PC (I'm on Windows 7).

![example-on-my-pc](https://user-images.githubusercontent.com/24422213/27846437-7a409b42-618b-11e7-9639-49cab9491fce.png)

So I added a preference in the "Tools" page to set it to either checkered or white.

Screenshot below:

![color-palette-background-preference-screenshot](https://cloud.githubusercontent.com/assets/24422213/25793898/a809be32-3422-11e7-9e68-b34388be7096.png)

Video below:
[color-palette-background-preference-video.zip](https://github.com/pencil2d/pencil/files/982653/color-palette-background-preference-video.zip)
