### PR TITLE
Load the FPS value when opening an animation

### DIFF
--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -1168,6 +1168,8 @@ void MainWindow2::makeConnections( Editor* pEditor, TimeLine* pTimeline )
     connect( pTimeline, &TimeLine::soundClick, pPlaybackManager, &PlaybackManager::enbaleSound );
     connect( pTimeline, &TimeLine::fpsClick, pPlaybackManager, &PlaybackManager::setFps );
 
+    connect( pEditor, &Editor::fpsUpdateForSpinBox, pTimeline, &TimeLine::updateFpsNoSignal );
+
     connect( pTimeline, &TimeLine::addKeyClick, mCommands, &ActionCommands::addNewKey );
     connect( pTimeline, &TimeLine::removeKeyClick, mCommands, &ActionCommands::removeKey );
     

--- a/core_lib/interface/editor.cpp
+++ b/core_lib/interface/editor.cpp
@@ -514,6 +514,9 @@ void Editor::updateObject()
 		mScribbleArea->updateAllFrames();
 	}
 
+    // Load the FPS setting.
+    emit fpsUpdateForSpinBox( mObject->data()->getFrameRate() );
+
     emit updateLayerCount();
 }
 

--- a/core_lib/interface/editor.h
+++ b/core_lib/interface/editor.h
@@ -105,6 +105,8 @@ Q_SIGNALS:
 
     void currentFrameChanged( int n );
 
+    void fpsUpdateForSpinBox( int value );
+
     // save
     void needSave();
     void fileLoaded();

--- a/core_lib/interface/timecontrols.cpp
+++ b/core_lib/interface/timecontrols.cpp
@@ -194,6 +194,12 @@ void TimeControls::updatePlayState()
     }
 }
 
+void TimeControls::updateFpsNoSignal(int value)
+{
+    SignalBlocker blocker(mFpsBox);
+    mFpsBox->setValue(value);
+}
+
 void TimeControls::jumpToStartButtonClicked()
 {
     if ( mPlaybackRangeCheckBox->isChecked() )

--- a/core_lib/interface/timecontrols.h
+++ b/core_lib/interface/timecontrols.h
@@ -43,6 +43,8 @@ public:
     int getRangeLower() { return mPlaybackRangeCheckBox->isChecked() ? mLoopStartSpinBox->value() : -1; }
     int getRangeUpper() { return mPlaybackRangeCheckBox->isChecked() ? mLoopEndSpinBox->value() : -1; }
 
+    void updateFpsNoSignal( int value );
+
 Q_SIGNALS:
     void soundClick( bool );
     void fpsClick(int);

--- a/core_lib/interface/timeline.cpp
+++ b/core_lib/interface/timeline.cpp
@@ -381,3 +381,8 @@ int TimeLine::getRangeUpper()
 {
     return mTimeControls->getRangeUpper();
 }
+
+void TimeLine::updateFpsNoSignal(int value)
+{
+    mTimeControls->updateFpsNoSignal(value);
+}

--- a/core_lib/interface/timeline.h
+++ b/core_lib/interface/timeline.h
@@ -73,6 +73,9 @@ Q_SIGNALS:
     void onionPrevClick();
     void onionNextClick();
 
+public slots:
+    void updateFpsNoSignal( int value );
+
 public:
     bool scrubbing = false;
 

--- a/core_lib/structure/filemanager.cpp
+++ b/core_lib/structure/filemanager.cpp
@@ -394,7 +394,7 @@ void FileManager::extractObjectData( const QDomElement& element, ObjectData* dat
         
         data->setCurrentView( QTransform( m11, m12, m21, m22, dx, dy ) );
     }
-    else if ( strName == "fps" )
+    else if ( strName == "fps" || strName == "currentFps" )
     {
         data->setFrameRate( element.attribute( "value", "12" ).toInt() );
     }


### PR DESCRIPTION
When opening an animation, load the "currentFPS" value if present. For example if the saved file has:

    <currentFps value="12"/>

...then set the FPS value in the editor to 12.

This will save me having to remember and adjust the FPS each time (I usually have a sound-track timed to a certain fps).

Video below (apologies, this runs quite slow):

[load-fps-value-video.zip](https://github.com/pencil2d/pencil/files/1125805/load-fps-value-video.zip)
