### PR TITLE
Upload nightly builds only from master branch or when forced

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ os:
   - linux
   - osx
 
-branches:
-  only:
-  - master
-  
 python:
  - "3.4"
 addons:
@@ -115,16 +111,17 @@ after_success:
   - ls
 
   # Upload to google drive
-  - echo "Initiate deployment on Google Drive"
-  - cd "$TRAVIS_BUILD_DIR/util"
-
-  - 'if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    python nightly-build-upload.py "$LINUX_NIGHTLY_PARENT" "$TRAVIS_BUILD_DIR/build/pencil2d-linux-$(date +"%Y-%m-%d").AppImage";
+  - 'if [ "$TRAVIS_BRANCH" == "master" -o "$FORCE_NIGHTLY_UPLOAD" == "yes" ]; then
+    echo "Initiate deployment on Google Drive";
+    cd "$TRAVIS_BUILD_DIR/util";
+    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      python nightly-build-upload.py "$LINUX_NIGHTLY_PARENT" "$TRAVIS_BUILD_DIR/build/pencil2d-linux-$(date +"%Y-%m-%d").AppImage";
+    fi;
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      python nightly-build-upload.py "$OSX_NIGHTLY_PARENT" "$TRAVIS_BUILD_DIR/build/pencil2d-mac-$(date +"%Y-%m-%d").zip";
+    fi;
+    echo "Operation done";
   fi'
-  - 'if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    python nightly-build-upload.py "$OSX_NIGHTLY_PARENT" "$TRAVIS_BUILD_DIR/build/pencil2d-mac-$(date +"%Y-%m-%d").zip";
-  fi'
-  - echo "Operation done"
 
 after_script:
   - cd "$TRAVIS_BUILD_DIR/build"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,6 +54,9 @@ build_script:
   - if %PLATFORM_%==amd64     call msbuild %SOLUTIONFILE64% %BUILDTYPE% %BUILDTARGET64%
 
 after_build:
+  - set upload=no
+  - if %APPVEYOR_REPO_BRANCH%==master set upload=yes
+  - if "%FORCE_NIGHTLY_UPLOAD%"==yes set upload=yes
   - if %PLATFORM_%==x86 (
     echo "-----Deploying 32 Bit Version-----" &
     dir /s &
@@ -73,10 +76,11 @@ after_build:
     echo "zipping done" &
     echo "what's inside?" &
     call 7z.exe l "pencil2d-win32-%date:~-4,4%"-"%date:~-10,2%"-"%date:~7,2%.zip" &
+    if %upload%==yes (
     echo "deploying to google drive" &
     cd %APPVEYOR_BUILD_FOLDER%\util &
     call %PYTHON%\\python.exe nightly-build-upload.py "%WIN32_NIGHTLY_PARENT%" "%APPVEYOR_BUILD_FOLDER%\build\pencil2d-win32-%date:~-4,4%"-"%date:~-10,2%"-"%date:~7,2%.zip" &
-    echo "32 Bit deployed" )
+    echo "32 Bit deployed" ) )
 
   - if %PLATFORM_%==amd64 (
     echo "----- Deploying 64 Bit Version -----" &
@@ -98,7 +102,8 @@ after_build:
     echo "zipping done" &
     echo "what's inside?" &
     call 7z.exe l "pencil2d-win64-%date:~-4,4%"-"%date:~-10,2%"-"%date:~7,2%.zip" &
+    if %upload%==yes (
     echo "deploying to google drive" &
     cd %APPVEYOR_BUILD_FOLDER%\util &
     call %PYTHON%\\python.exe nightly-build-upload.py "%WIN64_NIGHTLY_PARENT%" "%APPVEYOR_BUILD_FOLDER%\build\pencil2d-win64-%date:~-4,4%"-"%date:~-10,2%"-"%date:~7,2%.zip" &
-    echo "64 Bit Deployed" )
+    echo "64 Bit Deployed" ) )


### PR DESCRIPTION
See [`1d67de0` (comment)](https://github.com/pencil2d/pencil/commit/1d67de0751e1b91bc0ee765a2ab6f73a58f65ff1#commitcomment-22953496). The way I implemented it, nightly builds can still be uploaded by setting the environment variable FORCE_NIGHTLY_UPLOAD to yes (because that’s what I want).