### PR TITLE
Add Clear Menu item to recent files list

### DIFF
--- a/3rdlib/quazip/quazip.pro
+++ b/3rdlib/quazip/quazip.pro
@@ -10,6 +10,8 @@ CONFIG += staticlib
 
 INCLUDEPATH += ../zlib
 
+QMAKE_CXXFLAGS += -std=c++11
+
 # Input
 include(quazip.pri)
 

--- a/core_lib/interface/recentfilemenu.cpp
+++ b/core_lib/interface/recentfilemenu.cpp
@@ -19,12 +19,17 @@ GNU General Public License for more details.
 #include <QSettings>
 #include <QVariant>
 #include <QDebug>
+#include <QApplication>
 
 #include "recentfilemenu.h"
 
 RecentFileMenu::RecentFileMenu( QString title, QWidget *parent ) :
 QMenu( title, parent )
 {
+    mClearSeparator = new QAction();
+    mClearSeparator->setSeparator( true );
+
+    mClearAction = new QAction( tr("Clear Menu") );
 }
 
 void RecentFileMenu::clear()
@@ -92,6 +97,9 @@ void RecentFileMenu::addRecentFile( QString filename )
     if ( mRecentFiles.size() == 1 )
     {
         addAction( action );
+        addAction( mClearSeparator );
+        addAction( mClearAction );
+        QObject::connect( mClearAction, &QAction::triggered, this, &RecentFileMenu::clear );
     }
     else
     {

--- a/core_lib/interface/recentfilemenu.h
+++ b/core_lib/interface/recentfilemenu.h
@@ -41,7 +41,6 @@ public:
 
     QStringList getRecentFiles() { return mRecentFiles; }
     void setRecentFiles(QStringList filenames);
-    void clear();
     ListItemModel *getRecentFilesModel();
 
     void addRecentFile(QString filename);
@@ -53,12 +52,16 @@ public:
 signals:
     void loadRecentFile(QString filename);
 
+public slots:
+    void clear();
+
 protected slots:
     void onRecentFileTriggered();
 
 private:
     QStringList mRecentFiles;
     std::map<QString, QAction*> mRecentActions;
+    QAction *mClearAction, *mClearSeparator;
 };
 
 #endif // RECENTFILEMENU_H


### PR DESCRIPTION
Now there's a 'Clear Menu' item in the recent files submenu that functions similarly to the preferences button added in #686, except in a better place.
![screen shot 2017-07-09 at 1 29 01 am](https://user-images.githubusercontent.com/3461051/27991998-30b144dc-6446-11e7-9687-3be9bb67641d.png)
