### PR TITLE
Add option to lock widget positions

### DIFF
--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -352,6 +352,14 @@ void MainWindow2::createMenus()
         winMenu->addAction( action );
     }
 
+    winMenu->addSeparator();
+    QAction *lockWidgets = new QAction( tr( "Lock Windows" ), winMenu );
+    lockWidgets->setCheckable( true );
+    winMenu->addAction( lockWidgets );
+    connect( lockWidgets, &QAction::toggled, this, &MainWindow2::lockWidgets );
+    bindActionWithSetting( lockWidgets, SETTING::LAYOUT_LOCK );
+
+
     // -------------- Help Menu ---------------
     connect( ui->actionHelp, &QAction::triggered, this, &MainWindow2::helpBox);
     connect( ui->actionAbout, &QAction::triggered, this, &MainWindow2::aboutPencil );
@@ -696,6 +704,18 @@ void MainWindow2::importMovie()
         return;
     }
     mEditor->importMovie( filePath, mEditor->playback()->fps() );
+}
+
+void MainWindow2::lockWidgets(bool shouldLock)
+{
+    QDockWidget::DockWidgetFeature feat = shouldLock ? QDockWidget::DockWidgetClosable : QDockWidget::AllDockWidgetFeatures;
+
+    mColorWheel->setFeatures(feat);
+    mColorPalette->setFeatures(feat);
+    mDisplayOptionWidget->setFeatures(feat);
+    mToolOptions->setFeatures(feat);
+    mToolBox->setFeatures(feat);
+    mTimeLine->setFeatures(feat);
 }
 
 void MainWindow2::exportImageSequence()

--- a/app/mainwindow2.h
+++ b/app/mainwindow2.h
@@ -91,6 +91,8 @@ public:
 
     void importMovie();
 
+    void lockWidgets( bool shouldLock );
+
     void preferences();
     void helpBox();
     void aboutPencil();

--- a/core_lib/managers/preferencemanager.cpp
+++ b/core_lib/managers/preferencemanager.cpp
@@ -73,6 +73,8 @@ void PreferenceManager::loadPrefs()
 
     set( SETTING::BACKGROUND_STYLE,         settings.value( SETTING_BACKGROUND_STYLE,       "white" ).toString() );
 
+    set( SETTING::LAYOUT_LOCK,              settings.value( SETTING_LAYOUT_LOCK,            false ).toBool() );
+
     // Files
     set( SETTING::AUTO_SAVE,                settings.value( SETTING_AUTO_SAVE,              true ).toBool() );
     set( SETTING::AUTO_SAVE_NUMBER,         settings.value( SETTING_AUTO_SAVE_NUMBER,       20 ).toInt() );
@@ -303,6 +305,9 @@ void PreferenceManager::set( SETTING option, bool value )
         break;
     case SETTING::QUICK_SIZING:
         settings.setValue ( SETTING_QUICK_SIZING, value );
+        break;
+    case SETTING::LAYOUT_LOCK:
+        settings.setValue( SETTING_LAYOUT_LOCK, value );
         break;
     default:
         Q_ASSERT( false );

--- a/core_lib/managers/preferencemanager.h
+++ b/core_lib/managers/preferencemanager.h
@@ -59,6 +59,7 @@ enum class SETTING
     QUICK_SIZING,
     MULTILAYER_ONION,
     LANGUAGE,
+    LAYOUT_LOCK,
     COUNT, // COUNT must always be the last one.
 };
 

--- a/core_lib/util/pencildef.h
+++ b/core_lib/util/pencildef.h
@@ -163,6 +163,7 @@ enum BackgroundStyle
 #define SETTING_LABEL_FONT_SIZE     "LabelFontSize"
 #define SETTING_DRAW_LABEL          "DrawLabel"
 #define SETTING_QUICK_SIZING        "QuickSizing"
+#define SETTING_LAYOUT_LOCK         "LayoutLock"
 
 #define SETTING_ANTIALIAS        "Antialiasing"
 #define SETTING_SHOW_GRID        "ShowGrid"


### PR DESCRIPTION
This adds an action to the Windows menu that can be toggled to prevent the QDockWidgets from being dragged around or popped out.

Requested by Charmly here:
http://www.pencil2d.org/forums/topic/is-there-a-way-to-lock-the-windows/

Edit: Also thanks @Jose-Moreno for bringing this one to my attention with the Pencil document.