### PR TITLE
Fix segfault when repopulating RecentFileMenu after clearing it

### DIFF
--- a/core_lib/interface/recentfilemenu.cpp
+++ b/core_lib/interface/recentfilemenu.cpp
@@ -37,7 +37,8 @@ void RecentFileMenu::clear()
     {
         removeRecentFile( filename );
     }
-    QMenu::clear();
+    removeAction( mClearSeparator );
+    removeAction( mClearAction );
     mRecentFiles.clear();
     mRecentActions.clear();
 }

--- a/core_lib/interface/recentfilemenu.cpp
+++ b/core_lib/interface/recentfilemenu.cpp
@@ -31,6 +31,12 @@ QMenu( title, parent )
     mClearAction = new QAction( tr("Clear"), this ); // share the same translation
 }
 
+RecentFileMenu::~RecentFileMenu()
+{
+    delete mClearSeparator;
+    delete mClearAction;
+}
+
 void RecentFileMenu::clear()
 {
     for( QString filename : mRecentFiles )

--- a/core_lib/interface/recentfilemenu.h
+++ b/core_lib/interface/recentfilemenu.h
@@ -36,6 +36,7 @@ class RecentFileMenu : public QMenu
                  WRITE setRecentFiles )
 public:
     explicit RecentFileMenu(QString title = tr("Open Recent"), QWidget *parent = 0);
+    ~RecentFileMenu();
 
     static const int MAX_RECENT_FILES = 10;
 
@@ -60,8 +61,8 @@ protected slots:
 private:
     QStringList mRecentFiles;
     std::map<QString, QAction*> mRecentActions;
-	QAction* mClearAction = nullptr;
-	QAction* mClearSeparator = nullptr;
+    QAction* mClearAction = nullptr;
+    QAction* mClearSeparator = nullptr;
 };
 
 #endif // RECENTFILEMENU_H


### PR DESCRIPTION
The call to QMenu::clear() wasn’t doing anything we didn’t do ourselves anyway except for deleting QActions we still needed. Instead we are now simply removing the clear actions without deleting them right away.