### PR TITLE
Flood Fill algorithm rewritten

### DIFF
--- a/app/tooloptionwidget.cpp
+++ b/app/tooloptionwidget.cpp
@@ -177,9 +177,9 @@ void ToolOptionWidget::createUI()
     mInpolLevelsBox->setLayout(inpolLayout);
     inpolLayout->setSpacing(2);
 
-    mToleranceSlider = new SpinSlider( tr( "Tolerance" ), SpinSlider::LINEAR, SpinSlider::INTEGER, 1, 100, this );
+    mToleranceSlider = new SpinSlider( tr( "Color Tolerance" ), SpinSlider::LINEAR, SpinSlider::INTEGER, 1, 100, this );
     mToleranceSlider->setValue( settings.value( "Tolerance" ).toInt() );
-    mToleranceSlider->setToolTip( tr( "Set Fill tolerance" ) );
+    mToleranceSlider->setToolTip( tr( "The extend to which the color variation will be treated as being equal" ) );
 
     mToleranceSpinBox = new QSpinBox(this);
     mToleranceSpinBox->setRange(1,100);

--- a/core_lib/canvasrenderer.cpp
+++ b/core_lib/canvasrenderer.cpp
@@ -457,14 +457,14 @@ void CanvasRenderer::paintCameraBorder(QPainter &painter)
 
             LayerCamera* cameraLayer = dynamic_cast< LayerCamera* >( layer );
 
-            QRect cameraRect = cameraLayer->getViewRect();
+            mCameraRect = cameraLayer->getViewRect();
 
             painter.setWorldMatrixEnabled( true );
             painter.setPen( Qt::NoPen );
             painter.setBrush( QColor( 0, 0, 0, 160 ) );
 
             QRegion rg1(boundingRect);
-            QRegion rg2(cameraRect);
+            QRegion rg2(mCameraRect);
             QRegion rg3=rg1.subtracted(rg2);
 
             painter.setClipRegion(rg3);
@@ -480,7 +480,12 @@ void CanvasRenderer::paintCameraBorder(QPainter &painter)
                       Qt::MiterJoin );
             painter.setPen( pen );
             painter.setBrush( Qt::NoBrush );
-            painter.drawRect( cameraRect.adjusted( -1, -1, 1, 1) );
+            painter.drawRect( mCameraRect.adjusted( -1, -1, 1, 1) );
         }
     }
+}
+
+QRect CanvasRenderer::getCameraRect()
+{
+    return mCameraRect;
 }

--- a/core_lib/canvasrenderer.h
+++ b/core_lib/canvasrenderer.h
@@ -63,6 +63,7 @@ public:
     void setOptions( RenderOptions p ) { mOptions = p; }
     void setTransformedSelection( QRect selection, QTransform transform );
     void ignoreTransformedSelection();
+    QRect getCameraRect();
 
     void paint( Object* object, int layer, int frame, QRect rect );
 
@@ -83,6 +84,7 @@ private:
     QPixmap* mCanvas = nullptr;
     Object* mObject = nullptr;
     QTransform mViewTransform;
+    QRect mCameraRect;
 
     int mLayerIndex = 0;
     int mFrameNumber = 0;

--- a/core_lib/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/graphics/bitmap/bitmapimage.cpp
@@ -502,69 +502,71 @@ bool BitmapImage::compareColor(QRgb color1, QRgb color2, int tolerance)
 // ----- http://lodev.org/cgtutor/floodfill.html
 void BitmapImage::floodFill(BitmapImage* targetImage, QRect cameraRect, QPoint point, QRgb oldColor, QRgb newColor, int tolerance)
 {
-    if (oldColor == newColor){
+    if ( oldColor == newColor ){
         return;
     }
 
-    oldColor = targetImage->pixel(point);
-    oldColor = qRgba(qRed(oldColor), qGreen(oldColor), qBlue(oldColor), qAlpha(oldColor));
+    oldColor = targetImage->pixel( point );
+    oldColor = qRgba( qRed(oldColor), qGreen(oldColor), qBlue(oldColor), qAlpha(oldColor) );
 
     // Preparations
     QList<QPoint> queue; // queue all the pixels of the filled area (as they are found)
 
     BitmapImage* replaceImage = nullptr;
     QPoint tempPoint;
-
     QRgb newPlacedColor;
 
     int xTemp;
     bool spanLeft, spanRight;
 
-    targetImage->extend(cameraRect);
+    // Extend to size of Camera
+    targetImage->extend( cameraRect );
     replaceImage = new BitmapImage(cameraRect, Qt::transparent);
 
     queue.append( point );
     // Preparations END
 
-    while (!queue.empty()) {
+    while ( !queue.empty() ) {
         tempPoint = queue.takeFirst();
 
-        point.setX(tempPoint.x());
-        point.setY(tempPoint.y());
+        point.setX( tempPoint.x() );
+        point.setY( tempPoint.y() );
 
         xTemp = point.x();
 
-        newPlacedColor = replaceImage->constScanLine(xTemp,point.y());
-        while (xTemp >= targetImage->topLeft().x() &&
-               compareColor( targetImage->constScanLine(xTemp, point.y()) , oldColor, tolerance)) xTemp--;
+        newPlacedColor = replaceImage->constScanLine(xTemp, point.y() );
+        while ( xTemp >= targetImage->topLeft().x() &&
+               compareColor( targetImage->constScanLine(xTemp, point.y()) , oldColor, tolerance) ) xTemp--;
         xTemp++;
 
         spanLeft = spanRight = false;
-        while (xTemp <= targetImage->right() &&
+        while ( xTemp <= targetImage->right() &&
                compareColor( targetImage->constScanLine(xTemp, point.y()), oldColor, tolerance) &&
-               newPlacedColor != newColor) {
+               newPlacedColor != newColor ) {
 
             // Set pixel color
-            replaceImage->scanLine(xTemp, point.y(), newColor);
+            replaceImage->scanLine( xTemp, point.y(), newColor );
 
-            if (!spanLeft && (point.y() > targetImage->top() ) &&
-                    compareColor( targetImage->constScanLine(xTemp, point.y() - 1), oldColor, tolerance)) {
-                queue.append(QPoint(xTemp, point.y() - 1));
+            if ( !spanLeft && (point.y() > targetImage->top() ) &&
+                    compareColor( targetImage->constScanLine( xTemp, point.y() -1 ), oldColor, tolerance) ) {
+                queue.append( QPoint( xTemp, point.y() - 1) );
                 spanLeft = true;
-            } else if(spanLeft && (point.y() > targetImage->top()) &&
-                      !compareColor( targetImage->constScanLine(xTemp, point.y() - 1), oldColor, tolerance)) {
+            } else if( spanLeft && (point.y() > targetImage->top() ) &&
+                      !compareColor( targetImage->constScanLine( xTemp, point.y() - 1 ), oldColor, tolerance) ) {
                 spanLeft = false;
             }
 
             if (!spanRight && point.y() < targetImage->bottom() &&
-                    compareColor( targetImage->constScanLine(xTemp, point.y() + 1), oldColor, tolerance)) {
-                queue.append(QPoint(xTemp, point.y() + 1));
+                    compareColor( targetImage->constScanLine( xTemp, point.y() + 1 ), oldColor, tolerance) ) {
+                queue.append( QPoint( xTemp, point.y() + 1 ) );
                 spanRight = true;
 
-            } else if(spanRight && point.y() < targetImage->bottom() &&
-                      !compareColor( targetImage->constScanLine(xTemp, point.y() + 1), oldColor, tolerance)) {
+            } else if( spanRight && point.y() < targetImage->bottom() &&
+                      !compareColor( targetImage->constScanLine( xTemp, point.y() + 1 ), oldColor, tolerance) ) {
                 spanRight = false;
             }
+
+            Q_ASSERT( queue.count() < (targetImage->width() * targetImage->height() ) );
             xTemp++;
         }
     }

--- a/core_lib/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/graphics/bitmap/bitmapimage.cpp
@@ -428,6 +428,21 @@ void BitmapImage::clear()
     mBounds = QRect(0,0,0,0);
 }
 
+void BitmapImage::scanLine(int x, int y, QRgb colour)
+{
+//    extend( P );
+    if( mBounds.contains(QPoint(x,y) ) ) {
+
+        // setting pixels directly requires to multiply wihh alpha and div 255
+        // manually for premultiplied images.
+        *( (QRgb*) mImage->scanLine(y - topLeft().y()) + x - topLeft().x() ) =
+                qRgba( qRed ( colour ) * qAlpha( colour ) / 255,
+                       qGreen ( colour ) * qAlpha( colour ) / 255,
+                       qBlue ( colour ) * qAlpha( colour ) / 255,
+                       qAlpha ( colour ) );
+    }
+}
+
 void BitmapImage::clear(QRect rectangle)
 {
     QRect clearRectangle = mBounds.intersected( rectangle );
@@ -463,7 +478,7 @@ bool BitmapImage::compareColor(QRgb color1, QRgb color2, int tolerance)
     int diffBlue = abs( blue2 - blue1 );
     int diffAlpha = abs( alpha2 - alpha1 );
 
-    qDebug() << diffRed << " " << diffGreen << " " << diffBlue << " " << diffAlpha << " " << tolerance;
+//    qDebug() << diffRed << " " << diffGreen << " " << diffBlue << " " << diffAlpha << " " << tolerance;
 
     if ( diffRed > tolerance ||
          diffGreen > tolerance ||
@@ -517,10 +532,10 @@ void BitmapImage::floodFill(BitmapImage* targetImage, BitmapImage* fillImage, QP
         spanLeft = spanRight = false;
         while (yTemp < fillImage->height() &&
                compareColor(fillImage->pixel(point.x(), yTemp), oldColor, tolerance) ) {
-//            fillImage->setPixel(point.x(), yTemp, qRgb(qRed(newColor), qGreen(newColor), qBlue(newColor)));
-              fillImage->setPixel(point.x(), yTemp, newColor);
+//            fillImage->setPixel(point.x(), yTemp, qRgba(qRed(newColor) * qAlpha(newColor) / 255, qGreen(newColor) * qAlpha(newColor) / 255, qBlue(newColor) * qAlpha(newColor) / 255, qAlpha(newColor )));
+//              fillImage->setPixel(point.x(), yTemp, newColor);
+            fillImage->scanLine(point.x(), yTemp, newColor);
 
-//            fillImage->image()->scanLine((yTemp)+point.x()); // figure out how scanline works
             if (!spanLeft && (point.x() > fillImage->left() || point.x() < fillImage->right()) &&
                     compareColor(fillImage->pixel(point.x() - 1, yTemp), oldColor, tolerance)) {
                 queue.append(QPoint(point.x() - 1, yTemp));

--- a/core_lib/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/graphics/bitmap/bitmapimage.cpp
@@ -112,7 +112,7 @@ void BitmapImage::paste(BitmapImage* bitmapImage, QPainter::CompositionMode cm)
     extend( newBoundaries );
 
     QImage* image2 = bitmapImage->image();
-    
+
     QPainter painter( mImage.get() );
     painter.setCompositionMode(cm);
     painter.drawImage( bitmapImage->mBounds.topLeft() - mBounds.topLeft(), *image2);
@@ -410,7 +410,7 @@ void BitmapImage::drawPath( QPainterPath path, QPen pen, QBrush brush,
                     painter.drawPoint( QPointF( x, y ) );
                 }
             }
-            
+
             //painter.drawPath( path );
         }
         else
@@ -429,9 +429,9 @@ void BitmapImage::clear()
 }
 
 QRgb BitmapImage::constScanLine(int x, int y) {
-    QRgb result = qRgba(0,0,0,0);
-    if ( mBounds.contains( QPoint(x,y) ) ) {
-        result = *(reinterpret_cast< const QRgb* >(mImage->constScanLine( y - topLeft().y() ) )+ x - topLeft().x());
+    QRgb result = qRgba( 0, 0, 0, 0 );
+    if ( mBounds.contains( QPoint( x, y ) ) ) {
+        result = *( reinterpret_cast< const QRgb* >( mImage->constScanLine( y - topLeft().y() ) ) + x - topLeft().x() );
     }
 
     return result;
@@ -439,11 +439,11 @@ QRgb BitmapImage::constScanLine(int x, int y) {
 
 void BitmapImage::scanLine(int x, int y, QRgb colour)
 {
-    extend( QPoint(x,y) );
-    if( mBounds.contains(QPoint(x,y) ) ) {
+    extend( QPoint( x, y ) );
+    if( mBounds.contains( QPoint( x, y ) ) ) {
 
         // Make sure color is premultiplied before calling
-        *(reinterpret_cast< QRgb* >(mImage->scanLine(y - topLeft().y())) + x - topLeft().x()) =
+        *( reinterpret_cast< QRgb* >( mImage->scanLine( y - topLeft().y() ) ) + x - topLeft().x() ) =
                  qRgba(
                        qRed( colour ),
                        qGreen( colour ),
@@ -456,7 +456,7 @@ void BitmapImage::clear(QRect rectangle)
 {
     QRect clearRectangle = mBounds.intersected( rectangle );
     clearRectangle.moveTopLeft( clearRectangle.topLeft() - topLeft() );
-    
+
     QPainter painter( mImage.get() );
     painter.setCompositionMode(QPainter::CompositionMode_Clear);
     painter.fillRect( clearRectangle, QColor(0,0,0,0) );
@@ -470,17 +470,17 @@ int BitmapImage::pow(int n)   // pow of a number
 
 bool BitmapImage::compareColor(QRgb color1, QRgb color2, int tolerance)
 {
-    if (color1 == color2) return true;
+    if ( color1 == color2 ) return true;
 
-    int red1 = qRed(color1);
-    int green1 = qGreen(color1);
-    int blue1 = qBlue(color1);
-    int alpha1 = qAlpha(color1);
+    int red1 = qRed( color1 );
+    int green1 = qGreen( color1 );
+    int blue1 = qBlue( color1 );
+    int alpha1 = qAlpha( color1 );
 
-    int red2 = qRed(color2);
-    int green2 = qGreen(color2);
-    int blue2 = qBlue(color2);
-    int alpha2 = qAlpha(color2);
+    int red2 = qRed( color2 );
+    int green2 = qGreen( color2 );
+    int blue2 = qBlue( color2 );
+    int alpha2 = qAlpha( color2 );
 
     int diffRed = abs( red2 - red1 );
     int diffGreen = abs( green2 - green1 );
@@ -507,7 +507,7 @@ void BitmapImage::floodFill(BitmapImage* targetImage, QRect cameraRect, QPoint p
     }
 
     oldColor = targetImage->pixel( point );
-    oldColor = qRgba( qRed(oldColor), qGreen(oldColor), qBlue(oldColor), qAlpha(oldColor) );
+    oldColor = qRgba( qRed( oldColor ), qGreen( oldColor ), qBlue( oldColor ), qAlpha( oldColor ) );
 
     // Preparations
     QList<QPoint> queue; // queue all the pixels of the filled area (as they are found)
@@ -521,12 +521,12 @@ void BitmapImage::floodFill(BitmapImage* targetImage, QRect cameraRect, QPoint p
 
     // Extend to size of Camera
     targetImage->extend( cameraRect );
-    replaceImage = new BitmapImage(cameraRect, Qt::transparent);
+    replaceImage = new BitmapImage( cameraRect, Qt::transparent );
 
     queue.append( point );
     // Preparations END
 
-    while ( !queue.empty() ) {
+    while( !queue.empty() ) {
         tempPoint = queue.takeFirst();
 
         point.setX( tempPoint.x() );
@@ -534,43 +534,43 @@ void BitmapImage::floodFill(BitmapImage* targetImage, QRect cameraRect, QPoint p
 
         xTemp = point.x();
 
-        newPlacedColor = replaceImage->constScanLine(xTemp, point.y() );
-        while ( xTemp >= targetImage->topLeft().x() &&
-               compareColor( targetImage->constScanLine(xTemp, point.y()) , oldColor, tolerance) ) xTemp--;
+        newPlacedColor = replaceImage->constScanLine( xTemp, point.y() );
+        while( xTemp >= targetImage->topLeft().x() &&
+               compareColor( targetImage->constScanLine( xTemp, point.y() ), oldColor, tolerance) ) xTemp--;
         xTemp++;
 
         spanLeft = spanRight = false;
-        while ( xTemp <= targetImage->right() &&
-               compareColor( targetImage->constScanLine(xTemp, point.y()), oldColor, tolerance) &&
+        while( xTemp <= targetImage->right() &&
+               compareColor( targetImage->constScanLine( xTemp, point.y() ), oldColor, tolerance ) &&
                newPlacedColor != newColor ) {
 
             // Set pixel color
             replaceImage->scanLine( xTemp, point.y(), newColor );
 
-            if ( !spanLeft && (point.y() > targetImage->top() ) &&
-                    compareColor( targetImage->constScanLine( xTemp, point.y() -1 ), oldColor, tolerance) ) {
+            if( !spanLeft && (point.y() > targetImage->top() ) &&
+                    compareColor( targetImage->constScanLine( xTemp, point.y() - 1 ), oldColor, tolerance ) ) {
                 queue.append( QPoint( xTemp, point.y() - 1) );
                 spanLeft = true;
-            } else if( spanLeft && (point.y() > targetImage->top() ) &&
-                      !compareColor( targetImage->constScanLine( xTemp, point.y() - 1 ), oldColor, tolerance) ) {
+            } else if( spanLeft && ( point.y() > targetImage->top() ) &&
+                      !compareColor( targetImage->constScanLine( xTemp, point.y() - 1 ), oldColor, tolerance ) ) {
                 spanLeft = false;
             }
 
-            if (!spanRight && point.y() < targetImage->bottom() &&
-                    compareColor( targetImage->constScanLine( xTemp, point.y() + 1 ), oldColor, tolerance) ) {
+            if( !spanRight && point.y() < targetImage->bottom() &&
+                    compareColor( targetImage->constScanLine( xTemp, point.y() + 1 ), oldColor, tolerance ) ) {
                 queue.append( QPoint( xTemp, point.y() + 1 ) );
                 spanRight = true;
 
             } else if( spanRight && point.y() < targetImage->bottom() &&
-                      !compareColor( targetImage->constScanLine( xTemp, point.y() + 1 ), oldColor, tolerance) ) {
+                      !compareColor( targetImage->constScanLine( xTemp, point.y() + 1 ), oldColor, tolerance ) ) {
                 spanRight = false;
             }
 
-            Q_ASSERT( queue.count() < (targetImage->width() * targetImage->height() ) );
+            Q_ASSERT( queue.count() < ( targetImage->width() * targetImage->height() ) );
             xTemp++;
         }
     }
 
-    targetImage->paste(replaceImage);
+    targetImage->paste( replaceImage );
     delete replaceImage;
 }

--- a/core_lib/graphics/bitmap/bitmapimage.h
+++ b/core_lib/graphics/bitmap/bitmapimage.h
@@ -44,6 +44,7 @@ public:
     BitmapImage copy( QRect rectangle );
     void paste( BitmapImage* );
     void paste( BitmapImage*, QPainter::CompositionMode cm );
+
     void add( BitmapImage* );
     void compareAlpha( BitmapImage* );
     void moveTopLeft( QPoint point );
@@ -67,9 +68,9 @@ public:
     void clear( QRect rectangle );
     void clear( QRectF rectangle ) { clear( rectangle.toRect() ); }
 
-    static int pow( int );
-    static int rgbDistance( QRgb rgba1, QRgb rgba2 );
-    static void floodFill( BitmapImage* targetImage, BitmapImage* fillImage, QPoint point, QRgb targetColour, QRgb replacementColour, int tolerance, bool extendFillImage );
+    int pow( int );
+    int rgbDistance( QRgb rgba1, QRgb rgba2 );
+    void floodFill(BitmapImage* fillImage, QPoint point, QRgb oldColor, QRgb replacementColour, int tolerance, bool extendFillImage );
 
     void drawLine( QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm, bool antialiasing );
     void drawRect( QRectF rectangle, QPen pen, QBrush brush, QPainter::CompositionMode cm, bool antialiasing );

--- a/core_lib/graphics/bitmap/bitmapimage.h
+++ b/core_lib/graphics/bitmap/bitmapimage.h
@@ -64,6 +64,7 @@ public:
     QRgb pixel( QPoint P );
     void setPixel( int x, int y, QRgb colour );
     void setPixel( QPoint P, QRgb colour );
+    void scanLine( int x, int y, QRgb colour);
     void clear();
     void clear( QRect rectangle );
     void clear( QRectF rectangle ) { clear( rectangle.toRect() ); }

--- a/core_lib/graphics/bitmap/bitmapimage.h
+++ b/core_lib/graphics/bitmap/bitmapimage.h
@@ -64,6 +64,7 @@ public:
     QRgb pixel( QPoint P );
     void setPixel( int x, int y, QRgb colour );
     void setPixel( QPoint P, QRgb colour );
+    QRgb constScanLine(int x, int y);
     void scanLine( int x, int y, QRgb colour);
     void clear();
     void clear( QRect rectangle );
@@ -71,7 +72,7 @@ public:
 
     static int pow( int );
     static bool compareColor(QRgb color1, QRgb color2, int tolerance);
-    static void floodFill(BitmapImage* targetImage, BitmapImage* fillImage, QPoint point, QRgb oldColor, QRgb newColor, int tolerance, bool extendFillImage );
+    static void floodFill(BitmapImage* targetImage, QRect cameraRect, QPoint point, QRgb oldColor, QRgb newColor, int tolerance );
 
     void drawLine( QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm, bool antialiasing );
     void drawRect( QRectF rectangle, QPen pen, QBrush brush, QPainter::CompositionMode cm, bool antialiasing );

--- a/core_lib/graphics/bitmap/bitmapimage.h
+++ b/core_lib/graphics/bitmap/bitmapimage.h
@@ -68,9 +68,9 @@ public:
     void clear( QRect rectangle );
     void clear( QRectF rectangle ) { clear( rectangle.toRect() ); }
 
-    int pow( int );
-    int rgbDistance( QRgb rgba1, QRgb rgba2 );
-    void floodFill(BitmapImage* fillImage, QPoint point, QRgb oldColor, QRgb replacementColour, int tolerance, bool extendFillImage );
+    static int pow( int );
+    static bool compareColor(QRgb color1, QRgb color2, int tolerance);
+    static void floodFill(BitmapImage* targetImage, BitmapImage* fillImage, QPoint point, QRgb oldColor, QRgb newColor, int tolerance, bool extendFillImage );
 
     void drawLine( QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm, bool antialiasing );
     void drawRect( QRectF rectangle, QPen pen, QBrush brush, QPainter::CompositionMode cm, bool antialiasing );

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1233,6 +1233,11 @@ QRectF ScribbleArea::getViewRect()
     }
 }
 
+QRectF ScribbleArea::getCameraRect()
+{
+    return mCanvasRenderer.getCameraRect();
+}
+
 QPointF ScribbleArea::getCentralPoint()
 {
     return mEditor->view()->mapScreenToCanvas( QPointF( width() / 2, height() / 2 ) );

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -88,6 +88,7 @@ public:
 
     QTransform getView();
     QRectF getViewRect();
+    QRectF getCameraRect();
     QPointF getCentralPoint();
 
     void updateCurrentFrame();

--- a/core_lib/managers/toolmanager.cpp
+++ b/core_lib/managers/toolmanager.cpp
@@ -122,7 +122,7 @@ void ToolManager::resetAllTools()
     getTool( BRUSH )->properties.inpolLevel = -1;
     getTool( SMUDGE )->properties.width = 25.0;
     getTool( SMUDGE )->properties.feather = 200.0;
-    getTool( BUCKET )->properties.tolerance = 100.0;
+    getTool( BUCKET )->properties.tolerance = 10.0;
 
     // todo: add all the default settings
 

--- a/core_lib/tool/buckettool.cpp
+++ b/core_lib/tool/buckettool.cpp
@@ -130,11 +130,14 @@ void BucketTool::paintBitmap(Layer* layer)
     int layerNumber = mEditor->layers()->currentLayerIndex(); // by default
 
     BitmapImage *targetImage = ( ( LayerBitmap * )targetLayer )->getLastBitmapImageAtFrame( mEditor->currentFrame(), 0 );
+    QRgb oldColor = sourceImage->pixel(getLastPoint().toPoint().x(), getLastPoint().toPoint().y());
 
-    BitmapImage::floodFill( sourceImage,
-                            targetImage,
-                            getLastPoint().toPoint(),
-                            qRgba( 0, 0, 0, 0 ),
+    QPoint point = getLastPoint().toPoint();
+
+    BitmapImage bitmapImage;
+    bitmapImage.floodFill( targetImage,
+                            point,
+                            oldColor,
                             mEditor->color()->frontColor().rgba(),
                             properties.tolerance * 2.2,
                             true );

--- a/core_lib/tool/buckettool.cpp
+++ b/core_lib/tool/buckettool.cpp
@@ -125,22 +125,21 @@ void BucketTool::mouseMoveEvent( QMouseEvent *event )
 
 void BucketTool::paintBitmap(Layer* layer)
 {
-    BitmapImage *sourceImage = ( ( LayerBitmap * )layer )->getLastBitmapImageAtFrame( mEditor->currentFrame(), 0 );
     Layer *targetLayer = layer; // by default
     int layerNumber = mEditor->layers()->currentLayerIndex(); // by default
 
     BitmapImage *targetImage = ( ( LayerBitmap * )targetLayer )->getLastBitmapImageAtFrame( mEditor->currentFrame(), 0 );
-    QRgb oldColor = sourceImage->pixel(getLastPoint().toPoint().x(), getLastPoint().toPoint().y());
 
     QPoint point = getLastPoint().toPoint();
 
-    BitmapImage::floodFill( sourceImage,
-                            targetImage,
+    QRect cameraRect = mScribbleArea->getCameraRect().toRect();
+
+    BitmapImage::floodFill( targetImage,
+                            cameraRect,
                             point,
-                            oldColor,
-                            mEditor->color()->frontColor().rgba(),
-                            properties.tolerance * 2.55,
-                            false );
+                            Qt::transparent,
+                            qPremultiply(mEditor->color()->frontColor().rgba()),
+                            properties.tolerance * 2.55 );
 
     mScribbleArea->setModified( layerNumber, mEditor->currentFrame() );
     mScribbleArea->setAllDirty();

--- a/core_lib/tool/buckettool.cpp
+++ b/core_lib/tool/buckettool.cpp
@@ -49,7 +49,7 @@ void BucketTool::loadSettings()
     properties.feather = 10;
     properties.inpolLevel = -1;
     properties.useAA = -1;
-    properties.tolerance = 100;
+    properties.tolerance = 10;
 
     m_enabledProperties[TOLERANCE] = true;
 }
@@ -59,8 +59,6 @@ QCursor BucketTool::cursor()
     if( mEditor->preference()->isOn( SETTING::TOOL_CURSOR ) ) {
         QPixmap pixmap( ":icons/bucketTool.png" );
         QPainter painter( &pixmap );
-        painter.setPen( Qt::blue );   // FIXME: need to get current color
-        painter.drawLine( QPoint( 5, 16 ), QPoint( 5, 18 ) );
         painter.end();
 
         return QCursor( pixmap, 4, 20 );
@@ -138,7 +136,7 @@ void BucketTool::paintBitmap(Layer* layer)
                             cameraRect,
                             point,
                             Qt::transparent,
-                            qPremultiply(mEditor->color()->frontColor().rgba()),
+                            qPremultiply( mEditor->color()->frontColor().rgba() ),
                             properties.tolerance * 2.55 );
 
     mScribbleArea->setModified( layerNumber, mEditor->currentFrame() );

--- a/core_lib/tool/buckettool.cpp
+++ b/core_lib/tool/buckettool.cpp
@@ -134,13 +134,13 @@ void BucketTool::paintBitmap(Layer* layer)
 
     QPoint point = getLastPoint().toPoint();
 
-    BitmapImage bitmapImage;
-    bitmapImage.floodFill( targetImage,
+    BitmapImage::floodFill( sourceImage,
+                            targetImage,
                             point,
                             oldColor,
                             mEditor->color()->frontColor().rgba(),
-                            properties.tolerance * 2.2,
-                            true );
+                            properties.tolerance * 2.55,
+                            false );
 
     mScribbleArea->setModified( layerNumber, mEditor->currentFrame() );
     mScribbleArea->setAllDirty();


### PR DESCRIPTION
Floodfill algorithm has been rewritten from scratch.
![flood fill](https://user-images.githubusercontent.com/1045397/28572815-d3416d6c-7148-11e7-947f-ba1255146b1f.gif)

New:
+ Filling outside a figure (or on a empty canvas) will lead to filling the size of the camera, the effect is similar to that of filling a fixed canvas in a painting application.
+ Support alpha values

Edits:
+ rephrased tolerance tooltip
+ set default tolerance to 10

Remaining issues?
When you click outside the camera area, filling the empty space, the fill behaviour will become similar to the old algorithm, filling a temp rect. It's a minor issue, but I thought I would mention it anyway.