### PR TITLE
fix selection rect not being removed when pressing backspace

### DIFF
--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -242,11 +242,6 @@ void ScribbleArea::setModified( int layerNumber, int frameNumber )
 /* key event handlers                                                   */
 /************************************************************************/
 
-void ScribbleArea::escape()
-{
-    deselectAll();
-}
-
 void ScribbleArea::keyPressEvent( QKeyEvent *event )
 {
     // Don't handle this event on auto repeat
@@ -349,7 +344,7 @@ void ScribbleArea::keyPressEvent( QKeyEvent *event )
         case Qt::Key_Escape:
             if ( somethingSelected )
             {
-                escape();
+                deselectAll();
                 applyTransformedSelection();
             }
             break;
@@ -357,6 +352,7 @@ void ScribbleArea::keyPressEvent( QKeyEvent *event )
             if ( somethingSelected )
             {
                 deleteSelection();
+                deselectAll();
             }
             break;
         case Qt::Key_Space:
@@ -1555,7 +1551,7 @@ void ScribbleArea::setCurrentTool( ToolType eToolMode )
         }
         else if ( currentTool()->type() == POLYLINE )
         {
-            escape();
+            deselectAll();
         }
     }
 

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -138,7 +138,6 @@ public slots:
     void toggleThinLines();
     void toggleOutlines();
     void toggleShowAllLayers();
-    void escape();
 
     void updateToolCursor();
     void paletteColorChanged(QColor);


### PR DESCRIPTION
note: this only occurred when selecting vector curves.