### PR TITLE
Draw circle cursor within canvas area

### DIFF
--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -851,6 +851,7 @@ void MainWindow2::preferences()
         //qDebug() << "Preference dialog closed!";
         clearKeyboardShortcuts();
         setupKeyboardShortcuts();
+        mScribbleArea->updateCanvasCursor();
     } );
 
     mPrefDialog->show();

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -83,6 +83,8 @@ bool ScribbleArea::init()
     mOffset.setY( 0 );
     selectionTransformation.reset();
 
+    updateCanvasCursor();
+
     tol = 7.0;
 
     setMouseTracking( true ); // reacts to mouse move events, even if the button is not pressed
@@ -141,6 +143,7 @@ void ScribbleArea::settingUpdated(SETTING setting)
 void ScribbleArea::updateToolCursor()
 {
     setCursor( currentTool()->cursor() );
+    updateCanvasCursor();
     updateAllFrames();
 }
 
@@ -605,6 +608,7 @@ void ScribbleArea::mouseMoveEvent( QMouseEvent *event )
             ToolPropertyType tool_type;
             tool_type = event->modifiers() & Qt::ControlModifier ? FEATHER : WIDTH;
             currentTool()->adjustCursor( mOffset.x(), tool_type ); //updates cursors given org width or feather and x
+            updateCanvasCursor();
             return;
         }
     }
@@ -616,6 +620,9 @@ void ScribbleArea::mouseMoveEvent( QMouseEvent *event )
     }
 
     currentTool()->mouseMoveEvent( event );
+
+    // used to clear and update canvas cursor
+    update();
 
 #ifdef DEBUG_FPS
     // debug fps count.
@@ -821,6 +828,33 @@ void ScribbleArea::refreshVector( const QRectF& rect, int rad )
     //update();
 }
 
+void ScribbleArea::paintCanvasCursor( QPainter& painter )
+{
+    QPoint center( 0,0 );
+    center.setX( ( mCursorImg.width() ) / 2 );
+    center.setY( ( mCursorImg.height() ) / 2 );
+    QPoint mousePos = currentTool()->getCurrentPoint().toPoint();
+    painter.drawPixmap( QPoint( mousePos.x() - center.x(),
+                                mousePos.y() - center.y() ),
+                                mCursorImg );
+}
+
+void ScribbleArea::updateCanvasCursor()
+{
+    if ( currentTool()->isAdjusting )
+    {
+        mCursorImg = currentTool()->quickSizeCursor();
+    }
+    else if ( mEditor->preference()->isOn( SETTING::DOTTED_CURSOR ) )
+    {
+        mCursorImg = currentTool()->canvasCursor();
+    } else
+    {
+        // if above does not comply, delocate image
+        mCursorImg = QPixmap();
+    }
+}
+
 void ScribbleArea::paintEvent( QPaintEvent* event )
 {
     if ( !mMouseInUse || currentTool()->type() == MOVE || currentTool()->type() == HAND )
@@ -978,7 +1012,11 @@ void ScribbleArea::paintEvent( QPaintEvent* event )
             {
                 painter.setWorldMatrixEnabled( false );
             }
+
+            // TODO: move to above if vector statement
             mBufferImg->paintImage( painter );
+
+            paintCanvasCursor( painter );
         }
 
         // paints the selection outline
@@ -1563,6 +1601,7 @@ void ScribbleArea::setCurrentTool( ToolType eToolMode )
 
     // --- change cursor ---
     setCursor( currentTool()->cursor() );
+    updateCanvasCursor();
     qDebug() << "fn: setCurrentTool " << "call: setCursor()" << "current tool" << currentTool()->typeName();
 }
 

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -167,13 +167,18 @@ public:
 
     void paintBitmapBuffer();
     void paintBitmapBufferRect( QRect rect );
+    void paintCanvasCursor( QPainter& painter );
     void clearBitmapBuffer();
     void refreshBitmap( const QRectF& rect, int rad );
     void refreshVector( const QRectF& rect, int rad );
     void setGaussianGradient( QGradient &gradient, QColor colour, qreal opacity, qreal offset );
 
+    void updateCanvasCursor();
+
     BitmapImage* mBufferImg = nullptr; // used to pre-draw vector modifications
     BitmapImage* mStrokeImg = nullptr; // used for brush strokes before they are finalized
+
+    QPixmap mCursorImg;
 
 private:
     void drawCanvas( int frame, QRect rect );

--- a/core_lib/tool/basetool.h
+++ b/core_lib/tool/basetool.h
@@ -23,6 +23,8 @@ GNU General Public License for more details.
 #include <QCursor>
 #include <QMouseEvent>
 #include <QPointF>
+#include <QPixmap>
+#include <QPen>
 #include "pencildef.h"
 
 class Editor;
@@ -89,8 +91,8 @@ public:
     virtual void clear() {}
 
     static bool isAdjusting;
-    QCursor circleCursors(); //precision circular cursor: used for assisted cursor adjustment (wysiwyg)
-    QCursor dottedCursor(); //precision circular cursor: used for seeing stroke size before it happens (wysiwyg)
+    QPixmap canvasCursor();
+    QPixmap quickSizeCursor();
 
     virtual void setWidth( const qreal width );
     virtual void setFeather( const qreal feather );
@@ -127,6 +129,20 @@ protected:
     ScribbleArea* mScribbleArea = nullptr;
     StrokeManager* m_pStrokeManager = nullptr;
     qreal mAdjustmentStep = 0.0f;
+
+private:
+    int propWidth;
+    int propFeather;
+    int width;
+    int cursorWidth;
+
+    int radius;
+    int xyA;
+    int xyB;
+    int whA;
+    int whB;
+    QPixmap cursorPixmap;
+    QPen cursorPen;
 };
 
 #endif // BASETOOL_H

--- a/core_lib/tool/brushtool.cpp
+++ b/core_lib/tool/brushtool.cpp
@@ -157,15 +157,7 @@ void BrushTool::setAA( const int AA )
 
 QCursor BrushTool::cursor()
 {
-    if ( isAdjusting ) // being dynamically resized
-    {
-        return circleCursors(); // two circles cursor
-    }
-    if ( mEditor->preference()->isOn( SETTING::DOTTED_CURSOR ) )
-    {
-        return dottedCursor(); // preview stroke size cursor
-    }
-    if ( mEditor->preference()->isOn( SETTING::TOOL_CURSOR ) ) // doesn't need else
+    if ( mEditor->preference()->isOn( SETTING::TOOL_CURSOR ) )
     {
         return QCursor( QPixmap( ":icons/brush.png" ), 0, 13 );
     }

--- a/core_lib/tool/erasertool.cpp
+++ b/core_lib/tool/erasertool.cpp
@@ -112,18 +112,6 @@ void EraserTool::setInpolLevel(const int level)
 
 QCursor EraserTool::cursor()
 {
-    if ( isAdjusting ) // being dynamically resized
-    {
-        return circleCursors(); // two circles cursor
-    }
-    if ( mEditor->preference()->isOn( SETTING::DOTTED_CURSOR ) )
-    {
-        return dottedCursor(); // preview stroke size cursor
-    }
-    if ( mEditor->preference()->isOn( SETTING::TOOL_CURSOR ) )
-    {
-        return circleCursors();
-    }
     return Qt::CrossCursor;
 }
 

--- a/core_lib/tool/penciltool.cpp
+++ b/core_lib/tool/penciltool.cpp
@@ -126,14 +126,6 @@ void PencilTool::setUseFillContour(const bool useFillContour)
 
 QCursor PencilTool::cursor()
 {
-    if ( isAdjusting ) // being dynamically resized
-    {
-        return circleCursors(); // two circles cursor
-    }
-    if ( mEditor->preference()->isOn( SETTING::DOTTED_CURSOR ) )
-    {
-        return dottedCursor(); // preview stroke size cursor
-    }
     if ( mEditor->preference()->isOn( SETTING::TOOL_CURSOR ) )
     {
         return QCursor( QPixmap( ":icons/pencil2.png" ), 0, 16 );

--- a/core_lib/tool/pentool.cpp
+++ b/core_lib/tool/pentool.cpp
@@ -104,17 +104,9 @@ void PenTool::setInpolLevel(const int level)
 
 QCursor PenTool::cursor()
 {
-    if ( isAdjusting ) // being dynamically resized
-    {
-        return circleCursors(); // two circles cursor
-    }
-    if ( mEditor->preference()->isOn( SETTING::DOTTED_CURSOR ) )
-    {
-        return dottedCursor(); // preview stroke size cursor
-    }
     if ( mEditor->preference()->isOn( SETTING::TOOL_CURSOR ) )
     {
-        return QCursor( QPixmap( ":icons/pen.png" ), 2, 22 );
+        return QCursor( QPixmap( ":icons/pen.png" ), -5, 0 );
     }
     return Qt::CrossCursor;
 }

--- a/core_lib/tool/polylinetool.cpp
+++ b/core_lib/tool/polylinetool.cpp
@@ -88,12 +88,8 @@ void PolylineTool::setAA( const int AA )
     settings.sync();
 }
 
-QCursor PolylineTool::cursor() //Not working this one, any guru to fix it?
+QCursor PolylineTool::cursor()
 {
-    if ( isAdjusting ) { // being dynamically resized
-        qDebug() << "adjusting";
-        return QCursor( this->circleCursors() ); // two circles cursor
-    }
     return Qt::CrossCursor;
 }
 

--- a/core_lib/tool/smudgetool.cpp
+++ b/core_lib/tool/smudgetool.cpp
@@ -96,18 +96,10 @@ void SmudgeTool::setPressure( const bool pressure )
 QCursor SmudgeTool::cursor()
 {
     qDebug() << "smudge tool";
-    if (isAdjusting) // being dynamically resized
-    {
-        return circleCursors(); // two circles cursor
-    }
-    if ( mEditor->preference()->isOn( SETTING::DOTTED_CURSOR ) )
-    {
-        return dottedCursor(); // preview stroke size cursor
-    }
     if ( toolMode == 0 ) { //normal mode
-        return QCursor(QPixmap(":icons/smudge.png"),3 ,16);
+        return QCursor(QPixmap(":icons/smudge.png"),0 ,16);
     } else { // blured mode
-        return QCursor(QPixmap(":icons/liquify.png"),3,16);
+        return QCursor(QPixmap(":icons/liquify.png"),-4,16);
     }
 }
 


### PR DESCRIPTION
Circle cursor is now drawn only within canvas area, see #655

Also changed such that cursor size is affected by zooming.

You can see the difference below:
## Old behavior
![canvas cursor-old](https://user-images.githubusercontent.com/1045397/29232805-ecce4414-7eed-11e7-82be-f7e3e125750a.gif)

## New behavior
![canvas cursor](https://user-images.githubusercontent.com/1045397/29232816-fa97965e-7eed-11e7-94d3-06a2459fca79.gif)

