### PR TITLE
Flip selection along x and y axis

### DIFF
--- a/app/actioncommands.cpp
+++ b/app/actioncommands.cpp
@@ -196,20 +196,16 @@ void ActionCommands::ZoomOut()
     mEditor->view()->scale( newScaleValue );
 }
 
-void ActionCommands::flipX()
+void ActionCommands::flipSelectionX()
 {
-    auto view = mEditor->view();
-
-    bool b = view->isFlipHorizontal();
-    view->flipHorizontal( !b );
+   bool flipVertical = false;
+   mEditor->flipSelection(flipVertical);
 }
 
-void ActionCommands::flipY()
+void ActionCommands::flipSelectionY()
 {
-    auto view = mEditor->view();
-
-    bool b = view->isFlipVertical();
-    view->flipVertical( !b );
+    bool flipVertical = true;
+    mEditor->flipSelection(flipVertical);
 }
 
 void ActionCommands::rotateClockwise()

--- a/app/actioncommands.h
+++ b/app/actioncommands.h
@@ -43,8 +43,8 @@ public:
     // view
     void ZoomIn();
     void ZoomOut();
-    void flipX();
-    void flipY();
+    void flipSelectionX();
+    void flipSelectionY();
     void rotateClockwise();
     void rotateCounterClockwise();
 
@@ -67,7 +67,7 @@ public:
 
 private:
     Editor* mEditor  = nullptr;
-	QWidget* mParent = nullptr;
+    QWidget* mParent = nullptr;
 };
 
 #endif // COMMANDCENTER_H

--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -260,8 +260,8 @@ void MainWindow2::createMenus()
     connect( ui->actionCopy, &QAction::triggered, mEditor, &Editor::copy );
     connect( ui->actionPaste, &QAction::triggered, mEditor, &Editor::paste );
     connect( ui->actionClearFrame, &QAction::triggered, mEditor, &Editor::clearCurrentFrame );
-    connect( ui->actionFlip_X, &QAction::triggered, mCommands, &ActionCommands::flipX );
-    connect( ui->actionFlip_Y, &QAction::triggered, mCommands, &ActionCommands::flipY );
+    connect( ui->actionFlip_X, &QAction::triggered, mCommands, &ActionCommands::flipSelectionX );
+    connect( ui->actionFlip_Y, &QAction::triggered, mCommands, &ActionCommands::flipSelectionY );
     connect( ui->actionSelect_All, &QAction::triggered, mEditor, &Editor::selectAll );
     connect( ui->actionDeselect_All, &QAction::triggered, mEditor, &Editor::deselectAll );
     connect( ui->actionPreference, &QAction::triggered, [=] { preferences(); } );

--- a/core_lib/interface/editor.cpp
+++ b/core_lib/interface/editor.cpp
@@ -411,6 +411,11 @@ void Editor::paste()
 	mScribbleArea->updateCurrentFrame();
 }
 
+void Editor::flipSelection(bool flipVertical)
+{
+    mScribbleArea->flipSelection(flipVertical);
+}
+
 void Editor::deselectAll()
 {
 	mScribbleArea->deselectAll();

--- a/core_lib/interface/editor.h
+++ b/core_lib/interface/editor.h
@@ -149,6 +149,7 @@ public: //slots
     void toggleMirror();
     void toggleMirrorV();
     void toggleShowAllLayers();
+    void flipSelection(bool flipVertical);
 
     void toogleOnionSkinType();
 

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1118,6 +1118,32 @@ void ScribbleArea::drawBrush( QPointF thePoint, qreal brushWidth, qreal mOffset,
     mBufferImg->paste( &gradientImg );
 }
 
+/**
+ * @brief ScribbleArea::flipSelectionX
+ * flip selection along the X or Y axis
+*/
+void ScribbleArea::flipSelection(bool flipVertical)
+{
+    int scaleX = myTempTransformedSelection.width() / mySelection.width();
+    int scaleY = myTempTransformedSelection.height() / mySelection.height();
+    QVector<QPoint> centerPoints = calcSelectionCenterPoints();
+
+    QTransform translate = QTransform::fromTranslate( centerPoints[0].x(), centerPoints[0].y() );
+    QTransform _translate = QTransform::fromTranslate( -centerPoints[1].x(), -centerPoints[1].y() );
+    QTransform scale = QTransform::fromScale( -scaleX, 1.0 );
+    if (flipVertical == true)
+    {
+       scale = QTransform::fromScale( 1.0, -scaleY );
+    }
+
+    // reset transformation for vector selections
+    selectionTransformation.reset();
+    selectionTransformation = selectionTransformation * _translate * scale * translate;
+
+    paintTransformedSelection();
+    applyTransformedSelection(); // TODO: apply shouldn't deselect;
+}
+
 void ScribbleArea::blurBrush( BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal mOffset_, qreal opacity_ )
 {
     QRadialGradient radialGrad( thePoint_, 0.5 * brushWidth_ );
@@ -1264,13 +1290,33 @@ void ScribbleArea::calculateSelectionRect()
     }
 }
 
+/**
+ * @brief ScribbleArea::calculateSelectionCenter
+ * @return QPoint of tempTransformSelection center at [0] and selection center at [1]
+ */
+QVector<QPoint> ScribbleArea::calcSelectionCenterPoints()
+{
+    QVector<QPoint> centerPoints;
+    float selectionCenterX,
+          selectionCenterY,
+          tempSelectionCenterX,
+          tempSelectionCenterY;
+
+    tempSelectionCenterX = 0.5 * ( myTempTransformedSelection.left() +
+                                   myTempTransformedSelection.right() );
+    tempSelectionCenterY = 0.5 * ( myTempTransformedSelection.top() +
+                                   myTempTransformedSelection.bottom() );
+    selectionCenterX = 0.5 * ( mySelection.left() + mySelection.right() );
+    selectionCenterY = 0.5 * ( mySelection.top() + mySelection.bottom() );
+    centerPoints.append( QPoint( tempSelectionCenterX, tempSelectionCenterY ) );
+    centerPoints.append( QPoint( selectionCenterX, selectionCenterY ) );
+    return centerPoints;
+}
+
 void ScribbleArea::calculateSelectionTransformation() // Vector layer transform
 {
-    qreal c1x, c1y, c2x, c2y, scaleX, scaleY;
-    c1x = 0.5 * ( myTempTransformedSelection.left() + myTempTransformedSelection.right() );
-    c1y = 0.5 * ( myTempTransformedSelection.top() + myTempTransformedSelection.bottom() );
-    c2x = 0.5 * ( mySelection.left() + mySelection.right() );
-    c2y = 0.5 * ( mySelection.top() + mySelection.bottom() );
+    float scaleX, scaleY;
+    QVector<QPoint> centerPoints = calcSelectionCenterPoints();
 
     if ( mySelection.width() == 0 )
     {
@@ -1291,10 +1337,10 @@ void ScribbleArea::calculateSelectionTransformation() // Vector layer transform
     }
 
     selectionTransformation.reset();
-    selectionTransformation.translate( c1x, c1y );
+    selectionTransformation.translate( centerPoints[0].x(), centerPoints[0].y() );
     selectionTransformation.rotate(myRotatedAngle);
     selectionTransformation.scale( scaleX, scaleY );
-    selectionTransformation.translate( -c2x, -c2y );
+    selectionTransformation.translate( -centerPoints[1].x(), -centerPoints[1].y() );
 
     //modification();
 }

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -75,6 +75,10 @@ public:
     bool areLayersSane() const;
     bool isLayerPaintable() const;
 
+    void flipSelection(bool flipVertical);
+
+    QVector<QPoint> calcSelectionCenterPoints();
+
     void setEffect( SETTING e, bool isOn );
 
     int showAllLayers() const { return mShowAllLayers; }


### PR DESCRIPTION
implemented for #723 
![flip selection xy](https://user-images.githubusercontent.com/1045397/29279214-74bfe604-8117-11e7-8ae1-56135c1ac17c.gif)

Because of the way applyTransformedSelection works atm. deselectAll is required for the transformation to be set properly and will therefore remove the selection rectangle upon clicking one of the options. I would like to change that behaviour but simply lack the knowledge of how these selections are applied right now. Maybe this is why most drawing applications has a "Transform" state（￣ ー￣)... food for thought.