### PR TITLE
Fixed sound not starting over when loop is active

### DIFF
--- a/core_lib/managers/playbackmanager.cpp
+++ b/core_lib/managers/playbackmanager.cpp
@@ -147,7 +147,7 @@ void PlaybackManager::playSounds( int frame )
             }
 
             // Set flag to false, since this check should only be done when
-            // starting play-back.
+            // starting play-back, or when looping.
             mCheckForSoundsHalfway = false;
         }
         else if ( layer->keyExists( frame ) )
@@ -156,6 +156,16 @@ void PlaybackManager::playSounds( int frame )
             SoundClip* clip = static_cast< SoundClip* >( key );
 
             clip->play();
+
+            // save the position of our active sound frame
+            mActiveSoundFrame = frame;
+        }
+
+        if ( frame >= mEndFrame )
+        {
+            KeyFrame* key = layer->getKeyFrameWhichCovers( mActiveSoundFrame );
+            SoundClip* clip = static_cast< SoundClip* >( key );
+            clip->stop();
         }
     }
 }
@@ -191,6 +201,7 @@ void PlaybackManager::timerTick()
         if ( mIsLooping )
         {
             editor()->scrubTo( mStartFrame );
+            mCheckForSoundsHalfway = true;
         }
         else
         {

--- a/core_lib/managers/playbackmanager.h
+++ b/core_lib/managers/playbackmanager.h
@@ -75,6 +75,7 @@ private:
     bool mIsRangedPlayback = false;
     int mMarkInFrame = 1;
     int mMarkOutFrame = 10;
+    int mActiveSoundFrame = 0;
 
     int mFps = 12;
 


### PR DESCRIPTION
fixes #733
### Future improvements:
Changes on the timeline made while playback is on, are not updated until it has been stopped again.
This can cause various problems that may crash the program. 
A simple solution could be to stop playback whenever you click on the timeline.