### PR TITLE
Travis and AppVeyor should ignore certain files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ install:
   - pip -V
 
 before_script:
+  - echo "are changes related to source code?"
+  - bash $TRAVIS_BUILD_DIR/util/checkchanges.sh
   - 'if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     . /opt/qt59/bin/qt59-env.sh;
     export DISPLAY=:99.0;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,15 @@ environment:
       PYTHON: "C:\\Python35"
       PLATFORM_: "amd64"
 
+skip_commits:
+  files:
+    - '*.md'
+    - dir/*.md
+    - dir/*.sh
+    - dir/*.py
+    - dir/*.ps1
+    - '*.yml'
+
 install:
   - set PYTHON3="%PYTHON%\python.exe"
   - set UseEnv=true

--- a/util/checkchanges.sh
+++ b/util/checkchanges.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+CHANGED_FILES=`git diff --name-only master..${TRAVIS_COMMIT}`
+ONLY_READMES=True
+MD=".md"
+YAML=".yml"
+SH=".sh"
+PY=".py"
+PS1=".ps1"
+
+for CHANGED_FILE in $CHANGED_FILES; do
+  if ! [[ $CHANGED_FILE =~ $MD && 
+  		  $CHANGED_FILE =~ $YAML && 
+  		  $CHANGED_FILE =~ $SH && 
+  		  $CHANGED_FILE =~ $PY &&
+  		  $CHANGED_FILE =~ $PS1 ]] ; then
+    ONLY_READMES=False
+    break
+  fi
+done
+
+if [[ $ONLY_READMES == True ]]; then
+  echo "Only non source code files found, exiting."
+  travis_terminate 0
+  exit 1
+else
+  echo "source code changes found, continuing with build."
+fi


### PR DESCRIPTION
This should avoid making duplicate builds when changes are not related to source code.