### PR TITLE
removed travis_terminate as it doesn't work for some reason

### DIFF
--- a/util/checkchanges.sh
+++ b/util/checkchanges.sh
@@ -25,7 +25,6 @@ done
 
 if [[ $ONLY_READMES == True ]]; then
   echo "Only non source code files found, exiting."
-  travis_terminate 0
   exit 1
 else
   echo `git diff --name-only origin/master...${TRAVIS_COMMIT}`


### PR DESCRIPTION
It will still output fail because the build doesn't succeed. As far as I know, there is no way to get successful when you cancel the build early.