### PR TITLE
Implemented duplicate for sound frames.

### DIFF
--- a/core_lib/interface/editor.cpp
+++ b/core_lib/interface/editor.cpp
@@ -39,6 +39,7 @@ GNU General Public License for more details.
 #include "objectdata.h"
 #include "vectorimage.h"
 #include "bitmapimage.h"
+#include "soundclip.h"
 #include "layerbitmap.h"
 #include "layervector.h"
 #include "layersound.h"
@@ -62,13 +63,15 @@ GNU General Public License for more details.
 
 static BitmapImage g_clipboardBitmapImage;
 static VectorImage g_clipboardVectorImage;
+static SoundClip g_clipboardSoundClip;
 
 
 Editor::Editor( QObject* parent ) : QObject( parent )
 {
 	mBackupIndex = -1;
 	clipboardBitmapOk = false;
-	clipboardVectorOk = false;	
+        clipboardVectorOk = false;
+        clipboardSoundClipOk = false;
 }
 
 Editor::~Editor()
@@ -349,66 +352,89 @@ void Editor::cut()
 
 void Editor::copy()
 {
-	Layer* layer = mObject->getLayer( layers()->currentLayerIndex() );
-	if ( layer != NULL )
-	{
-		if ( layer->type() == Layer::BITMAP )
-		{
-			if ( mScribbleArea->somethingSelected )
-			{
-				g_clipboardBitmapImage = ( (LayerBitmap*)layer )->getLastBitmapImageAtFrame( currentFrame(), 0 )->copy( mScribbleArea->getSelection().toRect() );  // copy part of the image
-			}
-			else
-			{
-				g_clipboardBitmapImage = ( (LayerBitmap*)layer )->getLastBitmapImageAtFrame( currentFrame(), 0 )->copy();  // copy the whole image
-			}
-			clipboardBitmapOk = true;
-			if ( g_clipboardBitmapImage.image() != NULL ) QApplication::clipboard()->setImage( *g_clipboardBitmapImage.image() );
-		}
-		if ( layer->type() == Layer::VECTOR )
-		{
-			clipboardVectorOk = true;
-			g_clipboardVectorImage = *( ( (LayerVector*)layer )->getLastVectorImageAtFrame( currentFrame(), 0 ) );  // copy the image
-		}
-	}
+    Layer* layer = mObject->getLayer( layers()->currentLayerIndex() );
+    if ( layer != NULL )
+    {
+        if ( layer->type() == Layer::BITMAP )
+        {
+            if ( mScribbleArea->somethingSelected )
+            {
+                g_clipboardBitmapImage = ( (LayerBitmap*)layer )->getLastBitmapImageAtFrame( currentFrame(), 0 )->copy( mScribbleArea->getSelection().toRect() );  // copy part of the image
+            }
+            else
+            {
+                g_clipboardBitmapImage = ( (LayerBitmap*)layer )->getLastBitmapImageAtFrame( currentFrame(), 0 )->copy();  // copy the whole image
+            }
+            clipboardBitmapOk = true;
+            if ( g_clipboardBitmapImage.image() != NULL ) QApplication::clipboard()->setImage( *g_clipboardBitmapImage.image() );
+        }
+        if ( layer->type() == Layer::VECTOR )
+        {
+            clipboardVectorOk = true;
+            g_clipboardVectorImage = *( ( (LayerVector*)layer )->getLastVectorImageAtFrame( currentFrame(), 0 ) );  // copy the image
+        }
+        if ( layer->type() == Layer::SOUND )
+        {
+            clipboardSoundClipOk = true;
+            g_clipboardSoundClip = *( ( (LayerSound*) layer )->getSoundClipWhichCovers( currentFrame() ) ); // copy sound clip
+        }
+    }
 }
 
 void Editor::paste()
 {
-	Layer* layer = mObject->getLayer( layers()->currentLayerIndex() );
-	if ( layer != NULL )
-	{
-		if ( layer->type() == Layer::BITMAP && g_clipboardBitmapImage.image() != NULL )
-		{
-			backup( tr( "Paste" ) );
-			BitmapImage tobePasted = g_clipboardBitmapImage.copy();
-			qDebug() << "to be pasted --->" << tobePasted.image()->size();
-			if ( mScribbleArea->somethingSelected )
-			{
-				QRectF selection = mScribbleArea->getSelection();
-				if ( g_clipboardBitmapImage.width() <= selection.width() && g_clipboardBitmapImage.height() <= selection.height() )
-				{
-					tobePasted.moveTopLeft( selection.topLeft() );
-				}
-				else
-				{
-					tobePasted.transform( selection, true );
-				}
-			}
-			auto pLayerBitmap = static_cast<LayerBitmap*>( layer );
-			pLayerBitmap->getLastBitmapImageAtFrame( currentFrame(), 0 )->paste( &tobePasted ); // paste the clipboard
-		}
-		else if ( layer->type() == Layer::VECTOR && clipboardVectorOk )
-		{
-			backup( tr( "Paste" ) );
-			mScribbleArea->deselectAll();
-			VectorImage* vectorImage = ( (LayerVector*)layer )->getLastVectorImageAtFrame( currentFrame(), 0 );
-			vectorImage->paste( g_clipboardVectorImage );  // paste the clipboard
-			mScribbleArea->setSelection( vectorImage->getSelectionRect(), true );
-			//((LayerVector*)layer)->getLastVectorImageAtFrame(backupFrame, 0)->modification(); ????
-		}
-	}
-	mScribbleArea->updateCurrentFrame();
+    Layer* layer = mObject->getLayer( layers()->currentLayerIndex() );
+    if ( layer != NULL )
+    {
+        if ( layer->type() == Layer::BITMAP && g_clipboardBitmapImage.image() != NULL )
+        {
+            backup( tr( "Paste" ) );
+            BitmapImage tobePasted = g_clipboardBitmapImage.copy();
+            qDebug() << "to be pasted --->" << tobePasted.image()->size();
+            if ( mScribbleArea->somethingSelected )
+            {
+                QRectF selection = mScribbleArea->getSelection();
+                if ( g_clipboardBitmapImage.width() <= selection.width() && g_clipboardBitmapImage.height() <= selection.height() )
+                {
+                        tobePasted.moveTopLeft( selection.topLeft() );
+                }
+                else
+                {
+                        tobePasted.transform( selection, true );
+                }
+            }
+            auto pLayerBitmap = static_cast<LayerBitmap*>( layer );
+            pLayerBitmap->getLastBitmapImageAtFrame( currentFrame(), 0 )->paste( &tobePasted ); // paste the clipboard
+        }
+        else if ( layer->type() == Layer::VECTOR && clipboardVectorOk )
+        {
+            backup( tr( "Paste" ) );
+            mScribbleArea->deselectAll();
+            VectorImage* vectorImage = ( (LayerVector*)layer )->getLastVectorImageAtFrame( currentFrame(), 0 );
+            vectorImage->paste( g_clipboardVectorImage );  // paste the clipboard
+            mScribbleArea->setSelection( vectorImage->getSelectionRect(), true );
+            //((LayerVector*)layer)->getLastVectorImageAtFrame(backupFrame, 0)->modification(); ????
+        }
+        else if ( layer->type() == Layer::SOUND && clipboardSoundClipOk )
+        {
+            backup( tr( "Paste sound") );
+            KeyFrame* key = addNewKey();
+
+            SoundClip* clip = dynamic_cast< SoundClip* >( key );
+            if ( clip )
+            {
+                QString strSoundFile = g_clipboardSoundClip.fileName();
+
+                if ( strSoundFile.isEmpty() )
+                {
+                    removeKey();
+                }
+                Status st = sound()->pasteSound( clip, strSoundFile );
+                Q_ASSERT( st.ok() );
+            }
+        }
+    }
+    mScribbleArea->updateCurrentFrame();
 }
 
 void Editor::flipSelection(bool flipVertical)
@@ -418,44 +444,44 @@ void Editor::flipSelection(bool flipVertical)
 
 void Editor::deselectAll()
 {
-	mScribbleArea->deselectAll();
+    mScribbleArea->deselectAll();
 }
 
 void Editor::clipboardChanged()
 {
-	if ( clipboardBitmapOk == false )
-	{
-		g_clipboardBitmapImage.setImage( new QImage( QApplication::clipboard()->image() ) );
-		g_clipboardBitmapImage.bounds() = QRect( g_clipboardBitmapImage.topLeft(), g_clipboardBitmapImage.image()->size() );
-		qDebug() << "New clipboard image" << g_clipboardBitmapImage.image()->size();
-	}
-	else
-	{
-		clipboardBitmapOk = false;
-		qDebug() << "The image has been saved in the clipboard";
-	}
+    if ( clipboardBitmapOk == false )
+    {
+        g_clipboardBitmapImage.setImage( new QImage( QApplication::clipboard()->image() ) );
+        g_clipboardBitmapImage.bounds() = QRect( g_clipboardBitmapImage.topLeft(), g_clipboardBitmapImage.image()->size() );
+        qDebug() << "New clipboard image" << g_clipboardBitmapImage.image()->size();
+    }
+    else
+    {
+        clipboardBitmapOk = false;
+        qDebug() << "The image has been saved in the clipboard";
+    }
 }
 
 int Editor::allLayers()
 {
-	return mScribbleArea->showAllLayers();
+    return mScribbleArea->showAllLayers();
 }
 
 void Editor::toggleMirror()
 {
-	bool flipX = view()->isFlipHorizontal();
-	view()->flipHorizontal( !flipX );
+    bool flipX = view()->isFlipHorizontal();
+    view()->flipHorizontal( !flipX );
 }
 
 void Editor::toggleMirrorV()
 {
-	bool flipY = view()->isFlipVertical();
-	view()->flipVertical( !flipY );
+    bool flipY = view()->isFlipVertical();
+    view()->flipVertical( !flipY );
 }
 
 void Editor::toggleShowAllLayers()
 {
-	mScribbleArea->toggleShowAllLayers();
+    mScribbleArea->toggleShowAllLayers();
     emit updateTimeLine();
 }
 
@@ -510,15 +536,15 @@ void Editor::updateObject()
     scrubTo( mObject->data()->getCurrentFrame() );
     if (layers() != NULL)
     {
-		layers()->setCurrentLayer( mObject->data()->getCurrentLayer() );
+        layers()->setCurrentLayer( mObject->data()->getCurrentLayer() );
     }
 
-	clearUndoStack();
+    clearUndoStack();
 
-	if ( mScribbleArea )
-	{
-		mScribbleArea->updateAllFrames();
-	}
+    if ( mScribbleArea )
+    {
+        mScribbleArea->updateAllFrames();
+    }
 
     emit updateLayerCount();
 }
@@ -529,19 +555,19 @@ bool Editor::exportSeqCLI( QString filePath, QString format, int width, int heig
     int cameraLayerId = mLayerManager->getLastCameraLayer();
     LayerCamera *cameraLayer = dynamic_cast< LayerCamera* >(mObject->getLayer(cameraLayerId));
 
-	if ( width < 0 )
-	{
+    if ( width < 0 )
+    {
         width = cameraLayer->getViewRect().width();
     }
-	if ( height < 0 )
-	{
+    if ( height < 0 )
+    {
         height = cameraLayer->getViewRect().height();
     }
 
-	QSize exportSize = QSize( width, height );
-	QByteArray exportFormat( format.toLatin1() );
+    QSize exportSize = QSize( width, height );
+    QByteArray exportFormat( format.toLatin1() );
 
-	//QTransform view = RectMapTransform( mScribbleArea->getViewRect(), QRectF( QPointF( 0, 0 ), exportSize ) );
+    //QTransform view = RectMapTransform( mScribbleArea->getViewRect(), QRectF( QPointF( 0, 0 ), exportSize ) );
     //view = mScribbleArea->getView() * view;
 
     int projectLength = mLayerManager->projectLength();
@@ -549,16 +575,15 @@ bool Editor::exportSeqCLI( QString filePath, QString format, int width, int heig
     mObject->exportFrames( 1,
                            projectLength,
                            cameraLayer,
-						   exportSize,
-						   filePath,
+                           exportSize,
+                           filePath,
                            exportFormat,
                            -1,
                            transparency,
                            antialias,
                            NULL,
                            0 );
-
-	return true;
+    return true;
 }
 
 QString Editor::workingDir() const
@@ -570,27 +595,27 @@ bool Editor::importBitmapImage( QString filePath )
 {
     backup( tr( "Import Image" ) );
 
-	QImageReader reader( filePath );
+    QImageReader reader( filePath );
 
-	Q_ASSERT( layers()->currentLayer()->type() == Layer::BITMAP );
-	auto layer = static_cast<LayerBitmap*>( layers()->currentLayer() );
+    Q_ASSERT( layers()->currentLayer()->type() == Layer::BITMAP );
+    auto layer = static_cast<LayerBitmap*>( layers()->currentLayer() );
 
-	QImage img( reader.size(), QImage::Format_ARGB32_Premultiplied );
-	if ( img.isNull() )
-	{
-		return false;
-	}
+    QImage img( reader.size(), QImage::Format_ARGB32_Premultiplied );
+    if ( img.isNull() )
+    {
+        return false;
+    }
 
-	while ( reader.read( &img ) )
-	{
-		if ( !layer->keyExists( currentFrame() ) )
-		{
-			addNewKey();
-		}
-		BitmapImage* bitmapImage = layer->getBitmapImageAtFrame( currentFrame() );
+    while ( reader.read( &img ) )
+    {
+        if ( !layer->keyExists( currentFrame() ) )
+        {
+                addNewKey();
+        }
+        BitmapImage* bitmapImage = layer->getBitmapImageAtFrame( currentFrame() );
 
-		QRect boundaries = img.rect();
-		boundaries.moveTopLeft( mScribbleArea->getCentralPoint().toPoint() - QPoint( boundaries.width() / 2, boundaries.height() / 2 ) );
+        QRect boundaries = img.rect();
+        boundaries.moveTopLeft( mScribbleArea->getCentralPoint().toPoint() - QPoint( boundaries.width() / 2, boundaries.height() / 2 ) );
 
         BitmapImage importedBitmapImage{boundaries, img};
         bitmapImage->paste(&importedBitmapImage);
@@ -603,36 +628,37 @@ bool Editor::importBitmapImage( QString filePath )
 
 bool Editor::importVectorImage( QString filePath )
 {
-	Q_ASSERT( layers()->currentLayer()->type() == Layer::VECTOR );
+    Q_ASSERT( layers()->currentLayer()->type() == Layer::VECTOR );
 
     backup( tr( "Import Image" ) );
 
-	auto layer = static_cast<LayerVector*>( layers()->currentLayer() );
+    auto layer = static_cast<LayerVector*>( layers()->currentLayer() );
 
-	VectorImage* vectorImage = ( (LayerVector*)layer )->getVectorImageAtFrame( currentFrame() );
-	if ( vectorImage == NULL )
-	{
-		addNewKey();
-		vectorImage = ( (LayerVector*)layer )->getVectorImageAtFrame( currentFrame() );
-	}
+    VectorImage* vectorImage = ( (LayerVector*)layer )->getVectorImageAtFrame( currentFrame() );
+    if ( vectorImage == NULL )
+    {
+        addNewKey();
+        vectorImage = ( (LayerVector*)layer )->getVectorImageAtFrame( currentFrame() );
+    }
+
     VectorImage importedVectorImage;
     bool ok = importedVectorImage.read( filePath );
-	if ( ok )
-	{
+    if ( ok )
+    {
         importedVectorImage.selectAll();
         vectorImage->paste(importedVectorImage);
-	}
-	/*
-	else
-	{
-	QMessageBox::warning( mMainWindow,
-	tr( "Warning" ),
-	tr( "Unable to load vector image.<br><b>TIP:</b> Use Vector layer to import vectors." ),
-	QMessageBox::Ok,
-	QMessageBox::Ok );
-	}
-	*/
-	return ok;
+    }
+    /*
+    else
+    {
+    QMessageBox::warning( mMainWindow,
+    tr( "Warning" ),
+    tr( "Unable to load vector image.<br><b>TIP:</b> Use Vector layer to import vectors." ),
+    QMessageBox::Ok,
+    QMessageBox::Ok );
+    }
+    */
+    return ok;
 }
 
 bool Editor::importImage( QString filePath )
@@ -641,23 +667,23 @@ bool Editor::importImage( QString filePath )
 
 	switch ( layer->type() )
 	{
-	case Layer::BITMAP:
-		return importBitmapImage( filePath );
+            case Layer::BITMAP:
+                return importBitmapImage( filePath );
 
-	case Layer::VECTOR:
-		return importVectorImage( filePath );
+            case Layer::VECTOR:
+                return importVectorImage( filePath );
 
-	default:
-	{
-		//mLastError = Status::ERROR_INVALID_LAYER_TYPE;
-		return false;
-	}
+            default:
+            {
+                //mLastError = Status::ERROR_INVALID_LAYER_TYPE;
+                return false;
+            }
 	}
 }
 
 void Editor::updateFrame( int frameNumber )
 {
-	mScribbleArea->updateFrame( frameNumber );
+    mScribbleArea->updateFrame( frameNumber );
 }
 
 void Editor::updateFrameAndVector( int frameNumber )
@@ -672,15 +698,15 @@ void Editor::updateCurrentFrame()
 
 void Editor::scrubTo( int frame )
 {
-	if ( frame < 1 )
-	{
-		frame = 1;
-	}
-	int oldFrame = mFrame;
-	mFrame = frame;
+    if ( frame < 1 )
+    {
+        frame = 1;
+    }
+    int oldFrame = mFrame;
+    mFrame = frame;
 
-	Q_EMIT currentFrameChanged( frame );
-	Q_EMIT currentFrameChanged( oldFrame );
+    Q_EMIT currentFrameChanged( frame );
+    Q_EMIT currentFrameChanged( oldFrame );
     
     // FIXME: should not emit Timeline update here.
     // Editor must be an individual class.
@@ -693,55 +719,55 @@ void Editor::scrubTo( int frame )
 
 void Editor::scrubForward()
 {
-	scrubTo( currentFrame() + 1 );
+    scrubTo( currentFrame() + 1 );
 }
 
 void Editor::scrubBackward()
 {
-	if ( currentFrame() > 1 )
-	{
-		scrubTo( currentFrame() - 1 );
-	}
+    if ( currentFrame() > 1 )
+    {
+        scrubTo( currentFrame() - 1 );
+    }
 }
 
 void Editor::moveFrameForward()
 {
-	Layer* layer = layers()->currentLayer();
-	if ( layer != NULL )
-	{
-		if ( layer->moveKeyFrameForward( currentFrame() ) )
-		{
-			mScribbleArea->updateAllFrames();
-			scrubForward();
-		}
-	}
+    Layer* layer = layers()->currentLayer();
+    if ( layer != NULL )
+    {
+        if ( layer->moveKeyFrameForward( currentFrame() ) )
+        {
+                mScribbleArea->updateAllFrames();
+                scrubForward();
+        }
+    }
 }
 
 void Editor::moveFrameBackward()
 {
-	Layer* layer = layers()->currentLayer();
-	if ( layer != NULL )
-	{
-		if ( layer->moveKeyFrameBackward( currentFrame() ) )
-		{
-			mScribbleArea->updateAllFrames();
-			scrubBackward();
-		}
-	}
+    Layer* layer = layers()->currentLayer();
+    if ( layer != NULL )
+    {
+        if ( layer->moveKeyFrameBackward( currentFrame() ) )
+        {
+            mScribbleArea->updateAllFrames();
+            scrubBackward();
+        }
+    }
 }
 
 KeyFrame* Editor::addNewKey()
 {
-	return addKeyFame( layers()->currentLayerIndex(), currentFrame() );
+    return addKeyFrame( layers()->currentLayerIndex(), currentFrame() );
 }
 
 void Editor::duplicateKey()
 {
-	Layer* layer = mObject->getLayer( layers()->currentLayerIndex() );
-	if ( layer != NULL )
-	{
+    Layer* layer = mObject->getLayer( layers()->currentLayerIndex() );
+    if ( layer != NULL )
+    {
         if ( layer->type() == Layer::VECTOR || layer->type() == Layer::BITMAP )
-		{
+        {
             // Will copy the selection if any or the entire image if there is none
             //
             if(!mScribbleArea->somethingSelected) {
@@ -754,20 +780,28 @@ void Editor::duplicateKey()
 
             mScribbleArea->setModified( layers()->currentLayerIndex(), currentFrame() );
             mScribbleArea->update();
-		}
-	}
+        }
+        if ( layer->type() == Layer::SOUND )
+        {
+            // TODO: get frame which is selected by mouse
+            if ( layer->isFrameSelected( currentFrame() ) ) {
+                copy();
+                paste();
+            }
+        }
+    }
 }
 
-KeyFrame* Editor::addKeyFame( int layerNumber, int frameIndex )
+KeyFrame* Editor::addKeyFrame( int layerNumber, int frameIndex )
 {
-	Layer* layer = mObject->getLayer( layerNumber );
-	if ( layer == NULL )
-	{
+    Layer* layer = mObject->getLayer( layerNumber );
+    if ( layer == NULL )
+    {
         Q_ASSERT( false );
-		return nullptr;
-	}
+        return nullptr;
+    }
 
-	bool isOK = false;
+    bool isOK = false;
 
     while ( layer->keyExists( frameIndex ) )
     {
@@ -784,11 +818,11 @@ KeyFrame* Editor::addKeyFame( int layerNumber, int frameIndex )
         Q_ASSERT( false );
     }
 
-	if ( isOK )
-	{
-        scrubTo( frameIndex ); // currentFrameChanged() emit inside.
-        //getScribbleArea()->updateCurrentFrame();
-	}
+    if ( isOK )
+    {
+    scrubTo( frameIndex ); // currentFrameChanged() emit inside.
+    //getScribbleArea()->updateCurrentFrame();
+    }
 
     return keyFrame;
 }

--- a/core_lib/interface/editor.h
+++ b/core_lib/interface/editor.h
@@ -188,7 +188,7 @@ private:
     int autosaveNumber = 12;
 
     void makeConnections();
-    KeyFrame* addKeyFame( int layerNumber, int frameNumber );
+    KeyFrame* addKeyFrame( int layerNumber, int frameNumber );
 
     // backup
     void clearUndoStack();
@@ -196,7 +196,7 @@ private:
     int lastModifiedLayer;
 
     // clipboard
-    bool clipboardBitmapOk, clipboardVectorOk;
+    bool clipboardBitmapOk, clipboardVectorOk, clipboardSoundClipOk;
 };
 
 #endif

--- a/core_lib/managers/playbackmanager.cpp
+++ b/core_lib/managers/playbackmanager.cpp
@@ -35,7 +35,6 @@ bool PlaybackManager::init()
     mTimer = new QTimer( this );
     mFrameTimer = new QElapsedTimer( );
     connect( mTimer, &QTimer::timeout, this, &PlaybackManager::timerTick );
-    emit playStateChanged(true);
     return true;
 }
 

--- a/core_lib/managers/playbackmanager.cpp
+++ b/core_lib/managers/playbackmanager.cpp
@@ -35,6 +35,7 @@ bool PlaybackManager::init()
     mTimer = new QTimer( this );
     mFrameTimer = new QElapsedTimer( );
     connect( mTimer, &QTimer::timeout, this, &PlaybackManager::timerTick );
+    emit playStateChanged(true);
     return true;
 }
 

--- a/core_lib/managers/soundmanager.cpp
+++ b/core_lib/managers/soundmanager.cpp
@@ -90,7 +90,7 @@ Status SoundManager::loadSound( Layer* soundLayer, int frameNumber, QString strS
         soundLayer->addKeyFrame( frameNumber, key );
     }
 
-    if ( !key->fileName().isEmpty() )
+    if ( key->fileName().isEmpty() )
     {
         return Status::FAIL;
     }
@@ -114,6 +114,32 @@ Status SoundManager::loadSound( Layer* soundLayer, int frameNumber, QString strS
     return Status::OK;
 }
 
+Status SoundManager::pasteSound( SoundClip* soundClip, QString strSoundFile)
+{
+    Q_ASSERT( soundClip );
+
+    if ( !QFile::exists( strSoundFile ) )
+    {
+        return Status::FILE_NOT_FOUND;
+    }
+
+    if ( strSoundFile.isEmpty() )
+    {
+        return Status::FAIL;
+    }
+
+    soundClip->init( strSoundFile );
+
+    Status st = createMediaPlayer( soundClip );
+    if ( !st.ok() )
+    {
+        delete soundClip;
+        return st;
+    }
+
+    return Status::OK;
+}
+
 Status SoundManager::loadSound( SoundClip* soundClip, QString strSoundFile )
 {
     Q_ASSERT( soundClip );
@@ -123,7 +149,7 @@ Status SoundManager::loadSound( SoundClip* soundClip, QString strSoundFile )
         return Status::FILE_NOT_FOUND;
     }
 
-    if ( !soundClip->fileName().isEmpty() )
+    if ( strSoundFile.isEmpty() )
     {
         return Status::FAIL;
     }

--- a/core_lib/managers/soundmanager.h
+++ b/core_lib/managers/soundmanager.h
@@ -40,6 +40,7 @@ public:
 
     Status loadSound( Layer* soundLayer, int frameNumber, QString strSoundFile );
     Status loadSound( SoundClip* soundClip, QString strSoundFile );
+    Status pasteSound( SoundClip* soundClip, QString strSoundFile );
 
 signals:
     void soundClipDurationChanged();

--- a/core_lib/structure/layer.cpp
+++ b/core_lib/structure/layer.cpp
@@ -339,7 +339,7 @@ void Layer::paintTrack( QPainter& painter, TimeLineCells* cells, int x, int y, i
         QColor col;
         if ( type() == BITMAP ) col = QColor( 151, 176, 244 );
         if ( type() == VECTOR ) col = QColor( 150, 242, 150 );
-        if ( type() == SOUND ) col = QColor( 237, 147, 147 );
+        if ( type() == SOUND ) col = QColor( 237, 147, 147, 100 );
         if ( type() == CAMERA ) col = QColor( 239, 232, 148 );
 
         painter.setBrush( col );

--- a/core_lib/structure/layersound.cpp
+++ b/core_lib/structure/layersound.cpp
@@ -130,3 +130,9 @@ Status LayerSound::saveKeyFrame( KeyFrame*, QString path )
 
     return Status::OK;
 }
+
+SoundClip* LayerSound::getSoundClipWhichCovers( int frameNumber )
+{
+    KeyFrame* key = getKeyFrameWhichCovers( frameNumber );
+    return static_cast< SoundClip* >( key );
+}

--- a/core_lib/structure/layersound.h
+++ b/core_lib/structure/layersound.h
@@ -21,6 +21,7 @@ GNU General Public License for more details.
 #include "keyframe.h"
 #include "layer.h"
 
+class SoundClip;
 class LayerSound : public Layer
 {
     Q_OBJECT
@@ -42,6 +43,8 @@ public:
     QString getSoundFilepathAt( int ) { return ""; }
     bool isEmpty() { return true; }
     // These functions will be removed.
+
+    SoundClip* getSoundClipWhichCovers(int frameNumber);
 
 protected:
     Status saveKeyFrame( KeyFrame*, QString path ) override;

--- a/core_lib/structure/soundclip.cpp
+++ b/core_lib/structure/soundclip.cpp
@@ -33,7 +33,7 @@ SoundClip::~SoundClip()
 
 Status SoundClip::init( const QString& strSoundFile )
 {
-    if ( !fileName().isEmpty() )
+    if ( strSoundFile.isEmpty() )
     {
         return Status::FAIL;
     }


### PR DESCRIPTION
![duplicate-sound-tracks](https://user-images.githubusercontent.com/1045397/30454305-202ff0b4-999c-11e7-8af1-3f4a9031dfa2.gif)

### Added
* duplicate for sound frames
* made sound frames slightly transparent to be able to see overlapping sound tracks

### Fixed
* typos? referring to these `if ( !key->fileName().isEmpty() ) { return Status::FAIL; }` which made no sense before... not empty == fail? how does that make sense O_o

### Other
* refactoring.

### Future improvements:
It should be possible to duplicate frames to the current scrub position by selecting a frame and clicking duplicate. Atm. you are required to have the scrubber within the frame you want to duplicate.