### PR TITLE
Implemented UNDO frame deletion for Bitmap, Vector and Sound

### DIFF
--- a/app/actioncommands.cpp
+++ b/app/actioncommands.cpp
@@ -299,6 +299,7 @@ void ActionCommands::removeKey()
         {
             case Layer::BITMAP:
             case Layer::VECTOR:
+            case Layer::SOUND:
             case Layer::CAMERA:
                 layer->addNewEmptyKeyAt( 1 );
                 break;

--- a/core_lib/interface/backupelement.h
+++ b/core_lib/interface/backupelement.h
@@ -21,7 +21,7 @@ GNU General Public License for more details.
 #include <QObject>
 #include "vectorimage.h"
 #include "bitmapimage.h"
-
+#include "soundclip.h"
 
 class Editor;
 
@@ -29,7 +29,7 @@ class BackupElement : public QObject
 {
     Q_OBJECT
 public:
-    enum types { UNDEFINED, BITMAP_MODIF, VECTOR_MODIF };
+    enum types { UNDEFINED, BITMAP_MODIF, VECTOR_MODIF, SOUND_MODIF };
 
     QString undoText;
     bool somethingSelected;
@@ -47,7 +47,6 @@ public:
 
     int layer, frame;
     BitmapImage bitmapImage;
-    //BackupBitmapElement() { type = BackupElement::BITMAP_MODIF; }
     int type() { return BackupElement::BITMAP_MODIF; }
     void restore(Editor*);
 };
@@ -62,6 +61,19 @@ public:
 
     int type() { return BackupElement::VECTOR_MODIF; }
     void restore(Editor*);
+};
+
+class BackupSoundElement : public BackupElement
+{
+    Q_OBJECT
+public:
+    BackupSoundElement(SoundClip* sound) { clip = *sound; }
+    int layer, frame;
+    SoundClip clip;
+    QString fileName;
+
+    int type() { return BackupElement::SOUND_MODIF; }
+    void restore( Editor* );
 };
 
 #endif // BACKUPELEMENT_H

--- a/core_lib/interface/editor.h
+++ b/core_lib/interface/editor.h
@@ -118,6 +118,8 @@ public: //slots
 
     bool importImage( QString filePath );
     void updateFrame( int frameNumber );
+    void restoreKey();
+
     void updateFrameAndVector( int frameNumber );
     void updateCurrentFrame();
 


### PR DESCRIPTION
Lo and behold! you can now undo frame deletions.
This is related to #748, #36 

![1](https://user-images.githubusercontent.com/1045397/30712899-d8d77594-9f0d-11e7-8871-6bf192b96d9f.gif)

Because of the way the timeline works with 1 frame being required on a layer, you can't restore a soundclip if it overlaps the first empty frame.


