### PR TITLE
Downgrade linux desktop entry file to version 1.0

### DIFF
--- a/pencil2d.desktop
+++ b/pencil2d.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.1
+Version=1.0
 Type=Application
 Name=Pencil2D
 GenericName=Animation Software
@@ -10,5 +10,3 @@ Icon=pencil2d
 Exec=Pencil2D %f
 MimeType=application/x-pencil-pcl;application/x-pencil-pclx;
 Categories=AudioVideo;AudioVideoEditing;Graphics;2DGraphics;VectorGraphics;RasterGraphics;Qt;
-Keywords=picture;drawing;vector;bitmap;cartoon;
-Keywords[de]=Bild;Zeichnen;Vektor;Raster;Zeichentrick;


### PR DESCRIPTION
This had to be done because linuxdeployqt can't handle higher versions at the moment (see errors here: https://travis-ci.org/chchwy/pencil2d/jobs/297832888#L1602-L1603). The Keyword key had to be removed because it is not supported by version 1.0.

Fixes #779.

[See successful travis build with this change](https://travis-ci.org/scribblemaniac/pencil/builds/297848345)