### PR TITLE
Fix nightly AppImages (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,15 @@ install:
   - pip install -U google-api-python-client
   - python3 -V
   - pip -V
+  - 'if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    curl -fsSLO http://www.freedesktop.org/software/desktop-file-utils/releases/desktop-file-utils-0.23.tar.xz;
+    bsdtar xf desktop-file-utils-0.23.tar.xz;
+    pushd desktop-file-utils-0.23;
+    ./configure;
+    make;
+    export "PATH=$PWD/src:$PATH";
+    popd;
+  fi'
 
 before_script:
   - echo "are changes related to source code?"

--- a/pencil2d.desktop
+++ b/pencil2d.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.0
+Version=1.1
 Type=Application
 Name=Pencil2D
 GenericName=Animation Software
@@ -10,3 +10,5 @@ Icon=pencil2d
 Exec=Pencil2D %f
 MimeType=application/x-pencil-pcl;application/x-pencil-pclx;
 Categories=AudioVideo;AudioVideoEditing;Graphics;2DGraphics;VectorGraphics;RasterGraphics;Qt;
+Keywords=picture;drawing;vector;bitmap;cartoon;
+Keywords[de]=Bild;Zeichnen;Vektor;Raster;Zeichentrick;


### PR DESCRIPTION
Travis really gotta update their Ubuntu, I tell you.

Luckily, though, impact on build time is hardly noticeable, since desktop-file-utils is so small.