### PR TITLE
Proper playback update on range controls change

### DIFF
--- a/app/actioncommands.cpp
+++ b/app/actioncommands.cpp
@@ -467,6 +467,7 @@ Status ActionCommands::addNewKey()
         camLayer->LinearInterpolateTransform(cam);
         mEditor->view()->updateViewTransforms();
     }
+    return Status::OK;
 }
 
 void ActionCommands::removeKey()

--- a/core_lib/interface/timecontrols.cpp
+++ b/core_lib/interface/timecontrols.cpp
@@ -28,6 +28,7 @@ GNU General Public License for more details.
 #include "preferencemanager.h"
 #include "timeline.h"
 
+static auto spinBoxValueChanged = static_cast< void ( QSpinBox::* )( int ) >( &QSpinBox::valueChanged );
 
 TimeControls::TimeControls(TimeLine *parent ) : QToolBar( parent )
 {
@@ -106,7 +107,6 @@ TimeControls::TimeControls(TimeLine *parent ) : QToolBar( parent )
 
     makeConnections();
 
-    auto spinBoxValueChanged = static_cast< void ( QSpinBox::* )( int ) >( &QSpinBox::valueChanged );
     connect( mLoopStartSpinBox, spinBoxValueChanged, this, &TimeControls::preLoopStartClick );
     connect( mLoopEndSpinBox, spinBoxValueChanged, this, &TimeControls::loopEndClick );
 
@@ -162,6 +162,9 @@ void TimeControls::setCore( Editor* editor )
 {
     Q_ASSERT( editor != nullptr );
     mEditor = editor;
+
+    connect( mLoopStartSpinBox, spinBoxValueChanged, mEditor->playback(), &PlaybackManager::setRangedStartFrame );
+    connect( mLoopEndSpinBox, spinBoxValueChanged, mEditor->playback(), &PlaybackManager::setRangedEndFrame );
 }
 
 void TimeControls::makeConnections()

--- a/core_lib/managers/playbackmanager.cpp
+++ b/core_lib/managers/playbackmanager.cpp
@@ -69,11 +69,6 @@ bool PlaybackManager::isPlaying()
 
 void PlaybackManager::play()
 {
-    int projectLength = editor()->layers()->projectLength();
-
-    mStartFrame = ( mIsRangedPlayback ) ? mMarkInFrame : 1;
-    mEndFrame = ( mIsRangedPlayback ) ? mMarkOutFrame : projectLength;
-
     int frame = editor()->currentFrame();
     if ( ( frame >= mEndFrame ) ||
          ( frame >= mEndFrame && mIsRangedPlayback ) )
@@ -299,8 +294,35 @@ void PlaybackManager::enableRangedPlayback( bool b )
     if ( mIsRangedPlayback != b )
     {
         mIsRangedPlayback = b;
+
+        updateStartFrame();
+        updateEndFrame();
+
         emit rangedPlaybackStateChanged( mIsRangedPlayback );
     }
+}
+
+void PlaybackManager::setRangedStartFrame( int frame )
+{
+    mMarkInFrame = frame;
+    updateStartFrame();
+}
+
+void PlaybackManager::setRangedEndFrame( int frame )
+{
+    mMarkOutFrame = frame;
+    updateEndFrame();
+}
+
+void PlaybackManager::updateStartFrame()
+{
+    mStartFrame = ( mIsRangedPlayback ) ? mMarkInFrame : 1;
+}
+
+void PlaybackManager::updateEndFrame()
+{
+    int projectLength = editor()->layers()->projectLength();
+    mEndFrame = ( mIsRangedPlayback ) ? mMarkOutFrame : projectLength;
 }
 
 void PlaybackManager::enableSound(bool b)

--- a/core_lib/managers/playbackmanager.h
+++ b/core_lib/managers/playbackmanager.h
@@ -51,8 +51,8 @@ public:
     void setFps( int fps );
     void setLooping( bool isLoop );
     void enableRangedPlayback( bool b );
-    void setRangedStartFrame( int frame ) { mMarkInFrame = frame; }
-    void setRangedEndFrame( int frame ) { mMarkOutFrame = frame; }
+    void setRangedStartFrame( int frame );
+    void setRangedEndFrame( int frame );
     void enableSound( bool b );
 
     void stopSounds();
@@ -70,6 +70,9 @@ private:
 
     int mStartFrame = 1;
     int mEndFrame = 60;
+
+    void updateStartFrame();
+    void updateEndFrame();
 
     bool mIsLooping = false;
     bool mIsPlaySound = true;


### PR DESCRIPTION
Hello!
I'm a member of the Pinguem.ru competition on finding errors in open source projects.
I found an issue with Pencil playback where you can make playback state in out of sync with the range-playback controls. It is especially noticeable when you work with a sound. To reproduce the bug please follow steps:

- Create new sound layer with `Ctrl+Alt+W` shortcut;
- Add new frame by pushing `Keys: Add Frame (+)` button;
- Choose an audio file;
- Push `Loop` button (just for convinience);
- Push `Play` button;
- While playing try to trigger `Range` box or change `Strat of playback loop`/`End of playback loop` spinbox values — you'll see no difference in playback behaviour, it'll still play with old settings even after end of a loop iteration. But at the same time graphical range indication (yellow selection at the top of time scale) changes immediately, so we'll observe a lost of sync between graphical/controls indication and real behaviour. This pull request is intended to fix that.

Also there are additional errors/warnings found by PVS-Studio analyzer:

- [V591](https://www.viva64.com/en/w/v591/) Non-void function should return a value. actioncommands.cpp 471. This one caused crash on my side when I tried to add a frame. Very dangerous bug!

Don't know how to treat these warnings, but please take a look. There might be potential typos here.
- [V523](https://www.viva64.com/en/w/v523/) The 'then' statement is equivalent to the 'else' statement. vectorimage.cpp 2311
- [V686](https://www.viva64.com/en/w/v686/) A pattern was detected: (frame >= mEndFrame) || ((frame >= mEndFrame) && ...). The expression is excessive or contains a logical error. playbackmanager.cpp 73
- [V686](https://www.viva64.com/en/w/v686/) A pattern was detected: (currentFrame >= mEndFrame) || ((currentFrame >= mEndFrame) && ...). The expression is excessive or contains a logical error. playbackmanager.cpp 259