### PR TITLE
Fix Linux AppImage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ addons:
     - doxygen-latex
     - doxygen-gui
     - graphviz
+    - squashfs-tools
 
 before_install:
   - 'if [ "$TRAVIS_OS_NAME" == "osx" ]; then
@@ -64,15 +65,6 @@ install:
   - pip install -U google-api-python-client
   - python3 -V
   - pip -V
-  - 'if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    curl -fsSLO http://www.freedesktop.org/software/desktop-file-utils/releases/desktop-file-utils-0.23.tar.xz;
-    bsdtar xf desktop-file-utils-0.23.tar.xz;
-    pushd desktop-file-utils-0.23;
-    ./configure;
-    make;
-    export "PATH=$PWD/src:$PATH";
-    popd;
-  fi'
 
 before_script:
   - echo "are changes related to source code?"
@@ -103,7 +95,18 @@ after_success:
       install -Dm755 /usr/bin/ffmpeg Pencil2D/usr/plugins/ffmpeg;
       curl -fsSLO https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage;
       chmod 755 linuxdeployqt-continuous-x86_64.AppImage;
-      LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/pulseaudio" ./linuxdeployqt-continuous-x86_64.AppImage Pencil2D/usr/share/applications/pencil2d.desktop -executable=Pencil2D/usr/plugins/ffmpeg -appimage;
+      ./linuxdeployqt-continuous-x86_64.AppImage --appimage-extract;
+      curl -fsSLO http://www.freedesktop.org/software/desktop-file-utils/releases/desktop-file-utils-0.23.tar.xz;
+      bsdtar xf desktop-file-utils-0.23.tar.xz;
+      cd desktop-file-utils-0.23;
+      ./configure;
+      make;
+      cd ../;
+      cp desktop-file-utils-0.23/src/desktop-file-validate squashfs-root/usr/bin/desktop-file-validate;
+      curl -fsSLO https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage;
+      chmod a+x appimagetool-x86_64.AppImage;
+      ./appimagetool-x86_64.AppImage squashfs-root linuxdeployqt-fixed.AppImage;
+      LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/pulseaudio" ./linuxdeployqt-fixed.AppImage Pencil2D/usr/share/applications/pencil2d.desktop -executable=Pencil2D/usr/plugins/ffmpeg -appimage;
       mv "Pencil2D-x86_64.AppImage" "pencil2d-linux-$(date +"%Y-%m-%d").AppImage";
      fi'
   - 'if [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/util/checkchanges-win.ps1
+++ b/util/checkchanges-win.ps1
@@ -6,13 +6,13 @@ $branch=$env:APPVEYOR_REPO_BRANCH
 $CHANGED_FILES=$(git diff --name-only origin/master...${commit})
 
 if ($branch -eq "master") {
-  $CHANGED_FILES=$(git diff --name-only HEAD^ HEAD) 
+  $CHANGED_FILES=$(git diff --name-only HEAD^ HEAD)
 }
 Write-Host "check against: $CHANGED_FILES"
 Write-Host "branch is $branch"
 $ONLY_READMES=$true
 
-$regex='(\.md)|(\.yml)|(\.sh)|(\.py)|(\.ps1)'
+$regex='(\.md)|(\.sh)|(\.py)|(\.ps1)'
 $code='(\.cpp)|(\.h)'
 
 foreach ($CHANGED_FILE in $CHANGED_FILES) {

--- a/util/checkchanges.sh
+++ b/util/checkchanges.sh
@@ -17,7 +17,6 @@ echo "branch is: $branch"
 
 ONLY_READMES=True
 MD=".md"
-YAML=".yml"
 SH=".sh"
 PY=".py"
 PS1=".ps1"
@@ -28,9 +27,8 @@ printf "=============\n"
 
 for CHANGED_FILE in $CHANGED_FILES; do
   printf "Check ${CHANGED_FILES}"
-  if ! [[ $CHANGED_FILE =~ $MD || 
-  		  $CHANGED_FILE =~ $YAML || 
-  		  $CHANGED_FILE =~ $SH || 
+  if ! [[ $CHANGED_FILE =~ $MD ||
+  		  $CHANGED_FILE =~ $SH ||
   		  $CHANGED_FILE =~ $PY ||
   		  $CHANGED_FILE =~ $PS1 ]] ; then
     ONLY_READMES=False


### PR DESCRIPTION
Basically linuxdeployqt has a version of desktop-file-validate embedded in it which it copies from the version embedded in appimagetool, which happens to only validate 1.0 desktop files ([and it does not appear that they plan on changing this any time soon](https://github.com/AppImage/AppImages/issues/166#issuecomment-343829147)). What this change does is extract the linuxdeployqt continuous build AppImage to an AppDir, update the desktop-file-validate version inside it, then convert it back to an AppImage and run it. As you can see [here](https://travis-ci.org/scribblemaniac/pencil/jobs/306231748#L1755), we are no longer getting the errors with desktop-file-validate, so everything should work properly.

Fixes #779 (yet again).

