### PR TITLE
fixed save, open and quit dialog issues

### DIFF
--- a/app/mainwindow2.h
+++ b/app/mainwindow2.h
@@ -70,8 +70,9 @@ public:
     void openDocument();
     bool saveDocument();
     bool saveAsNewDocument();
-    bool maybeSave();
+    int maybeSave();
     bool autoSave();
+    bool openedPopup;
 
     // import
     void importImage();


### PR DESCRIPTION
* Fixed cancel dialog button being ignored.
* Fixed save dialog appearing twice when quitting from dock on OSX 
  * The problem is caused by a bug in Qt, so for now i’ve added a simple
workaround. See: https://bugreports.qt.io/browse/QTBUG-43344