### PR TITLE
dotted cursor improvement and fixes

### DIFF
--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -863,13 +863,14 @@ void ScribbleArea::paintCanvasCursor(QPainter& painter)
 
 void ScribbleArea::updateCanvasCursor()
 {
+    float scalingFac = mEditor->view()->scaling();
     if (currentTool()->isAdjusting)
     {
-        mCursorImg = currentTool()->quickSizeCursor();
+        mCursorImg = currentTool()->quickSizeCursor(scalingFac);
     }
     else if (mEditor->preference()->isOn(SETTING::DOTTED_CURSOR))
     {
-        mCursorImg = currentTool()->canvasCursor();
+        mCursorImg = currentTool()->canvasCursor(scalingFac, width());
     }
     else
     {

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -864,13 +864,16 @@ void ScribbleArea::paintCanvasCursor(QPainter& painter)
 void ScribbleArea::updateCanvasCursor()
 {
     float scalingFac = mEditor->view()->scaling();
+    qreal brushWidth = currentTool()->properties.width;
+    qreal brushFeather = currentTool()->properties.feather;
     if (currentTool()->isAdjusting)
     {
-        mCursorImg = currentTool()->quickSizeCursor(scalingFac);
+        mCursorImg = currentTool()->quickSizeCursor(brushWidth, brushFeather, scalingFac);
     }
     else if (mEditor->preference()->isOn(SETTING::DOTTED_CURSOR))
     {
-        mCursorImg = currentTool()->canvasCursor(scalingFac, width());
+        bool useFeather = currentTool()->properties.useFeather;
+        mCursorImg = currentTool()->canvasCursor(brushWidth, brushFeather, useFeather, scalingFac, width());
     }
     else
     {
@@ -1124,9 +1127,9 @@ void ScribbleArea::drawPen(QPointF thePoint, qreal brushWidth, QColor fillColour
                             QPainter::CompositionMode_Source, useAA);
 }
 
-void ScribbleArea::drawPencil(QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity)
+void ScribbleArea::drawPencil(QPointF thePoint, qreal brushWidth, qreal fixedBrushFeather, QColor fillColour, qreal opacity)
 {
-    drawBrush(thePoint, brushWidth, 50, fillColour, opacity, true);
+    drawBrush(thePoint, brushWidth, fixedBrushFeather, fillColour, opacity, true);
 }
 
 void ScribbleArea::drawBrush(QPointF thePoint, qreal brushWidth, qreal mOffset, QColor fillColour, qreal opacity, bool usingFeather, int useAA)

--- a/core_lib/interface/scribblearea.h
+++ b/core_lib/interface/scribblearea.h
@@ -167,7 +167,7 @@ public:
     void drawLine( QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm );
     void drawPath( QPainterPath path, QPen pen, QBrush brush, QPainter::CompositionMode cm );
     void drawPen( QPointF thePoint, qreal brushWidth, QColor fillColour, bool useAA = true );
-    void drawPencil( QPointF thePoint, qreal brushWidth, QColor fillColour, qreal opacity );
+    void drawPencil( QPointF thePoint, qreal brushWidth, qreal fixedBrushFeather, QColor fillColour, qreal opacity );
     void drawBrush( QPointF thePoint, qreal brushWidth, qreal offset, QColor fillColour, qreal opacity, bool usingFeather = true, int useAA = 0 );
     void blurBrush( BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal offset_, qreal opacity_ );
     void liquifyBrush( BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal offset_, qreal opacity_ );

--- a/core_lib/tool/basetool.cpp
+++ b/core_lib/tool/basetool.cpp
@@ -28,6 +28,7 @@ GNU General Public License for more details.
 ToolPropertyType BaseTool::assistedSettingType; // setting beeing changed
 qreal BaseTool::OriginalSettingValue;  // start value (width, feather ..)
 bool BaseTool::isAdjusting = false;
+Properties BaseTool::properties;
 
 
 QString BaseTool::TypeName( ToolType type )
@@ -104,81 +105,81 @@ void BaseTool::mouseDoubleClickEvent( QMouseEvent* event )
  * @brief precision circular cursor: used for drawing a cursor within scribble area.
  * @return QPixmap
  */
-QPixmap BaseTool::canvasCursor() // Todo: only one instance required: make fn static?
+QPixmap BaseTool::canvasCursor(float scalingFac, int windowWidth)
 {
-        Q_ASSERT( mEditor->getScribbleArea() );
 
-        float scalingFac = mEditor->view()->scaling();
-        propWidth = properties.width * scalingFac;
-        propFeather = properties.feather * scalingFac;
-        cursorWidth = propWidth + 0.5 * propFeather;
+    float propWidth = properties.width * scalingFac;
+    float propFeather = properties.feather * scalingFac;
+    float cursorWidth = propWidth + 0.5 * propFeather;
 
-        if ( cursorWidth < 1 ) { cursorWidth = 1; }
-        radius = cursorWidth / 2;
-        xyA = 1 + propFeather / 2;
-        xyB = 1 + propFeather / 8;
-        whA = qMax( 0, propWidth - xyA - 1 );
-        whB = qMax( 0, cursorWidth - propFeather / 4 - 2 );
-        cursorPixmap = QPixmap( cursorWidth, cursorWidth );
-        if ( !cursorPixmap.isNull() )
-        {
-            cursorPixmap.fill( QColor( 255, 255, 255, 0 ) );
-            QPainter cursorPainter( &cursorPixmap );
-            cursorPen = cursorPainter.pen();
-            cursorPainter.setRenderHint(QPainter::HighQualityAntialiasing);
+    // delocate when cursor width gets some value larger than the widget
+    if (cursorWidth > windowWidth * 2) {
+        return QPixmap(0,0);
+    }
 
-            // Draw cross in center
-            cursorPen.setStyle( Qt::SolidLine );
-            cursorPen.setColor( QColor( 0, 0, 0, 127 ) );
-            cursorPainter.setPen(cursorPen);
-            cursorPainter.drawLine( QPointF( radius - 2, radius ), QPointF( radius + 2, radius ) );
-            cursorPainter.drawLine( QPointF( radius, radius - 2 ), QPointF( radius, radius + 2 ) );
+    if ( cursorWidth < 1 ) { cursorWidth = 1; }
+    float radius = cursorWidth / 2;
+    float xyA = 1 + propFeather / 2;
+    float xyB = 1 + propFeather / 8;
+    float whA = qMax<float>( 0, propWidth - xyA - 1 );
+    float whB = qMax<float>( 0, cursorWidth - propFeather / 4 - 2 );
+    QPixmap cursorPixmap = QPixmap( cursorWidth, cursorWidth );
+    if ( !cursorPixmap.isNull() )
+    {
+        cursorPixmap.fill( QColor( 255, 255, 255, 0 ) );
+        QPainter cursorPainter( &cursorPixmap );
+        QPen cursorPen = cursorPainter.pen();
+        cursorPainter.setRenderHint(QPainter::HighQualityAntialiasing);
 
-            // Draw outer circle
-            cursorPen.setStyle( Qt::DotLine );
-            cursorPen.setColor( QColor( 0, 0, 0, 255 ) );
-            cursorPainter.setPen(cursorPen);
-            cursorPainter.drawEllipse( QRectF( xyB, xyB, whB, whB ) );
-            cursorPen.setDashOffset( 4 );
-            cursorPen.setColor( QColor( 255, 255, 255, 255 ) );
-            cursorPainter.setPen(cursorPen);
-            cursorPainter.drawEllipse( QRectF( xyB, xyB, whB, whB ) );
+        // Draw cross in center
+        cursorPen.setStyle( Qt::SolidLine );
+        cursorPen.setColor( QColor( 0, 0, 0, 127 ) );
+        cursorPainter.setPen(cursorPen);
+        cursorPainter.drawLine( QPointF( radius - 2, radius ), QPointF( radius + 2, radius ) );
+        cursorPainter.drawLine( QPointF( radius, radius - 2 ), QPointF( radius, radius + 2 ) );
 
-            // Draw inner circle
-            cursorPen.setStyle( Qt::DotLine );
-            cursorPen.setColor( QColor( 0, 0, 0, 255 ) );
-            cursorPainter.setPen(cursorPen);
-            cursorPainter.drawEllipse( QRectF( xyA, xyA, whA, whA ) );
-            cursorPen.setDashOffset( 4 );
-            cursorPen.setColor( QColor( 255, 255, 255, 255 ) );
-            cursorPainter.setPen(cursorPen);
-            cursorPainter.drawEllipse( QRectF( xyA, xyA, whA, whA ) );
+        // Draw outer circle
+        cursorPen.setStyle( Qt::DotLine );
+        cursorPen.setColor( QColor( 0, 0, 0, 255 ) );
+        cursorPainter.setPen(cursorPen);
+        cursorPainter.drawEllipse( QRectF( xyB, xyB, whB, whB ) );
+        cursorPen.setDashOffset( 4 );
+        cursorPen.setColor( QColor( 255, 255, 255, 255 ) );
+        cursorPainter.setPen(cursorPen);
+        cursorPainter.drawEllipse( QRectF( xyB, xyB, whB, whB ) );
 
-            cursorPainter.end();
-        }
-        return cursorPixmap;
+        // Draw inner circle
+        cursorPen.setStyle( Qt::DotLine );
+        cursorPen.setColor( QColor( 0, 0, 0, 255 ) );
+        cursorPainter.setPen(cursorPen);
+        cursorPainter.drawEllipse( QRectF( xyA, xyA, whA, whA ) );
+        cursorPen.setDashOffset( 4 );
+        cursorPen.setColor( QColor( 255, 255, 255, 255 ) );
+        cursorPainter.setPen(cursorPen);
+        cursorPainter.drawEllipse( QRectF( xyA, xyA, whA, whA ) );
+
+        cursorPainter.end();
+    }
+    return cursorPixmap;
 }
 
 /**
  * @brief precision circular cursor: used for drawing stroke size while adjusting
  * @return QPixmap
  */
-QPixmap BaseTool::quickSizeCursor() // Todo: only one instance required: make fn static?
+QPixmap BaseTool::quickSizeCursor(float scalingFac)
 {
-    Q_ASSERT( mEditor->getScribbleArea() );
-
-    float scalingFac = mEditor->view()->scaling();
-    propWidth = properties.width * scalingFac;
-    propFeather = properties.feather * scalingFac;
-    cursorWidth = propWidth + 0.5 * propFeather;
+    float propWidth = properties.width * scalingFac;
+    float propFeather = properties.feather * scalingFac;
+    float cursorWidth = propWidth + 0.5 * propFeather;
 
     if ( cursorWidth < 1 ) { cursorWidth = 1; }
-    radius = cursorWidth / 2;
-    xyA = 1 + propFeather / 2;
-    xyB = 1 + propFeather / 8;
-    whA = qMax( 0, propWidth - xyA - 1 );
-    whB = qMax( 0, cursorWidth - propFeather / 4 - 2 );
-    cursorPixmap = QPixmap( cursorWidth, cursorWidth );
+    float radius = cursorWidth / 2;
+    float xyA = 1 + propFeather / 2;
+    float xyB = 1 + propFeather / 8;
+    float whA = qMax<float>( 0, propWidth - xyA - 1 );
+    float whB = qMax<float>( 0, cursorWidth - propFeather / 4 - 2 );
+    QPixmap cursorPixmap = QPixmap( cursorWidth, cursorWidth );
     if ( !cursorPixmap.isNull() )
     {
         cursorPixmap.fill( QColor( 255, 255, 255, 0 ) );

--- a/core_lib/tool/basetool.h
+++ b/core_lib/tool/basetool.h
@@ -91,8 +91,8 @@ public:
     virtual void clear() {}
 
     static bool isAdjusting;
-    static QPixmap canvasCursor(float scalingFac, int windowWidth);
-    static QPixmap quickSizeCursor(float scalingFac);
+    static QPixmap canvasCursor(float brushWidth, float brushFeather, bool useFeather, float scalingFac, int windowWidth);
+    static QPixmap quickSizeCursor(float brushWidth, float brushFeather, float scalingFac);
 
     virtual void setWidth( const qreal width );
     virtual void setFeather( const qreal feather );
@@ -110,7 +110,7 @@ public:
     virtual void leavingThisTool(){}
     virtual void switchingLayers(){}
 
-    static Properties properties;
+    Properties properties;
 
     QPointF getCurrentPixel();
     QPointF getCurrentPoint();

--- a/core_lib/tool/basetool.h
+++ b/core_lib/tool/basetool.h
@@ -91,8 +91,8 @@ public:
     virtual void clear() {}
 
     static bool isAdjusting;
-    QPixmap canvasCursor();
-    QPixmap quickSizeCursor();
+    static QPixmap canvasCursor(float scalingFac, int windowWidth);
+    static QPixmap quickSizeCursor(float scalingFac);
 
     virtual void setWidth( const qreal width );
     virtual void setFeather( const qreal feather );
@@ -110,7 +110,7 @@ public:
     virtual void leavingThisTool(){}
     virtual void switchingLayers(){}
 
-    Properties properties;
+    static Properties properties;
 
     QPointF getCurrentPixel();
     QPointF getCurrentPoint();
@@ -131,18 +131,6 @@ protected:
     qreal mAdjustmentStep = 0.0f;
 
 private:
-    int propWidth;
-    int propFeather;
-    int width;
-    int cursorWidth;
-
-    int radius;
-    int xyA;
-    int xyB;
-    int whA;
-    int whB;
-    QPixmap cursorPixmap;
-    QPen cursorPen;
 };
 
 #endif // BASETOOL_H

--- a/core_lib/tool/penciltool.h
+++ b/core_lib/tool/penciltool.h
@@ -45,6 +45,7 @@ public:
 
     void setWidth( const qreal width ) override;
     void setFeather( const qreal feather ) override;
+    void setUseFeather( const bool useFeather ) override;
     void setInvisibility( const bool invisibility ) override;
     void setPressure( const bool pressure ) override;
     void setPreserveAlpha( const bool preserveAlpha ) override;


### PR DESCRIPTION
*  fixed an issue that could make dotted cursor stall application.
    It would only happen whenever dotted cursor was enabled and you zoomed
    too close with a huge brush. An example would be > 150 brushWidth and + 4000% zoom.
* Fixed feather cursor visual would be shown even though feather is off.

Additionally I’ve also made canvasCursor and quickSizeCursor static.