### PR TITLE
get Qt 5.9 from history, since homebrew updated to 5.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,8 @@ before_install:
     brew update;
     brew install p7zip;
     brew install python3;
-    brew install qt@5.9;
-    brew link qt@5.9 --force;
+    brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/13d52537d1e0e5f913de46390123436d220035f6/Formula/qt.rb;
+    brew link qt --force;
   fi'
 
 install:


### PR DESCRIPTION
I tried to get the formula from git but homebrew just kept ignoring it, now grabbing directly from githubs raw https.