### PR TITLE
Improve GIF export quality by removing first pass conversion to mp4

### DIFF
--- a/core_lib/movieexporter.h
+++ b/core_lib/movieexporter.h
@@ -54,9 +54,8 @@ private:
     Status generateImageSequence(const Object* obj, std::function<void(float)> progress);
     Status combineVideoAndAudio(QString ffmpegPath, QString strOutputFile);
 
-    Status twoPassEncoding(QString ffmpeg, QString strOutputFile);
     Status convertVideoAgain(QString ffmpeg, QString strIn, QString strOut);
-    Status convertToGif(QString ffmpeg, QString strIn, QString strOut);
+    Status convertToGif(QString ffmpeg, QString strOut);
 
     Status executeFFMpegCommand(QString strCmd);
     Status checkInputParameters(const ExportMovieDesc&);


### PR DESCRIPTION
I was content to wait for #681, however since there were already attempts to improve the current exporting lately (ac5e19f, 17bff13), I thought I would take a moment to finish this up. GIF export is now greatly improved, no more video artifacts. Based on my tests, it is visually identical to ImageMagick's GIF export and looks about as good as GIFs possibly can.

Closes #818