### PR TITLE
properly downscale canvas when zooming out

### DIFF
--- a/core_lib/canvasrenderer.h
+++ b/core_lib/canvasrenderer.h
@@ -27,6 +27,8 @@ GNU General Public License for more details.
 
 class Object;
 class Layer;
+class BitmapImage;
+class ViewManager;
 
 
 struct RenderOptions
@@ -60,17 +62,19 @@ public:
 
     void setCanvas( QPixmap* canvas );
     void setViewTransform( QTransform viewTransform );
+    void setView( ViewManager* view ) {mView = view; }
     void setOptions( RenderOptions p ) { mOptions = p; }
     void setTransformedSelection( QRect selection, QTransform transform );
     void ignoreTransformedSelection();
     QRect getCameraRect();
 
-    void paint( Object* object, int layer, int frame, QRect rect );
+    void paint(Object* object, int layer, int frame, QRect rect);
     void renderGrid(QPainter& painter);
 
 private:
     void paintBackground();
     void paintOnionSkin( QPainter& painter );
+
     void paintCurrentFrame( QPainter& painter );
 
     void paintBitmapFrame( QPainter&, int layerId, int nFrame, bool colorize = false , bool useLastKeyFrame = true );
@@ -80,15 +84,20 @@ private:
     void paintGrid( QPainter& painter );
     void paintCameraBorder(QPainter& painter);
     void paintAxis( QPainter& painter );
+    void prescale(QPainter &painter, BitmapImage* bitmapImage);
 
 private:
     QPixmap* mCanvas = nullptr;
     Object* mObject = nullptr;
+    ViewManager* mView = nullptr;
     QTransform mViewTransform;
+
     QRect mCameraRect;
 
     int mCurrentLayerIndex = 0;
     int mFrameNumber = 0;
+
+    QImage mScaledBitmap;
 
     bool bMultiLayerOnionSkin = false;
     

--- a/core_lib/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/graphics/bitmap/bitmapimage.cpp
@@ -82,6 +82,13 @@ void BitmapImage::paintImage(QPainter& painter)
     painter.drawImage(topLeft(), *mImage);
 }
 
+void BitmapImage::paintImage(QPainter& painter, QImage& image,QRect sourceRect, QRect destRect)
+{
+    painter.drawImage(QRect(QPoint(topLeft()), destRect.size()),
+                      image,
+                      sourceRect);
+}
+
 BitmapImage BitmapImage::copy()
 {
     return BitmapImage(mBounds, QImage(*mImage));

--- a/core_lib/graphics/bitmap/bitmapimage.h
+++ b/core_lib/graphics/bitmap/bitmapimage.h
@@ -35,6 +35,7 @@ public:
     BitmapImage& operator=( const BitmapImage& a );
 
     void paintImage( QPainter& painter );
+    void paintImage(QPainter &painter, QImage &image, QRect sourceRect, QRect destRect);
 
     QImage* image() { return mImage.get(); }
     void    setImage( QImage* pImg );

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -1088,6 +1088,7 @@ void ScribbleArea::drawCanvas(int frame, QRect rect)
     //qDebug() << "Antialias=" << options.bAntiAlias;
 
     mCanvasRenderer.setCanvas(&mCanvas);
+    mCanvasRenderer.setView(mEditor->view());
     mCanvasRenderer.setViewTransform(mEditor->view()->getView());
 
     mCanvasRenderer.paint(object, mEditor->layers()->currentLayerIndex(), frame, rect);


### PR DESCRIPTION
This will properly downscale the canvas when the view is below 100%
### before:
![wip](https://user-images.githubusercontent.com/1045397/33984046-8d86a28c-e0b6-11e7-8bbb-d1b54eb77aa7.gif)

### after:
![wip2](https://user-images.githubusercontent.com/1045397/33984055-97c6bd40-e0b6-11e7-9a75-aa057e2ef437.gif)

I've been trying to get it to work when zooming in too, but the way the renderer currently works makes it impossible as the canvas has to be upscaled a lot and qimage is not made for that.

When we migrate to myPaintLib, I will look into this again, because its renderer splits the canvas up into smaller sections and therefore should provide the solution we need to make that work.
This will additionally also make it possible for us to prescale the brush stroke, so the representation will have the same look.