### PR TITLE
[WIP] Modify the bitmap bucket flood fill algorithm

### DIFF
--- a/core_lib/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/graphics/bitmap/bitmapimage.cpp
@@ -508,13 +508,9 @@ bool BitmapImage::compareColor(QRgb color1, QRgb color2, int tolerance)
 
 // Flood fill
 // ----- http://lodev.org/cgtutor/floodfill.html
-void BitmapImage::floodFill(BitmapImage* targetImage, QRect cameraRect, QPoint point, QRgb oldColor, QRgb newColor, int tolerance)
+void BitmapImage::floodFill(BitmapImage* targetImage, QRect cameraRect, QPoint point, QRgb newColor, int tolerance)
 {
-    if ( oldColor == newColor ){
-        return;
-    }
-
-    oldColor = targetImage->pixel( point );
+    QRgb oldColor = targetImage->pixel( point );
     oldColor = qRgba( qRed( oldColor ), qGreen( oldColor ), qBlue( oldColor ), qAlpha( oldColor ) );
 
     // Preparations

--- a/core_lib/graphics/bitmap/bitmapimage.h
+++ b/core_lib/graphics/bitmap/bitmapimage.h
@@ -72,7 +72,6 @@ public:
     void clear( QRectF rectangle ) { clear( rectangle.toRect() ); }
 
     static int pow( int );
-    static bool compareColor(QRgb color1, QRgb color2, int tolerance);
     static void floodFill(BitmapImage* targetImage, QRect cameraRect, QPoint point, QRgb newColor, int tolerance );
 
     void drawLine( QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm, bool antialiasing );
@@ -94,6 +93,8 @@ public:
     QRect& bounds() { return mBounds; }
 
 private:
+    static bool floodFillCompareColor(QRgb color1, QRgb color2, int tolerance, QHash<QRgb, bool> *cache);
+
     std::shared_ptr< QImage > mImage;
     QRect   mBounds;
     bool    mExtendable = true;

--- a/core_lib/graphics/bitmap/bitmapimage.h
+++ b/core_lib/graphics/bitmap/bitmapimage.h
@@ -73,7 +73,7 @@ public:
 
     static int pow( int );
     static bool compareColor(QRgb color1, QRgb color2, int tolerance);
-    static void floodFill(BitmapImage* targetImage, QRect cameraRect, QPoint point, QRgb oldColor, QRgb newColor, int tolerance );
+    static void floodFill(BitmapImage* targetImage, QRect cameraRect, QPoint point, QRgb newColor, int tolerance );
 
     void drawLine( QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm, bool antialiasing );
     void drawRect( QRectF rectangle, QPen pen, QBrush brush, QPainter::CompositionMode cm, bool antialiasing );

--- a/core_lib/tool/buckettool.cpp
+++ b/core_lib/tool/buckettool.cpp
@@ -150,7 +150,6 @@ void BucketTool::paintBitmap(Layer* layer)
     BitmapImage::floodFill( targetImage,
                             cameraRect,
                             point,
-                            Qt::transparent,
                             qPremultiply( mEditor->color()->frontColor().rgba() ),
                             properties.tolerance * 2.55 );
 


### PR DESCRIPTION
This makes some significant changes to the flood fill algorithm of the Bucket tool. Here's my best summary of the changes and why they're needed.

### Color difference
Instead of checking if any one channel has a difference in color greater than the threshold, we check if the Euclidean distance between the colors (excluding the alpha channel) is less than the threshold. This means if you have two colors that are 14 values apart on the red, blue, and green channels, then with a threshold of 15 it will be over the threshold because the Euclidean distance is ~26. Differences in transparency are immediately assumed to be different colors, primarily because a transparency of 0 is the same color regardless of the other channels. There is one exception to this which I will talk about shortly.

### Speed optimization
Inspired by how Krita does flood filling, I have added a hash map to remember if colors are within the threshold for the duration of the operation (threshold and oldColor will remain constant, so only newColor is needed for lookup). Since the vast majority of the pixels that will be encountered are usually from a small subset of colors, this should have significant speed benefits. The Euclidean difference operation is probably a bit slower than the old difference operation, so this is even more important.

### Limit fill boundaries
There is currently an issue in Pencil2D where filling outside of the camera area creates some weird behavior. To fix this, here is the behavior I propose (and implemented already 😝 ). If the place you click is outside the union of the the current camera view bounds and active layer keyframe bounds, then do nothing. Otherwise, expand the image size to the union bounds, and then apply the flood fill at the location pressed to the entire layer keyframe image.

### Different behavior for filling fully transparent areas
This is the only change I made that could really be contentious. I am not aware of any applications that implement bucket fill this way, but I think this is the best way for us to do it, specifically for the workflows that Pencil2D animators will typically be following.

Basically, when you try to fill a transparent area, it will assume that all transparent *and translucent* pixels are below the threshold. In addition to this change, instead of composting the filled color pixmap over top of the original image, it is composited *underneath*. There are two main user-noticeable differences as a result of these changes:
1. Antialiased lines are filled smoothly. This is the desired effect and the whole reason for making this change. Instead of the fill stopping at the antialiased lines, it goes under them. If for instance you drew an aliased or feathered black line and then flood filled the background with black, an outline would remain filled with translucent black pixels normally. With this new technique it would just be a fully black canvas. Here's a demonstration the difference:

| Unfilled | Old Fill Algorithm | New Fill Algorithm|
|---|---|---|
| ![example unfilled](https://user-images.githubusercontent.com/3461051/34013691-bc3fe6fa-e0d5-11e7-88b1-c748254daa79.png) | ![example old filled](https://user-images.githubusercontent.com/3461051/34013698-c1b9bd2c-e0d5-11e7-9b38-9fd3ff4ac297.png) | ![example new filled](https://user-images.githubusercontent.com/3461051/34013704-c5beda88-e0d5-11e7-98c9-6a3f1704c4b4.png) |

2. Now for the catch (maybe). If there are solid, translucent lines, they will not stop the flood fill. However I don't think this is a significant issue since translucent lines are hardly every used in animation. Far more frequently you seen antialiased/feathered opaque lines than translucent lines. Slightly more likely, two lines may only be connected by feathering, in which case the will not form a "closed" segment as far as the flood fill is concerned. Depending on the situation, I could see this as either a feature or a bug.

I think that the benefits of this new transparent fill algorithm outweighs its drawbacks, especially for traditional animation and the typical "cartoon style".