### PR TITLE
Fix ram consumption and lag when zooming out 

### DIFF
--- a/core_lib/canvaspainter.cpp
+++ b/core_lib/canvaspainter.cpp
@@ -77,7 +77,7 @@ void CanvasPainter::paint(const Object* object, int layer, int frame, QRect rect
     mCurrentLayerIndex = layer;
     mFrameNumber = frame;
 
-    QRectF mappedInvCanvas = mViewInverse.mapRect(mCanvas->rect());
+    QRectF mappedInvCanvas = mViewInverse.mapRect(QRectF(mCanvas->rect()));
     QSizeF croppedPainter = QSizeF(mappedInvCanvas.size());
     QRectF aligned = QRectF(QPointF(mappedInvCanvas.topLeft()), croppedPainter);
     QPainter painter(mCanvas);
@@ -257,14 +257,14 @@ void CanvasPainter::prescale(BitmapImage* bitmapImage)
     // to our (not yet) scaled bitmap
     mScaledBitmap = origImage.copy();
 
-    // map to correct matrix
-    QRectF mappedOrigImage = mViewInverse.mapRect(QRectF(origImage.rect()));
-
     if (mOptions.scaling >= 1.0) {
         // TODO: Qt doesn't handle huge upscaled qimages well...
         // possible solution, myPaintLib canvas renderer splits its canvas up in chunks.
     }
     else {
+
+        // map to correct matrix
+        QRectF mappedOrigImage = mViewTransform.mapRect(QRectF(origImage.rect()));
         mScaledBitmap = mScaledBitmap.scaled(mappedOrigImage.size().toSize(),
                                              Qt::KeepAspectRatio, Qt::SmoothTransformation);
     }


### PR DESCRIPTION
The problem occurred here https://github.com/pencil2d/pencil/commit/fac2c762c8ecaf4246369fc851c9a93bdce21271
when my transform was accidentally reversed :P 

So basically what caused the lag here is that the canvas got upscaled A LOT and then downscaled again (by the painter) to get a good subsampled picture. This is not a problem when the image is small but when it becomes 50x larger then it gets hairy because it's trying to allocate a huge image in memory (in case of 96x scale) that has to be made for each time it's being asked to zoom the canvas.