### PR TITLE
Dock nesting and UI tweaking

### DIFF
--- a/app/mainwindow2.cpp
+++ b/app/mainwindow2.cpp
@@ -207,6 +207,7 @@ void MainWindow2::createDockWidgets()
     addDockWidget(Qt::LeftDockWidgetArea, mToolBox);
     addDockWidget(Qt::LeftDockWidgetArea, mToolOptions);
     addDockWidget(Qt::BottomDockWidgetArea, mTimeLine);
+    setDockNestingEnabled(true);
     //addDockWidget( Qt::BottomDockWidgetArea, mTimeline2);
 
     /*

--- a/app/toolbox.cpp
+++ b/app/toolbox.cpp
@@ -31,156 +31,259 @@ GNU General Public License for more details.
 // ----------------------------------------------------------------------------------
 QString GetToolTips( QString strCommandName )
 {
-	strCommandName = QString( "shortcuts/" ) + strCommandName;
-	QKeySequence keySequence( pencilSettings().value( strCommandName ).toString() );
-	return QString("<b>%1</b>").arg( keySequence.toString() ); // don't tr() this string.
+    strCommandName = QString( "shortcuts/" ) + strCommandName;
+    QKeySequence keySequence( pencilSettings().value( strCommandName ).toString() );
+    return QString("<b>%1</b>").arg( keySequence.toString() ); // don't tr() this string.
 }
 
 ToolBoxWidget::ToolBoxWidget( QWidget* parent ) : BaseDockWidget( parent )
 {
-	setWindowTitle( tr( "Tools", "Window title of tool box" ) );
+    setWindowTitle( tr( "Tools", "Window title of tool box" ) );
+    setWindowIcon(QIcon());
 }
 
 void ToolBoxWidget::initUI()
 {
-	QGridLayout* layout = new QGridLayout();
+
+    layout = new QGridLayout();
 
     pencilButton = newToolButton( QIcon( ":icons/new/svg/pencil_detailed.svg" ),
-		tr( "Pencil Tool (%1): Sketch with pencil" )
-		.arg( GetToolTips( CMD_TOOL_PENCIL ) ) );
+                tr( "Pencil Tool (%1): Sketch with pencil" )
+                .arg( GetToolTips( CMD_TOOL_PENCIL ) ) );
     selectButton = newToolButton( QIcon( ":icons/new/svg/selection.svg" ),
-		tr( "Select Tool (%1): Select an object" )
-		.arg( GetToolTips( CMD_TOOL_SELECT ) ) );
+                tr( "Select Tool (%1): Select an object" )
+                .arg( GetToolTips( CMD_TOOL_SELECT ) ) );
     moveButton = newToolButton( QIcon( ":icons/new/svg/arrow.svg" ),
-		tr( "Move Tool (%1): Move an object" )
-		.arg( GetToolTips( CMD_TOOL_MOVE ) ) );
+                tr( "Move Tool (%1): Move an object" )
+                .arg( GetToolTips( CMD_TOOL_MOVE ) ) );
     handButton = newToolButton( QIcon( ":icons/new/svg/hand_detailed.svg" ),
-		tr( "Hand Tool (%1): Move the canvas" )
-		.arg( GetToolTips( CMD_TOOL_HAND ) ) );
+                tr( "Hand Tool (%1): Move the canvas" )
+                .arg( GetToolTips( CMD_TOOL_HAND ) ) );
     penButton = newToolButton( QIcon( ":icons/new/svg/pen_detailed.svg" ),
-		tr( "Pen Tool (%1): Sketch with pen" )
-		.arg( GetToolTips( CMD_TOOL_PEN ) ) );
+                tr( "Pen Tool (%1): Sketch with pen" )
+                .arg( GetToolTips( CMD_TOOL_PEN ) ) );
     eraserButton = newToolButton( QIcon( ":icons/new/svg/eraser_detailed.svg" ),
-		tr( "Eraser Tool (%1): Erase" )
-		.arg( GetToolTips( CMD_TOOL_ERASER ) ) );
+                tr( "Eraser Tool (%1): Erase" )
+                .arg( GetToolTips( CMD_TOOL_ERASER ) ) );
     polylineButton = newToolButton( QIcon( ":icons/new/svg/line.svg" ),
-		tr( "Polyline Tool (%1): Create line/curves" )
-		.arg( GetToolTips( CMD_TOOL_POLYLINE ) ) );
+                tr( "Polyline Tool (%1): Create line/curves" )
+                .arg( GetToolTips( CMD_TOOL_POLYLINE ) ) );
     bucketButton = newToolButton( QIcon( ":icons/new/svg/bucket_detailed.svg" ),
-		tr( "Paint Bucket Tool (%1): Fill selected area with a color" )
-		.arg( GetToolTips( CMD_TOOL_BUCKET ) ) );
+                tr( "Paint Bucket Tool (%1): Fill selected area with a color" )
+                .arg( GetToolTips( CMD_TOOL_BUCKET ) ) );
     colouringButton = newToolButton( QIcon( ":icons/new/svg/brush_detailed.svg" ),
-		tr( "Brush Tool (%1): Paint smooth stroke with a brush" )
-		.arg( GetToolTips( CMD_TOOL_BRUSH ) ) );
+                tr( "Brush Tool (%1): Paint smooth stroke with a brush" )
+                .arg( GetToolTips( CMD_TOOL_BRUSH ) ) );
     eyedropperButton = newToolButton( QIcon( ":icons/new/svg/eyedropper_detailed.svg" ),
-		tr( "Eyedropper Tool (%1): "
-			"Set color from the stage<br>[ALT] for instant access" )
-		.arg( GetToolTips( CMD_TOOL_EYEDROPPER ) ) );
+                tr( "Eyedropper Tool (%1): "
+                        "Set color from the stage<br>[ALT] for instant access" )
+                .arg( GetToolTips( CMD_TOOL_EYEDROPPER ) ) );
     clearButton = newToolButton( QIcon( ":icons/new/svg/trash_detailed.svg" ),
-		tr( "Clear Frame (%1): Erases content of selected frame" )
-		.arg( GetToolTips( CMD_CLEAR_FRAME ) ) );
+                tr( "Clear Frame (%1): Erases content of selected frame" )
+                .arg( GetToolTips( CMD_CLEAR_FRAME ) ) );
     smudgeButton = newToolButton( QIcon( ":icons/new/svg/smudge_detailed.svg" ),
-		tr( "Smudge Tool (%1):<br>Edit polyline/curves<br>"
-			"Liquify bitmap pixels<br> (%1)+[Alt]: Smooth" )
-		.arg( GetToolTips( CMD_TOOL_SMUDGE ) ) );
+                tr( "Smudge Tool (%1):<br>Edit polyline/curves<br>"
+                        "Liquify bitmap pixels<br> (%1)+[Alt]: Smooth" )
+                .arg( GetToolTips( CMD_TOOL_SMUDGE ) ) );
 
-	pencilButton->setWhatsThis( tr( "Pencil Tool (%1)" )
-		.arg( GetToolTips( CMD_TOOL_PENCIL ) ) );
-	selectButton->setWhatsThis( tr( "Select Tool (%1)" )
-		.arg( GetToolTips( CMD_TOOL_SELECT ) ) );
-	moveButton->setWhatsThis( tr( "Move Tool (%1)" )
-		.arg( GetToolTips( CMD_TOOL_MOVE ) ) );
-	handButton->setWhatsThis( tr( "Hand Tool (%1)" )
-		.arg( GetToolTips( CMD_TOOL_HAND ) ) );
-	penButton->setWhatsThis( tr( "Pen Tool (%1)" )
-		.arg( GetToolTips( CMD_TOOL_PEN ) ) );
-	eraserButton->setWhatsThis( tr( "Eraser Tool (%1)" )
-		.arg( GetToolTips( CMD_TOOL_ERASER ) ) );
-	polylineButton->setWhatsThis( tr( "Polyline Tool (%1)" )
-		.arg( GetToolTips( CMD_TOOL_POLYLINE ) ) );
-	bucketButton->setWhatsThis( tr( "Paint Bucket Tool (%1)" )
-		.arg( GetToolTips( CMD_TOOL_BUCKET ) ) );
-	colouringButton->setWhatsThis( tr( "Brush Tool (%1)" )
-		.arg( GetToolTips( CMD_TOOL_BRUSH ) ) );
-	eyedropperButton->setWhatsThis( tr( "Eyedropper Tool (%1)" )
-		.arg( GetToolTips( CMD_TOOL_EYEDROPPER ) ) );
-	clearButton->setWhatsThis( tr( "Clear Tool (%1)" )
-		.arg( GetToolTips( CMD_CLEAR_FRAME ) ) );
-	smudgeButton->setWhatsThis( tr( "Smudge Tool (%1)" )
-		.arg( GetToolTips( CMD_TOOL_SMUDGE ) ) );
+    pencilButton->setWhatsThis( tr( "Pencil Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_PENCIL ) ) );
+    selectButton->setWhatsThis( tr( "Select Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_SELECT ) ) );
+    moveButton->setWhatsThis( tr( "Move Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_MOVE ) ) );
+    handButton->setWhatsThis( tr( "Hand Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_HAND ) ) );
+    penButton->setWhatsThis( tr( "Pen Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_PEN ) ) );
+    eraserButton->setWhatsThis( tr( "Eraser Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_ERASER ) ) );
+    polylineButton->setWhatsThis( tr( "Polyline Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_POLYLINE ) ) );
+    bucketButton->setWhatsThis( tr( "Paint Bucket Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_BUCKET ) ) );
+    colouringButton->setWhatsThis( tr( "Brush Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_BRUSH ) ) );
+    eyedropperButton->setWhatsThis( tr( "Eyedropper Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_EYEDROPPER ) ) );
+    clearButton->setWhatsThis( tr( "Clear Tool (%1)" )
+        .arg( GetToolTips( CMD_CLEAR_FRAME ) ) );
+    smudgeButton->setWhatsThis( tr( "Smudge Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_SMUDGE ) ) );
 
-	pencilButton->setCheckable( true );
-	penButton->setCheckable( true );
-	polylineButton->setCheckable( true );
-	bucketButton->setCheckable( true );
-	colouringButton->setCheckable( true );
-	smudgeButton->setCheckable( true );
-	eyedropperButton->setCheckable( true );
-	selectButton->setCheckable( true );
-	moveButton->setCheckable( true );
-	handButton->setCheckable( true );
-	eraserButton->setCheckable( true );
-	pencilButton->setChecked( true );
+    pencilButton->setCheckable( true );
+    penButton->setCheckable( true );
+    polylineButton->setCheckable( true );
+    bucketButton->setCheckable( true );
+    colouringButton->setCheckable( true );
+    smudgeButton->setCheckable( true );
+    eyedropperButton->setCheckable( true );
+    selectButton->setCheckable( true );
+    moveButton->setCheckable( true );
+    handButton->setCheckable( true );
+    eraserButton->setCheckable( true );
+    pencilButton->setChecked( true );
 
-	layout->setMargin( 2 );
-	layout->setSpacing( 0 );
+    layout->setMargin( 0 );
+    layout->setSpacing( 0 );
 
-	layout->addWidget( moveButton, 0, 0 );
-	layout->setAlignment( moveButton, Qt::AlignRight );
-	layout->addWidget( clearButton, 0, 1 );
-	layout->setAlignment( clearButton, Qt::AlignLeft );
+    QWidget* toolGroup = new QWidget();
 
-	layout->addWidget( selectButton, 1, 0 );
-	layout->setAlignment( selectButton, Qt::AlignRight );
-	layout->addWidget( colouringButton, 1, 1 );
-	layout->setAlignment( colouringButton, Qt::AlignLeft );
+    setWidget( toolGroup );
+    toolGroup->setLayout( layout );
 
-	layout->addWidget( polylineButton, 2, 0 );
-	layout->setAlignment( polylineButton, Qt::AlignRight );
-	layout->addWidget( smudgeButton, 2, 1 );
-	layout->setAlignment( smudgeButton, Qt::AlignLeft );
+    connect( pencilButton, &QToolButton::clicked, this, &ToolBoxWidget::pencilOn );
+    connect( eraserButton, &QToolButton::clicked, this, &ToolBoxWidget::eraserOn );
+    connect( selectButton, &QToolButton::clicked, this, &ToolBoxWidget::selectOn );
+    connect( moveButton, &QToolButton::clicked, this, &ToolBoxWidget::moveOn );
+    connect( penButton, &QToolButton::clicked, this, &ToolBoxWidget::penOn );
+    connect( handButton, &QToolButton::clicked, this, &ToolBoxWidget::handOn );
+    connect( polylineButton, &QToolButton::clicked, this, &ToolBoxWidget::polylineOn );
+    connect( bucketButton, &QToolButton::clicked, this, &ToolBoxWidget::bucketOn );
+    connect( eyedropperButton, &QToolButton::clicked, this, &ToolBoxWidget::eyedropperOn );
+    connect( colouringButton, &QToolButton::clicked, this, &ToolBoxWidget::brushOn );
+    connect( smudgeButton, &QToolButton::clicked, this, &ToolBoxWidget::smudgeOn );
+    connect( clearButton, &QToolButton::clicked, this, &ToolBoxWidget::clearButtonClicked );
 
-	layout->addWidget( penButton, 3, 0 );
-	layout->setAlignment( penButton, Qt::AlignRight );
-	layout->addWidget( handButton, 3, 1 );
-	layout->setAlignment( handButton, Qt::AlignLeft );
-
-	layout->addWidget( pencilButton, 4, 0 );
-	layout->setAlignment( pencilButton, Qt::AlignRight );
-	layout->addWidget( bucketButton, 4, 1 );
-	layout->setAlignment( bucketButton, Qt::AlignLeft );
-
-	layout->addWidget( eyedropperButton, 5, 0 );
-	layout->setAlignment( eyedropperButton, Qt::AlignRight );
-	layout->addWidget( eraserButton, 5, 1 );
-	layout->setAlignment( eraserButton, Qt::AlignLeft );
-
-	QWidget* toolGroup = new QWidget();
-	setWidget( toolGroup );
-	toolGroup->setLayout( layout );
-	toolGroup->setMaximumHeight( 6 * 32 + 1 );
-
-	setMaximumHeight( 200 );
-
-	connect( pencilButton, &QToolButton::clicked, this, &ToolBoxWidget::pencilOn );
-	connect( eraserButton, &QToolButton::clicked, this, &ToolBoxWidget::eraserOn );
-	connect( selectButton, &QToolButton::clicked, this, &ToolBoxWidget::selectOn );
-	connect( moveButton, &QToolButton::clicked, this, &ToolBoxWidget::moveOn );
-	connect( penButton, &QToolButton::clicked, this, &ToolBoxWidget::penOn );
-	connect( handButton, &QToolButton::clicked, this, &ToolBoxWidget::handOn );
-	connect( polylineButton, &QToolButton::clicked, this, &ToolBoxWidget::polylineOn );
-	connect( bucketButton, &QToolButton::clicked, this, &ToolBoxWidget::bucketOn );
-	connect( eyedropperButton, &QToolButton::clicked, this, &ToolBoxWidget::eyedropperOn );
-	connect( colouringButton, &QToolButton::clicked, this, &ToolBoxWidget::brushOn );
-	connect( smudgeButton, &QToolButton::clicked, this, &ToolBoxWidget::smudgeOn );
-
-	// pass to editor
-	connect( clearButton, &QToolButton::clicked, this, &ToolBoxWidget::clearButtonClicked );
-
+    QSettings settings(PENCIL2D, PENCIL2D);
+    this->restoreGeometry(settings.value( "ToolBoxGeom" ).toByteArray());
 }
 
 void ToolBoxWidget::updateUI()
 {
+}
+
+void ToolBoxWidget::resizeEvent(QResizeEvent* event)
+{
+    QRect geom = this->geometry();
+    QSize buttonSize = clearButton->size(); // all buttons share same size
+
+    // Vertical layout
+    if (geom.width() < geom.height()) {
+        if (geom.width() > buttonSize.width()*5) {
+            layout->addWidget( clearButton, 0, 0 );
+            layout->addWidget( moveButton, 0, 1 );
+
+            layout->addWidget( selectButton, 0, 2 );
+            layout->addWidget( colouringButton, 1, 0 );
+
+            layout->addWidget( polylineButton, 1, 1 );
+            layout->addWidget( smudgeButton, 1, 2 );
+
+            layout->addWidget( penButton, 2, 0 );
+            layout->addWidget( handButton, 2, 1 );
+
+            layout->addWidget( pencilButton, 2, 2 );
+            layout->addWidget( bucketButton, 3, 0 );
+
+            layout->addWidget( eyedropperButton, 3, 1 );
+            layout->addWidget( eraserButton, 3, 2 );
+        } else if (geom.width() > buttonSize.width()*3) {
+            layout->addWidget( clearButton, 0, 0 );
+            layout->addWidget( moveButton, 0, 1 );
+
+            layout->addWidget( selectButton, 1, 0 );
+            layout->addWidget( colouringButton, 1, 1 );
+
+            layout->addWidget( polylineButton, 2, 0 );
+            layout->addWidget( smudgeButton, 2, 1 );
+
+            layout->addWidget( penButton, 3, 0 );
+            layout->addWidget( handButton, 3, 1 );
+
+            layout->addWidget( pencilButton, 4, 0 );
+            layout->addWidget( bucketButton, 4, 1 );
+
+            layout->addWidget( eyedropperButton, 5, 0 );
+            layout->addWidget( eraserButton, 5, 1 );
+        } else if (geom.width() > buttonSize.width()) {
+            layout->addWidget( clearButton, 0, 0 );
+
+            layout->addWidget( moveButton, 1, 0 );
+
+            layout->addWidget( selectButton, 2, 0 );
+
+            layout->addWidget( colouringButton, 3, 0 );
+
+            layout->addWidget( polylineButton, 4, 0 );
+
+            layout->addWidget( smudgeButton, 5, 0 );
+
+            layout->addWidget( penButton, 6, 0 );
+
+            layout->addWidget( handButton, 7, 0 );
+
+            layout->addWidget( pencilButton, 8, 0 );
+
+            layout->addWidget( bucketButton, 9, 0 );
+
+            layout->addWidget( eyedropperButton, 10, 0 );
+
+            layout->addWidget( eraserButton, 11, 0 );
+        }
+    } else { // Horizontal
+        if (geom.height() > buttonSize.height()*5) {
+            layout->addWidget( clearButton, 0, 0 );
+            layout->addWidget( moveButton, 1, 0 );
+
+            layout->addWidget( selectButton, 0, 3 );
+            layout->addWidget( colouringButton, 0, 1 );
+
+            layout->addWidget( polylineButton, 1, 1 );
+            layout->addWidget( smudgeButton, 2, 1 );
+
+            layout->addWidget( penButton, 0, 2 );
+            layout->addWidget( handButton, 1, 2 );
+
+            layout->addWidget( pencilButton, 2, 2 );
+            layout->addWidget( bucketButton, 2, 0 );
+
+            layout->addWidget( eyedropperButton, 1, 3 );
+            layout->addWidget( eraserButton, 2, 3 );
+        } else if (geom.height() > buttonSize.height()*3) {
+            layout->addWidget( clearButton, 0, 0 );
+            layout->addWidget( moveButton, 1, 0 );
+
+            layout->addWidget( selectButton, 0, 1 );
+            layout->addWidget( colouringButton, 1, 1 );
+
+            layout->addWidget( polylineButton, 0, 2 );
+            layout->addWidget( smudgeButton, 1, 2 );
+
+            layout->addWidget( penButton, 0, 3 );
+            layout->addWidget( handButton, 1, 3 );
+
+            layout->addWidget( pencilButton, 0, 4 );
+            layout->addWidget( bucketButton, 1, 4 );
+
+            layout->addWidget( eyedropperButton, 0, 5 );
+            layout->addWidget( eraserButton, 1, 5 );
+
+        } else if (geom.height() > buttonSize.height() ) {
+            layout->addWidget( clearButton, 0, 0 );
+            layout->addWidget( moveButton, 0, 1 );
+
+            layout->addWidget( selectButton, 0, 2 );
+            layout->addWidget( colouringButton, 0, 3 );
+
+            layout->addWidget( polylineButton, 0, 4 );
+            layout->addWidget( smudgeButton, 0, 5 );
+
+            layout->addWidget( penButton, 0, 6 );
+            layout->addWidget( handButton, 0, 7 );
+
+            layout->addWidget( pencilButton, 0, 8 );
+            layout->addWidget( bucketButton, 0, 9 );
+
+            layout->addWidget( eyedropperButton, 0, 10 );
+            layout->addWidget( eraserButton, 0, 11 );
+        }
+    }
+
+    QWidget::resizeEvent(event);
+
+    QSettings settings(PENCIL2D, PENCIL2D);
+    settings.setValue("ToolBoxGeom", this->saveGeometry());
 }
 
 QToolButton* ToolBoxWidget::newToolButton(const QIcon& icon, QString strToolTip)
@@ -189,6 +292,21 @@ QToolButton* ToolBoxWidget::newToolButton(const QIcon& icon, QString strToolTip)
     toolButton->setAutoRaise(true);
     toolButton->setIconSize( QSize(24,24) );
     toolButton->setFixedSize(32, 32);
+    toolButton->setStyleSheet("QToolButton {"
+                              "border: 0px;"
+                                "}"
+
+                              "QToolButton:pressed {"
+                                "border: 1px solid #ADADAD;"
+                                "border-radius: 2px;"
+                                "background-color: #D5D5D5;"
+                              "}"
+
+                              "QToolButton:checked {"
+                                "border: 1px solid #ADADAD;"
+                                "border-radius: 2px;"
+                                "background-color: #D5D5D5;"
+                              "}");
     toolButton->setIcon(icon);
     toolButton->setToolTip(strToolTip);
 

--- a/app/toolbox.h
+++ b/app/toolbox.h
@@ -21,6 +21,7 @@ GNU General Public License for more details.
 #include "basedockwidget.h"
 
 class QToolButton;
+class QGridLayout;
 class QIcon;
 class SpinSlider;
 class DisplayOptionWidget;
@@ -58,6 +59,8 @@ private:
     QToolButton* newToolButton(const QIcon&, QString);
     void deselectAllTools();
 
+    QGridLayout* layout;
+
     QToolButton* pencilButton = nullptr;
     QToolButton* selectButton = nullptr;
     QToolButton* moveButton = nullptr;
@@ -70,6 +73,9 @@ private:
     QToolButton* eyedropperButton = nullptr;
     QToolButton* smudgeButton = nullptr;
     QToolButton* clearButton = nullptr;
+
+protected:
+    void resizeEvent(QResizeEvent* event) override;
 };
 
 #endif

--- a/app/ui/displayoption.ui
+++ b/app/ui/displayoption.ui
@@ -13,6 +13,23 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
+  <property name="styleSheet">
+   <string notr="true">QToolButton {
+	border: 0px;
+}
+
+QToolButton:pressed {
+	border: 1px solid #ADADAD;
+	border-radius: 2px;
+	background-color: #D5D5D5;
+}
+
+QToolButton:checked {
+	border: 1px solid #ADADAD;
+	border-radius: 2px;
+	background-color: #D5D5D5;
+}</string>
+  </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
     <number>4</number>


### PR DESCRIPTION
![ui-dock-custom](https://user-images.githubusercontent.com/1045397/34680181-9561c23e-f498-11e7-8973-6847336b2714.gif)

I've wanted nested docks for a long time, just never prioritized it enough to do it.
Now it's implemented though as well as some UI tweakings.

If you haven't noticed, I've removed the border around the toolbox icons when they're not active, same for "display options". Additionally the border which is still visible on a focused icon has been rounded and the background color changed slightly.

As for the toolbox, which is the main change in this PR, you can now drag it to fit horizontal, vertical layout, as well as the old "side by side" grid layout.
 
  
  