### PR TITLE
Switch AppVeyor from 5.9.2 to 5.9.x

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
     - arch:       win32
       bitsize:    x86
       platform:   x86
-      qt:         5.9.2\msvc2015
+      qt:         5.9\msvc2015
       suffix:     msvc2015
       generator:  "Visual Studio 2015"
       PYTHON: "C:\\Python35"
@@ -19,7 +19,7 @@ environment:
     - arch:       win32
       bitsize:    x64
       platform:   amd64
-      qt:         5.9.2\msvc2015_64
+      qt:         5.9\msvc2015_64
       suffix:     msvc2015
       generator:  "Visual Studio 2015 Win64"
       PYTHON: "C:\\Python35"


### PR DESCRIPTION
Apparently AppVeyor recently switched from 5.9.2 to 5.9.3 which broke builds for me. With this, our build will always use whatever version of the 5.9 release is currently available on AppVeyor.