### PR TITLE
Patch desktop entry to be version 1.0 in AppImages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ addons:
       - doxygen-latex
       - doxygen-gui
       - graphviz
-      - squashfs-tools
       - python3
       - python3-pip
 
@@ -97,21 +96,11 @@ after_success:
       make INSTALL_ROOT="${PWD}/Pencil2D" install;
       rm -rf Pencil2D/usr/lib;
       echo "Creating AppImage...";
+      sed -i "/^Keywords\(\[[a-zA-Z_.@]\+\]\)\?=/d;/^Version=/cVersion=1.0" Pencil2D/usr/share/applications/pencil2d.desktop;
       install -Dm755 /usr/bin/ffmpeg Pencil2D/usr/plugins/ffmpeg;
       curl -fsSLO https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage;
       chmod 755 linuxdeployqt-continuous-x86_64.AppImage;
-      ./linuxdeployqt-continuous-x86_64.AppImage --appimage-extract;
-      curl -fsSLO http://www.freedesktop.org/software/desktop-file-utils/releases/desktop-file-utils-0.23.tar.xz;
-      bsdtar xf desktop-file-utils-0.23.tar.xz;
-      cd desktop-file-utils-0.23;
-      ./configure;
-      make;
-      cd ../;
-      cp desktop-file-utils-0.23/src/desktop-file-validate squashfs-root/usr/bin/desktop-file-validate;
-      curl -fsSLO https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage;
-      chmod a+x appimagetool-x86_64.AppImage;
-      ./appimagetool-x86_64.AppImage squashfs-root linuxdeployqt-fixed.AppImage;
-      LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/pulseaudio" ./linuxdeployqt-fixed.AppImage Pencil2D/usr/share/applications/pencil2d.desktop -executable=Pencil2D/usr/plugins/ffmpeg -appimage;
+      LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/pulseaudio" ./linuxdeployqt-continuous-x86_64.AppImage Pencil2D/usr/share/applications/pencil2d.desktop -executable=Pencil2D/usr/plugins/ffmpeg -appimage;
       mv "Pencil2D-x86_64.AppImage" "pencil2d-linux-$(date +"%Y-%m-%d").AppImage";
      fi'
   - 'if [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/pencil2d.desktop
+++ b/pencil2d.desktop
@@ -9,6 +9,6 @@ Comment[de]=Traditionelle handgezeichnete Animation sowohl mit Raster- als auch 
 Icon=pencil2d
 Exec=Pencil2D %f
 MimeType=application/x-pencil-pcl;application/x-pencil-pclx;
-Categories=Graphics;2DGraphics;VectorGraphics;RasterGraphics;Qt;AudioVideo;Video
+Categories=Graphics;2DGraphics;VectorGraphics;RasterGraphics;Qt;AudioVideo;Video;
 Keywords=picture;drawing;vector;bitmap;cartoon;
 Keywords[de]=Bild;Zeichnen;Vektor;Raster;Zeichentrick;


### PR DESCRIPTION
This should allow us to use linuxdeployqt without any modifications. Replaces #823.