### PR TITLE
Improve movie export dialog

### DIFF
--- a/app/DoubleProgressDialog.ui
+++ b/app/DoubleProgressDialog.ui
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DoubleProgressDialog</class>
+ <widget class="QDialog" name="DoubleProgressDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>132</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QProgressBar" name="majorProgressBar">
+     <property name="value">
+      <number>24</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="progressStatus">
+     <property name="text">
+      <string>Loading...</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="minorProgressBar">
+     <property name="value">
+      <number>24</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="cancelButton">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/app/actioncommands.cpp
+++ b/app/actioncommands.cpp
@@ -218,8 +218,8 @@ Status ActionCommands::exportMovie()
 
             QApplication::processEvents();
         },
-        [&progressDlg](const char *s) {
-            progressDlg.setStatus(tr(s));
+        [&progressDlg](QString s) {
+            progressDlg.setStatus(s);
             QApplication::processEvents();
         }
     );

--- a/app/actioncommands.cpp
+++ b/app/actioncommands.cpp
@@ -46,6 +46,7 @@ GNU General Public License for more details.
 #include "exportmoviedialog.h"
 #include "exportimagedialog.h"
 #include "aboutdialog.h"
+#include "doubleprogressdialog.h"
 
 
 ActionCommands::ActionCommands(QWidget* parent) : QObject(parent)
@@ -183,25 +184,45 @@ Status ActionCommands::exportMovie()
     desc.exportSize = dialog->getExportSize();
     desc.strCameraName = dialog->getSelectedCameraName();
 
-    QProgressDialog progressDlg;
+    DoubleProgressDialog progressDlg;
     progressDlg.setWindowModality(Qt::WindowModal);
-    progressDlg.setLabelText(tr("Exporting movie..."));
+    progressDlg.setWindowTitle(tr("Exporting movie"));
     Qt::WindowFlags eFlags = Qt::Dialog | Qt::WindowTitleHint;
     progressDlg.setWindowFlags(eFlags);
     progressDlg.show();
 
     MovieExporter ex;
 
-    connect(&progressDlg, &QProgressDialog::canceled, [&ex]
+    connect(&progressDlg, &DoubleProgressDialog::canceled, [&ex]
     {
         ex.cancel();
     });
 
-    Status st = ex.run(mEditor->object(), desc, [&progressDlg](float f)
-    {
-        progressDlg.setValue((int)(f * 100.f));
-        QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-    });
+    // The start points and length for the current minor operation segment on the major progress bar
+    float minorStart, minorLength;
+
+    Status st = ex.run(mEditor->object(), desc,
+        [&progressDlg, &minorStart, &minorLength](float f, float final)
+        {
+            progressDlg.major->setValue(f);
+
+            minorStart = f;
+            minorLength = qMax(0.f, final - minorStart);
+
+            QApplication::processEvents();
+        },
+        [&progressDlg, &minorStart, &minorLength](float f) {
+            progressDlg.minor->setValue(f);
+
+            progressDlg.major->setValue(minorStart + f * minorLength);
+
+            QApplication::processEvents();
+        },
+        [&progressDlg](const char *s) {
+            progressDlg.setStatus(tr(s));
+            QApplication::processEvents();
+        }
+    );
 
     if (st.ok() && QFile::exists(strMoviePath))
     {

--- a/app/app.pro
+++ b/app/app.pro
@@ -56,7 +56,8 @@ HEADERS += \
     importexportdialog.h \
     exportimagedialog.h \
     importimageseqdialog.h \
-    spinslider.h
+    spinslider.h \
+    doubleprogressdialog.h
 
 SOURCES += \
     main.cpp \
@@ -82,7 +83,8 @@ SOURCES += \
     importexportdialog.cpp \
     exportimagedialog.cpp \
     importimageseqdialog.cpp \
-    spinslider.cpp
+    spinslider.cpp \
+    doubleprogressdialog.cpp
 
 FORMS += \
     ui/mainwindow2.ui \
@@ -96,7 +98,8 @@ FORMS += \
     ui/exportmovieoptions.ui \
     ui/exportimageoptions.ui \
     ui/importimageseqoptions.ui \
-    ui/tooloptions.ui
+    ui/tooloptions.ui \
+    doubleprogressdialog.ui
 
 DEPENDPATH += .
 

--- a/app/doubleprogressdialog.cpp
+++ b/app/doubleprogressdialog.cpp
@@ -1,0 +1,70 @@
+#include "doubleprogressdialog.h"
+#include "ui_DoubleProgressDialog.h"
+
+#include <QtMath>
+
+DoubleProgressDialog::DoubleProgressDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::DoubleProgressDialog)
+{
+    ui->setupUi(this);
+
+    major = new ProgressBarControl(ui->majorProgressBar);
+    minor = new ProgressBarControl(ui->minorProgressBar);
+
+    connect(ui->cancelButton, &QPushButton::pressed, this, &DoubleProgressDialog::canceled);
+}
+
+DoubleProgressDialog::~DoubleProgressDialog()
+{
+    delete ui;
+}
+
+QString DoubleProgressDialog::getStatus() {
+    return ui->progressStatus->text();
+}
+
+void DoubleProgressDialog::setStatus(QString msg)
+{
+    ui->progressStatus->setText(msg);
+}
+
+DoubleProgressDialog::ProgressBarControl::ProgressBarControl(QProgressBar *b)
+{
+    bar = b;
+}
+
+void DoubleProgressDialog::ProgressBarControl::setMin(float minimum)
+{
+    min = minimum;
+    if(max < min) setMax(min);
+    bar->setMinimum(convertUnits(min));
+}
+
+void DoubleProgressDialog::ProgressBarControl::setMax(float maximum)
+{
+    max = maximum;
+    if(min > max) setMin(max);
+    bar->setMaximum(convertUnits(max));
+}
+
+void DoubleProgressDialog::ProgressBarControl::setValue(float value)
+{
+    val = qBound(min, value, max);
+    bar->setValue(convertUnits(val));
+}
+
+int DoubleProgressDialog::ProgressBarControl::getPrecision()
+{
+    return qLn(unitFactor) / qLn(10);
+}
+
+void DoubleProgressDialog::ProgressBarControl::setPrecision(int e)
+{
+    unitFactor = qPow(10, e);
+}
+
+int DoubleProgressDialog::ProgressBarControl::convertUnits(float value)
+{
+    return qRound(value * unitFactor);
+}

--- a/app/doubleprogressdialog.h
+++ b/app/doubleprogressdialog.h
@@ -1,0 +1,56 @@
+#ifndef DOUBLEPROGRESSDIALOG_H
+#define DOUBLEPROGRESSDIALOG_H
+
+#include <QDialog>
+#include <QProgressBar>
+
+namespace Ui {
+class DoubleProgressDialog;
+}
+
+class DoubleProgressDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit DoubleProgressDialog(QWidget *parent = 0);
+    ~DoubleProgressDialog();
+
+    QString getStatus();
+    void setStatus(QString msg);
+
+    class ProgressBarControl {
+        public:
+            ProgressBarControl(QProgressBar *b);
+
+            float getMin() { return min; }
+            void setMin(float minimum);
+
+            float getMax() { return max; }
+            void setMax(float maximum);
+
+            void setRange(float minimum, float maximum) { setMin(minimum); setMax(maximum); }
+
+            float getValue() { return val; }
+            void setValue(float value);
+
+            int getPrecision();
+            void setPrecision(int e);
+        private:
+            QProgressBar *bar;
+            float min = 0, max = 1, val = 0;
+
+            int convertUnits(float value);
+            int unitFactor = 100;
+    };
+
+    ProgressBarControl *major, *minor;
+
+signals:
+    void canceled();
+
+private:
+    Ui::DoubleProgressDialog *ui;
+};
+
+#endif // DOUBLEPROGRESSDIALOG_H

--- a/core_lib/interface/editor.cpp
+++ b/core_lib/interface/editor.cpp
@@ -739,7 +739,7 @@ bool Editor::exportMovieCLI(QString filePath, LayerCamera *cameraLayer, int widt
     desc.strCameraName = cameraLayer->name();
 
     MovieExporter ex;
-    ex.run(object(), desc, [](float){});
+    ex.run(object(), desc, [](float,float){}, [](float){}, [](QString){});
     return true;
 }
 

--- a/core_lib/movieexporter.cpp
+++ b/core_lib/movieexporter.cpp
@@ -132,11 +132,11 @@ Status MovieExporter::run(const Object* obj,
                           const ExportMovieDesc& desc,
                           std::function<void(float, float)> majorProgress,
                           std::function<void(float)> minorProgress,
-                          std::function<void(const char *)> progressMessage)
+                          std::function<void(QString)> progressMessage)
 {
     majorProgress(0.f, 0.03f);
     minorProgress(0.f);
-    progressMessage("Checking environment...");
+    progressMessage(QApplication::tr("Checking environment..."));
 
     QString ffmpegPath = ffmpegLocation();
     qDebug() << ffmpegPath;
@@ -169,14 +169,14 @@ Status MovieExporter::run(const Object* obj,
 
     if (!desc.strFileName.endsWith("gif"))
     {
-        progressMessage("Assembling audio...");
+        progressMessage(QApplication::tr("Assembling audio..."));
         minorProgress(0.f);
         STATUS_CHECK(assembleAudio(obj, ffmpegPath, minorProgress));
         minorProgress(1.f);
     }
     majorProgress(0.1f, 0.5f);
     qDebug() << "Time:" << clock();
-    progressMessage("Generating frames...");
+    progressMessage(QApplication::tr("Generating frames..."));
     minorProgress(0.f);
 
     STATUS_CHECK(generateImageSequence(obj, minorProgress));
@@ -186,26 +186,26 @@ Status MovieExporter::run(const Object* obj,
     minorProgress(0.f);
     if (desc.strFileName.endsWith("gif", Qt::CaseInsensitive))
     {
-        progressMessage("Generating palette...");
+        progressMessage(QApplication::tr("Generating palette..."));
         majorProgress(0.5f, 0.7f);
         STATUS_CHECK(generatePalette(ffmpegPath, minorProgress));
         minorProgress(1.f);
 
-        progressMessage("Combining...");
+        progressMessage(QApplication::tr("Combining..."));
         majorProgress(0.7f, 1.f);
         minorProgress(0.f);
         STATUS_CHECK(convertToGif(ffmpegPath, desc.strFileName, minorProgress));
     }
     else
     {
-        progressMessage("Combining...");
+        progressMessage(QApplication::tr("Combining..."));
         majorProgress(0.5f, 1.f);
         combineVideoAndAudio(ffmpegPath, desc.strFileName, minorProgress);
     }
     qDebug() << "Time:" << clock();
     minorProgress(1.f);
     majorProgress(1.f, 1.f);
-    progressMessage("Done");
+    progressMessage(QApplication::tr("Done"));
 
     return Status::OK;
 }

--- a/core_lib/movieexporter.h
+++ b/core_lib/movieexporter.h
@@ -44,18 +44,20 @@ public:
 
     Status run(const Object* obj,
                const ExportMovieDesc& desc,
-               std::function<void(float)> progress);
+               std::function<void(float, float)> majorProgress,
+               std::function<void(float)> minorProgress,
+               std::function<void(const char *)> progressMessage);
     QString error();
 
     void cancel() { mCanceled = true; }
-
 private:
     Status assembleAudio(const Object* obj, QString ffmpegPath, std::function<void(float)> progress);
     Status generateImageSequence(const Object* obj, std::function<void(float)> progress);
-    Status combineVideoAndAudio(QString ffmpegPath, QString strOutputFile);
-    Status convertToGif(QString ffmpeg, QString strOut);
+    Status combineVideoAndAudio(QString ffmpegPath, QString strOutputFile, std::function<void(float)> progress);
+    Status generatePalette(QString ffmpeg, std::function<void (float)> progress);
+    Status convertToGif(QString ffmpeg, QString strOut, std::function<void(float)>  progress);
 
-    Status executeFFMpegCommand(QString strCmd);
+    Status executeFFMpegCommand(QString strCmd, std::function<void(float)> progress);
     Status checkInputParameters(const ExportMovieDesc&);
 
 private:

--- a/core_lib/movieexporter.h
+++ b/core_lib/movieexporter.h
@@ -46,7 +46,7 @@ public:
                const ExportMovieDesc& desc,
                std::function<void(float, float)> majorProgress,
                std::function<void(float)> minorProgress,
-               std::function<void(const char *)> progressMessage);
+               std::function<void(QString)> progressMessage);
     QString error();
 
     void cancel() { mCanceled = true; }


### PR DESCRIPTION
In addition to the main progress bar, a second progress bar and a
label have been added to display subtasks of the exporting. Not only
does this better show progress, but it also makes reports about
freezing/crashing during export more useful (ex. "it says Generating
Palette and then crashes").

The ffmpeg execution code was modified to detect the progress
of the operation. This also fixes a hidden serious bug with movie
exporting: waitForFinished has a timeout of 30 seconds by default,
so any movie that takes longer than that to export would timeout
and fail. This should hopeful fix some of the exporting errors
we've been seeing. waitForReadyRead also has a timeout (default 30s
I think), but this isn't an issue because FFmpeg will write updates
and flush every second or so, returning waitForReadyRead well
before the timeout.

This commit also fixes another issue, where it was impossible to
cancel during the movie export operation because processEvents was
only every being called with QEventLoop::ExcludeUserInputEvents,
which prevented the cancel button event from registering until
after the export is done! The dialog is modal so it still prevents other user input events.

Related: #681