### PR TITLE
Fix background in hidden layer warning dialog

### DIFF
--- a/core_lib/interface/backgroundwidget.cpp
+++ b/core_lib/interface/backgroundwidget.cpp
@@ -107,6 +107,8 @@ void BackgroundWidget::loadBackgroundStyle()
         mStyle = "background-image: url(:background/grid.jpg); background-repeat: repeat-xy; border: 1px solid lightGrey;";
     }
 
+    mStyle = QString("BackgroundWidget { %1 }").arg(mStyle);
+
     setStyleSheet(mStyle);
 }
 

--- a/core_lib/interface/scribblearea.cpp
+++ b/core_lib/interface/scribblearea.cpp
@@ -662,8 +662,6 @@ void ScribbleArea::resizeEvent(QResizeEvent *event)
     mCanvas = QPixmap(size());
     mCanvas.fill(Qt::transparent);
 
-    this->setStyleSheet("background-color:yellow;");
-
     mEditor->view()->setCanvasSize(size());
     updateAllFrames();
 }


### PR DESCRIPTION
Just a small modification to limit the background styling to the background widget. Prevents stuff like this from happening:
![Warning Dialog fail](https://user-images.githubusercontent.com/3461051/35548428-92b85886-053c-11e8-9308-8cf8f7486594.png)
