### PR TITLE
Remove hardcoded fonts

### DIFF
--- a/app/ui/errordialog.ui
+++ b/app/ui/errordialog.ui
@@ -81,20 +81,8 @@
    </item>
    <item>
     <widget class="QTextEdit" name="details">
-     <property name="font">
-      <font>
-       <family>.SF NS Text</family>
-      </font>
-     </property>
      <property name="readOnly">
       <bool>true</bool>
-     </property>
-     <property name="html">
-      <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.SF NS Text'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Monaco'; font-size:13pt;&quot;&gt;Details&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -17,11 +17,6 @@
    <string notr="true">this-&gt;setStyleSheet(&quot;background-color:yellow;&quot;);</string>
   </property>
   <widget class="BackgroundWidget" name="background">
-   <property name="font">
-    <font>
-     <family>Trebuchet MS</family>
-    </font>
-   </property>
    <layout class="QVBoxLayout" name="layout">
     <property name="spacing">
      <number>0</number>

--- a/core_lib/graphics/vector/beziercurve.cpp
+++ b/core_lib/graphics/vector/beziercurve.cpp
@@ -488,8 +488,7 @@ void BezierCurve::drawPath(QPainter& painter, Object* object, QTransform transfo
 
                 //painter.fillRect(QRectF(myCurve.getVertex(i).x()-0.5*squareWidth, myCurve.getVertex(i).y()-0.5*squareWidth, squareWidth, squareWidth), colour);
 
-                /*painter.setFont( QFont("Arial", floor(12.0/painter.matrix().m11()), -1, false) );
-                //painter.drawText(myCurve.getVertex(i)+QPointF(4.0,0.0), QString::number(i)+"-"+QString::number(myCurve.getVertex(i).x())+","+QString::number(myCurve.getVertex(i).y()));
+                /*painter.drawText(myCurve.getVertex(i)+QPointF(4.0,0.0), QString::number(i)+"-"+QString::number(myCurve.getVertex(i).x())+","+QString::number(myCurve.getVertex(i).y()));
                 QPointF normale = QPointF(4.0, 0.0);
                 if (i>-1) { normale = (myCurve.getVertex(i)-myCurve.getC2(i)); } else { normale = (myCurve.getC1(i+1)-myCurve.getVertex(i)); }
                 normale = QPointF(-normale.y(), normale.x());

--- a/core_lib/interface/timecontrols.cpp
+++ b/core_lib/interface/timecontrols.cpp
@@ -40,7 +40,6 @@ void TimeControls::initUI()
     QSettings settings(PENCIL2D, PENCIL2D);
 
     mFpsBox = new QSpinBox(this);
-    mFpsBox->setFont(QFont("Helvetica", 10));
     mFpsBox->setFixedHeight(24);
     mFpsBox->setValue(settings.value("fps").toInt());
     mFpsBox->setMinimum(1);
@@ -50,7 +49,6 @@ void TimeControls::initUI()
     mFpsBox->setFocusPolicy(Qt::WheelFocus);
 
     mLoopStartSpinBox = new QSpinBox(this);
-    mLoopStartSpinBox->setFont(QFont("Helvetica", 10));
     mLoopStartSpinBox->setFixedHeight(24);
     mLoopStartSpinBox->setValue(settings.value("loopStart").toInt());
     mLoopStartSpinBox->setMinimum(1);
@@ -58,7 +56,6 @@ void TimeControls::initUI()
     mLoopStartSpinBox->setFocusPolicy(Qt::WheelFocus);
 
     mLoopEndSpinBox = new QSpinBox(this);
-    mLoopEndSpinBox->setFont(QFont("Helvetica", 10));
     mLoopEndSpinBox->setFixedHeight(24);
     mLoopEndSpinBox->setValue(settings.value("loopEnd").toInt());
     mLoopEndSpinBox->setMinimum(2);
@@ -66,7 +63,6 @@ void TimeControls::initUI()
     mLoopEndSpinBox->setFocusPolicy(Qt::WheelFocus);
 
     mPlaybackRangeCheckBox = new QCheckBox(tr("Range"));
-    mPlaybackRangeCheckBox->setFont(QFont("Helvetica", 10));
     mPlaybackRangeCheckBox->setFixedHeight(24);
     mPlaybackRangeCheckBox->setToolTip(tr("Playback range"));
 

--- a/core_lib/interface/timeline.cpp
+++ b/core_lib/interface/timeline.cpp
@@ -71,7 +71,6 @@ void TimeLine::initUI()
     QToolBar* layerButtons = new QToolBar( this );
     QLabel* layerLabel = new QLabel( tr( "Layers:" ) );
     layerLabel->setIndent( 5 );
-    layerLabel->setFont( QFont( "Helvetica", 10 ) );
 
     QToolButton* addLayerButton = new QToolButton( this );
     addLayerButton->setIcon( QIcon( ":icons/add.png" ) );
@@ -117,7 +116,6 @@ void TimeLine::initUI()
     // --------- key buttons ---------
     QToolBar* timelineButtons = new QToolBar( this );
     QLabel* keyLabel = new QLabel( tr( "Keys:" ) );
-    keyLabel->setFont( QFont( "Helvetica", 10 ) );
     keyLabel->setIndent( 5 );
 
     QToolButton* addKeyButton = new QToolButton( this );
@@ -136,7 +134,6 @@ void TimeLine::initUI()
     duplicateKeyButton->setFixedSize( 24, 24 );
 
     QLabel* onionLabel = new QLabel( tr( "Onion skin:" ) );
-    onionLabel->setFont( QFont( "Helvetica", 10 ) );
 
     QToolButton* onionTypeButton = new QToolButton( this );
     onionTypeButton->setIcon( QIcon( ":icons/onion_type.png" ) );

--- a/core_lib/interface/timelinecells.cpp
+++ b/core_lib/interface/timelinecells.cpp
@@ -263,7 +263,6 @@ void TimeLineCells::drawContent()
         // --- draw ticks
         painter.setPen( QColor( 70, 70, 70, 255 ) );
         painter.setBrush( Qt::darkGray );
-        painter.setFont( QFont( "helvetica", 10 ) );
         int incr = 0;
         int fps = mEditor->playback()->fps();
         for ( int i = mFrameOffset; i < mFrameOffset + ( width() - mOffsetX ) / mFrameSize; i++ )
@@ -393,7 +392,6 @@ void TimeLineCells::paintEvent( QPaintEvent* event )
         {
             painter.setBrush( QColor( 255, 0, 0, 128 ) );
             painter.setPen( Qt::NoPen );
-            painter.setFont( QFont( "helvetica", 10 ) );
             //painter.setCompositionMode(QPainter::CompositionMode_Source); // this causes the message: QPainter::setCompositionMode: PorterDuff modes not supported on device
             QRect scrubRect;
             scrubRect.setTopLeft( QPoint( getFrameX( mEditor->currentFrame() - 1 ), 0 ) );

--- a/core_lib/structure/layer.cpp
+++ b/core_lib/structure/layer.cpp
@@ -315,7 +315,6 @@ Status Layer::save(QString strDataFolder, ProgressCallback progressStep)
 
 void Layer::paintTrack(QPainter& painter, TimeLineCells* cells, int x, int y, int width, int height, bool selected, int frameSize)
 {
-    painter.setFont(QFont("helvetica", height / 2));
     if (mVisible)
     {
         QColor col;
@@ -410,7 +409,6 @@ void Layer::paintLabel(QPainter& painter, TimeLineCells* cells, int x, int y, in
     if (type() == SOUND) painter.drawPixmap(QPoint(21, y + 2), QPixmap(":/icons/layer-sound.png"));
     if (type() == CAMERA) painter.drawPixmap(QPoint(21, y + 2), QPixmap(":/icons/layer-camera.png"));
 
-    painter.setFont(QFont("helvetica", height / 2));
     painter.setPen(Qt::black);
     painter.drawText(QPoint(45, y + (2 * height) / 3), mName);
 }

--- a/core_lib/structure/object.cpp
+++ b/core_lib/structure/object.cpp
@@ -584,7 +584,6 @@ bool Object::exportX(int frameStart, int frameEnd, QTransform view, QSize export
             xPainter.resetMatrix();
             xPainter.setClipping(false);
             xPainter.setPen(Qt::black);
-            xPainter.setFont(QFont("helvetica", 50));
             xPainter.drawRect(target);
             xPainter.drawText(QPoint((y % 3) * 800 + 35, (y / 3) * 680 + 65 - page * 3400), QString::number(i));
             y++;


### PR DESCRIPTION
The html property in errordialog.ui was overridden from the code anyway, so I removed it completely. The other changes should be quite self-explanatory. Resolves #874.