### PR TITLE
Link API documentation to Qt documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,5 +148,8 @@ after_success:
   # Deploy doxygen documentation to github pages
   - 'if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_OS_NAME" == "linux" ]; then
       cd "$TRAVIS_BUILD_DIR/util";
+      for i in core svg xmlpatterns; do
+        curl -fsSLO "https://doc.qt.io/qt-5/qt$i.tags";
+      done;
       ./documentation-deploy.sh;
     fi'

--- a/Doxyfile
+++ b/Doxyfile
@@ -2118,7 +2118,17 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               =
+TAGFILES               = util/qtcore.tags=https://doc.qt.io/qt-5/ \
+                         util/qtsvg.tags=https://doc.qt.io/qt-5/ \
+                         util/qtxmlpatterns.tags=https://doc.qt.io/qt-5/ \
+                         /usr/share/qt5/doc/qtcore/qtcore.tags=/usr/share/qt5/doc/qtcore/ \
+                         /usr/share/qt5/doc/qtsvg/qtsvg.tags=/usr/share/qt5/doc/qtsvg/ \
+                         /usr/share/qt5/doc/qtxmlpatterns/qtxmlpatterns.tags=/usr/share/qt5/doc/qtxmlpatterns/ \
+                         /usr/share/doc/qt/qtcore/qtcore.tags=/usr/share/doc/qt/qtcore/ \
+                         /usr/share/doc/qt/qtsvg/qtsvg.tags=/usr/share/doc/qt/qtsvg/ \
+                         /usr/share/doc/qt/qtxmlpatterns/qtxmlpatterns.tags=/usr/share/doc/qt/qtxmlpatterns/
+                         # Currently Qt Multimedia isn't configured to generate a tagfile, see
+                         # https://github.com/qt/qtmultimedia/blob/5.9/src/multimedia/doc/qtmultimedia.qdocconf
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to


### PR DESCRIPTION
As the title says. For the tag file location I used util/ and the system documentation locations for Ubuntu and Arch, Doxygen will skip the ones that do not exist and the first one found will take precedence. Tag files in util/ are assumed to belong to Qt’s online documentation (downloaded when documentation is deployed, for instance), the other ones will be linked to local documentation. If Qt also has a standard documentation path that can be relied on on Windows and/or OS X, adding those would probably be a good idea, too.


![](https://user-images.githubusercontent.com/2063777/36226275-a278fbac-11cd-11e8-9f0e-347639958067.gif)