### PR TITLE
Fix #851. Make sure the FPS spin-box works on Linux.

### DIFF
--- a/core_lib/src/interface/timecontrols.cpp
+++ b/core_lib/src/interface/timecontrols.cpp
@@ -166,9 +166,12 @@ void TimeControls::makeConnections()
 
     connect(mSoundButton, &QPushButton::clicked, this, &TimeControls::soundClick);
     connect(mSoundButton, &QPushButton::clicked, this, &TimeControls::updateSoundIcon);
-    connect(mFpsBox, spinBoxValueChanged, this, &TimeControls::fpsClick);
-
-
+    auto connection = connect(mFpsBox, spinBoxValueChanged, this, &TimeControls::fpsClick);
+    if(!connection)
+    {
+        // Use "editingFinished" if the "spinBoxValueChanged" signal doesn't work...
+        connect(mFpsBox, &QSpinBox::editingFinished, this, &TimeControls::onFpsEditingFinished);
+    }
 }
 
 void TimeControls::playButtonClicked()
@@ -263,6 +266,11 @@ void TimeControls::updateSoundIcon(bool soundEnabled)
     {
         mSoundButton->setIcon(QIcon(":icons/controls/sound-disabled.png"));
     }
+}
+
+void TimeControls::onFpsEditingFinished()
+{
+    emit fpsClick(mFpsBox->value());
 }
 
 void TimeControls::updateLength(int frameLength)

--- a/core_lib/src/interface/timecontrols.h
+++ b/core_lib/src/interface/timecontrols.h
@@ -52,6 +52,9 @@ public slots:
     void toggleLoop(bool);
     void toggleLoopControl(bool);
 
+    /// Work-around in case the FPS spin-box "valueChanged" signal doesn't work.
+    void onFpsEditingFinished();
+
 private:
     void makeConnections();
 


### PR DESCRIPTION
Fixes #851. This works for me on Ubuntu 14.04.

## Technical Details ##
The connection from the FPS spin-box is set up here:

`connect(mFpsBox, spinBoxValueChanged, this, &TimeControls::fpsClick);`

The Application Output tab showed a warning that the connection was not valid. I added a breakpoint to "fpsClick" and changed the FPS value, but "fpsClick" was never called. 

I tried a couple of other things (from https://stackoverflow.com/questions/16794695/connecting-overloaded-signals-and-slots-in-qt-5/16795664) but couldn't get the valueChanged signal to work. 

So finally I changed it so that if the "spinBoxValueChanged" connection is invalid, we use the "editingFinished" signal instead. 