### PR TITLE
Progress bar for importing image sequences

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -715,8 +715,8 @@ void MainWindow2::importImageSequence()
     progress.show();
 
     int totalImagesToImport = files.count();
+    progress.setMaximum(totalImagesToImport);
     int imagesImportedSoFar = 0;
-    int progressMax = 100;
 
     for (QString strImgFile : files)
     {
@@ -734,11 +734,8 @@ void MainWindow2::importImageSequence()
             }
 
             imagesImportedSoFar++;
-            if (totalImagesToImport != 0) // Avoid dividing by zero.
-            {
-                progress.setValue((imagesImportedSoFar + 1)*progressMax / totalImagesToImport);
-                QApplication::processEvents();  // Required to make progress bar update on-screen.
-            }
+            progress.setValue(imagesImportedSoFar);
+            QApplication::processEvents();  // Required to make progress bar update on-screen.
 
             if (progress.wasCanceled())
             {

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -646,6 +646,9 @@ bool MainWindow2::autoSave()
     if (mEditor->autoSaveNeverAskAgain())
         return false;
 
+    if(mIsImportingImageSequence)
+        return false;
+
     QMessageBox msgBox(this);
     msgBox.setIcon(QMessageBox::Question);
     msgBox.setWindowTitle("AutoSave Reminder");
@@ -699,6 +702,9 @@ void MainWindow2::importImageSequence()
         return;
     }
 
+    // Flag this so we don't prompt the user about auto-save in the middle of the import.
+    mIsImportingImageSequence = true;
+
     QStringList files = imageSeqDialog->getFilePaths();
     int number = imageSeqDialog->getSpace();
 
@@ -743,6 +749,8 @@ void MainWindow2::importImageSequence()
     mEditor->layers()->notifyAnimationLengthChanged();
 
     progress.close();
+
+    mIsImportingImageSequence = false;
 }
 
 void MainWindow2::importMovie()

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -701,6 +701,17 @@ void MainWindow2::importImageSequence()
 
     QStringList files = imageSeqDialog->getFilePaths();
     int number = imageSeqDialog->getSpace();
+
+    // Show a progress dialog, as this can take a while if you have lots of images.
+    QProgressDialog progress(tr("Importing image sequence..."), tr("Abort"), 0, 100, this);
+    hideQuestionMark(progress);
+    progress.setWindowModality(Qt::WindowModal);
+    progress.show();
+
+    int totalImagesToImport = files.count();
+    int imagesImportedSoFar = 0;
+    int progressMax = 100;
+
     for (QString strImgFile : files)
     {
         if (strImgFile.endsWith(".png") ||
@@ -715,9 +726,23 @@ void MainWindow2::importImageSequence()
             {
                 mEditor->scrubForward();
             }
+
+            imagesImportedSoFar++;
+            if (totalImagesToImport != 0) // Avoid dividing by zero.
+            {
+                progress.setValue((imagesImportedSoFar + 1)*progressMax / totalImagesToImport);
+                QApplication::processEvents();  // Required to make progress bar update on-screen.
+            }
+
+            if (progress.wasCanceled())
+            {
+                break;
+            }
         }
     }
     mEditor->layers()->notifyAnimationLengthChanged();
+
+    progress.close();
 }
 
 void MainWindow2::importMovie()

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -150,6 +150,9 @@ private:
 
     // a hack for MacOS because closeEvent fires twice
     bool m2ndCloseEvent = false;
+
+    // whether we are currently importing an image sequence.
+    bool mIsImportingImageSequence = false;
     
     Ui::MainWindow2* ui = nullptr;
 };


### PR DESCRIPTION
Fix for #857. Adds a progress dialog when importing image sequences, just like the one for exporting.

Note: The auto-save prompt is disabled while doing the import.

![import-dialog-demo](https://user-images.githubusercontent.com/24422213/36529434-3977eac6-17b0-11e8-8cab-bbb337cdfb87.gif)
.



