### PR TITLE
Add non-API documentation to Doxygen input

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = app core_lib tests README.md
+INPUT                  = app core_lib tests docs README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/build_linux.md
+++ b/docs/build_linux.md
@@ -1,6 +1,6 @@
 # Building Pencil2D on Linux
 
-These are instructions for building Pencil2D on Linux. If you are using Windows go [here](build_win.md), and if you are using macOS go [here](build_mac.md). This guide is primarily targeted towards developers. If you just want to use the latest version you can just download one of our [nightly builds](https://drive.google.com/drive/folders/0BxdcdOiOmg-CcWhLazdKR1oydHM).
+These are instructions for building Pencil2D on Linux. If you are using Windows go [here](docs/build_win.md), and if you are using macOS go [here](docs/build_mac.md). This guide is primarily targeted towards developers. If you just want to use the latest version you can just download one of our [nightly builds](https://drive.google.com/drive/folders/0BxdcdOiOmg-CcWhLazdKR1oydHM).
 
 This tutorial was made with Ubuntu Xenial Xerus (16.04) and Arch Linux in mind, however you should be able to adapt this guide to other versions or distributions if necessary.
 
@@ -107,4 +107,4 @@ You can then open Pencil2D by running this from the source directory:
 
 ## Next steps
 
-Now that you can build Pencil2D, the next step is to learn about [navigating the source code](https://github.com/pencil2d/pencil/wiki/Dive-into-code).
+Now that you can build Pencil2D, the next step is to learn about [navigating the source code](docs/dive-into-code.md).

--- a/docs/build_mac.md
+++ b/docs/build_mac.md
@@ -1,6 +1,6 @@
 # Building Pencil2D on macOS
 
-These are instructions for building Pencil2D on a Mac. If you are using Windows go [here](build_win.md), and Linux please go [here](build_linux.md).
+These are instructions for building Pencil2D on a Mac. If you are using Windows go [here](docs/build_win.md), and Linux please go [here](docs/build_linux.md).
 
 This guide is primarily targeted towards developers. If you just want to use the latest version, download it from our [nightly builds](https://drive.google.com/drive/folders/0BxdcdOiOmg-CcWhLazdKR1oydHM). This tutorial was made with macOS Sierra (10.12) in mind, however this will probably work with all versions Mountain Lion (10.8) and up.
 
@@ -90,4 +90,4 @@ You can then open Pencil2D by opening Pencil2D.app in app or by running:
 
 ## Next steps
 
-Now that you can build Pencil2D, the next step is to learn about [navigating the source code](https://github.com/pencil2d/pencil/wiki/Dive-into-code).
+Now that you can build Pencil2D, the next step is to learn about [navigating the source code](docs/dive-into-code.md).

--- a/docs/build_win.md
+++ b/docs/build_win.md
@@ -1,6 +1,6 @@
 # Building Pencil2D on Windows
 
-These are instructions for building Pencil2D on a Windows PC. If you are using Mac go [here](build_mac.md), and Linux please go [here](build_linux.md).
+These are instructions for building Pencil2D on a Windows PC. If you are using Mac go [here](docs/build_mac.md), and Linux please go [here](docs/build_linux.md).
 
 This guide is primarily targeted towards developers. If you just want to use the latest version, download it from our [nightly builds](https://drive.google.com/drive/folders/0BxdcdOiOmg-CcWhLazdKR1oydHM). This tutorial was made with Windows 10 in mind, however this will work with Windows 7 and up.
 
@@ -62,4 +62,4 @@ It will create a Visual Studio solution `pencil.sln` for you in the folder, doub
 
 ## Next steps
 
-Now that you can build Pencil2D, the next step is to learn about [navigating the source code](https://github.com/pencil2d/pencil/wiki/Dive-into-code).
+Now that you can build Pencil2D, the next step is to learn about [navigating the source code](docs/dive-into-code.md).

--- a/docs/dive-into-code.md
+++ b/docs/dive-into-code.md
@@ -1,0 +1,28 @@
+# Navigating the source code
+
+This is an overview of Pencil2D code base.
+
+# Projects
+
+The whole project is organized into 3 sub-projects:
+
+ - `app`: holding everything about the GUI, e.g, tool panel, color wheel and Timeline etc.
+ - `core_lib`: the engine of Pencil2D, mostly about animation, drawing things and tool manipulations.
+ - `tests`: a collection of unit tests.
+
+You will be able to see these 3 sub-projects in QtCreator when you open the Pencil2D project, and you will find the identical folder names in the repository.
+
+# Where to start with?
+
+At the time of writing, there are nearly 200 source files in the Pencil2D repository. But at the beginning you only have to pay attention at a few of them, these main classes formed the **backbone** of Pencil2D. If you know how these classes work, you will be able to pick up Pencil2D code base very soon.
+
+Let's start from the [app/main.cpp](app/main.cpp), it is the entry point of Pencil2D (and most of other C++ programs as well). There are a lot of command line parameter handling code, just ignore them at the moment. What you need to know is it creates the MainWindow2 at line 215 `MainWindow2 mainWindow;`
+
+The MainWindow2, as the name said, is the main window of Pencil2D. The whole application starts here. Go to [MainWindow2's constructor](@ref MainWindow2::MainWindow2), you will see the Pencil2D's initialization process. It introduces some most important classes of Pencil2D, @ref Object, @ref Editor, and @ref ScribbleArea.
+
+### Object
+
+### Editor
+
+### ScribbleArea
+

--- a/util/Doxyfile-Travis
+++ b/util/Doxyfile-Travis
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = $(TRAVIS_BUILD_DIR)/app $(TRAVIS_BUILD_DIR)/core_lib $(TRAVIS_BUILD_DIR)/tests $(TRAVIS_BUILD_DIR)/README.md
+INPUT                  = $(TRAVIS_BUILD_DIR)/app $(TRAVIS_BUILD_DIR)/core_lib $(TRAVIS_BUILD_DIR)/tests $(TRAVIS_BUILD_DIR)/docs $(TRAVIS_BUILD_DIR)/README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
As I previously mentioned on IRC, it is possible to integrate our existing non-API developer documentation with Doxygen as well, which allows us to have all documentation aimed at developers under one roof. This is what this PR does. It also includes the page about navigating the code from the wiki. As with #900, take this as a suggestion, any opinions are welcome.

Some notes:

- Unfortunately Doxygen requries links to be relative to the project root, so they will no longer work on GitHub with this
- For Doxygen to generate links to class members, these class members must already have documentation or EXTRACT_ALL must be turned on
- Currently we have autolinking enabled in our Doxygen configuration, which leads to some… interesting results:

  ![screenshot from 2018-02-22 18-38-54](https://user-images.githubusercontent.com/2063777/36554522-cb15aeec-17ff-11e8-89d9-ebe55ffed83e.png)
