### PR TITLE
[Feature] Options when drawing on an empty key-frame

### DIFF
--- a/app/src/preferencesdialog.cpp
+++ b/app/src/preferencesdialog.cpp
@@ -272,6 +272,9 @@ TimelinePage::TimelinePage(QWidget* parent) :
     connect(ui->frameSize, &QSlider::valueChanged, this, &TimelinePage::frameSizeChange);
     connect(ui->timelineLength, spinBoxValueChange, this, &TimelinePage::timelineLengthChanged);
     connect(ui->scrubBox, &QCheckBox::stateChanged, this, &TimelinePage::scrubChange);
+    connect(ui->radioButtonAddNewKey, &QRadioButton::toggled, this, &TimelinePage::radioButtonToggled);
+    connect(ui->radioButtonDuplicate, &QRadioButton::toggled, this, &TimelinePage::radioButtonToggled);
+    connect(ui->radioButtonDrawOnPrev, &QRadioButton::toggled, this, &TimelinePage::radioButtonToggled);
 }
 
 TimelinePage::~TimelinePage()
@@ -295,6 +298,24 @@ void TimelinePage::updateValues()
     ui->timelineLength->setValue(mManager->getInt(SETTING::TIMELINE_SIZE));
     if (mManager->getString(SETTING::TIMELINE_SIZE).toInt() <= 0)
         ui->timelineLength->setValue(240);
+
+    SignalBlocker b4(ui->radioButtonAddNewKey);
+    SignalBlocker b5(ui->radioButtonDuplicate);
+    SignalBlocker b6(ui->radioButtonDrawOnPrev);
+    int action = mManager->getInt(SETTING::DRAW_ON_EMPTY_FRAME_ACTION);
+    switch (action) {
+    case CREATE_NEW_KEY:
+        ui->radioButtonAddNewKey->setChecked(true);
+        break;
+    case DUPLICATE_PREVIOUS_KEY:
+        ui->radioButtonDuplicate->setChecked(true);
+        break;
+    case KEEP_DRAWING_ON_PREVIOUS_KEY:
+        ui->radioButtonDrawOnPrev->setChecked(true);
+        break;
+    default:
+        break;
+    }
 }
 
 void TimelinePage::timelineLengthChanged(int value)
@@ -320,6 +341,22 @@ void TimelinePage::labelChange(bool value)
 void TimelinePage::scrubChange(int value)
 {
     mManager->set(SETTING::SHORT_SCRUB, value != Qt::Unchecked);
+}
+
+void TimelinePage::radioButtonToggled(bool)
+{
+    if(ui->radioButtonAddNewKey->isChecked())
+    {
+        mManager->set(SETTING::DRAW_ON_EMPTY_FRAME_ACTION, CREATE_NEW_KEY);
+    }
+    else if(ui->radioButtonDuplicate->isChecked())
+    {
+        mManager->set(SETTING::DRAW_ON_EMPTY_FRAME_ACTION, DUPLICATE_PREVIOUS_KEY);
+    }
+    else if(ui->radioButtonDrawOnPrev->isChecked())
+    {
+        mManager->set(SETTING::DRAW_ON_EMPTY_FRAME_ACTION, KEEP_DRAWING_ON_PREVIOUS_KEY);
+    }
 }
 
 FilesPage::FilesPage(QWidget* parent) :

--- a/app/src/preferencesdialog.h
+++ b/app/src/preferencesdialog.h
@@ -135,6 +135,7 @@ public slots:
     void frameSizeChange(int);
     void labelChange(bool);
     void scrubChange(int);
+    void radioButtonToggled(bool);
 
 private:
     Ui::TimelinePage* ui = nullptr;

--- a/app/ui/timelinepage.ui
+++ b/app/ui/timelinepage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>315</width>
-    <height>262</height>
+    <width>342</width>
+    <height>374</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="lay2">
@@ -77,6 +77,67 @@
        <widget class="QCheckBox" name="scrubBox">
         <property name="text">
          <string>Short scrub</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="emptyFrameBox">
+     <property name="title">
+      <string>Drawing</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="labelDrawingBehaviour">
+        <property name="text">
+         <string>When drawing on an empty frame:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButtonAddNewKey">
+        <property name="statusTip">
+         <string>Create a new (blank) key-frame and start drawing on it.</string>
+        </property>
+        <property name="text">
+         <string>Create a new (blank) key-frame</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButtonDuplicate">
+        <property name="statusTip">
+         <string>Duplicate the previous key-frame and start drawing on the duplicate.</string>
+        </property>
+        <property name="text">
+         <string>Duplicate the previous key-frame</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButtonDrawOnPrev">
+        <property name="text">
+         <string>Keep drawing on the previous key-frame</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="labelAppliesTo">
+        <property name="font">
+         <font>
+          <pointsize>10</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(Applies to Pencil, Erasor, Pen, Polyline, Bucket and Brush tools)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -675,7 +675,9 @@ void ScribbleArea::paintBitmapBuffer()
 
     int frameNumber = mEditor->currentFrame();
 
-    if (layer->getKeyFrameAt(frameNumber) == nullptr)
+    // If there is no keyframe at or before the current position,
+    // just return (since we have nothing to paint on).
+    if (layer->getLastKeyFrameAtPosition(frameNumber) == nullptr)
     {
         updateCurrentFrame();
         return;
@@ -711,8 +713,10 @@ void ScribbleArea::paintBitmapBuffer()
     drawCanvas(frameNumber, rect.adjusted(-1, -1, 1, 1));
     update(rect);
 
-    QPixmapCache::remove(mPixmapCacheKeys[frameNumber]);
-    mPixmapCacheKeys[frameNumber] = QPixmapCache::Key();
+    // Update the cache for the last key-frame.
+    auto lastKeyFramePosition = mEditor->layers()->LastFrameAtFrame(frameNumber);
+    QPixmapCache::remove(mPixmapCacheKeys[lastKeyFramePosition]);
+    mPixmapCacheKeys[lastKeyFramePosition] = QPixmapCache::Key();
     layer->setModified(frameNumber, true);
 
     mBufferImg->clear();

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -856,6 +856,73 @@ void ScribbleArea::updateCanvasCursor()
 
 }
 
+void ScribbleArea::handleDrawingOnEmptyFrame()
+{
+    auto layer = mEditor->layers()->currentLayer();
+
+    if(!layer  ||  !layer->isPaintable())
+    {
+        return;
+    }
+
+    int frameNumber = mEditor->currentFrame();
+    auto previousKeyFrame = layer->getLastKeyFrameAtPosition(frameNumber);
+
+    if(layer->getKeyFrameAt(frameNumber) == nullptr)
+    {
+        // Drawing on an empty frame; take action based on preference.
+        int action = mPrefs->getInt(SETTING::DRAW_ON_EMPTY_FRAME_ACTION);
+
+        switch(action)
+        {
+        case CREATE_NEW_KEY:
+            mEditor->addNewKey();
+            mEditor->scrubTo(frameNumber);  // Refresh timeline.
+
+            // Hack to clear previous frame's content.
+            if(layer->type() == Layer::BITMAP  &&  previousKeyFrame)
+            {
+                auto asBitmapImage = dynamic_cast<BitmapImage *> (previousKeyFrame);
+
+                if(asBitmapImage)
+                {
+                    drawCanvas(frameNumber, asBitmapImage->bounds());
+                }
+            }
+
+            if(layer->type() == Layer::VECTOR)
+            {
+                auto asVectorImage = dynamic_cast<VectorImage *> (previousKeyFrame);
+
+                if(asVectorImage)
+                {
+                    auto copy(*asVectorImage);
+                    copy.selectAll();
+
+                    drawCanvas(frameNumber, copy.getSelectionRect().toRect());
+                }
+            }
+
+            break;
+        case DUPLICATE_PREVIOUS_KEY:
+        {
+            if(previousKeyFrame)
+            {
+                KeyFrame* dupKey = previousKeyFrame->clone();
+                layer->addKeyFrame(frameNumber, dupKey);
+                mEditor->scrubTo(frameNumber);  // Refresh timeline.
+            }
+            break;
+        }
+        case KEEP_DRAWING_ON_PREVIOUS_KEY:
+            // No action needed.
+            break;
+        default:
+            break;
+        }
+    }
+}
+
 void ScribbleArea::paintEvent(QPaintEvent* event)
 {
     if (!mMouseInUse || currentTool()->type() == MOVE || currentTool()->type() == HAND || mMouseRightButtonInUse)

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -179,6 +179,10 @@ public:
 
     void updateCanvasCursor();
 
+    /// Call this when starting to use a paint tool. Checks whether we are drawing
+    /// on an empty frame, and if so, takes action according to use preference.
+    void handleDrawingOnEmptyFrame();
+
     BitmapImage* mBufferImg = nullptr; // used to pre-draw vector modifications
     BitmapImage* mStrokeImg = nullptr; // used for brush strokes before they are finalized
 

--- a/core_lib/src/managers/preferencemanager.cpp
+++ b/core_lib/src/managers/preferencemanager.cpp
@@ -84,6 +84,9 @@ void PreferenceManager::loadPrefs()
     set( SETTING::DRAW_LABEL,               settings.value( SETTING_DRAW_LABEL,             false ).toBool() );
     set( SETTING::LABEL_FONT_SIZE,          settings.value( SETTING_LABEL_FONT_SIZE,        12 ).toInt() );
 
+    set( SETTING::DRAW_ON_EMPTY_FRAME_ACTION, settings.value( SETTING_DRAW_ON_EMPTY_FRAME_ACTION,
+                                                              KEEP_DRAWING_ON_PREVIOUS_KEY).toInt() );
+
     // Onion Skin
     //
     set( SETTING::PREV_ONION,               settings.value( SETTING_PREV_ONION,             false ).toBool() );
@@ -222,6 +225,9 @@ void PreferenceManager::set( SETTING option, int value )
         break;
     case SETTING::GRID_SIZE:
         settings.setValue ( SETTING_GRID_SIZE, value );
+        break;
+    case SETTING::DRAW_ON_EMPTY_FRAME_ACTION:
+        settings.setValue( SETTING_DRAW_ON_EMPTY_FRAME_ACTION, value);
         break;
     default:
         Q_ASSERT( false );

--- a/core_lib/src/managers/preferencemanager.h
+++ b/core_lib/src/managers/preferencemanager.h
@@ -59,7 +59,16 @@ enum class SETTING
     MULTILAYER_ONION,
     LANGUAGE,
     LAYOUT_LOCK,
+    DRAW_ON_EMPTY_FRAME_ACTION,
     COUNT, // COUNT must always be the last one.
+};
+
+// Actions for drawing on an empty frame.
+enum DrawOnEmptyFrameAction
+{
+    CREATE_NEW_KEY,
+    DUPLICATE_PREVIOUS_KEY,
+    KEEP_DRAWING_ON_PREVIOUS_KEY
 };
 
 class PreferenceManager : public BaseManager

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -130,7 +130,38 @@ void MoveTool::pressOperation(QMouseEvent* event, Layer* layer)
         QRectF selectionRect = mScribbleArea->myTransformedSelection;
         if (!selectionRect.isEmpty())
         {
+            // Hack to "carry over" the selected part of the drawing.
+            // Commented out for now, since it doesn't work right for
+            // vector layers.
+
+//            bool onEmptyFrame = layer->getKeyFrameAt(mEditor->currentFrame()) == nullptr;
+//            bool preferCreateNewKey = mEditor->preference()->getInt(SETTING::DRAW_ON_EMPTY_FRAME_ACTION) == CREATE_NEW_KEY;
+//            bool preferDuplicate = mEditor->preference()->getInt(SETTING::DRAW_ON_EMPTY_FRAME_ACTION) == DUPLICATE_PREVIOUS_KEY;
+
+//            if(onEmptyFrame)
+//            {
+//                if(preferCreateNewKey)
+//                {
+//                    mEditor->copy();
+//                    mScribbleArea->deleteSelection();
+//                }
+//                else if(preferDuplicate)
+//                {
+//                    mEditor->copy();
+//                }
+//            }
+
+//            mScribbleArea->handleDrawingOnEmptyFrame();
             mEditor->backup(typeName());
+
+            // Hack to "carry over" the selected part of the drawing.
+//            if(onEmptyFrame)
+//            {
+//                if(preferCreateNewKey || preferDuplicate)
+//                {
+//                    mEditor->paste();
+//                }
+//            }
         }
 
         if (mScribbleArea->somethingSelected) // there is an area selection

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -107,6 +107,8 @@ void PolylineTool::mousePressEvent( QMouseEvent *event )
     {
         if ( layer->type() == Layer::BITMAP || layer->type() == Layer::VECTOR )
         {
+            mScribbleArea->handleDrawingOnEmptyFrame();
+
             if ( layer->type() == Layer::VECTOR )
             {
                 ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0)->deselectAll();

--- a/core_lib/src/tool/smudgetool.cpp
+++ b/core_lib/src/tool/smudgetool.cpp
@@ -92,6 +92,12 @@ void SmudgeTool::setPressure( const bool pressure )
     settings.sync();
 }
 
+bool SmudgeTool::emptyFrameActionEnabled()
+{
+    // Disabled till we get it working for vector layers...
+    return false;
+}
+
 QCursor SmudgeTool::cursor()
 {
     qDebug() << "smudge tool";
@@ -161,6 +167,13 @@ void SmudgeTool::mousePressEvent(QMouseEvent *event)
 
             if (mScribbleArea->mClosestVertices.size() > 0 || mScribbleArea->mClosestCurves.size() > 0)      // the user clicks near a vertex or a curve
             {
+                // Since startStroke() isn't called, handle empty frame behaviour here.
+                // Commented out for now - leads to segfault on mouse-release event.
+//                if(emptyFrameActionEnabled())
+//                {
+//                    mScribbleArea->handleDrawingOnEmptyFrame();
+//                }
+
                 //qDebug() << "closestCurves:" << closestCurves << " | closestVertices" << closestVertices;
                 VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
 

--- a/core_lib/src/tool/smudgetool.h
+++ b/core_lib/src/tool/smudgetool.h
@@ -43,6 +43,9 @@ public:
     void setFeather( const qreal feather );
     void setPressure( const bool pressure );
 
+protected:
+    bool emptyFrameActionEnabled() override;
+
 private:
     QPointF mLastBrushPoint;
 };

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -43,6 +43,11 @@ BaseTool( parent )
 
 void StrokeTool::startStroke()
 {
+    if(emptyFrameActionEnabled())
+    {
+        mScribbleArea->handleDrawingOnEmptyFrame();
+    }
+
     mFirstDraw = true;
     mLastPixel = getCurrentPixel();
     
@@ -74,6 +79,11 @@ bool StrokeTool::keyPressEvent(QKeyEvent *event)
 bool StrokeTool::keyReleaseEvent(QKeyEvent *event)
 {
     Q_UNUSED(event);
+    return true;
+}
+
+bool StrokeTool::emptyFrameActionEnabled()
+{
     return true;
 }
 

--- a/core_lib/src/tool/stroketool.h
+++ b/core_lib/src/tool/stroketool.h
@@ -47,6 +47,13 @@ protected:
     qreal mCurrentWidth    = 0.0;
     qreal mCurrentPressure = 0.5;
 
+    /// Whether to enable the "drawing on empty frame" preference.
+    /// If true, then the user preference is honored.
+    /// If false, then the stroke is drawn on the previous key-frame (i.e. the
+    /// "old" Pencil behaviour).
+    /// Returns true by default.
+    virtual bool emptyFrameActionEnabled();
+
 private:
 	QPointF mLastPixel = { 0, 0 };
 };

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -184,6 +184,8 @@ enum BackgroundStyle
 #define SETTING_ONION_NEXT_FRAMES_NUM   "OnionNextFramesNum"
 #define SETTING_ONION_TYPE              "OnionType"
 
+#define SETTING_DRAW_ON_EMPTY_FRAME_ACTION  "DrawOnEmptyFrameAction"
+
 #define SETTING_LANGUAGE        "Language"
 
 #endif // PENCILDEF_H


### PR DESCRIPTION
Fixes a "vanishing line" bug in Bitmap layers. To reproduce the issue:

1. Create a new animation.
2. Select the Bitmap layer.
3. Go to frame 2.
4. Draw a line with the pencil, pen or brush tool.
5. The line will "disappear".

Video demos below before and after the fix.

### Before 

![vanishing-line-bug-before](https://user-images.githubusercontent.com/24422213/37004352-11b88808-20c8-11e8-9ed5-c986d663cefa.gif)

### After

![vanishing-line-bug-after](https://user-images.githubusercontent.com/24422213/37004361-1a1a91d0-20c8-11e8-84e4-f7c8c8773ce4.gif)
