### PR TITLE
A temporary solution for high dpi displays

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -305,7 +305,7 @@ int handleArguments( PencilApplication& app )
 int main(int argc, char* argv[])
 {
     Q_INIT_RESOURCE(core_lib);
-
+    PencilApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     PencilApplication app( argc, argv );
 
     installTranslator( app );

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -305,7 +305,16 @@ int handleArguments( PencilApplication& app )
 int main(int argc, char* argv[])
 {
     Q_INIT_RESOURCE(core_lib);
-    PencilApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
+    QSettings settings(PENCIL2D, PENCIL2D);
+    if (settings.value("EnableHighDpiScaling", "true").toBool())
+    {
+        // Enable auto screen scaling on high dpi display, for example, a 4k monitor
+        // This attr has to be set before the QApplication is constructed
+        // Only work in Windows & X11
+        PencilApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    }
+    
     PencilApplication app( argc, argv );
 
     installTranslator( app );


### PR DESCRIPTION
A temporary solution for high DPI displays by setting `Qt::AA_EnableHighDpiScaling`.

I test it on an 15-inch MacBook Pro with Win 10 installed, resolution 2800x1800, 200% display scaling.

1. `Qt::AA_EnableHighDpiScaling` On:

Generally it's fine, but take a closer look at the play and add-key button, you will see pixelated icons.

![Imgur](https://i.imgur.com/x4jiRI5.png)

2. `Qt::AA_EnableHighDpiScaling` Off (as 0.6 official build)

Very tiny icons, and overlapped font on Timeline

![Imgur](https://i.imgur.com/alfgn2b.png)

It's not a perfect solution but will make the Pencil2D UI *usable* on a 4k monitor.