### PR TITLE
Install the icon in the right path

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -144,7 +144,7 @@ linux {
     desktopentry.path = $${PREFIX}/share/applications
 
     icon.files = data/pencil2d.png
-    icon.path = $${PREFIX}/share/icons/hicolor/128x128/apps
+    icon.path = $${PREFIX}/share/icons/hicolor/256x256/apps
 
     INSTALLS += target mimepackage desktopentry icon
 }


### PR DESCRIPTION
The icon currently in app/data/pencil2d.png is actually 256x256 px, so
it should be installed in the 256x256 dir, not the 128x128 one!