### PR TITLE
Fix 1x1 pixel dot appearing in center of canvas.

### DIFF
--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 BitmapImage::BitmapImage()
 {
     mImage = std::make_shared<QImage>(1, 1, QImage::Format_ARGB32_Premultiplied); // don't create null image
+    mImage->fill(QColor(0,0,0,0));
     mBounds = QRect(0, 0, 1, 1);
 }
 
@@ -485,6 +486,7 @@ void BitmapImage::clear()
 {
     mImage = std::make_shared<QImage>(1, 1, QImage::Format_ARGB32_Premultiplied); // null image
     mBounds = QRect(0, 0, 1, 1);
+    mImage->fill(QColor(0,0,0,0));
     modification();
 }
 


### PR DESCRIPTION
As a result of https://github.com/pencil2d/pencil/commit/ad8393733ad950ab1c3d178a559b062d5119148e

this was re-introduced https://github.com/pencil2d/pencil/issues/510

This PR should fix that by making sure that the pixel is transparent.

@chchwy maybe this should be applied as a 0.6.1.1 hotfix?