### PR TITLE
Remove .tiff (doesn't work) and add warning if file is not imported

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -721,21 +721,18 @@ void MainWindow2::importImageSequence()
     progress.setMaximum(totalImagesToImport);
     int imagesImportedSoFar = 0;
 
+    QString failedFiles;
+    bool failedImport = false;
     for (QString strImgFile : files)
     {
         QString strImgFileLower = strImgFile.toLower();
+
         if (strImgFileLower.endsWith(".png") ||
             strImgFileLower.endsWith(".jpg") ||
             strImgFileLower.endsWith(".jpeg") ||
-            strImgFileLower.endsWith(".tif") ||
-            strImgFileLower.endsWith(".tiff") ||
             strImgFileLower.endsWith(".bmp"))
         {
             mEditor->importImage(strImgFile);
-            for (int i = 1; i < number; i++)
-            {
-                mEditor->scrubForward();
-            }
 
             imagesImportedSoFar++;
             progress.setValue(imagesImportedSoFar);
@@ -745,8 +742,29 @@ void MainWindow2::importImageSequence()
             {
                 break;
             }
+        } else {
+            failedFiles += strImgFile + "\n";
+            if (!failedImport)
+            {
+                failedImport = true;
+            }
         }
     }
+
+    if (failedImport)
+    {
+        QMessageBox::warning(this,
+                             tr("Warning"),
+                             tr("was unable to import") + failedFiles,
+                             QMessageBox::Ok,
+                             QMessageBox::Ok);
+    }
+
+    for (int i = 1; i < number; i++)
+    {
+        mEditor->scrubForward();
+    }
+
     mEditor->layers()->notifyAnimationLengthChanged();
 
     progress.close();

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -22,7 +22,7 @@ GNU General Public License for more details.
     QObject::tr( "AVI (*.avi);;MPEG(*.mpg);;MOV(*.mov);;MP4(*.mp4);;SWF(*.swf);;FLV(*.flv);;WMV(*.wmv)" )
 
 #define PENCIL_IMAGE_FILTER \
-   QObject::tr( "Images (*.png *.jpg *.jpeg *.tiff *.tif *.bmp *.gif);;PNG (*.png);;JPG(*.jpg *.jpeg);;TIFF(*.tif *.tiff);;BMP(*.bmp);;GIF(*.gif)" )
+   QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp *.gif);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);;GIF(*.gif)" )
 
 
 enum ToolType : int


### PR DESCRIPTION
strImgFileLower was only used as a mean to check the file extension but never used with importImage(QString). The if statement is unnecessary because we filter the allowed file formats to be imported via pencildef.h

Prior to this, if the file format was read as invalid from the if statement, the for loop would simply continue. This could lead to files not being imported correctly.

I've also removed .tiff format because it doesn't appear to be working.