### PR TITLE
Fix selection rectangle disappearing

### DIFF
--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1444,6 +1444,56 @@ void ScribbleArea::setSelection(QRectF rect, bool trueOrFalse)
     // displaySelectionProperties();
 }
 
+/**
+ * @brief ScribbleArea::manageSelectionOrigin
+ * switches anchor point when crossing threshold
+ */
+void ScribbleArea::manageSelectionOrigin(QPointF currentPoint, QPointF originPoint)
+{
+    int mouseX = currentPoint.x();
+    int mouseY = currentPoint.y();
+
+    QRectF selectRect;
+    if (currentTool()->type() == ToolType::SELECT) {
+        selectRect = mySelection;
+    }
+    else // MOVE
+    {
+        selectRect = myTempTransformedSelection;
+    }
+
+    if (mouseX <= originPoint.x())
+    {
+        selectRect.setLeft(mouseX);
+        selectRect.setRight(originPoint.x());
+    }
+    else
+    {
+        selectRect.setLeft(originPoint.x());
+        selectRect.setRight(mouseX);
+    }
+
+    if (mouseY <= originPoint.y())
+    {
+        selectRect.setTop(mouseY);
+        selectRect.setBottom(originPoint.y());
+    }
+    else
+    {
+        selectRect.setTop(originPoint.y());
+        selectRect.setBottom(mouseY);
+    }
+
+    if (currentTool()->type() == ToolType::SELECT) {
+        mySelection = selectRect;
+    }
+    else // MOVE
+    {
+        myTempTransformedSelection = selectRect;
+    }
+
+}
+
 void ScribbleArea::displaySelectionProperties()
 {
     Layer* layer = mEditor->layers()->currentLayer();

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -121,6 +121,8 @@ public:
 
     bool isMouseInUse() { return mMouseInUse; }
 
+    void manageSelectionOrigin(QPointF currentPoint, QPointF originPoint);
+
 signals:
     void modification( int );
     void multiLayerOnionSkinChanged( bool );

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -148,6 +148,8 @@ void MoveTool::pressOperation(QMouseEvent* event, Layer* layer)
 
             mScribbleArea->setSelection(mScribbleArea->myTransformedSelection, true);
             resetSelectionProperties();
+        } else {
+            anchorOriginPoint = getLastPoint();
         }
 
         if (mScribbleArea->getMoveMode() == ScribbleArea::MIDDLE)
@@ -216,18 +218,22 @@ void MoveTool::whichTransformationPoint()
     if (QLineF(getLastPoint(), transformPoint.topLeft()).length() < 10)
     {
         mScribbleArea->setMoveMode(ScribbleArea::TOPLEFT);
+        anchorOriginPoint = mScribbleArea->mySelection.bottomRight();
     }
     if (QLineF(getLastPoint(), transformPoint.topRight()).length() < 10)
     {
         mScribbleArea->setMoveMode(ScribbleArea::TOPRIGHT);
+        anchorOriginPoint = mScribbleArea->mySelection.bottomLeft();
     }
     if (QLineF(getLastPoint(), transformPoint.bottomLeft()).length() < 10)
     {
         mScribbleArea->setMoveMode(ScribbleArea::BOTTOMLEFT);
+        anchorOriginPoint = mScribbleArea->mySelection.topRight();
     }
     if (QLineF(getLastPoint(), transformPoint.bottomRight()).length() < 10)
     {
         mScribbleArea->setMoveMode(ScribbleArea::BOTTOMRIGHT);
+        anchorOriginPoint = mScribbleArea->mySelection.topLeft();
     }
 }
 
@@ -244,30 +250,45 @@ void MoveTool::transformSelection(qreal offsetX, qreal offsetY)
         break;
 
     case ScribbleArea::TOPRIGHT:
+    {
         mScribbleArea->myTempTransformedSelection =
             mScribbleArea->myTransformedSelection.adjusted(0, offsetY, offsetX, 0);
-        break;
 
+        mScribbleArea->manageSelectionOrigin(getCurrentPoint(), anchorOriginPoint);
+        break;
+    }
     case ScribbleArea::TOPLEFT:
+    {
         mScribbleArea->myTempTransformedSelection =
             mScribbleArea->myTransformedSelection.adjusted(offsetX, offsetY, 0, 0);
-        break;
 
+        mScribbleArea->manageSelectionOrigin(getCurrentPoint(), anchorOriginPoint);
+        break;
+    }
     case ScribbleArea::BOTTOMLEFT:
+    {
         mScribbleArea->myTempTransformedSelection =
             mScribbleArea->myTransformedSelection.adjusted(offsetX, 0, 0, offsetY);
-        break;
 
+        mScribbleArea->manageSelectionOrigin(getCurrentPoint(), anchorOriginPoint);
+        break;
+    }
     case ScribbleArea::BOTTOMRIGHT:
+    {
         mScribbleArea->myTempTransformedSelection =
             mScribbleArea->myTransformedSelection.adjusted(0, 0, offsetX, offsetY);
+
+        mScribbleArea->manageSelectionOrigin(getCurrentPoint(), anchorOriginPoint);
         break;
 
+    }
     case ScribbleArea::ROTATION:
+    {
         mScribbleArea->myTempTransformedSelection =
             mScribbleArea->myTransformedSelection; // @ necessary?
         mScribbleArea->myRotatedAngle = getCurrentPixel().x() - getLastPressPixel().x();
         break;
+    }
     default:
         break;
     }

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -49,6 +49,8 @@ private:
     void actionOnVector(QMouseEvent *event, Layer *layer);
     void storeClosestVectorCurve();
     QPointF maintainAspectRatio(qreal offsetX, qreal offsetY);
+
+    QPointF anchorOriginPoint;
 };
 
 #endif

--- a/core_lib/src/tool/selecttool.h
+++ b/core_lib/src/tool/selecttool.h
@@ -36,6 +36,11 @@ public:
     void mouseMoveEvent(QMouseEvent*) override;
 
     bool keyPressEvent(QKeyEvent *event) override;
+
+
+    // Store selection origin so we can calculate
+    // the selection rectangle in mousePressEvent.
+    QPointF anchorOriginPoint;
 };
 
 #endif


### PR DESCRIPTION
Fixes the selection rectangle disappearing when overlapping origin edges.
Affects: MoveTool and SelectTool

### BUG
![old1](https://user-images.githubusercontent.com/1045397/38887964-8608dca2-427a-11e8-8ba2-efcf7ceb68b8.gif) 
![old2](https://user-images.githubusercontent.com/1045397/38887969-8bab11e8-427a-11e8-9795-c75e8a586125.gif)

### FIX
![fix2](https://user-images.githubusercontent.com/1045397/38888012-ace37af8-427a-11e8-820c-252c3f4f8cf9.gif)
![fix1](https://user-images.githubusercontent.com/1045397/38888003-a5d10bc2-427a-11e8-854c-5f2b579f0216.gif)
