### PR TITLE
Modify Bucket Fill to use different color comparison algorithm

### DIFF
--- a/core_lib/src/graphics/bitmap/bitmapimage.h
+++ b/core_lib/src/graphics/bitmap/bitmapimage.h
@@ -74,7 +74,7 @@ public:
     void clear(QRect rectangle);
     void clear(QRectF rectangle) { clear(rectangle.toRect()); }
 
-    static bool compareColor(QRgb color1, QRgb color2, int tolerance);
+    static bool compareColor(QRgb newColor, QRgb oldColor, int tolerance);
     static void floodFill(BitmapImage* targetImage, QRect cameraRect, QPoint point, QRgb newColor, int tolerance);
 
     void drawLine(QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm, bool antialiasing);

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -151,7 +151,7 @@ void BucketTool::paintBitmap(Layer* layer)
                             cameraRect,
                             point,
                             qPremultiply( mEditor->color()->frontColor().rgba() ),
-                            properties.tolerance * 2.55 );
+                            properties.tolerance );
 
     mScribbleArea->setModified( layerNumber, mEditor->currentFrame() );
     mScribbleArea->setAllDirty();


### PR DESCRIPTION
This is mainly from #837. The relevant section from there:

> Instead of checking if any one channel has a difference in color greater than the threshold, we check if the Euclidean distance between the colors (excluding the alpha channel) is less than the threshold. This means if you have two colors that are 14 values apart on the red, blue, and green channels, then with a threshold of 15 it will be over the threshold because the Eulcidian distance is ~26. Differences in transparency are immediately assumed to be different colors, primarily because a transparency of 0 is the same color regardless of the other channels. There is one exception to this which I will talk about shortly.

Some modifications have been made since then. I fixed some unexpected behavior from the threshold being multiplied earlier in the code, and I decided to factor in alpha differences just like the other channels. There are a few reasons for the latter change. First, we're not going with the composite under approach for transparent areas. Second, that's what we were doing before and it wasn't a noticeable issue. Third, it will probably get changed again anyway when updating the flood fill algorithm.