### PR TITLE
Fix remove color button and add context menu

### DIFF
--- a/app/src/colorpalettewidget.cpp
+++ b/app/src/colorpalettewidget.cpp
@@ -510,9 +510,11 @@ void ColorPaletteWidget::clickRemoveColorButton()
         // items are not deleted by qt, has to be done manually
         // delete should happen before removing the color from from palette
         // as the palette will be one ahead and crash otherwise
-        delete item;
-
-        editor()->object()->removeColour(index);
+        if (editor()->object()->shouldDeleteColor(index)) {
+            delete item;
+            editor()->object()->removeColour(index);
+            editor()->updateCurrentFrame();
+        }
     }
 }
 

--- a/app/src/colorpalettewidget.h
+++ b/app/src/colorpalettewidget.h
@@ -53,15 +53,16 @@ public:
     void setColor(QColor, int);
     void refreshColorList();
 
+    void showContextMenu(const QPoint&);
+
 signals:
     void colorChanged(QColor);
     void colorNumberChanged(int);
 
 protected:
-    void resizeEvent(QResizeEvent *event) override;
+    void resizeEvent(QResizeEvent* event) override;
 
 private slots:
-    void colorListCurrentItemChanged(QListWidgetItem*, QListWidgetItem*);
     void clickColorListItem(QListWidgetItem*);
     void changeColourName(QListWidgetItem*);
     void onActiveColorNameChange(QString name);
@@ -74,6 +75,10 @@ private slots:
     void setSwatchSizeSmall();
     void setSwatchSizeMedium();
     void setSwatchSizeLarge();
+    QList<QListWidgetItem*> selectedItems() const;
+    void addItem();
+    void replaceItem();
+    void removeItem();
 
 private:
     void updateItemColor(int, QColor);

--- a/app/src/colorpalettewidget.h
+++ b/app/src/colorpalettewidget.h
@@ -75,10 +75,10 @@ private slots:
     void setSwatchSizeSmall();
     void setSwatchSizeMedium();
     void setSwatchSizeLarge();
-    QList<QListWidgetItem*> selectedItems() const;
     void addItem();
     void replaceItem();
     void removeItem();
+    bool showPaletteWarning();
 
 private:
     void updateItemColor(int, QColor);

--- a/app/src/colorpalettewidget.h
+++ b/app/src/colorpalettewidget.h
@@ -41,6 +41,7 @@ class ColorPaletteWidget : public BaseDockWidget
     Q_OBJECT
 
 public:
+
     explicit ColorPaletteWidget(QWidget* parent);
     ~ColorPaletteWidget();
 
@@ -78,6 +79,8 @@ private slots:
     void addItem();
     void replaceItem();
     void removeItem();
+    void showPaletteReminder();
+
     bool showPaletteWarning();
 
 private:
@@ -103,6 +106,7 @@ private:
     QString buttonStylesheet;
 
     bool mIsColorDialog = false;
+    bool mMultipleSelected = false;
 
 };
 

--- a/app/ui/colorpalette.ui
+++ b/app/ui/colorpalette.ui
@@ -228,6 +228,9 @@
         <property name="autoScrollMargin">
          <number>16</number>
         </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::ExtendedSelection</enum>
+        </property>
         <property name="resizeMode">
          <enum>QListView::Fixed</enum>
         </property>
@@ -312,24 +315,7 @@
  <resources>
   <include location="../data/app.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>removeColorButton</sender>
-   <signal>clicked()</signal>
-   <receiver>ColorPalette</receiver>
-   <slot>clickRemoveColorButton()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>36</x>
-     <y>43</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>133</x>
-     <y>128</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
  <slots>
   <slot>colorListCurrentItemChanged(QListWidgetItem*,QListWidgetItem*)</slot>
   <slot>clickColorListItem(QListWidgetItem*)</slot>

--- a/core_lib/src/graphics/vector/colourref.cpp
+++ b/core_lib/src/graphics/vector/colourref.cpp
@@ -16,6 +16,8 @@ GNU General Public License for more details.
 */
 #include "colourref.h"
 
+#include <QDebug>
+
 ColourRef::ColourRef()
 {
     colour = Qt::green;
@@ -51,3 +53,12 @@ bool ColourRef::operator!=(ColourRef colourRef1)
         return false;
     }
 }
+
+QDebug operator<<(QDebug debug, const ColourRef& colourRef)
+{
+    debug.nospace() << "ColourRef(" << colourRef.colour << " " << colourRef.name <<")";
+    return debug.maybeSpace();
+}
+
+
+

--- a/core_lib/src/graphics/vector/colourref.cpp
+++ b/core_lib/src/graphics/vector/colourref.cpp
@@ -54,7 +54,7 @@ bool ColourRef::operator!=(ColourRef colourRef1)
     }
 }
 
-QDebug operator<<(QDebug debug, const ColourRef& colourRef)
+QDebug& operator<<(QDebug debug, const ColourRef& colourRef)
 {
     debug.nospace() << "ColourRef(" << colourRef.colour << " " << colourRef.name <<")";
     return debug.maybeSpace();

--- a/core_lib/src/graphics/vector/colourref.h
+++ b/core_lib/src/graphics/vector/colourref.h
@@ -33,6 +33,6 @@ public:
     QString name;
 };
 
-QDebug operator<<(QDebug debug, const ColourRef &colourRef);
+QDebug& operator<<(QDebug debug, const ColourRef &colourRef);
 
 #endif

--- a/core_lib/src/graphics/vector/colourref.h
+++ b/core_lib/src/graphics/vector/colourref.h
@@ -33,4 +33,6 @@ public:
     QString name;
 };
 
+QDebug operator<<(QDebug debug, const ColourRef &colourRef);
+
 #endif

--- a/core_lib/src/managers/colormanager.cpp
+++ b/core_lib/src/managers/colormanager.cpp
@@ -62,15 +62,7 @@ QColor ColorManager::frontColor()
 {
 
     if (mIsWorkingOnVectorLayer)
-        if (object()->getColourCount() == 0)
-        {
-            object()->useAsTempPaletteColor(mCurrentFrontColor);
-            return mCurrentFrontColor;
-        }
-        else
-        {
-            return object()->getColour(mCurrentColorIndex).colour;
-        }
+        return object()->getColour(mCurrentColorIndex).colour;
     else
         return mCurrentFrontColor;
 }

--- a/core_lib/src/managers/colormanager.cpp
+++ b/core_lib/src/managers/colormanager.cpp
@@ -62,7 +62,15 @@ QColor ColorManager::frontColor()
 {
 
     if (mIsWorkingOnVectorLayer)
-        return object()->getColour(mCurrentColorIndex).colour;
+        if (object()->getColourCount() == 0)
+        {
+            object()->useAsTempPaletteColor(mCurrentFrontColor);
+            return mCurrentFrontColor;
+        }
+        else
+        {
+            return object()->getColour(mCurrentColorIndex).colour;
+        }
     else
         return mCurrentFrontColor;
 }

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -278,8 +278,6 @@ ColourRef Object::getColour(int index) const
     if (index > -1 && index < mPalette.size())
     {
         result = mPalette.at(index);
-    } else {
-        return mFrontColor;
     }
     return result;
 }
@@ -288,20 +286,11 @@ void Object::setColour(int index, QColor newColour)
 {
     Q_ASSERT(index >= 0);
 
-    // To allow a clean color palette, we return if it's empty
-    if (mPalette.isEmpty())
-    {
-        return;
-    }
     mPalette[index].colour = newColour;
 }
 
 void Object::setColourRef(int index, ColourRef newColourRef)
 {
-    if (mPalette.isEmpty())
-    {
-        return;
-    }
     mPalette[index] = newColourRef;
 }
 
@@ -317,7 +306,6 @@ void Object::addColourAtIndex(int index, ColourRef newColour)
 
 bool Object::isColourInUse(int index)
 {
-    bool usesColor = false;
     for (int i = 0; i < getLayerCount(); i++)
     {
         Layer* layer = getLayer(i);
@@ -327,11 +315,11 @@ bool Object::isColourInUse(int index)
 
             if (layerVector->usesColour(index))
             {
-                usesColor = true;
+                return true;
             }
         }
     }
-    return true;
+    return false;
 
 }
 

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -20,8 +20,6 @@ GNU General Public License for more details.
 #include <QTextStream>
 #include <QProgressDialog>
 #include <QApplication>
-#include <QMessageBox>
-#include <QPushButton>
 
 #include "layer.h"
 #include "layerbitmap.h"
@@ -317,7 +315,7 @@ void Object::addColourAtIndex(int index, ColourRef newColour)
     mPalette.insert(index, newColour);
 }
 
-bool Object::shouldDeleteColor(int index)
+bool Object::isColourInUse(int index)
 {
     bool usesColor = false;
     for (int i = 0; i < getLayerCount(); i++)
@@ -333,30 +331,11 @@ bool Object::shouldDeleteColor(int index)
             }
         }
     }
-
-    if (usesColor)
-    {
-        QMessageBox msgBox;
-        msgBox.setText(tr("The color you are trying to delete is currently being used by one or multiple strokes, "
-                       "if you wish to delete it anyway, you accept that the stroke(s) will be bound to the next available color"));
-        QPushButton* cancelButton = msgBox.addButton(tr("Cancel"), QMessageBox::RejectRole);
-        QPushButton* removeButton = msgBox.addButton(tr("Remove anyway"), QMessageBox::AcceptRole);
-
-        msgBox.exec();
-        if (msgBox.clickedButton() == cancelButton)
-        {
-            return false;
-        }
-        else if (msgBox.clickedButton() == removeButton)
-        {
-            return true;
-        }
-    }
     return true;
 
 }
 
-bool Object::removeColour(int index)
+void Object::removeColour(int index)
 {
     for (int i = 0; i < getLayerCount(); i++)
     {
@@ -370,7 +349,6 @@ bool Object::removeColour(int index)
 
     mPalette.removeAt(index);
 
-    return true;
     // update the vector pictures using that colour !
 }
 

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -21,6 +21,7 @@ GNU General Public License for more details.
 #include <QProgressDialog>
 #include <QApplication>
 #include <QMessageBox>
+#include <QPushButton>
 
 #include "layer.h"
 #include "layerbitmap.h"
@@ -316,6 +317,45 @@ void Object::addColourAtIndex(int index, ColourRef newColour)
     mPalette.insert(index, newColour);
 }
 
+bool Object::shouldDeleteColor(int index)
+{
+    bool usesColor = false;
+    for (int i = 0; i < getLayerCount(); i++)
+    {
+        Layer* layer = getLayer(i);
+        if (layer->type() == Layer::VECTOR)
+        {
+            LayerVector* layerVector = (LayerVector*)layer;
+
+            if (layerVector->usesColour(index))
+            {
+                usesColor = true;
+            }
+        }
+    }
+
+    if (usesColor)
+    {
+        QMessageBox msgBox;
+        msgBox.setText(tr("The color you are trying to delete is currently being used by one or multiple strokes, "
+                       "if you wish to delete it anyway, you accept that the stroke(s) will be bound to the next available color"));
+        QPushButton* cancelButton = msgBox.addButton(tr("Cancel"), QMessageBox::RejectRole);
+        QPushButton* removeButton = msgBox.addButton(tr("Remove anyway"), QMessageBox::AcceptRole);
+
+        msgBox.exec();
+        if (msgBox.clickedButton() == cancelButton)
+        {
+            return false;
+        }
+        else if (msgBox.clickedButton() == removeButton)
+        {
+            return true;
+        }
+    }
+    return true;
+
+}
+
 bool Object::removeColour(int index)
 {
     for (int i = 0; i < getLayerCount(); i++)
@@ -324,7 +364,6 @@ bool Object::removeColour(int index)
         if (layer->type() == Layer::VECTOR)
         {
             LayerVector* layerVector = (LayerVector*)layer;
-
             layerVector->removeColour(index);
         }
     }

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -90,8 +90,8 @@ public:
 
     void addColour( ColourRef newColour ) { mPalette.append( newColour ); }
     void addColourAtIndex(int index, ColourRef newColour);
-    bool removeColour( int index );
-    bool shouldDeleteColor( int index );
+    void removeColour( int index );
+    bool isColourInUse( int index );
     void renameColour( int i, QString text );
     int getColourCount() { return mPalette.size(); }
     bool importPalette( QString filePath );

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -83,7 +83,6 @@ public:
 
     // Color palette
     ColourRef getColour( int index ) const;
-    void useAsTempPaletteColor(QColor color) { mFrontColor = ColourRef(color, "Front Color"); }
     void setColour(int index, QColor newColour);
     void setColourRef(int index, ColourRef newColourRef);
     void addColour( QColor );
@@ -154,8 +153,6 @@ private:
     bool modified = false;
 
     QList<ColourRef> mPalette;
-
-    ColourRef mFrontColor;
 
     std::unique_ptr<ObjectData> mData;
 };

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -91,6 +91,7 @@ public:
     void addColour( ColourRef newColour ) { mPalette.append( newColour ); }
     void addColourAtIndex(int index, ColourRef newColour);
     bool removeColour( int index );
+    bool shouldDeleteColor( int index );
     void renameColour( int i, QString text );
     int getColourCount() { return mPalette.size(); }
     bool importPalette( QString filePath );

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -82,10 +82,14 @@ public:
     QString copyFileToDataFolder( QString strFilePath );
 
     // Color palette
-    ColourRef getColour( int i ) const;
+    ColourRef getColour( int index ) const;
+    void useAsTempPaletteColor(QColor color) { mFrontColor = ColourRef(color, "Front Color"); }
     void setColour(int index, QColor newColour);
+    void setColourRef(int index, ColourRef newColourRef);
     void addColour( QColor );
+
     void addColour( ColourRef newColour ) { mPalette.append( newColour ); }
+    void addColourAtIndex(int index, ColourRef newColour);
     bool removeColour( int index );
     void renameColour( int i, QString text );
     int getColourCount() { return mPalette.size(); }
@@ -149,6 +153,8 @@ private:
     bool modified = false;
 
     QList<ColourRef> mPalette;
+
+    ColourRef mFrontColor;
 
     std::unique_ptr<ObjectData> mData;
 };


### PR DESCRIPTION
![it s back](https://user-images.githubusercontent.com/1045397/40271309-e23cfe92-5b9b-11e8-8536-d98f561f18e7.gif)

I've fixed the remove button and added some enhancements.
* Add, replace or remove using right-click through the context-menu shown above
* Drag to select multiple color swatches
* no auto color update on palette anymore, use replace via context menu.

~~When palette is empty, vector layer will use front color instead of palette.~~

Known bugs:
modifying first index in palette, doesn't update vector stroke for some reason..
this is an old bug but I wasn't able to find the cause this time around.
Considering my proposal https://github.com/pencil2d/pencil/issues/962 that changes this, I'm leaving the bug as is for now.

