### PR TITLE
Rearrange default dock widget locations

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -194,12 +194,12 @@ void MainWindow2::createDockWidgets()
     }
 
     addDockWidget(Qt::RightDockWidgetArea, mColorBox);
+    addDockWidget(Qt::RightDockWidgetArea, mColorInspector);
     addDockWidget(Qt::RightDockWidgetArea, mColorPalette);
-    addDockWidget(Qt::RightDockWidgetArea, mDisplayOptionWidget);
     addDockWidget(Qt::LeftDockWidgetArea, mToolBox);
     addDockWidget(Qt::LeftDockWidgetArea, mToolOptions);
+    addDockWidget(Qt::LeftDockWidgetArea, mDisplayOptionWidget);
     addDockWidget(Qt::BottomDockWidgetArea, mTimeLine);
-    addDockWidget(Qt::LeftDockWidgetArea, mColorInspector);
     setDockNestingEnabled(true);
     //addDockWidget( Qt::BottomDockWidgetArea, mTimeline2);
 


### PR DESCRIPTION
This is a small change that moves the color inspector to the right (under the color wheel) to match with the location of the sliders before they were made into a new widget. The display widget was moved to the left to balance the sides out. It should look like this now by default:
![screen shot 2018-05-20 at 4 20 20 pm](https://user-images.githubusercontent.com/3461051/40284263-b6d913c2-5c49-11e8-9f15-552ee3b640ed.png)

I think this is a much better setup because it has all of the color stuff on the right and all the tools/settings on the left.
