### PR TITLE
Improve timeline length updating

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -546,6 +546,8 @@ void ActionCommands::moveFrameForward()
             mEditor->scrubForward();
         }
     }
+
+    mEditor->layers()->notifyAnimationLengthChanged();
 }
 
 void ActionCommands::moveFrameBackward()

--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -240,12 +240,19 @@ void TimeLine::setLength(int frame)
     updateLength();
 }
 
+/** Extends the tineline frame length if necessary
+ *
+ *  If the new animation length is more than 75% of the timeline
+ *  frame length, then double the timeline frame length, otherwise
+ *  do nothing.
+ *
+ *  @param[in] frame The new animation length
+ */
 void TimeLine::extendLength(int frame)
 {
-    int extendFrame = frame + 10;
-    if (extendFrame > mTracks->getFrameLength())
-    {
-        mTracks->setFrameLength(extendFrame);
+    int frameLength = mTracks->getFrameLength();
+    if(frame > frameLength * 0.75) {
+        mTracks->setFrameLength(frameLength * 1.5);
         updateLength();
     }
 }

--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -592,6 +592,7 @@ void TimeLineCells::mouseMoveEvent(QMouseEvent* event)
 
                             int offset = frameNumber - mLastFrameNumber;
                             currentLayer->moveSelectedFrames(offset);
+                            mEditor->layers()->notifyAnimationLengthChanged();
                             mEditor->updateCurrentFrame();
                         }
                         else if (mCanBoxSelect)


### PR DESCRIPTION
This changes the behavior of the automatic timeline extension so that the length extends by 50% when you add a frame in the last 25% of the current timeline. This should make it much less noticeable. Before you would always be working on the very end of the timeline if you did not extend the timeline length manually.

It also also updates the length when frames are moved to the end now.