### PR TITLE
Optimize bucket fill with cache

### DIFF
--- a/core_lib/src/graphics/bitmap/bitmapimage.h
+++ b/core_lib/src/graphics/bitmap/bitmapimage.h
@@ -74,7 +74,7 @@ public:
     void clear(QRect rectangle);
     void clear(QRectF rectangle) { clear(rectangle.toRect()); }
 
-    static bool compareColor(QRgb newColor, QRgb oldColor, int tolerance);
+    static bool compareColor(QRgb newColor, QRgb oldColor, int tolerance, QHash<QRgb, bool> *cache);
     static void floodFill(BitmapImage* targetImage, QRect cameraRect, QPoint point, QRgb newColor, int tolerance);
 
     void drawLine(QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm, bool antialiasing);


### PR DESCRIPTION
This is all from #837. The relevant section from there:

> Inspired by how Krita does flood filling, I have added a hash map to remember if colors are within the threshold for the duration of the operation (threshold and oldColor will remain constant, so only newColor is needed for lookup). Since the vast majority of the pixels that will be encountered are usually from a small subset of colors, this should have significant speed benefits. The Euclidean difference operation is probably a bit slower than the old difference operation, so this is even more important.

Hmm, I wonder if this will work: Closes #837.