### PR TITLE
Look for next frame if previous doesn't exist - #950

### DIFF
--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -517,16 +517,28 @@ void ScribbleArea::mousePressEvent(QMouseEvent* event)
     Layer* layer = mEditor->layers()->currentLayer();
     Q_ASSUME(layer != nullptr);
 
+    bool keyExists = layer->keyExists(mEditor->currentFrame());
+    int keyFrameIndex = mEditor->currentFrame();
+
+    // usually we look the previous frame but if there's no previous frame to look for
+    // bad stuff happens, therefore look for next index
+    // we know that one has to exist.
+    if (!keyExists)
+        keyFrameIndex = mEditor->layers()->currentLayer()->getNextFrameNumber(mEditor->currentFrame(), true);
+
     if (layer->type() == Layer::VECTOR)
     {
         auto pLayerVector = static_cast<LayerVector*>(layer);
-        VectorImage* vectorImage = pLayerVector->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+        VectorImage* vectorImage = pLayerVector->getLastVectorImageAtFrame(keyFrameIndex, 0);
+
         Q_CHECK_PTR(vectorImage);
     }
     else if (layer->type() == Layer::BITMAP)
     {
         auto pLayerBitmap = static_cast<LayerBitmap*>(layer);
-        BitmapImage* bitmapImage = pLayerBitmap->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0);
+
+        BitmapImage* bitmapImage = pLayerBitmap->getLastBitmapImageAtFrame(keyFrameIndex, 0);
+
         Q_CHECK_PTR(bitmapImage);
     }
 

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -517,31 +517,6 @@ void ScribbleArea::mousePressEvent(QMouseEvent* event)
     Layer* layer = mEditor->layers()->currentLayer();
     Q_ASSUME(layer != nullptr);
 
-    bool keyExists = layer->keyExists(mEditor->currentFrame());
-    int keyFrameIndex = mEditor->currentFrame();
-
-    // usually we look the previous frame but if there's no previous frame to look for
-    // bad stuff happens, therefore look for next index
-    // we know that one has to exist.
-    if (!keyExists)
-        keyFrameIndex = mEditor->layers()->currentLayer()->getNextFrameNumber(mEditor->currentFrame(), true);
-
-    if (layer->type() == Layer::VECTOR)
-    {
-        auto pLayerVector = static_cast<LayerVector*>(layer);
-        VectorImage* vectorImage = pLayerVector->getLastVectorImageAtFrame(keyFrameIndex, 0);
-
-        Q_CHECK_PTR(vectorImage);
-    }
-    else if (layer->type() == Layer::BITMAP)
-    {
-        auto pLayerBitmap = static_cast<LayerBitmap*>(layer);
-
-        BitmapImage* bitmapImage = pLayerBitmap->getLastBitmapImageAtFrame(keyFrameIndex, 0);
-
-        Q_CHECK_PTR(bitmapImage);
-    }
-
     if (!layer->visible() && currentTool()->type() != HAND && (event->button() != Qt::RightButton))
     {
         QMessageBox::warning(this, tr("Warning"),

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -451,11 +451,26 @@ void Object::paintImage(QPainter& painter, int frameNumber,
             if (layer->type() == Layer::BITMAP)
             {
                 LayerBitmap* layerBitmap = (LayerBitmap*)layer;
-                layerBitmap->getLastBitmapImageAtFrame(frameNumber, 0)->paintImage(painter);
+
+                // Make sure there's a key before painting anything
+                // otherwise return
+                if (!layer->keyExists(frameNumber)) {
+                    return;
+                }
+
+                layerBitmap->getLastBitmapImageAtFrame(frameNumber)->paintImage(painter);
+
             }
             // paints the vector images
             if (layer->type() == Layer::VECTOR)
             {
+
+                // Make sure there's a key before painting anything
+                // otherwise return
+                if (!layer->keyExists(frameNumber)) {
+                    return;
+                }
+
                 LayerVector* layerVector = (LayerVector*)layer;
                 layerVector->getLastVectorImageAtFrame(frameNumber, 0)->paintImage(painter,
                                                                                    false,


### PR DESCRIPTION
When the mouse is pressed, we expect there to be a frame either on the exact pos or a previous frame, if that's not the case, the key return as nullptr and therefore crash the application.

This PR fixes that problem by looking for the next index if a previous doesn't exist.