### PR TITLE
fix tool properties being shared in some cases

### DIFF
--- a/core_lib/src/tool/brushtool.cpp
+++ b/core_lib/src/tool/brushtool.cpp
@@ -61,7 +61,7 @@ void BrushTool::loadSettings()
     properties.pressure = settings.value( "brushPressure", false ).toBool();
     properties.invisibility = settings.value("brushInvisibility", true).toBool();
     properties.preserveAlpha = OFF;
-    properties.stabilizerLevel = settings.value("brushStabilization").toInt();
+    properties.stabilizerLevel = settings.value("brushLineStabilization").toInt();
     properties.useAA = settings.value("brushAA").toInt();
 
     if (properties.useFeather == true) {
@@ -140,7 +140,7 @@ void BrushTool::setStabilizerLevel(const int level)
     properties.stabilizerLevel = level;
 
     QSettings settings( PENCIL2D, PENCIL2D);
-    settings.setValue("brushStabilization", level);
+    settings.setValue("brushLineStabilization", level);
     settings.sync();
 }
 

--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -50,7 +50,7 @@ void PencilTool::loadSettings()
     properties.width = settings.value("pencilWidth").toDouble();
     properties.feather = 50;
     properties.pressure = settings.value("pencilPressure").toBool();
-    properties.stabilizerLevel = settings.value("stabilizerLevel").toInt();
+    properties.stabilizerLevel = settings.value("pencilLineStabilization").toInt();
     properties.useAA = DISABLED;
     properties.useFeather = true;
     properties.useFillContour = false;
@@ -124,7 +124,7 @@ void PencilTool::setStabilizerLevel(const int level)
     properties.stabilizerLevel = level;
 
     QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("stabilizerLevel", level);
+    settings.setValue("pencilLineStabilization", level);
     settings.sync();
 }
 

--- a/core_lib/src/tool/pentool.cpp
+++ b/core_lib/src/tool/pentool.cpp
@@ -47,8 +47,8 @@ void PenTool::loadSettings()
     properties.pressure = settings.value("penPressure").toBool();
     properties.invisibility = OFF;
     properties.preserveAlpha = OFF;
-    properties.useAA = settings.value("brushAA").toBool();
-    properties.stabilizerLevel = settings.value("stabilizerLevel").toInt();
+    properties.useAA = settings.value("penAA").toBool();
+    properties.stabilizerLevel = settings.value("penLineStabilization").toInt();
 
     // First run
     if (properties.width <= 0)
@@ -89,7 +89,7 @@ void PenTool::setAA(const int AA)
 
     // Update settings
     QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("brushAA", AA);
+    settings.setValue("penAA", AA);
     settings.sync();
 }
 
@@ -98,7 +98,7 @@ void PenTool::setStabilizerLevel(const int level)
     properties.stabilizerLevel = level;
 
     QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("stabilizerLevel", level);
+    settings.setValue("penLineStabilization", level);
     settings.sync();
 }
 


### PR DESCRIPTION
Fixes line interpolation being shared in some cases across tools.

Given that the changes are so small, I'm going to merge this myself.