### PR TITLE
Improve GIF UI/UX import/export

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -133,9 +133,20 @@ Status ActionCommands::importSound()
     return st;
 }
 
-Status ActionCommands::exportMovie()
+Status ActionCommands::exportGif()
 {
-    auto dialog = new ExportMovieDialog(mParent);
+    // exporting gif
+    return exportMovie(true);
+}
+
+Status ActionCommands::exportMovie(bool isGif)
+{
+    ExportMovieDialog* dialog = nullptr;
+    if (isGif) {
+        dialog = new ExportMovieDialog(mParent, ImportExportDialog::Export, FileType::GIF);
+    } else {
+        dialog = new ExportMovieDialog(mParent);
+    }
     OnScopeExit(dialog->deleteLater());
 
     dialog->init();
@@ -227,11 +238,16 @@ Status ActionCommands::exportMovie()
 
     if (st.ok() && QFile::exists(strMoviePath))
     {
+        if (isGif) {
+            QMessageBox::information(mParent, "Pencil2D",
+                                             tr("Finished"));
+            return Status::OK;
+        }
         auto btn = QMessageBox::question(mParent, "Pencil2D",
                                          tr("Finished. Open movie now?", "When movie export done."));
         if (btn == QMessageBox::Yes)
         {
-            QDesktopServices::openUrl(QUrl::fromLocalFile(strMoviePath));
+            QDesktopServices::openUrl(QUrl::fromLocalFile(strMoviePath).path());
         }
     }
     return Status::OK;

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -36,9 +36,10 @@ public:
 
     // file 
     Status importSound();
-    Status exportMovie();
+    Status exportMovie(bool isGif = false);
     Status exportImageSequence();
     Status exportImage();
+    Status exportGif();
 
     // edit
     void flipSelectionX();

--- a/app/src/exportmoviedialog.cpp
+++ b/app/src/exportmoviedialog.cpp
@@ -19,12 +19,17 @@ GNU General Public License for more details.
 #include "ui_exportmovieoptions.h"
 #include "util.h"
 
-ExportMovieDialog::ExportMovieDialog(QWidget *parent) :
-    ImportExportDialog(parent, ImportExportDialog::Export, FileType::MOVIE),
+ExportMovieDialog::ExportMovieDialog(QWidget *parent, Mode mode, FileType fileType) :
+    ImportExportDialog(parent, mode, fileType),
     ui(new Ui::ExportMovieOptions)
 {
     ui->setupUi(getOptionsGroupBox());
-    setWindowTitle(tr("Export Movie"));
+
+    if (fileType == FileType::GIF) {
+        setWindowTitle(tr("Export Animated GIF"));
+    } else {
+        setWindowTitle(tr("Export Movie"));
+    }
     connect(this, &ExportMovieDialog::filePathsChanged, this, &ExportMovieDialog::onFilePathsChanged);
 }
 

--- a/app/src/exportmoviedialog.h
+++ b/app/src/exportmoviedialog.h
@@ -31,7 +31,7 @@ class ExportMovieDialog : public ImportExportDialog
     Q_OBJECT
 
 public:
-    explicit ExportMovieDialog(QWidget* parent = 0);
+    explicit ExportMovieDialog(QWidget* parent = 0, Mode mode = ImportExportDialog::Export, FileType fileType = FileType::MOVIE);
     ~ExportMovieDialog();
 
     void setCamerasInfo(const std::vector<std::pair<QString, QSize>>);

--- a/app/src/filedialogex.cpp
+++ b/app/src/filedialogex.cpp
@@ -148,6 +148,7 @@ QString FileDialog::saveDialogTitle( FileType fileType )
         case FileType::ANIMATION: return tr( "Save animation" );
         case FileType::IMAGE: return tr( "Export image" );
         case FileType::IMAGE_SEQUENCE: return tr( "Export image sequence" );
+        case FileType::GIF: return tr( "Export Animated GIF" );
         case FileType::MOVIE: return tr( "Export movie" );
         case FileType::SOUND: return tr( "Export sound" );
         case FileType::PALETTE: return tr( "Export palette" );
@@ -179,7 +180,8 @@ QString FileDialog::saveFileFilters( FileType fileType )
         case FileType::ANIMATION: return PFF_SAVE_ALL_FILE_FILTER;
         case FileType::IMAGE: return "";
         case FileType::IMAGE_SEQUENCE: return "";
-        case FileType::MOVIE: return tr( "MP4 (*.mp4);; AVI (*.avi);; WebM (*.webm);; GIF (*.gif);; APNG (*.apng)" );
+        case FileType::GIF: return tr("Animated GIF (*.gif)");
+        case FileType::MOVIE: return tr( "MP4 (*.mp4);; AVI (*.avi);; WebM (*.webm);; APNG (*.apng)" );
         case FileType::SOUND: return "";
         case FileType::PALETTE: return tr( "Pencil2D Palette (*.xml);; Gimp Palette (*.gpl)" );
         default: Q_ASSERT( false );

--- a/app/src/filedialogex.cpp
+++ b/app/src/filedialogex.cpp
@@ -161,7 +161,7 @@ QString FileDialog::openFileFilters( FileType fileType )
     {
         case FileType::ANIMATION: return PFF_OPEN_ALL_FILE_FILTER;
         case FileType::IMAGE: return PENCIL_IMAGE_FILTER;
-        case FileType::IMAGE_SEQUENCE: return PENCIL_IMAGE_FILTER;
+        case FileType::IMAGE_SEQUENCE: return PENCIL_IMAGE_SEQ_FILTER;
         case FileType::MOVIE: { Q_ASSERT(false); return PENCIL_MOVIE_EXT; } // currently not supported
         case FileType::SOUND: return tr( "Sounds (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)" );
         case FileType::PALETTE: return tr( "Pencil2D Palette (*.xml);; Gimp Palette (*.gpl)" );

--- a/app/src/filedialogex.cpp
+++ b/app/src/filedialogex.cpp
@@ -132,6 +132,7 @@ QString FileDialog::openDialogTitle( FileType fileType )
         case FileType::ANIMATION: return tr( "Open animation" );
         case FileType::IMAGE: return tr( "Import image" );
         case FileType::IMAGE_SEQUENCE: return tr( "Import image sequence" );
+        case FileType::GIF: return tr( "Import Animated GIF" );
         case FileType::MOVIE: return tr( "Import movie" );
         case FileType::SOUND: return tr( "Import sound" );
         case FileType::PALETTE: return tr( "Import palette" );
@@ -162,6 +163,7 @@ QString FileDialog::openFileFilters( FileType fileType )
         case FileType::ANIMATION: return PFF_OPEN_ALL_FILE_FILTER;
         case FileType::IMAGE: return PENCIL_IMAGE_FILTER;
         case FileType::IMAGE_SEQUENCE: return PENCIL_IMAGE_SEQ_FILTER;
+        case FileType::GIF: return tr("Animated GIF (*.gif)");
         case FileType::MOVIE: { Q_ASSERT(false); return PENCIL_MOVIE_EXT; } // currently not supported
         case FileType::SOUND: return tr( "Sounds (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)" );
         case FileType::PALETTE: return tr( "Pencil2D Palette (*.xml);; Gimp Palette (*.gpl)" );
@@ -222,6 +224,7 @@ QString FileDialog::defaultFileName( FileType fileType )
         case FileType::ANIMATION: return tr( "MyAnimation.pclx" );
         case FileType::IMAGE: return "untitled.png";
         case FileType::IMAGE_SEQUENCE: return "untitled.png";
+        case FileType::GIF: return "untitled.gif";
         case FileType::MOVIE: return "untitled.mp4";
         case FileType::SOUND: return "untitled.wav";
         case FileType::PALETTE: return "untitled.xml";
@@ -237,6 +240,7 @@ QString FileDialog::toSettingKey( FileType fileType )
         case FileType::ANIMATION: return "Animation";
         case FileType::IMAGE: return "Image";
         case FileType::IMAGE_SEQUENCE: return "ImageSequence";
+        case FileType::GIF: return "Animated GIF";
         case FileType::MOVIE: return "Movie";
         case FileType::SOUND: return "Sound";
         case FileType::PALETTE: return "Palette";

--- a/app/src/filedialogex.h
+++ b/app/src/filedialogex.h
@@ -25,6 +25,7 @@ enum class FileType
     ANIMATION,
     IMAGE,
     IMAGE_SEQUENCE,
+    GIF,
     MOVIE,
     SOUND,
     PALETTE

--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -19,13 +19,18 @@ GNU General Public License for more details.
 #include "ui_importimageseqoptions.h"
 #include "util.h"
 
-ImportImageSeqDialog::ImportImageSeqDialog(QWidget* parent) :
-    ImportExportDialog(parent, ImportExportDialog::Import, FileType::IMAGE_SEQUENCE)
+ImportImageSeqDialog::ImportImageSeqDialog(QWidget* parent, Mode mode, FileType fileType) :
+    ImportExportDialog(parent, mode, fileType)
 {
     ui = new Ui::ImportImageSeqOptions;
     ui->setupUi(getOptionsGroupBox());
 
-    setWindowTitle(tr("Import image sequence"));
+    if (fileType == FileType::GIF) {
+        setWindowTitle(tr("Import Animated GIF"));
+    } else {
+        setWindowTitle(tr("Import image sequence"));
+    }
+
     connect(ui->spaceSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &ImportImageSeqDialog::setSpace);
 }
 

--- a/app/src/importimageseqdialog.h
+++ b/app/src/importimageseqdialog.h
@@ -29,7 +29,7 @@ class ImportImageSeqDialog : public ImportExportDialog
     Q_OBJECT
 
 public:
-    explicit ImportImageSeqDialog(QWidget *parent = 0);
+    explicit ImportImageSeqDialog(QWidget *parent = 0, Mode mode = ImportExportDialog::Import, FileType fileType = FileType::IMAGE_SEQUENCE);
     ~ImportImageSeqDialog();
 
     int getSpace();

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -239,6 +239,7 @@ void MainWindow2::createMenus()
     connect(ui->actionExport_Image, &QAction::triggered, mCommands, &ActionCommands::exportImage);
     connect(ui->actionExport_ImageSeq, &QAction::triggered, mCommands, &ActionCommands::exportImageSequence);
     connect(ui->actionExport_Movie, &QAction::triggered, mCommands, &ActionCommands::exportMovie);
+    connect(ui->actionExport_Animated_GIF, &QAction::triggered, mCommands, &ActionCommands::exportGif);
 
     connect(ui->actionExport_Palette, &QAction::triggered, this, &MainWindow2::exportPalette);
 

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -79,6 +79,7 @@ public:
     void importImage();
     void importImageSequence();
     void importMovie();
+    void importGIF();
 
     void lockWidgets(bool shouldLock);
 

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -880,12 +880,12 @@
   </action>
   <action name="actionImport_Gif">
    <property name="text">
-    <string>Animated GIF</string>
+    <string>Animated GIF...</string>
    </property>
   </action>
   <action name="actionExport_Animated_GIF">
    <property name="text">
-    <string>Animated GIF</string>
+    <string>Animated GIF...</string>
    </property>
   </action>
  </widget>

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -64,6 +64,7 @@
      <addaction name="actionImport_Image"/>
      <addaction name="actionImport_ImageSeq"/>
      <addaction name="actionImport_Movie"/>
+     <addaction name="actionImport_Gif"/>
      <addaction name="actionImport_Sound"/>
      <addaction name="separator"/>
      <addaction name="actionImport_Palette"/>
@@ -874,6 +875,11 @@
    </property>
    <property name="shortcut">
     <string>F1</string>
+   </property>
+  </action>
+  <action name="actionImport_Gif">
+   <property name="text">
+    <string>Animated GIF</string>
    </property>
   </action>
  </widget>

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -77,6 +77,7 @@
      <addaction name="actionExport_Movie"/>
      <addaction name="actionExport_ImageSeq"/>
      <addaction name="actionExport_Image"/>
+     <addaction name="actionExport_Animated_GIF"/>
      <addaction name="separator"/>
      <addaction name="actionExport_Palette"/>
     </widget>
@@ -878,6 +879,11 @@
    </property>
   </action>
   <action name="actionImport_Gif">
+   <property name="text">
+    <string>Animated GIF</string>
+   </property>
+  </action>
+  <action name="actionExport_Animated_GIF">
    <property name="text">
     <string>Animated GIF</string>
    </property>

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -760,7 +760,7 @@ QString Editor::workingDir() const
     return mObject->workingDir();
 }
 
-bool Editor::importBitmapImage(QString filePath)
+bool Editor::importBitmapImage(QString filePath, int space)
 {
     QImageReader reader(filePath);
 
@@ -787,7 +787,11 @@ bool Editor::importBitmapImage(QString filePath)
         BitmapImage importedBitmapImage{ boundaries, img };
         bitmapImage->paste(&importedBitmapImage);
 
-        scrubTo(currentFrame() + 1);
+        if (space > 1) {
+            scrubTo(currentFrame() + space);
+        } else {
+            scrubTo(currentFrame() + 1);
+        }
 
         backup(tr("Import Image"));
     }
@@ -839,6 +843,17 @@ bool Editor::importImage(QString filePath)
         return false;
     }
     }
+}
+
+bool Editor::importGIF(QString filePath, int numOfImages)
+{
+    Layer* layer = layers()->currentLayer();
+    if (layer->type() == Layer::BITMAP) {
+        return importBitmapImage(filePath, numOfImages);
+    } else {
+        return false;
+    }
+
 }
 
 void Editor::updateFrame(int frameNumber)

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -122,6 +122,7 @@ public: //slots
     void cut();
 
     bool importImage(QString filePath);
+    bool importGIF(QString filePath, int numOfImages = 0);
     void updateFrame(int frameNumber);
     void restoreKey();
 
@@ -163,7 +164,7 @@ protected:
     void dropEvent(QDropEvent*);
 
 private:
-    bool importBitmapImage(QString);
+    bool importBitmapImage(QString, int space = 0);
     bool importVectorImage(QString);
 
     // the object to be edited by the editor

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -26,7 +26,7 @@ GNU General Public License for more details.
     QObject::tr( "AVI (*.avi);;MPEG(*.mpg);;MOV(*.mov);;MP4(*.mp4);;SWF(*.swf);;FLV(*.flv);;WMV(*.wmv)" )
 
 #define PENCIL_IMAGE_FILTER \
-   QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp *.gif);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);;GIF(*.gif)" )
+   QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp)" )
 
 #define PENCIL_IMAGE_SEQ_FILTER \
     QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);" )

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -28,6 +28,9 @@ GNU General Public License for more details.
 #define PENCIL_IMAGE_FILTER \
    QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp *.gif);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);;GIF(*.gif)" )
 
+#define PENCIL_IMAGE_SEQ_FILTER \
+    QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);" )
+
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
 #define S__GIT_TIMESTAMP TOSTRING(GIT_TIMESTAMP)


### PR DESCRIPTION
Importing/exporting gif has been improved. #903

- Gif has been given its own option under file->Import and file->Export
- Spacing between frames now works for GIF

![importexport](https://user-images.githubusercontent.com/1045397/42243745-a80d31fc-7f12-11e8-94fd-e54ea02c176a.gif)