### PR TITLE
Export movie/gif fixes

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -247,7 +247,7 @@ Status ActionCommands::exportMovie(bool isGif)
                                          tr("Finished. Open movie now?", "When movie export done."));
         if (btn == QMessageBox::Yes)
         {
-            QDesktopServices::openUrl(QUrl::fromLocalFile(strMoviePath).path());
+            QDesktopServices::openUrl(QUrl::fromLocalFile(strMoviePath));
         }
     }
     return Status::OK;

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -242,15 +242,10 @@ Status ActionCommands::exportMovie(bool isGif)
             auto btn = QMessageBox::question(mParent, "Pencil2D",
                                              tr("Finished. Open file location?"));
 
-            QString name = dialog->getFileName() + ".gif";
-
-            // Chop name + extension off the string
-            // to get folder path
-            strMoviePath.chop(name.size());
-
             if (btn == QMessageBox::Yes)
             {
-                QDesktopServices::openUrl(QUrl::fromLocalFile(strMoviePath));
+                QString path = dialog->getAbsolutePath();
+                QDesktopServices::openUrl(QUrl::fromLocalFile(path));
             }
             return Status::OK;
         }

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -239,8 +239,19 @@ Status ActionCommands::exportMovie(bool isGif)
     if (st.ok() && QFile::exists(strMoviePath))
     {
         if (isGif) {
-            QMessageBox::information(mParent, "Pencil2D",
-                                             tr("Finished"));
+            auto btn = QMessageBox::question(mParent, "Pencil2D",
+                                             tr("Finished. Open file location?"));
+
+            QString name = dialog->getFileName() + ".gif";
+
+            // Chop name + extension off the string
+            // to get folder path
+            strMoviePath.chop(name.size());
+
+            if (btn == QMessageBox::Yes)
+            {
+                QDesktopServices::openUrl(QUrl::fromLocalFile(strMoviePath));
+            }
             return Status::OK;
         }
         auto btn = QMessageBox::question(mParent, "Pencil2D",

--- a/app/src/importexportdialog.cpp
+++ b/app/src/importexportdialog.cpp
@@ -49,6 +49,12 @@ QStringList ImportExportDialog::getFilePaths()
     return m_filePaths;
 }
 
+QString ImportExportDialog::getFileName()
+{
+    QFileInfo info(m_filePaths.first());
+    return info.baseName();
+}
+
 void ImportExportDialog::init()
 {
     switch (mMode)

--- a/app/src/importexportdialog.cpp
+++ b/app/src/importexportdialog.cpp
@@ -49,10 +49,10 @@ QStringList ImportExportDialog::getFilePaths()
     return m_filePaths;
 }
 
-QString ImportExportDialog::getFileName()
+QString ImportExportDialog::getAbsolutePath()
 {
     QFileInfo info(m_filePaths.first());
-    return info.baseName();
+    return info.absolutePath();
 }
 
 void ImportExportDialog::init()

--- a/app/src/importexportdialog.h
+++ b/app/src/importexportdialog.h
@@ -38,6 +38,7 @@ public:
 
     void init();
     QString getFilePath();
+    QString getFileName();
     QStringList getFilePaths();
 
 signals:

--- a/app/src/importexportdialog.h
+++ b/app/src/importexportdialog.h
@@ -38,7 +38,7 @@ public:
 
     void init();
     QString getFilePath();
-    QString getFileName();
+    QString getAbsolutePath();
     QStringList getFilePaths();
 
 signals:

--- a/core_lib/src/movieexporter.cpp
+++ b/core_lib/src/movieexporter.cpp
@@ -553,8 +553,6 @@ Status MovieExporter::generateGif(
     }
     imageToExportBase.fill(bgColor);
 
-    QTransform view = cameraLayer->getViewAtFrame(currentFrame);
-
     QSize camSize = cameraLayer->getViewSize();
     QTransform centralizeCamera;
     centralizeCamera.translate(camSize.width() / 2, camSize.height() / 2);
@@ -597,6 +595,7 @@ Status MovieExporter::generateGif(
         QImage imageToExport = imageToExportBase.copy();
         QPainter painter(&imageToExport);
 
+        QTransform view = cameraLayer->getViewAtFrame(currentFrame);
         painter.setWorldTransform(view * centralizeCamera);
         painter.setWindow(QRect(0, 0, camSize.width(), camSize.height()));
 


### PR DESCRIPTION
* tweening didn't work for GIF exports ( hasn't worked since 0.6 apparently)
* fixed a bug that made the "open video" prompt not work when pressing yes. 
This was introduced via #1008 and discovered by @Jose-Moreno 
* Implemented "open file location" dialog for gif exports