### PR TITLE
Fix saving issue when moving frames

### DIFF
--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -83,6 +83,9 @@ BitmapImage& BitmapImage::operator=(const BitmapImage& a)
 
 BitmapImage* BitmapImage::clone()
 {
+    // try to load file if image appears to be null
+    loadFile();
+
     return new BitmapImage(*this);
 }
 

--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -83,9 +83,6 @@ BitmapImage& BitmapImage::operator=(const BitmapImage& a)
 
 BitmapImage* BitmapImage::clone()
 {
-    // try to load file if image appears to be null
-    loadFile();
-
     return new BitmapImage(*this);
 }
 
@@ -93,10 +90,8 @@ void BitmapImage::loadFile()
 {
     if (mImage == nullptr)
     {
-        Q_ASSERT(isModified() == false);
         mImage = std::make_shared<QImage>(fileName());
         mBounds.setSize(mImage->size());
-        //qDebug() << "Load file=" << fileName();
     }
 }
 

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -292,6 +292,10 @@ Status FileManager::save(Object* object, QString sFileName)
                       tr("Cannot Create Data Directory"),
                       tr("\"%1\" is a file. Please delete the file and try again.").arg(dataInfo.absoluteFilePath()));
     }
+    // There may be old files lying around
+    // from projects before this implementation, cleanup their dirty workfolder
+    // before saving new content
+    removeFilesWithNoXMLReference(sMainXMLFile, sDataFolder);
 
     // save data
     int numLayers = object->getLayerCount();
@@ -355,6 +359,10 @@ Status FileManager::save(Object* object, QString sFileName)
     xmlDoc.save(out, indentSize);
     out.flush();
     file.close();
+
+    // There may be old files may be lying around, cleanup workfolder before
+    // zipping
+    removeFilesWithNoXMLReference(sMainXMLFile, sDataFolder);
 
     dd << "Done writing main xml file at" << sMainXMLFile;
 
@@ -621,4 +629,55 @@ Status FileManager::verifyObject(Object* obj)
     }
 
     return Status::OK;
+}
+QStringList FileManager::getImageSrcNamesFromXML(QString mainXmlFile, QString dataFolderPath)
+{
+    QStringList listOfWorkFolderFiles = QDir(dataFolderPath).entryList(QDir::Files);
+
+    QFile xmlFile(mainXmlFile);
+    QDomDocument xmlDoc;
+    xmlDoc.setContent(&xmlFile);
+    QDomElement objectElem = xmlDoc.firstChildElement("document");
+
+    QStringList srcNames;
+
+    QDomNode objectNode = objectElem.namedItem("object");
+    QDomElement element = objectNode.toElement();
+
+    for (QDomNode child = element.firstChild(); !child.isNull(); child = child.nextSibling())
+    {
+       QDomElement element = child.toElement();
+       if (element.tagName() == "layer")
+       {
+           for (QDomNode child2 = element.firstChild(); !child2.isNull(); child2 = child2.nextSibling())
+           {
+               QDomElement element = child2.toElement();
+
+               srcNames << element.attribute("src");
+           }
+       }
+    }
+    return srcNames;
+}
+
+void FileManager::removeFilesWithNoXMLReference(QString xmlFilePath, QString dataFolderPath)
+{
+    QStringList srcNames = getImageSrcNamesFromXML(xmlFilePath, dataFolderPath);
+    QStringList listOfWorkFolderFiles = QDir(dataFolderPath).entryList(QDir::Files);
+    for (QString fileName: listOfWorkFolderFiles)
+    {
+        bool fileExists = false;
+        for (QString srcName: srcNames)
+        {
+            if (fileName == srcName)
+            {
+                fileExists = true;
+            }
+        }
+
+        if (!fileExists && !fileName.endsWith(".xml", Qt::CaseInsensitive))
+        {
+            QDir(dataFolderPath).remove(fileName);
+        }
+    }
 }

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -292,10 +292,6 @@ Status FileManager::save(Object* object, QString sFileName)
                       tr("Cannot Create Data Directory"),
                       tr("\"%1\" is a file. Please delete the file and try again.").arg(dataInfo.absoluteFilePath()));
     }
-    // There may be old files lying around
-    // from projects before this implementation, cleanup their dirty workfolder
-    // before saving new content
-    removeFilesWithNoXMLReference(sMainXMLFile, sDataFolder);
 
     // save data
     int numLayers = object->getLayerCount();
@@ -359,10 +355,6 @@ Status FileManager::save(Object* object, QString sFileName)
     xmlDoc.save(out, indentSize);
     out.flush();
     file.close();
-
-    // There may be old files may be lying around, cleanup workfolder before
-    // zipping
-    removeFilesWithNoXMLReference(sMainXMLFile, sDataFolder);
 
     dd << "Done writing main xml file at" << sMainXMLFile;
 

--- a/core_lib/src/structure/filemanager.h
+++ b/core_lib/src/structure/filemanager.h
@@ -67,6 +67,9 @@ private:
     void deleteBackupFile(const QString& fileName);
 
     void progressForward();
+    void removeFilesWithNoXMLReference(QString xmlFilePath, QString dataFolderPath);
+
+    QStringList getImageSrcNamesFromXML(QString mainXmlFile, QString dataFolderPath);
 
 private:
     Status mError = Status::OK;

--- a/core_lib/src/structure/keyframe.h
+++ b/core_lib/src/structure/keyframe.h
@@ -48,6 +48,8 @@ public:
 
     QString fileName() const { return mAttachedFileName; }
     void    setFileName(QString strFileName) { mAttachedFileName = strFileName; }
+    bool hasBeenRenamed() const { return mHasBeenRenamed; }
+    void setRenamed(bool b) { mHasBeenRenamed = b; }
 
     void addEventListener(KeyFrameEventListener*);
     void removeEventListner(KeyFrameEventListener*);
@@ -61,6 +63,7 @@ private:
     int mLength = 1;
     bool mIsModified = true;
     bool mIsSelected = false;
+    bool mHasBeenRenamed = false;
     QString mAttachedFileName;
 
     std::vector<KeyFrameEventListener*> mEventListeners;

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -59,8 +59,8 @@ Status LayerBitmap::saveKeyFrameFile(KeyFrame* keyframe, QString path)
 
     BitmapImage* bitmapImage = static_cast<BitmapImage*>(keyframe);
 
-    Status st = needSaveFrame(keyframe, strFilePath);
-    if (st == Status::OK)
+    bool needSave = needSaveFrame(keyframe, strFilePath);
+    if (!needSave)
     {
         return Status::SAFE;
     }
@@ -78,7 +78,7 @@ Status LayerBitmap::saveKeyFrameFile(KeyFrame* keyframe, QString path)
     }
     bitmapImage->setRenamed(true);
 
-    st = bitmapImage->writeFile(strFilePath);
+    Status st = bitmapImage->writeFile(strFilePath);
     if (!st.ok())
     {
         bitmapImage->setFileName("");
@@ -108,15 +108,15 @@ QString LayerBitmap::fileName(KeyFrame* key) const
     return QString::asprintf("%03d.%03d.png", id(), key->pos());
 }
 
-Status LayerBitmap::needSaveFrame(KeyFrame* key, const QString& strSavePath)
+bool LayerBitmap::needSaveFrame(KeyFrame* key, const QString& strSavePath)
 {
     if (key->isModified()) // keyframe was modified
-        return Status::KEYFRAME_MODIFIED;
+        return true;
     if (QFile::exists(strSavePath) == false) // hasn't been saved before
-        return Status::KEYFRAME_EXISTS;
+        return true;
     if (strSavePath != key->fileName()) // key frame moved
-        return Status::KEYFRAME_MOVED;
-    return Status::OK;
+        return true;
+    return false;
 }
 
 QDomElement LayerBitmap::createDomElement(QDomDocument& doc)

--- a/core_lib/src/structure/layerbitmap.h
+++ b/core_lib/src/structure/layerbitmap.h
@@ -43,7 +43,7 @@ protected:
 
 private:
     QString fileName(KeyFrame* key) const;
-    Status needSaveFrame(KeyFrame* key, const QString& strSavePath);
+    bool needSaveFrame(KeyFrame* key, const QString& strSavePath);
 };
 
 #endif

--- a/core_lib/src/structure/layerbitmap.h
+++ b/core_lib/src/structure/layerbitmap.h
@@ -43,7 +43,7 @@ protected:
 
 private:
     QString fileName(KeyFrame* key) const;
-    bool needSaveFrame(KeyFrame* key, const QString& strSavePath);
+    Status needSaveFrame(KeyFrame* key, const QString& strSavePath);
 };
 
 #endif

--- a/core_lib/src/util/pencilerror.h
+++ b/core_lib/src/util/pencilerror.h
@@ -73,7 +73,9 @@ public:
         ERROR_NEED_AT_LEAST_ONE_CAMERA_LAYER,
 
         // Timeline
-        KEYFRAME_MODIFIED
+        KEYFRAME_MODIFIED,
+        KEYFRAME_MOVED,
+        KEYFRAME_EXISTS
     };
 
     Status(ErrorCode code);

--- a/core_lib/src/util/pencilerror.h
+++ b/core_lib/src/util/pencilerror.h
@@ -71,6 +71,9 @@ public:
 
         // Layer
         ERROR_NEED_AT_LEAST_ONE_CAMERA_LAYER,
+
+        // Timeline
+        KEYFRAME_MODIFIED
     };
 
     Status(ErrorCode code);

--- a/core_lib/src/util/pencilerror.h
+++ b/core_lib/src/util/pencilerror.h
@@ -70,12 +70,7 @@ public:
 		ERROR_FFMPEG_NOT_FOUND,
 
         // Layer
-        ERROR_NEED_AT_LEAST_ONE_CAMERA_LAYER,
-
-        // Timeline
-        KEYFRAME_MODIFIED,
-        KEYFRAME_MOVED,
-        KEYFRAME_EXISTS
+        ERROR_NEED_AT_LEAST_ONE_CAMERA_LAYER
     };
 
     Status(ErrorCode code);


### PR DESCRIPTION
This implementation contains the following
+ fixes that solves: #966 
+ A way to remove old data folder file references.
  + This happens currently before saving new files and after having saved new files, to avoid cases where a project contains old file references beforehand and when frames has been moved but the reference hasn't been deleted.