### PR TITLE
Improve color palette selection behavior

### DIFF
--- a/app/src/colorpalettewidget.cpp
+++ b/app/src/colorpalettewidget.cpp
@@ -216,10 +216,12 @@ void ColorPaletteWidget::refreshColorList()
         swatchIcon.addPixmap(colourSwatch, QIcon::Normal);
 
         // Draw selection border
-        swatchPainter.setPen(borderHighlight);
-        swatchPainter.drawRect(0, 0, mIconSize.width() - 1, mIconSize.height() - 1);
-        swatchPainter.setPen(borderShadow);
-        swatchPainter.drawRect(0, 0, mIconSize.width() - 1, mIconSize.height() - 1);
+        if(ui->colorListWidget->viewMode() == QListView::IconMode) {
+            swatchPainter.setPen(borderHighlight);
+            swatchPainter.drawRect(0, 0, mIconSize.width() - 1, mIconSize.height() - 1);
+            swatchPainter.setPen(borderShadow);
+            swatchPainter.drawRect(0, 0, mIconSize.width() - 1, mIconSize.height() - 1);
+        }
         swatchIcon.addPixmap(colourSwatch, QIcon::Selected);
 
         colourItem->setIcon(swatchIcon);
@@ -582,11 +584,13 @@ void ColorPaletteWidget::updateItemColor(int itemIndex, QColor newColor)
     QIcon swatchIcon;
     swatchIcon.addPixmap(colourSwatch, QIcon::Normal);
 
-    // Draw selection border
-    swatchPainter.setPen(borderHighlight);
-    swatchPainter.drawRect(0, 0, mIconSize.width() - 1, mIconSize.height() - 1);
-    swatchPainter.setPen(borderShadow);
-    swatchPainter.drawRect(0, 0, mIconSize.width() - 1, mIconSize.height() - 1);
+    if(ui->colorListWidget->viewMode() == QListView::IconMode) {
+        // Draw selection border
+        swatchPainter.setPen(borderHighlight);
+        swatchPainter.drawRect(0, 0, mIconSize.width() - 1, mIconSize.height() - 1);
+        swatchPainter.setPen(borderShadow);
+        swatchPainter.drawRect(0, 0, mIconSize.width() - 1, mIconSize.height() - 1);
+    }
     swatchIcon.addPixmap(colourSwatch, QIcon::Selected);
 
     ui->colorListWidget->item(itemIndex)->setIcon(swatchIcon);


### PR DESCRIPTION
This includes:
- Showing the proper icon color when selected (Fixes #1024)
- Adding a border around the selected color, this is particularly
useful for grid mode which has no other way to display the selection
- Refactored the resizing code so that going to grid mode from list
mode does not result in unexpected icon spacing