### PR TITLE
Add completion for bash and zsh

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -139,6 +139,12 @@ win32 {
 linux {
     target.path = $${PREFIX}/bin
 
+    bashcompletion.files = data/pencil2d
+    bashcompletion.path = $${PREFIX}/share/bash-completion/completions
+
+    zshcompletion.files = data/_pencil2d
+    zshcompletion.path = $${PREFIX}/share/zsh/site-functions
+
     mimepackage.files = data/pencil2d.xml
     mimepackage.path = $${PREFIX}/share/mime/packages
 
@@ -148,7 +154,7 @@ linux {
     icon.files = data/pencil2d.png
     icon.path = $${PREFIX}/share/icons/hicolor/256x256/apps
 
-    INSTALLS += target mimepackage desktopentry icon
+    INSTALLS += bashcompletion zshcompletion target mimepackage desktopentry icon
 }
 
 

--- a/app/data/_pencil2d
+++ b/app/data/_pencil2d
@@ -1,0 +1,13 @@
+#compdef pencil2d
+
+_arguments \
+  {-h,--help}'[Display help]' \
+  {-v,--version}'[Display version information]' \
+  {-o+,--export=}'[Render the file to the given path]:output file:_files' \
+  '--camera=[Name of the camera layer to use]:name of the camera layer to use:' \
+  '--width=[Width of the output frames]:width of the output frames:' \
+  '--height=[Height of the output frames]:height of the output frames:' \
+  '--start=[The first frame to export]:number of first frame to include:' \
+  '--end=[The last frame to include]:number of last frame to include:((last\:"Last frame containing animation" last-sound\:"Last frame containing animation or sound"))' \
+  '--transparency[Render transparency when possible]' \
+  '::input file:_files -g "*.pcl|*.pclx"'

--- a/app/data/pencil2d
+++ b/app/data/pencil2d
@@ -1,0 +1,27 @@
+_pencil2d()
+{
+  local cur prev words cword opts
+  _init_completion || return
+  opts="-h --help -v --version -o --export --camera --width --height --start --end --transparency"
+
+  case "${prev}" in
+    --camera|--width|--height|--start)
+      return 0
+      ;;
+    --end)
+      COMPREPLY=( $(compgen -W "last last-sound" -- ${cur}) )
+      return 0
+      ;;
+    -o|--export)
+      _filedir
+      return 0
+      ;;
+  esac
+
+  if [[ ${cur} == -* ]]; then
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+  else
+    _filedir "pcl?(x)"
+  fi
+} &&
+complete -F _pencil2d pencil2d


### PR DESCRIPTION
A minor thing that’s been on my personal todo list since I last worked on our command line interface.

Right now the bash completion is noticeably more primitive than the zsh completion (mostly because bash’s completion system as a whole is noticeably more primitive than zsh’s) however both should be quite useful.