### PR TITLE
Timeline didn't extend to a correct length when opening a super long project

### DIFF
--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -250,6 +250,10 @@ void TimeLine::extendLength(int frame)
     if(frame > (currentLength * 0.75))
     {
         int newLength = std::max(frame, currentLength) * 1.5;
+
+        if (newLength > 9999)
+            newLength = 9999;
+
         mTracks->setFrameLength(newLength);
         updateLength();
     }

--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -242,17 +242,14 @@ void TimeLine::setLength(int frame)
 
 /** Extends the tineline frame length if necessary
  *
- *  If the new animation length is more than 75% of the timeline
- *  frame length, then double the timeline frame length, otherwise
- *  do nothing.
- *
  *  @param[in] frame The new animation length
  */
 void TimeLine::extendLength(int frame)
 {
-    int frameLength = mTracks->getFrameLength();
-    if(frame > frameLength * 0.75) {
-        mTracks->setFrameLength(frameLength * 1.5);
+    int currentLength = mTracks->getFrameLength();
+    if(frame > currentLength - 50)
+    {
+        mTracks->setFrameLength(frame + 100);
         updateLength();
     }
 }

--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -240,16 +240,17 @@ void TimeLine::setLength(int frame)
     updateLength();
 }
 
-/** Extends the tineline frame length if necessary
+/** Extends the timeline frame length if necessary
  *
  *  @param[in] frame The new animation length
  */
 void TimeLine::extendLength(int frame)
 {
     int currentLength = mTracks->getFrameLength();
-    if(frame > currentLength - 50)
+    if(frame > (currentLength * 0.75))
     {
-        mTracks->setFrameLength(frame + 100);
+        int newLength = std::max(frame, currentLength) * 1.5;
+        mTracks->setFrameLength(newLength);
         updateLength();
     }
 }


### PR DESCRIPTION
The issue:
1. Start pencil2d, the timeline length is 240 frames by default.
2. Open a 1000 frames project
3. Timeline length extends to 360 frames, which should be 1000 frames.

In the previous implementation, timeline grows 1.5 times longer based on the current length. But in this case, the timeline length must grow more.

Also, I changed the timeline extending rule. I think the previous 75% rule is a little too much for a long project. I work on a 1000 frames and timeline extends to 1500 frames when I create a keyframe at frame 750. 

The new rule is, Timeline will extend 100 more frames when a user adds a keyframe within 50 frames to the end of Timeline.