### PR TITLE
Extract pclx to a random generated folder name to avoid name conflicts

### DIFF
--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -41,6 +41,7 @@ FileManager::FileManager(QObject *parent) : QObject(parent),
 mLog("FileManager")
 {
     ENABLE_DEBUG_LOG(mLog, false);
+    srand(time(nullptr));
 }
 
 Object* FileManager::load(QString sFileName)

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -17,6 +17,7 @@ GNU General Public License for more details.
 
 #include "filemanager.h"
 
+#include <ctime>
 #include <QDir>
 #include "pencildef.h"
 #include "qminiz.h"

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -45,16 +45,11 @@ Object::~Object()
 {
     mActiveFramePool->clear();
 
-    while (!mLayers.empty())
-    {
-        delete mLayers.takeLast();
-    }
+    for (Layer* layer : mLayers)
+        delete layer;
+    mLayers.clear();
 
-    // Delete the working directory if this is not a "New" project.
-    if (!filePath().isEmpty())
-    {
-        deleteWorkingDir();
-    }
+    deleteWorkingDir();
 }
 
 void Object::init()

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -164,12 +164,20 @@ void Object::createWorkingDir()
         QFileInfo fileInfo(mFilePath);
         strFolderName = fileInfo.completeBaseName();
     }
-    const QString strWorkingDir = 
-        QString("%1/Pencil2D/%2_%3_%4/").arg(QDir::tempPath()).arg(strFolderName).arg(PFF_TMP_DECOMPRESS_EXT).arg(uniqueString(8));
-
     QDir dir(QDir::tempPath());
-    dir.mkpath(strWorkingDir);
 
+    QString strWorkingDir;
+    do
+    {
+        strWorkingDir = QString("%1/Pencil2D/%2_%3_%4/")
+            .arg(QDir::tempPath())
+            .arg(strFolderName)
+            .arg(PFF_TMP_DECOMPRESS_EXT)
+            .arg(uniqueString(8));
+    }
+    while(dir.exists(strWorkingDir));
+
+    dir.mkpath(strWorkingDir);
     mWorkingDirPath = strWorkingDir;
 
     QDir dataDir(strWorkingDir + PFF_DATA_DIR);

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -183,8 +183,11 @@ void Object::createWorkingDir()
 
 void Object::deleteWorkingDir() const
 {
-    QDir dir(mWorkingDirPath);
-    dir.removeRecursively();
+    if (!mWorkingDirPath.isEmpty())
+    {
+        QDir dir(mWorkingDirPath);
+        dir.removeRecursively();
+    }
 }
 
 void Object::createDefaultLayers()

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -164,11 +164,8 @@ void Object::createWorkingDir()
         QFileInfo fileInfo(mFilePath);
         strFolderName = fileInfo.completeBaseName();
     }
-    const QString strWorkingDir = QDir::tempPath()
-        + "/Pencil2D/"
-        + strFolderName
-        + PFF_TMP_DECOMPRESS_EXT
-        + "/";
+    const QString strWorkingDir = 
+        QString("%1/Pencil2D/%2_%3_%4/").arg(QDir::tempPath()).arg(strFolderName).arg(PFF_TMP_DECOMPRESS_EXT).arg(uniqueString(8));
 
     QDir dir(QDir::tempPath());
     dir.mkpath(strWorkingDir);

--- a/core_lib/src/util/fileformat.cpp
+++ b/core_lib/src/util/fileformat.cpp
@@ -37,3 +37,19 @@ bool removePFFTmpDirectory (const QString& dirName)
 	
 	return result;
 }
+
+QString uniqueString(int len)
+{
+    static const char alphanum[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+    const int alphanum_len = sizeof(alphanum);
+
+    if (len > 128) len = 128;
+
+    char s[128 + 1];
+    for (int i = 0; i < len; ++i)
+    {
+        s[i] = alphanum[rand() % (alphanum_len - 1)];
+    }
+    s[len] = 0;
+    return QString::fromUtf8(s);
+}

--- a/core_lib/src/util/fileformat.h
+++ b/core_lib/src/util/fileformat.h
@@ -33,7 +33,6 @@ GNU General Public License for more details.
 #define PFF_OLD_DATA_DIR 		"data"
 #define PFF_DATA_DIR            "data"
 #define PFF_XML_FILE_NAME 		"main.xml"
-#define PFF_TMP_COMPRESS_EXT 	"Y2xC"
 #define PFF_TMP_DECOMPRESS_EXT 	"Y2xD"
 #define PFF_PALETTE_FILE        "palette.xml"
 

--- a/core_lib/src/util/fileformat.h
+++ b/core_lib/src/util/fileformat.h
@@ -33,12 +33,13 @@ GNU General Public License for more details.
 #define PFF_OLD_DATA_DIR 		"data"
 #define PFF_DATA_DIR            "data"
 #define PFF_XML_FILE_NAME 		"main.xml"
-#define PFF_TMP_COMPRESS_EXT 	".Y2xC"
-#define PFF_TMP_DECOMPRESS_EXT 	".Y2xD"
+#define PFF_TMP_COMPRESS_EXT 	"Y2xC"
+#define PFF_TMP_DECOMPRESS_EXT 	"Y2xD"
 #define PFF_PALETTE_FILE        "palette.xml"
 
 
 bool removePFFTmpDirectory (const QString& dirName);
+QString uniqueString(int len);
 
 
 #endif


### PR DESCRIPTION
Related issues #932 #752  

The issue described by @scribblemaniac :
If a user opens the same project twice in a row, Penci2D will:

1. Create data folder for file to load
2. Load everything into the data folder
3. Stop if there is an error
4. Switch to using the new data folder
5. Delete the old data folder

However, if the old data folder and new data folder are the same, then step 5 ends up deleting all the data from our project! 

In order to resolve the name conflicts, the data folder will include an 8 character long random string.

For example:
- YourProject_Y2xD_6xseyd51
- Default_Y2xD_5zy4hsui