### PR TITLE
Reimplement autocropping

### DIFF
--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -19,13 +19,13 @@ GNU General Public License for more details.
 #include <cmath>
 #include <QDebug>
 #include <QtMath>
+#include <QFile>
 #include "util.h"
 
 BitmapImage::BitmapImage()
 {
-    mImage = std::make_shared<QImage>(1, 1, QImage::Format_ARGB32_Premultiplied); // don't create null image
-    mImage->fill(QColor(0,0,0,0));
-    mBounds = QRect(0, 0, 1, 1);
+    mImage = std::make_shared<QImage>(); // create null image
+    mBounds = QRect(0, 0, 0, 0);
 }
 
 BitmapImage::BitmapImage(const BitmapImage& a) : KeyFrame(a)
@@ -659,14 +659,26 @@ Status BitmapImage::writeFile(const QString& filename)
         bool b = mImage->save(filename);
         return (b) ? Status::OK : Status::FAIL;
     }
+    else
+    {
+        QFile f(filename);
+        if(f.exists())
+        {
+            bool b = f.remove();
+            return (b) ? Status::OK : Status::FAIL;
+        }
+        else
+        {
+            return Status::OK;
+        }
+    }
     return Status::SAFE;
 }
 
 void BitmapImage::clear()
 {
-    mImage = std::make_shared<QImage>(1, 1, QImage::Format_ARGB32_Premultiplied); // null image
-    mBounds = QRect(0, 0, 1, 1);
-    mImage->fill(QColor(0,0,0,0));
+    mImage = std::make_shared<QImage>(); // null image
+    mBounds = QRect(0, 0, 0, 0);
     modification();
 }
 

--- a/core_lib/src/graphics/bitmap/bitmapimage.h
+++ b/core_lib/src/graphics/bitmap/bitmapimage.h
@@ -46,8 +46,7 @@ public:
 
     BitmapImage copy();
     BitmapImage copy(QRect rectangle);
-    void paste(BitmapImage*);
-    void paste(BitmapImage*, QPainter::CompositionMode cm);
+    void paste(BitmapImage*, QPainter::CompositionMode cm = QPainter::CompositionMode_SourceOver);
 
     void add(BitmapImage*);
     void compareAlpha(BitmapImage*);
@@ -63,6 +62,7 @@ public:
     bool contains(QPointF P) { return contains(P.toPoint()); }
     void extend(QPoint P);
     void extend(QRect rectangle);
+    void autoCrop();
 
     QRgb pixel(int x, int y);
     QRgb pixel(QPoint P);

--- a/core_lib/src/graphics/bitmap/bitmapimage.h
+++ b/core_lib/src/graphics/bitmap/bitmapimage.h
@@ -27,9 +27,9 @@ class BitmapImage : public KeyFrame
 public:
     BitmapImage();
     BitmapImage(const BitmapImage&);
-    BitmapImage(const QRect& boundaries, const QColor& colour);
-    BitmapImage(const QRect& boundaries, const QImage& image);
-    BitmapImage(const QString& path, const QPoint& topLeft);
+    BitmapImage(const QRect &rectangle, const QColor& colour);
+    BitmapImage(const QPoint& topLeft, const QImage& image);
+    BitmapImage(const QPoint& topLeft, const QString& path);
 
     ~BitmapImage();
     BitmapImage& operator=(const BitmapImage& a);
@@ -60,14 +60,12 @@ public:
 
     bool contains(QPoint P) { return mBounds.contains(P); }
     bool contains(QPointF P) { return contains(P.toPoint()); }
-    void extend(QPoint P);
-    void extend(QRect rectangle);
     void autoCrop();
 
     QRgb pixel(int x, int y);
-    QRgb pixel(QPoint P);
+    QRgb pixel(QPoint p);
     void setPixel(int x, int y, QRgb colour);
-    void setPixel(QPoint P, QRgb colour);
+    void setPixel(QPoint p, QRgb colour);
     QRgb constScanLine(int x, int y);
     void scanLine(int x, int y, QRgb colour);
     void clear();
@@ -82,26 +80,47 @@ public:
     void drawEllipse(QRectF rectangle, QPen pen, QBrush brush, QPainter::CompositionMode cm, bool antialiasing);
     void drawPath(QPainterPath path, QPen pen, QBrush brush, QPainter::CompositionMode cm, bool antialiasing);
 
-    QPoint topLeft() { return mBounds.topLeft(); }
-    QPoint topRight() { return mBounds.topRight(); }
-    QPoint bottomLeft() { return mBounds.bottomLeft(); }
-    QPoint bottomRight() { return mBounds.bottomRight(); }
-    int left() { return mBounds.left(); }
-    int right() { return mBounds.right(); }
-    int top() { return mBounds.top(); }
-    int bottom() { return mBounds.bottom(); }
-    int width() { return mBounds.width(); }
-    int height() { return mBounds.height(); }
-    QSize size() { return mBounds.size(); }
+    QPoint topLeft() { autoCrop(); return mBounds.topLeft(); }
+    QPoint topRight() { autoCrop(); return mBounds.topRight(); }
+    QPoint bottomLeft() { autoCrop(); return mBounds.bottomLeft(); }
+    QPoint bottomRight() { autoCrop(); return mBounds.bottomRight(); }
+    int left() { autoCrop(); return mBounds.left(); }
+    int right() { autoCrop(); return mBounds.right(); }
+    int top() { autoCrop(); return mBounds.top(); }
+    int bottom() { autoCrop(); return mBounds.bottom(); }
+    int width() { autoCrop(); return mBounds.width(); }
+    int height() { autoCrop(); return mBounds.height(); }
+    QSize size() { autoCrop(); return mBounds.size(); }
 
-    QRect& bounds() { return mBounds; }
+    QRect& bounds() { autoCrop(); return mBounds; }
+
+    /** Determines if the BitmapImage is minimally bounded.
+     *
+     *  A BitmapImage is minimally bounded if all edges contain
+     *  at least 1 non-transparent pixel (alpha > 0). In other words,
+     *  the size of the image cannot be decreased without
+     *  cropping visible data.
+     *
+     *  @return True only if bounds() is the minimal bounding box
+     *          for the contained image.
+     */
+    bool isMinimallyBounded() const { return mMinBound; }
 
     Status writeFile(const QString& filename);
+
+protected:
+    void updateBounds(QRect rectangle);
+    void extend(const QPoint& p);
+    void extend(QRect rectangle);
+
+    void setCompositionModeBounds(BitmapImage *source, QPainter::CompositionMode cm);
+    void setCompositionModeBounds(QRect sourceBounds, bool isSourceMinBounds, QPainter::CompositionMode cm);
 
 private:
     std::shared_ptr< QImage > mImage;
     QRect   mBounds;
-    bool    mExtendable = true;
+    /** @see isMinimallyBounded() */
+    bool mMinBound;
 };
 
 #endif

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -754,10 +754,7 @@ bool Editor::importBitmapImage(QString filePath, int space)
         }
         BitmapImage* bitmapImage = layer->getBitmapImageAtFrame(currentFrame());
 
-        QRect boundaries = img.rect();
-        boundaries.moveTopLeft(mScribbleArea->getCentralPoint().toPoint() - QPoint(boundaries.width() / 2, boundaries.height() / 2));
-
-        BitmapImage importedBitmapImage{ boundaries, img };
+        BitmapImage importedBitmapImage(mScribbleArea->getCentralPoint().toPoint() - QPoint(img.width() / 2, img.height() / 2), img);
         bitmapImage->paste(&importedBitmapImage);
 
         if (space > 1) {

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -688,7 +688,7 @@ void ScribbleArea::paintBitmapBuffer()
         case PENCIL:
             if (getTool(currentTool()->type())->properties.preserveAlpha)
             {
-                cm = QPainter::CompositionMode_SourceAtop;
+                cm = QPainter::CompositionMode_SourceOver;
             }
             break;
         default: //nothing
@@ -1204,13 +1204,12 @@ void ScribbleArea::drawBrush(QPointF thePoint, qreal brushWidth, qreal mOffset, 
 {
     QRectF rectangle(thePoint.x() - 0.5 * brushWidth, thePoint.y() - 0.5 * brushWidth, brushWidth, brushWidth);
 
-    BitmapImage gradientImg;
     if (usingFeather)
     {
         QRadialGradient radialGrad(thePoint, 0.5 * brushWidth);
         setGaussianGradient(radialGrad, fillColour, opacity, mOffset);
 
-        gradientImg.drawEllipse(rectangle, Qt::NoPen, radialGrad,
+        mBufferImg->drawEllipse(rectangle, Qt::NoPen, radialGrad,
                                 QPainter::CompositionMode_SourceOver, false);
     }
     else
@@ -1218,7 +1217,6 @@ void ScribbleArea::drawBrush(QPointF thePoint, qreal brushWidth, qreal mOffset, 
         mBufferImg->drawEllipse(rectangle, Qt::NoPen, QBrush(fillColour, Qt::SolidPattern),
                                 QPainter::CompositionMode_SourceOver, useAA);
     }
-    mBufferImg->paste(&gradientImg);
 }
 
 /**

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -47,7 +47,7 @@ BitmapImage* LayerBitmap::getLastBitmapImageAtFrame(int frameNumber, int increme
 
 void LayerBitmap::loadImageAtFrame(QString path, QPoint topLeft, int frameNumber)
 {
-    BitmapImage* pKeyFrame = new BitmapImage(path, topLeft);
+    BitmapImage* pKeyFrame = new BitmapImage(topLeft, path);
     pKeyFrame->setPos(frameNumber);
     loadKey(pKeyFrame);
 }

--- a/tests/src/test_bitmapimage.cpp
+++ b/tests/src/test_bitmapimage.cpp
@@ -91,19 +91,4 @@ TEST_CASE("BitmapImage functions")
         REQUIRE(b->width() == 50);
         REQUIRE(b->height() == 50);
     }
-
-    SECTION("extend()")
-    {
-        auto b = std::make_shared<BitmapImage>(QRect(0, 0, 50, 50), Qt::red);
-
-        // before
-        REQUIRE(b->topLeft() == QPoint(0, 0));
-        REQUIRE(b->size() == QSize(50, 50));
-
-        b->extend(QPoint(-10, -10));
-
-        // after
-        REQUIRE(b->topLeft() == QPoint(-10, -10));
-        REQUIRE(b->size() == QSize(60, 60));
-    }
 }


### PR DESCRIPTION
This is a second attempt at what I did in #791. Quoting from there:

> Now the BitmapImage will automatically resize itself to be at the minimum size possible without cropping any data. This fixes the second issue of #774 and goes a step further to update the Select All bounding box when the edge is erased with an eraser, deleted with a selection clear, or brush strokes/flood fill with an alpha of 0 are applied. Since it resizes the image when necessary, this will also reduce the file size and speed up playback slightly whenever part of the minimum bounding box of an image decreases (most notably when moving the whole layer).

This has been optimized to prevent this feature from slowing down Pencil2D. The image should not be cropped at all until a brush stroke is finished so there should be little to no extra brush lag. There is also a flag to prevent running the function when the boundaries could not possibly have decreased since last time the function was called.

There are some other partly related changes slipped in here:
- completely cleared bitmap frames are no longer saved as single-pixel images
- an unnecessary image initialization+pasting step was removed in the brush/pencil drawing process, so there may be some speed improvement when using those tools.