### PR TITLE
Improve vector eraser tool

### DIFF
--- a/core_lib/src/graphics/vector/vectorimage.cpp
+++ b/core_lib/src/graphics/vector/vectorimage.cpp
@@ -1407,6 +1407,9 @@ QList<VertexRef> VectorImage::getVerticesCloseTo(QPointF P1, qreal maxDistance)
 {
     QList<VertexRef> result;
 
+    // Square maxDistance rather than taking the square root for each distance
+    maxDistance *= maxDistance;
+
     for (int curve = 0; curve < mCurves.size(); curve++)
     {
         for (int vertex = -1; vertex < mCurves.at(curve).getVertexSize(); vertex++)

--- a/core_lib/src/tool/erasertool.cpp
+++ b/core_lib/src/tool/erasertool.cpp
@@ -229,7 +229,7 @@ void EraserTool::drawStroke()
 
         qreal opacity = 1.0;
         mCurrentWidth = properties.width;
-        if (properties.pressure == true)
+        if (properties.pressure)
         {
             opacity = m_pStrokeManager->getPressure();
             mCurrentWidth = (mCurrentWidth + ( m_pStrokeManager->getPressure() * mCurrentWidth)) * 0.5;
@@ -274,16 +274,15 @@ void EraserTool::drawStroke()
     }
     else if ( layer->type() == Layer::VECTOR )
     {
-        qreal brushWidth = 0;
-        if (properties.pressure ) {
-            brushWidth = properties.width * m_pStrokeManager->getPressure();
+        mCurrentWidth = properties.width;
+        if (properties.pressure)
+        {
+            mCurrentWidth = (mCurrentWidth + ( m_pStrokeManager->getPressure() * mCurrentWidth)) * 0.5;
         }
-        else {
-            brushWidth = properties.width;
-        }
+        qreal brushWidth = mCurrentWidth;
 
         QPen pen( Qt::white, brushWidth, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin );
-        int rad = qRound( ( brushWidth / 2 + 2 ) * mEditor->view()->scaling() );
+        int rad = qRound(brushWidth) / 2 + 2;
 
         if ( p.size() == 4 )
         {
@@ -331,7 +330,7 @@ void EraserTool::updateStrokes()
 
     if ( layer->type() == Layer::VECTOR )
     {
-        qreal radius = ( properties.width / 2 ) / mEditor->view()->scaling();
+        qreal radius = properties.width / 2;
         QList<VertexRef> nearbyVertices = ( ( LayerVector * )layer )->getLastVectorImageAtFrame( mEditor->currentFrame(), 0 )
             ->getVerticesCloseTo( getCurrentPoint(), radius );
         for ( int i = 0; i < nearbyVertices.size(); i++ )


### PR DESCRIPTION
The distance to points was being calculated incorrectly since the dot product produces the *square* of the eulerian distance. There were also differences in how the vector eraser width was being calculated compared to the bitmap tools (particularly, it takes into consideration the scaling, which we removed I think). Overall these fixes will make the vector eraser less broken, but I would not go as far as to say completely fixed.

Please test to make sure that the pressure is working reasonably as I don't have a tablet to test this with at the moment.