### PR TITLE
Improve tablet resolution?

### DIFF
--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -424,7 +424,11 @@ void ScribbleArea::tabletEvent(QTabletEvent *event)
     else {
         editor()->tools()->tabletRestorePrevTool();
     }
-    event->ignore(); // indicates that the tablet event is not accepted yet, so that it is propagated as a mouse event)
+    // Tablet move events should not be ignored as that will propagate it as a mouse event with reduced resolution
+    if(event->type() != QEvent::TabletMove)
+    {
+        event->ignore(); // indicates that the tablet event is not accepted yet, and propagates it accordingly
+    }
 }
 
 bool ScribbleArea::isLayerPaintable() const

--- a/core_lib/src/tool/strokemanager.cpp
+++ b/core_lib/src/tool/strokemanager.cpp
@@ -40,6 +40,22 @@ StrokeManager::StrokeManager()
     connect(&timer, &QTimer::timeout, this, &StrokeManager::interpolatePollAndPaint);
 }
 
+void StrokeManager::genericMoveEvent(QPointF pos)
+{
+    // only applied to drawing tools.
+    if (mStabilizerLevel != -1)
+    {
+        smoothMousePos(pos);
+    }
+    else
+    {
+        // No smoothing
+        mLastPixel = mCurrentPixel;
+        mCurrentPixel = pos;
+        mLastInterpolated = mCurrentPixel;
+    }
+}
+
 void StrokeManager::reset()
 {
     mStrokeStarted = false;
@@ -56,41 +72,16 @@ void StrokeManager::setPressure(float pressure)
     mTabletPressure = pressure;
 }
 
-QPointF StrokeManager::getEventPosition(QMouseEvent* event)
-{
-    QPointF pos;
-
-    if ( mTabletInUse )
-    {
-        // QT BUG (Wacom Tablets): updates are not synchronised in Windows giving different coordinates.
-        // Clue: Not a Microsoft nor Wacom problem because other windows apps are working fine in the same tablet mode.
-        // Solved: Qt bug in Wacom coding -> a lot of patches but no real solutions.
-        // QPointF pos2 = event->pos() + mTabletPosition - event->globalPos();
-        // Patch: next line skips the coordinate problem and it seems safe .
-        pos = event->pos() + mTabletPosition - mTabletPosition.toPoint();
-        //pos = event->pos();
-        //qDebug() << "New pos" << pos << ", Old pos" << pos2;
-    }
-    else
-    {
-        pos = event->localPos();
-    }
-
-    return pos;
-}
-
 void StrokeManager::mousePressEvent(QMouseEvent* event)
 {
     reset();
     if ( !(event->button() == Qt::NoButton) ) // if the user is pressing the left/right button
     {
-        mLastPressPixel = getEventPosition(event);
+        mLastPressPixel = event->localPos();
     }
-    mLastPixel = getEventPosition( event );
-    mCurrentPixel = getEventPosition( event );
+    mLastPixel = mCurrentPixel = event->localPos();
 
     mStrokeStarted = true;
-
 }
 
 void StrokeManager::mouseReleaseEvent(QMouseEvent* event)
@@ -109,8 +100,12 @@ void StrokeManager::tabletEvent(QTabletEvent* event)
     if (event->type() == QEvent::TabletPress) { mTabletInUse = true; }
     if (event->type() == QEvent::TabletRelease) { mTabletInUse = false; }
 
-    mTabletPosition = event->posF();
     setPressure(event->pressure());
+
+    if(event->type() == QEvent::TabletMove)
+    {
+        genericMoveEvent(event->posF());
+    }
 }
 
 void StrokeManager::setStabilizerLevel(int level)
@@ -120,18 +115,7 @@ void StrokeManager::setStabilizerLevel(int level)
 
 void StrokeManager::mouseMoveEvent(QMouseEvent* event)
 {
-    QPointF pos = getEventPosition(event);
-
-    // only applied to drawing tools.
-    if (mStabilizerLevel != -1){
-        smoothMousePos(pos);
-    } else {
-        // No smoothing
-        mLastPixel = mCurrentPixel;
-        mCurrentPixel = pos;
-        mLastInterpolated = mCurrentPixel;
-
-    }
+    genericMoveEvent(event->localPos());
 }
 
 void StrokeManager::smoothMousePos(QPointF pos)

--- a/core_lib/src/tool/strokemanager.h
+++ b/core_lib/src/tool/strokemanager.h
@@ -34,6 +34,7 @@ class StrokeManager : public QObject
 public:
     StrokeManager();
 
+    void genericMoveEvent(QPointF pos);
     void tabletEvent(QTabletEvent* event);
     void mousePressEvent(QMouseEvent* event);
     void mouseMoveEvent(QMouseEvent* event);
@@ -67,8 +68,6 @@ private:
 
     void reset();
 
-    QPointF getEventPosition(QMouseEvent *);
-
     float pressure = 1.0f; // last pressure
     QQueue<QPointF> strokeQueue;
     QQueue<qreal> pressureQueue;
@@ -92,7 +91,6 @@ private:
     bool    mTabletInUse = false;
     float   mTabletPressure = 1.f;
     int     mStabilizerLevel = 0;
-    QPointF mTabletPosition;
     qreal mMeanPressure;
 
     clock_t m_timeshot;


### PR DESCRIPTION
From [the Qt docs](https://doc.qt.io/qt-5//qtabletevent.html):
> Qt will first send a tablet event, then if it is not accepted by any widget, it will send a mouse event. This allows users of applications that are not designed for tablets to use a tablet like a mouse. However high-resolution drawing applications should handle the tablet events, because they can occur at a higher frequency, which is a benefit for smooth and accurate drawing. If the tablet events are rejected, the synthetic mouse events may be compressed for efficiency.

So I refactored the code to handle the tablet event instead of ignoring it and Qt possibly compressing it as mouse events.

Please test thoroughly as I don't have a tablet to test this on myself. Particularly on a Wacom as I did remove the "patch".  As far as I can tell for tablet events, `event->posF()` should equal `event->pos() + mTabletPosition - mTabletPosition.toPoint()`.
