### PR TITLE
Small changes that can prevent users from duplicate layer names

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -595,9 +595,13 @@ Status ActionCommands::addNewBitmapLayer()
     QString text = QInputDialog::getText(nullptr, tr("Layer Properties"),
                                          tr("Layer name:"), QLineEdit::Normal,
                                          tr("Bitmap Layer"), &ok);
-    if (ok && !text.isEmpty())
+    if (ok && !text.isEmpty() && checkNewLayerName(text))
     {
         mEditor->layers()->createBitmapLayer(text);
+    }
+    else
+    {
+        uniqueNameMsg();
     }
     return Status::OK;
 }
@@ -608,9 +612,13 @@ Status ActionCommands::addNewVectorLayer()
     QString text = QInputDialog::getText(nullptr, tr("Layer Properties"),
                                          tr("Layer name:"), QLineEdit::Normal,
                                          tr("Vector Layer"), &ok);
-    if (ok && !text.isEmpty())
+    if (ok && !text.isEmpty() && checkNewLayerName(text))
     {
         mEditor->layers()->createVectorLayer(text);
+    }
+    else
+    {
+        uniqueNameMsg();
     }
 
     return Status::OK;
@@ -622,9 +630,13 @@ Status ActionCommands::addNewCameraLayer()
     QString text = QInputDialog::getText(nullptr, tr("Layer Properties"),
                                          tr("Layer name:"), QLineEdit::Normal,
                                          tr("Camera Layer"), &ok);
-    if (ok && !text.isEmpty())
+    if (ok && !text.isEmpty() && checkNewLayerName(text))
     {
         mEditor->layers()->createCameraLayer(text);
+    }
+    else
+    {
+        uniqueNameMsg();
     }
 
     return Status::OK;
@@ -636,12 +648,16 @@ Status ActionCommands::addNewSoundLayer()
     QString strLayerName = QInputDialog::getText(nullptr, tr("Layer Properties"),
                                                  tr("Layer name:"), QLineEdit::Normal,
                                                  tr("Sound Layer"), &ok);
-    if (ok && !strLayerName.isEmpty())
+    if (ok && !strLayerName.isEmpty() && checkNewLayerName(strLayerName))
     {
         Layer* layer = mEditor->layers()->createSoundLayer(strLayerName);
         mEditor->layers()->setCurrentLayer(layer);
 
         return Status::OK;
+    }
+    else
+    {
+        uniqueNameMsg();
     }
     return Status::FAIL;
 }
@@ -666,6 +682,27 @@ Status ActionCommands::deleteCurrentLayer()
         }
     }
     return Status::OK;
+}
+
+bool ActionCommands::checkNewLayerName(QString s)
+{
+    LayerManager* layerMgr = mEditor->layers();
+    bool b = true;
+    for (int i = 0; i < layerMgr->count(); i++)
+    {
+        if (layerMgr->getLayer(i)->name() == s)
+        {
+            b = false;
+        }
+    }
+    return b;
+}
+
+void ActionCommands::uniqueNameMsg()
+{
+    QMessageBox msgBox;
+    msgBox.setText(tr("Filename must be unique and not empty"));
+    msgBox.exec();
 }
 
 

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -72,6 +72,8 @@ public:
     Status addNewCameraLayer();
     Status addNewSoundLayer();
     Status deleteCurrentLayer();
+    bool checkNewLayerName(QString s);
+    void uniqueNameMsg();
 
     // Help
     void help();


### PR DESCRIPTION
It is a hidden bug in Pencil2D, that users can have duplicate layer names.
It is unlikely that anyone would name their layers with the same name, but it should not be possible at all. This PR would mend this bug - as I call it.