### PR TITLE
#1068 added support for tiff import/export

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -798,7 +798,9 @@ void MainWindow2::importImageSequence()
         if (strImgFileLower.endsWith(".png") ||
             strImgFileLower.endsWith(".jpg") ||
             strImgFileLower.endsWith(".jpeg") ||
-            strImgFileLower.endsWith(".bmp"))
+            strImgFileLower.endsWith(".bmp") ||
+            strImgFileLower.endsWith(".tif") ||
+            strImgFileLower.endsWith(".tiff"))
         {
             mEditor->importImage(strImgFile);
 

--- a/app/ui/exportimageoptions.ui
+++ b/app/ui/exportimageoptions.ui
@@ -93,6 +93,11 @@
           <string>BMP</string>
          </property>
         </item>
+        <item>
+         <property name="text">
+          <string>TIFF</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item>

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -751,7 +751,7 @@ bool Editor::importBitmapImage(QString filePath, int space)
         return false;
     }
 
-    while (reader.read(&img))
+    if (reader.read(&img))
     {
         if (!layer->keyExists(currentFrame()))
         {

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -751,7 +751,7 @@ bool Editor::importBitmapImage(QString filePath, int space)
         return false;
     }
 
-    if (reader.read(&img))
+    while (reader.read(&img))
     {
         if (!layer->keyExists(currentFrame()))
         {
@@ -769,6 +769,12 @@ bool Editor::importBitmapImage(QString filePath, int space)
         }
 
         backup(tr("Import Image"));
+
+        // Workaround for tiff import getting stuck in this loop
+        if (!reader.supportsAnimation())
+        {
+            break;
+        }
     }
 
     return true;

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -678,6 +678,11 @@ bool Object::exportFrames(int frameStart, int frameEnd,
         extension = ".jpg";
         transparency = false; // JPG doesn't support transparency so we have to include the background
     }
+    if (formatStr == "TIFF" || formatStr == "tiff" || formatStr == "TIF" || formatStr == "tif")
+    {
+        format = "TIFF";
+        extension = ".tiff";
+    }
     if (filePath.endsWith(extension, Qt::CaseInsensitive))
     {
         filePath.chop(extension.size());

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -26,10 +26,10 @@ GNU General Public License for more details.
     QObject::tr( "AVI (*.avi);;MPEG(*.mpg);;MOV(*.mov);;MP4(*.mp4);;SWF(*.swf);;FLV(*.flv);;WMV(*.wmv)" )
 
 #define PENCIL_IMAGE_FILTER \
-   QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff);;" )
+   QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)" )
 
 #define PENCIL_IMAGE_SEQ_FILTER \
-    QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff);;" )
+    QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)" )
 
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -26,10 +26,10 @@ GNU General Public License for more details.
     QObject::tr( "AVI (*.avi);;MPEG(*.mpg);;MOV(*.mov);;MP4(*.mp4);;SWF(*.swf);;FLV(*.flv);;WMV(*.wmv)" )
 
 #define PENCIL_IMAGE_FILTER \
-   QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp)" )
+   QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff);;" )
 
 #define PENCIL_IMAGE_SEQ_FILTER \
-    QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);" )
+    QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff);;" )
 
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)


### PR DESCRIPTION
Had to change "while" to "if" on core_lib/src/interface/editor.cpp:754 because usage of 'while' relies on fact that QImageReader::read(QImage) doesn't reset position inside the image file which apparently ain't working with TIFF files ( QImageReader::read(QImage) always returns true for TIFF which results in infinite loop)