### PR TITLE
issue 1101: Range spinboxes set uneditable at startup

### DIFF
--- a/core_lib/src/interface/timecontrols.cpp
+++ b/core_lib/src/interface/timecontrols.cpp
@@ -51,6 +51,7 @@ void TimeControls::initUI()
     mLoopStartSpinBox->setFixedHeight(24);
     mLoopStartSpinBox->setValue(settings.value("loopStart").toInt());
     mLoopStartSpinBox->setMinimum(1);
+    mLoopStartSpinBox->setEnabled(false);
     mLoopStartSpinBox->setToolTip(tr("Start of playback loop"));
     mLoopStartSpinBox->setFocusPolicy(Qt::WheelFocus);
 
@@ -58,6 +59,7 @@ void TimeControls::initUI()
     mLoopEndSpinBox->setFixedHeight(24);
     mLoopEndSpinBox->setValue(settings.value("loopEnd").toInt());
     mLoopEndSpinBox->setMinimum(2);
+    mLoopEndSpinBox->setEnabled(false);
     mLoopEndSpinBox->setToolTip(tr("End of playback loop"));
     mLoopEndSpinBox->setFocusPolicy(Qt::WheelFocus);
 


### PR DESCRIPTION
I've added two lines of code that set the spinboxes unabled at startup.
I have tried to open Pencil2D from command line, with a pclx-file as parameter. This file was saved with range set to 1-16, and that range was still active after loading the scene, so it works whether you open Pencil2D with or without a scene.