### PR TITLE
Fix most warnings in core_lib/structure from g++

### DIFF
--- a/core_lib/src/activeframepool.cpp
+++ b/core_lib/src/activeframepool.cpp
@@ -29,6 +29,8 @@ ActiveFramePool::ActiveFramePool(unsigned long n)
     mMaxSize = maxSize;
 }
 
+ActiveFramePool::~ActiveFramePool() {}
+
 void ActiveFramePool::put(KeyFrame* key)
 {
     if (key == nullptr)

--- a/core_lib/src/activeframepool.h
+++ b/core_lib/src/activeframepool.h
@@ -34,6 +34,7 @@ class ActiveFramePool : public KeyFrameEventListener
 {
 public:
     explicit ActiveFramePool(unsigned long n);
+    virtual ~ActiveFramePool();
 
     void put(KeyFrame* key);
     size_t size() const;

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1096,37 +1096,25 @@ void ScribbleArea::paintSelectionVisuals(QPainter& painter)
             int width = 6;
             int radius = width/2;
 
-            QRectF topLeftCorner = QRectF(mCurrentTransformSelection[0].x() - radius,
+            const QRectF topLeftCorner = QRectF(mCurrentTransformSelection[0].x() - radius,
                     mCurrentTransformSelection[0].y() - radius,
                     width, width);
+            painter.drawRect(topLeftCorner);
 
-            QRectF topRightCorner = QRectF(mCurrentTransformSelection[1].x() - radius,
+            const QRectF topRightCorner = QRectF(mCurrentTransformSelection[1].x() - radius,
                     mCurrentTransformSelection[1].y() - radius,
                     width, width);
+            painter.drawRect(topRightCorner);
 
-            QRectF bottomRightCorner = QRectF(mCurrentTransformSelection[2].x() - radius,
+            const QRectF bottomRightCorner = QRectF(mCurrentTransformSelection[2].x() - radius,
                     mCurrentTransformSelection[2].y() - radius,
                     width, width);
+            painter.drawRect(bottomRightCorner);
 
-            QRectF bottomLeftCorner = QRectF(mCurrentTransformSelection[3].x() - radius,
+            const QRectF bottomLeftCorner = QRectF(mCurrentTransformSelection[3].x() - radius,
                     mCurrentTransformSelection[3].y() - radius,
                     width, width);
-
-            painter.drawRect(topLeftCorner.x(),
-                             topLeftCorner.y(),
-                             width, width);
-
-            painter.drawRect(topRightCorner.x(),
-                             topRightCorner.y(),
-                             width, width);
-
-            painter.drawRect(bottomRightCorner.x(),
-                             bottomRightCorner.y(),
-                             width, width);
-
-            painter.drawRect(bottomLeftCorner.x(),
-                             bottomLeftCorner.y(),
-                             width, width);
+            painter.drawRect(bottomLeftCorner);
 
             painter.setBrush(QColor(0, 255, 0, 50));
             painter.setPen(Qt::green);

--- a/core_lib/src/structure/camera.cpp
+++ b/core_lib/src/structure/camera.cpp
@@ -20,7 +20,7 @@ Camera::Camera()
 {
 }
 
-Camera::Camera(QPointF translation, float rotation, float scaling)
+Camera::Camera(QPointF translation, qreal rotation, qreal scaling)
 {
     Q_ASSERT(scaling > 0);
     mTranslate = translation;
@@ -65,8 +65,8 @@ QTransform Camera::getView()
 void Camera::reset()
 {
     mTranslate = QPointF(0, 0);
-    mRotate = 0.f;
-    mScale = 1.f;
+    mRotate = 0.;
+    mScale = 1.;
     mNeedUpdateView = true;
     modification();
 }
@@ -89,7 +89,7 @@ void Camera::updateViewTransform()
     mNeedUpdateView = false;
 }
 
-void Camera::translate(float dx, float dy)
+void Camera::translate(qreal dx, qreal dy)
 {
     mTranslate.setX(dx);
     mTranslate.setY(dy);
@@ -103,16 +103,16 @@ void Camera::translate(const QPointF pt)
     translate(pt.x(), pt.y());
 }
 
-void Camera::rotate(float degree)
+void Camera::rotate(qreal degree)
 {
     mRotate = degree;
-    if (mRotate > 360.f)
+    if (mRotate > 360)
     {
-        mRotate = mRotate - 360.f;
+        mRotate = mRotate - 360;
     }
-    else if (mRotate < 0.f)
+    else if (mRotate < 0)
     {
-        mRotate = mRotate + 360.f;
+        mRotate = mRotate + 360;
     }
     mRotate = degree;
 
@@ -120,7 +120,7 @@ void Camera::rotate(float degree)
     modification();
 }
 
-void Camera::scale(float scaleValue)
+void Camera::scale(qreal scaleValue)
 {
     mScale = scaleValue;
 

--- a/core_lib/src/structure/camera.h
+++ b/core_lib/src/structure/camera.h
@@ -25,9 +25,9 @@ class Camera : public KeyFrame
 {
 public:
     explicit Camera();
-    explicit Camera(QPointF translation, float rotation, float scaling);
+    explicit Camera(QPointF translation, qreal rotation, qreal scaling);
     explicit Camera(const Camera&);
-    ~Camera();
+    ~Camera() override;
 
     Camera* clone() override;
 
@@ -36,15 +36,15 @@ public:
     void updateViewTransform();
     void assign(const Camera& rhs);
 
-    void translate(float dx, float dy);
+    void translate(qreal dx, qreal dy);
     void translate(const QPointF);
     QPointF translation() { return mTranslate; }
 
-    void rotate(float degree);
-    float rotation() { return mRotate; }
+    void rotate(qreal degree);
+    qreal rotation() { return mRotate; }
 
-    void scale(float scaleValue);
-    float scaling() { return mScale; }
+    void scale(qreal scaleValue);
+    qreal scaling() { return mScale; }
 
     QTransform view;
 
@@ -52,8 +52,8 @@ public:
 
 private:
     QPointF mTranslate;
-    float mRotate = 0.f;
-    float mScale = 1.f;
+    qreal mRotate = 0.;
+    qreal mScale = 1.;
     bool mNeedUpdateView = true;
 };
 

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -25,25 +25,26 @@ GNU General Public License for more details.
 #include "object.h"
 #include "layercamera.h"
 
-
-QString openErrorTitle = QObject::tr("Could not open file");
-QString openErrorDesc = QObject::tr("There was an error processing your file. This usually means that your project has "
-                         "been at least partially corrupted. You can try again with a newer version of Pencil2D, "
-                         "or you can try to use a backup file if you have one. If you contact us through one of "
-                         "our official channels we may be able to help you. For reporting issues, "
-                         "the best places to reach us are:");
-QString contactLinks = "<ul>"
-                       "<li><a href=\"https://discuss.pencil2d.org/c/bugs\">Pencil2D Forum</a></li>"
-                       "<li><a href=\"https://github.com/pencil2d/pencil/issues/new\">Github</a></li>"
-                       "<li><a href=\"https://discord.gg/8FxdV2g\">Discord<\a></li>"
-                       "</ul>";
-
+namespace
+{
+    QString openErrorTitle = QObject::tr("Could not open file");
+    QString openErrorDesc = QObject::tr("There was an error processing your file. This usually means that your project has "
+                             "been at least partially corrupted. You can try again with a newer version of Pencil2D, "
+                             "or you can try to use a backup file if you have one. If you contact us through one of "
+                             "our official channels we may be able to help you. For reporting issues, "
+                             "the best places to reach us are:");
+    QString contactLinks = "<ul>"
+                           "<li><a href=\"https://discuss.pencil2d.org/c/bugs\">Pencil2D Forum</a></li>"
+                           "<li><a href=\"https://github.com/pencil2d/pencil/issues/new\">Github</a></li>"
+                           "<li><a href=\"https://discord.gg/8FxdV2g\">Discord<\a></li>"
+                           "</ul>";
+}
 
 FileManager::FileManager(QObject *parent) : QObject(parent),
 mLog("FileManager")
 {
     ENABLE_DEBUG_LOG(mLog, false);
-    srand(time(nullptr));
+    srand(static_cast<uint>(time(nullptr)));
 }
 
 Object* FileManager::load(QString sFileName)

--- a/core_lib/src/structure/keyframe.h
+++ b/core_lib/src/structure/keyframe.h
@@ -41,7 +41,7 @@ public:
 
     void modification() { mIsModified = true; }
     void setModified(bool b) { mIsModified = b; }
-    bool isModified() const { return mIsModified; };
+    bool isModified() const { return mIsModified; }
 
     void setSelected(bool b) { mIsSelected = b; }
     bool isSelected() const { return mIsSelected; }
@@ -53,7 +53,7 @@ public:
     void removeEventListner(KeyFrameEventListener*);
 
     virtual KeyFrame* clone() { return nullptr; }
-    virtual void loadFile() {};
+    virtual void loadFile() {}
     virtual void unloadFile() {}
     virtual bool isLoaded() { return true; }
 

--- a/core_lib/src/structure/layercamera.cpp
+++ b/core_lib/src/structure/layercamera.cpp
@@ -78,7 +78,7 @@ LayerCamera::LayerCamera( Object* object ) : Layer( object, Layer::CAMERA )
 {
     setName(tr("Camera Layer"));
     viewRect = QRect(QPoint(-400, -300), QSize(800, 600));
-    dialog = NULL;
+    dialog = nullptr;
 }
 
 LayerCamera::~LayerCamera()
@@ -107,15 +107,15 @@ QTransform LayerCamera::getViewAtFrame(int frameNumber)
     int nextFrame = getNextKeyFramePosition( frameNumber );
 	Camera* camera2 = static_cast< Camera* >( getLastKeyFrameAtPosition( nextFrame ) );
 
-    if (camera1 == NULL && camera2 == NULL)
+    if (camera1 == nullptr && camera2 == nullptr)
     {
         return QTransform();
     }
-    else if (camera1 == NULL && camera2 != NULL)
+    else if (camera1 == nullptr && camera2 != nullptr)
     {
         return camera2->view;
     }
-    else if (camera2 == NULL && camera1 != NULL)
+    else if (camera2 == nullptr && camera1 != nullptr)
     {
         return camera1->view;
     }
@@ -157,15 +157,15 @@ void LayerCamera::linearInterpolateTransform(Camera* cam)
     int nextFrame = getNextKeyFramePosition(frameNumber);
     Camera* camera2 = static_cast<Camera*>(getLastKeyFrameAtPosition(nextFrame));
 
-    if (camera1 == NULL && camera2 == NULL)
+    if (camera1 == nullptr && camera2 == nullptr)
     {
         return; // do nothing
     }
-    else if (camera1 == NULL && camera2 != NULL)
+    else if (camera1 == nullptr && camera2 != nullptr)
     {
         return cam->assign(*camera2);
     }
-    else if (camera2 == NULL && camera1 != NULL)
+    else if (camera2 == nullptr && camera1 != nullptr)
     {
         return cam->assign(*camera1);
     }
@@ -206,7 +206,7 @@ QSize LayerCamera::getViewSize()
     return viewRect.size();
 }
 
-void LayerCamera::loadImageAtFrame( int frameNumber, float dx, float dy, float rotate, float scale)
+void LayerCamera::loadImageAtFrame( int frameNumber, qreal dx, qreal dy, qreal rotate, qreal scale)
 {
     if ( keyExists( frameNumber ) )
     {
@@ -232,7 +232,7 @@ KeyFrame* LayerCamera::createKeyFrame(int position, Object*)
 
 void LayerCamera::editProperties()
 {
-    if ( dialog == NULL )
+    if ( dialog == nullptr )
     {
         dialog = new CameraPropertiesDialog( name(), viewRect.width(), viewRect.height() );
     }

--- a/core_lib/src/structure/layercamera.h
+++ b/core_lib/src/structure/layercamera.h
@@ -54,7 +54,7 @@ public:
     LayerCamera(Object* object);
     ~LayerCamera();
 
-    void loadImageAtFrame(int frame, float dx, float dy, float rotate, float scale);
+    void loadImageAtFrame(int frame, qreal dx, qreal dy, qreal rotate, qreal scale);
     
     void editProperties() override;
     QDomElement createDomElement(QDomDocument& doc) override;

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -266,7 +266,6 @@ void Object::deleteLayer(int i)
 {
     if (i > -1 && i < mLayers.size())
     {
-        disconnect(mLayers[i], 0, 0, 0); // disconnect the layer from this object
         delete mLayers.takeAt(i);
     }
 }
@@ -277,7 +276,6 @@ void Object::deleteLayer(Layer* layer)
 
     if (it != mLayers.end())
     {
-        disconnect(layer, 0, 0, 0);
         delete layer;
         mLayers.erase(it);
     }
@@ -322,7 +320,7 @@ bool Object::isColourInUse(int index)
         Layer* layer = getLayer(i);
         if (layer->type() == Layer::VECTOR)
         {
-            LayerVector* layerVector = (LayerVector*)layer;
+            LayerVector* layerVector = static_cast<LayerVector*>(layer);
 
             if (layerVector->usesColour(index))
             {
@@ -341,7 +339,7 @@ void Object::removeColour(int index)
         Layer* layer = getLayer(i);
         if (layer->type() == Layer::VECTOR)
         {
-            LayerVector* layerVector = (LayerVector*)layer;
+            LayerVector* layerVector = static_cast<LayerVector*>(layer);
             layerVector->removeColour(index);
         }
     }
@@ -608,7 +606,7 @@ void Object::paintImage(QPainter& painter,int frameNumber,
             // paints the bitmap images
             if (layer->type() == Layer::BITMAP)
             {
-                LayerBitmap* layerBitmap = (LayerBitmap*)layer;
+                LayerBitmap* layerBitmap = static_cast<LayerBitmap*>(layer);
 
                 BitmapImage* bitmap = layerBitmap->getLastBitmapImageAtFrame(frameNumber);
                 if (bitmap)
@@ -618,7 +616,7 @@ void Object::paintImage(QPainter& painter,int frameNumber,
             // paints the vector images
             if (layer->type() == Layer::VECTOR)
             {
-                LayerVector* layerVector = (LayerVector*)layer;
+                LayerVector* layerVector = static_cast<LayerVector*>(layer);
                 VectorImage* vec = layerVector->getLastVectorImageAtFrame(frameNumber, 0);
                 if (vec)
                     vec->paintImage(painter, false, false, antialiasing);

--- a/core_lib/src/structure/soundclip.cpp
+++ b/core_lib/src/structure/soundclip.cpp
@@ -91,8 +91,8 @@ void SoundClip::playFromPosition(int frameNumber, int fps)
     {
         framesIntoSound = frameNumber - pos();
     }
-    float msPerFrame = (1000 / fps);
-    float msIntoSound = framesIntoSound * msPerFrame;
+    qreal msPerFrame = 1000.0 / fps;
+    qint64 msIntoSound = qRound(framesIntoSound * msPerFrame);
 
     if (mPlayer)
     {

--- a/core_lib/src/structure/soundclip.h
+++ b/core_lib/src/structure/soundclip.h
@@ -29,7 +29,7 @@ class SoundClip : public KeyFrame
 public:
     explicit SoundClip();
     explicit SoundClip(const SoundClip&);
-    ~SoundClip();
+    ~SoundClip() override;
 
     SoundClip* clone() override;
 


### PR DESCRIPTION
object.cpp:
- remove unnecessary disconnects (automatically called in QObject destructor) [zero-as-null-pointer-constant]
- change some c-style casts to static_cast [old-style-cast]

activeframepool.cpp/.h:
- add empty virtual destructor [non-virtual-dtor]

scribblearea.cpp:
- use QRectFs directly for selection corner drawing [float-conversion]

soundclip.cpp:
- change some types [float-conversion]
- add override to destructor [inconsistent-missing-destructor-override]

layercamera.cpp/.h:
- change NULLs to nullptrs [zero-as-null-pointer-constant]
- use qreal for loadImageAtFrame parameters [conversion,double-promotion]

camera.cpp/.h:
- use qreal for rotation and scaling [conversion]
- add override to destructor [inconsistent-missing-destructor-override]

keyframe.h:
- remove semicolons after functions [extra-semi]

filemanager.cpp:
- use static_cast for time_t -> uint conversion [shorten-64-to-32]
- move strings to an anonymous namespace [missing-variable-declarations]