### PR TITLE
Improve .gpl import

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -44,7 +44,6 @@ HEADERS += \
     src/colorinspector.h \
     src/colorpalettewidget.h \
     src/colorwheel.h \
-    src/colordictionary.h \
     src/filedialogex.h \
     src/displayoptionwidget.h \
     src/pencilapplication.h \

--- a/app/src/colorpalettewidget.cpp
+++ b/app/src/colorpalettewidget.cpp
@@ -33,7 +33,6 @@ GNU General Public License for more details.
 #include <QMenu>
 
 // Project
-#include "colordictionary.h"
 #include "colourref.h"
 #include "object.h"
 #include "editor.h"
@@ -118,7 +117,6 @@ void ColorPaletteWidget::addItem()
     int colorIndex = ui->colorListWidget->currentRow()+1;
 
     ColourRef ref(newColour);
-    ref.name = getDefaultColorName(newColour);
 
     editor()->object()->addColourAtIndex(colorIndex, ref);
     refreshColorList();
@@ -410,65 +408,6 @@ void ColorPaletteWidget::updateGridUI()
     }
 }
 
-QString ColorPaletteWidget::getDefaultColorName(QColor c)
-{
-    using std::pow;
-
-    // Separate rgb values for convenience
-    const int r = c.red();
-    const int g = c.green();
-    const int b = c.blue();
-
-    // Convert RGB to XYZ with D65 white point
-    // (algorithm source: https://www.cs.rit.edu/%7Encs/color/t_convert.html#RGB%20to%20XYZ%20&%20XYZ%20to%20RGB)
-    const qreal x = 0.412453*r + 0.357580*g + 0.180423*b;
-    const qreal y = 0.212671*r + 0.715160*g + 0.072169*b;
-    const qreal z = 0.019334*r + 0.119193*g + 0.950227*b;
-
-    // Convert XYZ to CEI L*u*v
-    // (algorithm source: https://www.cs.rit.edu/~ncs/color/t_convert.html#XYZ%20to%20CIE%20L*a*b*%20(CIELAB)%20&%20CIELAB%20to%20XYZ)
-    // Helper function for the conversion
-    auto f = [](const double a) { return a > 0.008856 ? std::cbrt(a) : 7.787 * a + 16 / 116; };
-    // XYZ tristimulus values for D65 (taken from: https://en.wikipedia.org/wiki/Illuminant_D65#Definition)
-    const qreal xn = 95.047,
-        yn = 100,
-        zn = 108.883;
-    const qreal l = y / yn > 0.008856 ? 116 * cbrt(y / yn) - 16 : 903.3*y / yn,
-        u = 500 * (f(x / xn) - f(y / yn)),
-        v = 200 * (f(y / yn) - f(z / zn));
-
-    // Find closest color match in colorDict to the luv values
-    int minLoc = 0;
-    if (u < 0.01 && u > -0.01 && v < 0.01 && v > -0.01)
-    {
-        // The color is grayscale so only compare to gray centroids so there is no 'false hue'
-        qreal minDist = pow(colorDict[dictSize - 5][0] - l, 2) + pow(colorDict[dictSize - 5][1] - u, 2) + pow(colorDict[dictSize - 5][2] - v, 2);
-        for (int i = dictSize - 4; i < dictSize; i++)
-        {
-            qreal curDist = pow(colorDict[i][0] - l, 2) + pow(colorDict[i][1] - u, 2) + pow(colorDict[i][2] - v, 2);
-            if (curDist < minDist)
-            {
-                minDist = curDist;
-                minLoc = i;
-            }
-        }
-    }
-    else
-    {
-        qreal minDist = pow(colorDict[0][0] - l, 2) + pow(colorDict[0][1] - u, 2) + pow(colorDict[0][2] - v, 2);
-        for (int i = 1; i < dictSize; i++)
-        {
-            qreal curDist = pow(colorDict[i][0] - l, 2) + pow(colorDict[i][1] - u, 2) + pow(colorDict[i][2] - v, 2);
-            if (curDist < minDist)
-            {
-                minDist = curDist;
-                minLoc = i;
-            }
-        }
-    }
-    return nameDict[minLoc];
-}
-
 void ColorPaletteWidget::clickColorDialogButton()
 {
     mIsColorDialog = true;
@@ -494,7 +433,6 @@ void ColorPaletteWidget::clickAddColorButton()
 
     int colorIndex = editor()->object()->getColourCount();
     ColourRef ref(newColour);
-    ref.name = getDefaultColorName(newColour);
 
     editor()->object()->addColour(ref);
     refreshColorList();

--- a/app/src/colorpalettewidget.h
+++ b/app/src/colorpalettewidget.h
@@ -87,8 +87,6 @@ private:
     void updateItemColor(int, QColor);
     void updateGridUI();
 
-    QString getDefaultColorName(QColor c);
-
     Ui::ColorPalette* ui = nullptr;
     QActionGroup* mLayoutModeActionGroup = nullptr;
     QAction* mListModeAction = nullptr;

--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -81,6 +81,7 @@ HEADERS +=  \
     src/tool/strokemanager.h \
     src/tool/stroketool.h \
     src/util/blitrect.h \
+    src/util/colordictionary.h \
     src/util/fileformat.h \
     src/util/pencildef.h \
     src/util/pencilerror.h \

--- a/core_lib/src/graphics/vector/colourref.cpp
+++ b/core_lib/src/graphics/vector/colourref.cpp
@@ -16,7 +16,11 @@ GNU General Public License for more details.
 */
 #include "colourref.h"
 
+#include <cmath>
+#include <QtMath>
 #include <QDebug>
+
+#include "util/colordictionary.h"
 
 ColourRef::ColourRef()
 {
@@ -27,7 +31,7 @@ ColourRef::ColourRef()
 ColourRef::ColourRef(QColor theColour, QString theName)
 {
     colour = theColour;
-    name = theName;
+    name = theName.isNull() ? ColourRef::getDefaultColorName(theColour) : theName;
 }
 
 bool ColourRef::operator==(ColourRef colourRef1)
@@ -60,5 +64,60 @@ QDebug& operator<<(QDebug debug, const ColourRef& colourRef)
     return debug.maybeSpace();
 }
 
+QString ColourRef::getDefaultColorName(const QColor c)
+{
+    // Separate rgb values for convenience
+    const int r = c.red();
+    const int g = c.green();
+    const int b = c.blue();
 
+    // Convert RGB to XYZ with D65 white point
+    // (algorithm source: https://www.cs.rit.edu/%7Encs/color/t_convert.html#RGB%20to%20XYZ%20&%20XYZ%20to%20RGB)
+    const qreal x = 0.412453*r + 0.357580*g + 0.180423*b;
+    const qreal y = 0.212671*r + 0.715160*g + 0.072169*b;
+    const qreal z = 0.019334*r + 0.119193*g + 0.950227*b;
+
+    // Convert XYZ to CEI L*u*v
+    // (algorithm source: https://www.cs.rit.edu/~ncs/color/t_convert.html#XYZ%20to%20CIE%20L*a*b*%20(CIELAB)%20&%20CIELAB%20to%20XYZ)
+    // Helper function for the conversion
+    auto f = [](const double a) { return a > 0.008856 ? std::cbrt(a) : 7.787 * a + 16 / 116; };
+    // XYZ tristimulus values for D65 (taken from: https://en.wikipedia.org/wiki/Illuminant_D65#Definition)
+    const qreal xn = 95.047,
+        yn = 100,
+        zn = 108.883;
+    const qreal l = y / yn > 0.008856 ? 116 * cbrt(y / yn) - 16 : 903.3*y / yn,
+        u = 500 * (f(x / xn) - f(y / yn)),
+        v = 200 * (f(y / yn) - f(z / zn));
+
+    // Find closest color match in colorDict to the luv values
+    int minLoc = 0;
+    if (u < 0.01 && u > -0.01 && v < 0.01 && v > -0.01)
+    {
+        // The color is grayscale so only compare to gray centroids so there is no 'false hue'
+        qreal minDist = qPow(colorDict[dictSize - 5][0] - l, 2) + qPow(colorDict[dictSize - 5][1] - u, 2) + qPow(colorDict[dictSize - 5][2] - v, 2);
+        for (int i = dictSize - 4; i < dictSize; i++)
+        {
+            qreal curDist = qPow(colorDict[i][0] - l, 2) + qPow(colorDict[i][1] - u, 2) + qPow(colorDict[i][2] - v, 2);
+            if (curDist < minDist)
+            {
+                minDist = curDist;
+                minLoc = i;
+            }
+        }
+    }
+    else
+    {
+        qreal minDist = qPow(colorDict[0][0] - l, 2) + qPow(colorDict[0][1] - u, 2) + qPow(colorDict[0][2] - v, 2);
+        for (int i = 1; i < dictSize; i++)
+        {
+            qreal curDist = qPow(colorDict[i][0] - l, 2) + qPow(colorDict[i][1] - u, 2) + qPow(colorDict[i][2] - v, 2);
+            if (curDist < minDist)
+            {
+                minDist = curDist;
+                minLoc = i;
+            }
+        }
+    }
+    return nameDict[minLoc];
+}
 

--- a/core_lib/src/graphics/vector/colourref.h
+++ b/core_lib/src/graphics/vector/colourref.h
@@ -25,12 +25,14 @@ class ColourRef
 {
 public:
     ColourRef();
-    ColourRef(QColor theColour, QString theName = "");
+    ColourRef(QColor theColour, QString theName = QString());
     bool operator==(ColourRef colourRef1);
     bool operator!=(ColourRef colourRef1);
 
     QColor colour;
     QString name;
+
+    static QString getDefaultColorName(const QColor c);
 };
 
 QDebug& operator<<(QDebug debug, const ColourRef &colourRef);

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -425,66 +425,69 @@ bool Object::exportPalette(QString filePath)
     return true;
 }
 
+/* Import the .gpl GIMP palette format.
+ *
+ * This functions supports importing both the old and new .gpl formats.
+ * This should load colors the same as GIMP, with the following intentional exceptions:
+ * - Whitespace before and after a name does not appear in the name
+ * - The last line is processed, even if there is not a trailing newline
+ * - Colours without a name will use are automatic naming system rather than "Untitled"
+ */
 void Object::importPaletteGPL(QFile& file)
 {
     QTextStream in(&file);
     QString line;
 
-    bool hashFound = false;
-    bool colorFound = false;
+    // First line must start with "GIMP Palette"
+    // Displaying an error here would be nice
+    in.readLineInto(&line);
+    if (!line.startsWith("GIMP Palette")) return;
 
-    int emptyColorNameCounter = 1;
+    in.readLineInto(&line);
 
-    while (in.readLineInto(&line))
+    // There are two GPL formats, the new one must start with "Name: " on the second line
+    if (line.startsWith("Name: "))
     {
-        quint8 red = 0;
-        quint8 green = 0;
-        quint8 blue = 0;
+        in.readLineInto(&line);
+        // The new format contains an optional thrid line starting with "Columns: "
+        if (line.startsWith("Columns: "))
+        {
+            // Skip to next line
+            in.readLineInto(&line);
+        }
+    }
+
+    // Colours inherit the value from the previous colour for missing channels
+    // Some palettes may rely on this behavior so we should try to replicate it
+    QColor prevColour(Qt::black);
+
+    do
+    {
+        // Ignore comments and empty lines
+        if (line.isEmpty() || line.startsWith("#")) continue;
+
+        int red = 0;
+        int green = 0;
+        int blue = 0;
 
         int countInLine = 0;
-        QString name= "";
+        QString name = "";
 
-        if (!colorFound)
+        for(const QString& snip : line.split(QRegExp("\\s|\\t"), QString::SkipEmptyParts))
         {
-            hashFound = (line == "#") ? true : false;
-        }
-
-        if (!hashFound)
-        {
-            continue;
-        }
-        else if (!colorFound)
-        {
-            colorFound = true;
-            continue;
-        }
-
-        for (const QString& snip : line.split(QRegExp("\\s|\\t"), QString::SkipEmptyParts))
-        {
-            if (countInLine == 0) // assume red
+            switch (countInLine)
             {
+            case 0:
                 red = snip.toInt();
-            }
-            else if (countInLine == 1) // assume green
-            {
+                break;
+            case 1:
                 green = snip.toInt();
-            }
-            else if (countInLine == 2) // assume blue
-            {
+                break;
+            case 2:
                 blue = snip.toInt();
-            }
-            else
-            {
-                // assume last bit of line is a name
-                // gimp interprets as untitled
-                if (snip == "---")
-                {
-                    name = "untitled";
-                }
-                else
-                {
-                    name += snip;
-                }
+                break;
+            default:
+                name += snip + " ";
             }
             countInLine++;
         }
@@ -492,17 +495,22 @@ void Object::importPaletteGPL(QFile& file)
         // trim additional spaces
         name = name.trimmed();
 
-        if (name.isEmpty())
-        {
-            name = "Color" + QString::number(emptyColorNameCounter);
-            ++emptyColorNameCounter;
-        }
+        // Get values from previous colour if necessary
+        if (countInLine < 2) green = prevColour.green();
+        if (countInLine < 3) blue = prevColour.blue();
 
-        if (QColor(red, green, blue).isValid())
+        // GIMP assigns colours the name "Untitled" by default now
+        // so in addition to missing names, we also use automatic
+        // naming for this
+        if (name.isEmpty() || name == "Untitled") name = QString();
+
+        QColor colour(red, green, blue);
+        if (colour.isValid())
         {
-            mPalette.append(ColourRef(QColor(red,green,blue), name));
+            mPalette.append(ColourRef(colour, name));
+            prevColour = colour;
         }
-    }
+    } while (in.readLineInto(&line));
 }
 
 void Object::importPalettePencil(QFile& file)

--- a/core_lib/src/util/colordictionary.h
+++ b/core_lib/src/util/colordictionary.h
@@ -3,6 +3,8 @@
 #ifndef _COLOR_DICTIONARY_H_
 #define _COLOR_DICTIONARY_H_
 
+#include <QObject>
+
 // Initialize NBS/ISCC Color dictionary, John Foster version (http://tx4.us/nbs-iscc.htm), converted to CIE L*u*v with D65 white point and rounded.
 const int dictSize = 267;
 


### PR DESCRIPTION
Modified the gpl importer to more closely match the behavior of GIMP as it was not working with some valid gpl files. Looked through the GIMP source and tested various edge cases. Also used the automatic naming function for any colors that do not have a name.