### PR TITLE
Function to import images by filename

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -22,6 +22,7 @@ GNU General Public License for more details.
 #include <QApplication>
 #include <QDesktopServices>
 #include <QStandardPaths>
+#include <QFileDialog>
 
 #include "pencildef.h"
 #include "editor.h"

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -868,7 +868,7 @@ void MainWindow2::importImageSequenceNumbered()
     int validLength = prefix.length() + digit.length() + suffix.length();
     for (int i = 0; i < sList.size(); i++)
     {
-        if (sList[i].contains(prefix) && sList[i].length() == validLength)
+        if (sList[i].startsWith(prefix) && sList[i].length() == validLength)
         {
             finalList.append(sList[i]);
         }
@@ -879,7 +879,6 @@ void MainWindow2::importImageSequenceNumbered()
     dot = finalList[0].lastIndexOf(".");
 
     QFile file;
-    QTime t;
     QString msg = "";
     for (int i = 0; i < finalList.size(); i++)
     {
@@ -896,18 +895,11 @@ void MainWindow2::importImageSequenceNumbered()
             return;
         }
     }
-    qDebug() << "Elapsed: " << t.elapsed();
     mEditor->layers()->createBitmapLayer(prefix);
     Layer *layer = mEditor->layers()->findLayerByName(prefix);
     Q_ASSERT(layer != nullptr);
-
     LayerManager* lMgr = mEditor->layers();
     lMgr->setCurrentLayer(layer);
-    /*
-    prefix = finalList[0].mid(0, dot - 4);
-    digit = finalList[0].mid(dot - 4, 4);
-    suffix = finalList[0].mid(dot, finalList[0].length() - 1);
-    */
     for (int i = 0; i < finalList.size(); i++)
     {
         mEditor->scrubTo(finalList[i].mid(dot - 4, 4).toInt());

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -78,6 +78,7 @@ public:
     // import
     void importImage();
     void importImageSequence();
+    void importImageSequenceNumbered();
     void importMovie();
     void importGIF();
 

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -49,7 +49,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -64,6 +64,7 @@
      <addaction name="actionImport_Image"/>
      <addaction name="actionImport_ImageSeq"/>
      <addaction name="actionImport_Movie"/>
+     <addaction name="actionImport_ImageSeqNum"/>
      <addaction name="actionImport_Gif"/>
      <addaction name="actionImport_Sound"/>
      <addaction name="separator"/>
@@ -886,6 +887,11 @@
   <action name="actionExport_Animated_GIF">
    <property name="text">
     <string>Animated GIF...</string>
+   </property>
+  </action>
+  <action name="actionImport_ImageSeqNum">
+   <property name="text">
+    <string>Image Sequence Numbered...</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This function will make it possible to import images based on the images filenames. This is mainly a feature that is usefull for traditional animators like myself.
Filenames must follow this format: 'prefix' + 'four digits' + 'suffix'.
If you have a layer with the character 'Joe', you could have the following files: 'Joe0001.png', 'Joe0013.png', 'Joe0015.png', 'Joe0017.png' and 'Joe0019.png'. If you import these drawings with the new function 'importImageSequenceNumbered()', you wil get a new layer named 'Joe' (the prefix), and the drawings will be placed at frames 1, 13, 15, 17 and 19.
I like it. I hope you like it too.