### PR TITLE
Fix rename optimization during save

### DIFF
--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -600,7 +600,6 @@ bool Layer::moveSelectedFrames(int offset)
                         mKeyFrames.erase(framePosition);
 
                         frame->setPos(targetPosition);
-                        frame->modification();
                         mKeyFrames.insert(std::make_pair(targetPosition, frame));
                     }
 
@@ -619,7 +618,6 @@ bool Layer::moveSelectedFrames(int offset)
 
                 // Update the position of the selected frame
                 selectedFrame->setPos(toPos);
-                selectedFrame->modification();
                 mKeyFrames.insert(std::make_pair(toPos, selectedFrame));
             }
             indexInSelection = indexInSelection + step;

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -54,8 +54,7 @@ void LayerBitmap::loadImageAtFrame(QString path, QPoint topLeft, int frameNumber
 
 Status LayerBitmap::saveKeyFrameFile(KeyFrame* keyframe, QString path)
 {
-    QString theFileName = fileName(keyframe);
-    QString strFilePath = QDir(path).filePath(theFileName);
+    QString strFilePath = filePath(keyframe, QDir(path));
 
     BitmapImage* bitmapImage = static_cast<BitmapImage*>(keyframe);
 
@@ -93,41 +92,47 @@ KeyFrame* LayerBitmap::createKeyFrame(int position, Object*)
     return b;
 }
 
-Status LayerBitmap::presave(const QString&)
+Status LayerBitmap::presave(const QString& sDataFolder)
 {
-    // handles those moved keys but note loaded yet
-    std::vector<BitmapImage*> bitmapArray;
-    foreachKeyFrame([&bitmapArray](KeyFrame* key)
+    QDir dataFolder(sDataFolder);
+    // Handles keys that have been moved but not modified
+    std::vector<BitmapImage*> movedOnlyBitmaps;
+    foreachKeyFrame([&movedOnlyBitmaps,&dataFolder,this](KeyFrame* key)
     {
         auto bitmap = static_cast<BitmapImage*>(key);
-        // null image + modified => the keyframe has been moved, but users didn't draw on it.
+        // (b->fileName() != fileName(b) && !modified => the keyframe has been moved, but users didn't draw on it.
         if (!bitmap->fileName().isEmpty()
-            && bitmap->image()->isNull() 
-            && bitmap->isModified())
+            && !bitmap->isModified()
+            && bitmap->fileName() != filePath(bitmap, dataFolder))
         {
-            bitmapArray.push_back(bitmap);
+            movedOnlyBitmaps.push_back(bitmap);
         }
     });
 
-    for (BitmapImage* b : bitmapArray) 
+    for (BitmapImage* b : movedOnlyBitmaps)
     {
-        if (b->fileName() != fileName(b))
-        {
-            QString tmpName = QString::asprintf("t_%03d.%03d.png", id(), b->pos());
-            QFile::rename(b->fileName(), tmpName);
-            b->setFileName(tmpName);
-        }
+        // Move to temporary locations first to avoid overwritting anything we shouldn't be
+        // Ex: Frame A moves from 1 -> 2, Frame B moves from 2 -> 3. Make sure A does not overwrite B
+        QString tmpName = QString::asprintf("t_%03d.%03d.png", id(), b->pos());
+        QFile::rename(b->fileName(), tmpName);
+        b->setFileName(tmpName);
     }
 
-    for (BitmapImage* b : bitmapArray)
+    for (BitmapImage* b : movedOnlyBitmaps)
     {
-        if (QFile::exists(fileName(b)))
-            QFile::remove(fileName(b));
+        QString dest = filePath(b, dataFolder);
+        QFile::remove(dest);
 
-        QFile::rename(b->fileName(), fileName(b));
+        QFile::rename(b->fileName(), dest);
+        b->setFileName(dest);
     }
 
     return Status::OK;
+}
+
+QString LayerBitmap::filePath(KeyFrame* key, const QDir& dataFolder) const
+{
+    return dataFolder.filePath(fileName(key));
 }
 
 QString LayerBitmap::fileName(KeyFrame* key) const
@@ -140,8 +145,6 @@ bool LayerBitmap::needSaveFrame(KeyFrame* key, const QString& strSavePath)
     if (key->isModified()) // keyframe was modified
         return true;
     if (QFile::exists(strSavePath) == false) // hasn't been saved before
-        return true;
-    if (strSavePath != key->fileName()) // key frame moved
         return true;
     return false;
 }

--- a/core_lib/src/structure/layerbitmap.h
+++ b/core_lib/src/structure/layerbitmap.h
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #include "layer.h"
 
 class BitmapImage;
+class QDir;
 
 class LayerBitmap : public Layer
 {
@@ -42,6 +43,7 @@ protected:
 
 private:
     void loadImageAtFrame(QString strFilePath, QPoint topLeft, int frameNumber);
+    QString filePath(KeyFrame* key, const QDir& dataFolder) const;
     QString fileName(KeyFrame* key) const;
     bool needSaveFrame(KeyFrame* key, const QString& strSavePath);
 };


### PR DESCRIPTION
During saving, there was some code to check if a frame changed position but was not modified so that a simple file rename could be used instead of a full image render and write.

However, there were many bugs that prevented this from working properly. I hope I have fixed them all. The most major one was caused by changes to the image loading, which would cause all frames to be loaded into memory during save. This fix will reduce memory consumption and increase the save speed by fixing this.

Thanks @Jose-Moreno for his extensive memory testing which brought this issue to my attention.

I have tested these changes in multiple scenarios and it is behaving as it should, but if I did make a mistake this could reintroduce the file wiping issues in the worst case scenario. So please review and test these changes thoroughly before merging.