### PR TITLE
Issue 1074. Slider to zoom framesize at timeline. Option removed from prefs.

### DIFF
--- a/app/src/preferencesdialog.cpp
+++ b/app/src/preferencesdialog.cpp
@@ -291,7 +291,6 @@ TimelinePage::TimelinePage()
     ui->setupUi(this);
 
     auto spinBoxValueChange = static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged);
-    connect(ui->frameSize, &QSlider::valueChanged, this, &TimelinePage::frameSizeChanged);
     connect(ui->timelineLength, spinBoxValueChange, this, &TimelinePage::timelineLengthChanged);
     connect(ui->scrubBox, &QCheckBox::stateChanged, this, &TimelinePage::scrubChanged);
     connect(ui->radioButtonAddNewKey, &QRadioButton::toggled, this, &TimelinePage::drawEmptyKeyRadioButtonToggled);
@@ -309,13 +308,6 @@ void TimelinePage::updateValues()
 {
     SignalBlocker b1(ui->scrubBox);
     ui->scrubBox->setChecked(mManager->isOn(SETTING::SHORT_SCRUB));
-
-    int frameSize = mManager->getInt(SETTING::FRAME_SIZE);
-    if (frameSize <= 0)
-        frameSize = 6;
-
-    SignalBlocker b2(ui->frameSize);
-    ui->frameSize->setValue(frameSize);
 
     SignalBlocker b3(ui->timelineLength);
     ui->timelineLength->setValue(mManager->getInt(SETTING::TIMELINE_SIZE));
@@ -353,11 +345,6 @@ void TimelinePage::timelineLengthChanged(int value)
 void TimelinePage::fontSizeChanged(int value)
 {
     mManager->set(SETTING::LABEL_FONT_SIZE, value);
-}
-
-void TimelinePage::frameSizeChanged(int value)
-{
-    mManager->set(SETTING::FRAME_SIZE, value);
 }
 
 void TimelinePage::scrubChanged(int value)

--- a/app/src/preferencesdialog.h
+++ b/app/src/preferencesdialog.h
@@ -111,7 +111,6 @@ public slots:
 
     void timelineLengthChanged(int);
     void fontSizeChanged(int);
-    void frameSizeChanged(int);
     void scrubChanged(int);
     void playbackStateChanged(int);
     void drawEmptyKeyRadioButtonToggled(bool);

--- a/app/ui/timelinepage.ui
+++ b/app/ui/timelinepage.ui
@@ -21,26 +21,6 @@
      </property>
      <layout class="QVBoxLayout" name="lay">
       <item>
-       <widget class="QLabel" name="frameSizeLabel">
-        <property name="text">
-         <string>Frame size</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QSlider" name="frameSize">
-        <property name="minimum">
-         <number>4</number>
-        </property>
-        <property name="maximum">
-         <number>20</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <property name="topMargin">
          <number>5</number>

--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -139,7 +139,7 @@ void TimeLine::initUI()
     zoomSlider->setRange(4, 40);
     zoomSlider->setFixedWidth(74);
     zoomSlider->setValue(mTracks->getFrameSize());
-    zoomSlider->setToolTip(tr("Choose Framesize"));
+    zoomSlider->setToolTip(tr("Adjust frame width"));
     zoomSlider->setOrientation(Qt::Horizontal);
 
     QLabel* onionLabel = new QLabel(tr("Onion skin:"));

--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -26,6 +26,7 @@ GNU General Public License for more details.
 #include <QMessageBox>
 #include <QLabel>
 #include <QWheelEvent>
+#include <QSlider>
 
 #include "layer.h"
 #include "editor.h"
@@ -131,6 +132,16 @@ void TimeLine::initUI()
     duplicateKeyButton->setToolTip(tr("Duplicate Frame"));
     duplicateKeyButton->setFixedSize(24, 24);
 
+    QLabel* zoomLabel = new QLabel(tr("Zoom:"));
+    zoomLabel->setIndent(5);
+
+    QSlider* zoomSlider = new QSlider(this);
+    zoomSlider->setRange(4, 40);
+    zoomSlider->setFixedWidth(74);
+    zoomSlider->setValue(mTracks->getFrameSize());
+    zoomSlider->setToolTip(tr("Choose Framesize"));
+    zoomSlider->setOrientation(Qt::Horizontal);
+
     QLabel* onionLabel = new QLabel(tr("Onion skin:"));
 
     QToolButton* onionTypeButton = new QToolButton(this);
@@ -142,6 +153,9 @@ void TimeLine::initUI()
     timelineButtons->addWidget(addKeyButton);
     timelineButtons->addWidget(removeKeyButton);
     timelineButtons->addWidget(duplicateKeyButton);
+    timelineButtons->addSeparator();
+    timelineButtons->addWidget(zoomLabel);
+    timelineButtons->addWidget(zoomSlider);
     timelineButtons->addSeparator();
     timelineButtons->addWidget(onionLabel);
     timelineButtons->addWidget(onionTypeButton);
@@ -198,6 +212,7 @@ void TimeLine::initUI()
     connect(addKeyButton, &QToolButton::clicked, this, &TimeLine::addKeyClick);
     connect(removeKeyButton, &QToolButton::clicked, this, &TimeLine::removeKeyClick);
     connect(duplicateKeyButton, &QToolButton::clicked, this, &TimeLine::duplicateKeyClick);
+    connect(zoomSlider, &QSlider::valueChanged, mTracks, &TimeLineCells::setFrameSize);
     connect(onionTypeButton, &QToolButton::clicked, this, &TimeLine::toogleAbsoluteOnionClick);
 
     connect(mTimeControls, &TimeControls::soundClick, this, &TimeLine::soundClick);

--- a/core_lib/src/interface/timeline.h
+++ b/core_lib/src/interface/timeline.h
@@ -82,6 +82,7 @@ protected:
 private:
     void deleteCurrentLayer();
 
+
     QScrollBar* mHScrollbar = nullptr;
     QScrollBar* mVScrollbar = nullptr;
     TimeLineCells* mTracks = nullptr;

--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -49,6 +49,7 @@ TimeLineCells::TimeLineCells(TimeLine* parent, Editor* editor, TIMELINE_CELL_TYP
     setAttribute(Qt::WA_OpaquePaintEvent, false);
 
     connect(mPrefs, &PreferenceManager::optionChanged, this, &TimeLineCells::loadSetting);
+
 }
 
 TimeLineCells::~TimeLineCells()
@@ -93,6 +94,14 @@ int TimeLineCells::getFrameX(int frameNumber)
 {
     int x = mOffsetX + (frameNumber - mFrameOffset) * mFrameSize;
     return x;
+}
+
+void TimeLineCells::setFrameSize(int size)
+{
+    mFrameSize = size;
+    QSettings settings (PENCIL2D, PENCIL2D);
+    settings.setValue(SETTING_FRAME_SIZE, mFrameSize);
+    updateContent();
 }
 
 int TimeLineCells::getLayerNumber(int y)

--- a/core_lib/src/interface/timelinecells.h
+++ b/core_lib/src/interface/timelinecells.h
@@ -55,6 +55,7 @@ public:
     
     int getFrameLength() {return mFrameLength;}
     void setFrameLength(int n) { mFrameLength = n; }
+    void setFrameSize(int size);
 
     int getFrameSize() { return mFrameSize; }
     void clearCache() { if ( mCache ) delete mCache; mCache = new QPixmap( size() ); }

--- a/core_lib/src/managers/preferencemanager.cpp
+++ b/core_lib/src/managers/preferencemanager.cpp
@@ -189,7 +189,7 @@ void PreferenceManager::set(SETTING option, int value)
         break;
     case SETTING::FRAME_SIZE:
         if (value < 4) { value = 4; }
-        else if (value > 20) { value = 20; }
+        else if (value > 40) { value = 40; }
         settings.setValue(SETTING_FRAME_SIZE, value);
         break;
     case SETTING::TIMELINE_SIZE:


### PR DESCRIPTION
A zoom slider to change frame size. 
Values from 4 to 40. (Was 4 to 20).
For some reason it rearranges layout? Besides from that it works fine.