### PR TITLE
Issue 978: Fliip roll and Flip InBetween feature

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -309,7 +309,7 @@ Status ActionCommands::exportImageSequence()
     int endFrame  = dialog->getEndFrame();
 
     QString sCameraLayerName = dialog->getCameraLayerName();
-    LayerCamera* cameraLayer = (LayerCamera*)mEditor->layers()->findLayerByName(sCameraLayerName, Layer::CAMERA);
+    LayerCamera* cameraLayer = static_cast<LayerCamera*>(mEditor->layers()->findLayerByName(sCameraLayerName, Layer::CAMERA));
 
     // Show a progress dialog, as this can take a while if you have lots of frames.
     QProgressDialog progress(tr("Exporting image sequence..."), tr("Abort"), 0, 100, mParent);
@@ -376,7 +376,7 @@ Status ActionCommands::exportImage()
 
     // Export
     QString sCameraLayerName = dialog->getCameraLayerName();
-    LayerCamera* cameraLayer = (LayerCamera*)mEditor->layers()->findLayerByName(sCameraLayerName, Layer::CAMERA);
+    LayerCamera* cameraLayer = static_cast<LayerCamera*>(mEditor->layers()->findLayerByName(sCameraLayerName, Layer::CAMERA));
 
     QTransform view = cameraLayer->getViewAtFrame(mEditor->currentFrame());
 
@@ -536,7 +536,7 @@ void ActionCommands::removeKey()
 void ActionCommands::duplicateKey()
 {
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer == NULL) return;
+    if (layer == nullptr) return;
 
     KeyFrame* key = layer->getKeyFrameAt(mEditor->currentFrame());
     if (key == nullptr) return;

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -29,7 +29,7 @@ class ActionCommands : public QObject
     Q_OBJECT
 
 public:
-    explicit ActionCommands(QWidget* parent = 0);
+    explicit ActionCommands(QWidget* parent = nullptr);
     virtual ~ActionCommands();
 
     void setCore(Editor* e) { mEditor = e; }

--- a/app/src/colorbox.h
+++ b/app/src/colorbox.h
@@ -26,7 +26,7 @@ class ColorBox : public BaseDockWidget
 
 public:
     explicit ColorBox( QWidget* parent );
-    virtual ~ColorBox();
+    virtual ~ColorBox() override;
 
     void initUI() override;
     void updateUI() override;

--- a/app/src/colorinspector.cpp
+++ b/app/src/colorinspector.cpp
@@ -321,9 +321,9 @@ void ColorInspector::onColorChanged()
     } else {
         c.setHsv(
             ui->RedspinBox->value(),
-            ui->GreenspinBox->value()* 2.55,
-            ui->BluespinBox->value()* 2.55,
-            ui->AlphaspinBox->value()* 2.55);
+                    static_cast<int>(ui->GreenspinBox->value()* 2.55),
+                    static_cast<int>(ui->BluespinBox->value()* 2.55),
+                    static_cast<int>(ui->AlphaspinBox->value()* 2.55));
     }
 
     emit colorChanged(c);

--- a/app/src/colorinspector.h
+++ b/app/src/colorinspector.h
@@ -30,8 +30,8 @@ class ColorInspector : public BaseDockWidget
     friend class ColorSliders;
     
 public:
-    explicit ColorInspector(QWidget *parent = 0);
-    ~ColorInspector();
+    explicit ColorInspector(QWidget *parent = nullptr);
+    ~ColorInspector() override;
     QColor color();
 
     void initUI() override;

--- a/app/src/colorpalettewidget.h
+++ b/app/src/colorpalettewidget.h
@@ -43,7 +43,7 @@ class ColorPaletteWidget : public BaseDockWidget
 public:
 
     explicit ColorPaletteWidget(QWidget* parent);
-    ~ColorPaletteWidget();
+    ~ColorPaletteWidget() override;
 
     void initUI() override;
     void updateUI() override;

--- a/app/src/colorslider.cpp
+++ b/app/src/colorslider.cpp
@@ -19,12 +19,12 @@ ColorSlider::~ColorSlider()
 
 }
 
-void ColorSlider::init(ColorType type, QColor color, qreal min, float max)
+void ColorSlider::init(ColorType type, QColor color, qreal min, qreal max)
 {
     init(type, color, min, max, QSize(this->size()));
 }
 
-void ColorSlider::init(ColorType type, QColor color, qreal min, float max, QSize size)
+void ColorSlider::init(ColorType type, QColor color, qreal min, qreal max, QSize size)
 {
     mMin = min;
     mMax = max;
@@ -298,14 +298,14 @@ void ColorSlider::drawPicker(QColor color)
 
 
     painter.setPen(pen);
-    painter.drawRect(val, 0, mPickerSize.width(), mPickerSize.height());
+    painter.drawRect(static_cast<int>(val), 0, mPickerSize.width(), mPickerSize.height());
     painter.end();
 }
 
 void ColorSlider::colorPicked(QPoint point)
 {
     QColor colorPicked = mColor;
-    int colorMax = mMax;
+    int colorMax = static_cast<int>(mMax);
     int colorVal = 0;
 
     colorVal = point.x()*colorMax/mBoxPixmapSource.width();

--- a/app/src/colorslider.h
+++ b/app/src/colorslider.h
@@ -26,10 +26,10 @@ public:
     };
 
     explicit ColorSlider(QWidget* parent);
-    ~ColorSlider();
+    ~ColorSlider() override;
 
-    void init(ColorType type, QColor color, qreal min, float max);
-    void init(ColorType type, QColor color, qreal min, float max, QSize size);
+    void init(ColorType type, QColor color, qreal min, qreal max);
+    void init(ColorType type, QColor color, qreal min, qreal max, QSize size);
 
     QLinearGradient setColorSpec(QColor color);
 
@@ -50,8 +50,8 @@ public:
     void setColorSpecType(ColorSpecType newType) { this->mSpecType = newType; }
     void setColorType(ColorType newType) { this->mColorType = newType; }
 
-    void setMin(float min) { mMin = min; }
-    void setMax(float max) { mMax = max; }
+    void setMin(qreal min) { mMin = min; }
+    void setMax(qreal max) { mMax = max; }
 
 protected:
     void paintEvent(QPaintEvent* event) override;
@@ -78,8 +78,8 @@ private:
     QPixmap mBoxPixmapSource;
 
     QColor mColor;
-    float mMin = 0.0;
-    float mMax = 0.0;
+    qreal mMin = 0.0;
+    qreal mMax = 0.0;
 
     ColorType mColorType;
     ColorSpecType mSpecType;

--- a/app/src/colorwheel.cpp
+++ b/app/src/colorwheel.cpp
@@ -85,7 +85,7 @@ QColor ColorWheel::pickColor(const QPoint& point)
         hue = (hue > 359) ? 359 : hue;
         hue = (hue < 0) ? 0 : hue;
 
-        return QColor::fromHsv(hue,
+        return QColor::fromHsv(static_cast<int>(hue),
                                mCurrentColor.saturation(),
                                mCurrentColor.value());
     }
@@ -243,7 +243,8 @@ void ColorWheel::drawWheelImage(const QSize &newSize)
     qreal wheelWidth = 2 * ir / qSqrt(2);
 
     // Calculate wheel region
-    mWheelRegion = QRegion(m1, m2, wheelWidth, wheelWidth);
+    mWheelRegion = QRegion(static_cast<int>(m1), static_cast<int>(m2),
+                           static_cast<int>(wheelWidth), static_cast<int>(wheelWidth));
 }
 
 void ColorWheel::drawSquareImage(const int &hue)
@@ -280,8 +281,9 @@ void ColorWheel::drawSquareImage(const int &hue)
     painter.fillRect(square.rect(), blackGradiantBrush);
 
     qreal SquareWidth = 2 * ir / qSqrt(2.1);
-    mSquareImage = square.scaled(SquareWidth, SquareWidth);
-    mSquareRegion = QRegion(m1, m2, SquareWidth, SquareWidth);
+    mSquareImage = square.scaled(static_cast<int>(SquareWidth), static_cast<int>(SquareWidth));
+    mSquareRegion = QRegion(static_cast<int>(m1), static_cast<int>(m2),
+                            static_cast<int>(SquareWidth), static_cast<int>(SquareWidth));
 }
 
 void ColorWheel::drawHueIndicator(const int &hue)
@@ -334,7 +336,7 @@ void ColorWheel::drawPicker(const QColor& color)
     transform.translate(-ellipseSize/2,-ellipseSize/2);
     transform.translate(squareTopLeft.x()+2,squareTopLeft.y()+2);
     painter.setTransform(transform);
-    painter.drawEllipse(S, V, ellipseSize, ellipseSize);
+    painter.drawEllipse(static_cast<int>(S), static_cast<int>(V), ellipseSize, ellipseSize);
 }
 
 void ColorWheel::composeWheel(QPixmap& pixmap)

--- a/app/src/displayoptionwidget.h
+++ b/app/src/displayoptionwidget.h
@@ -32,7 +32,7 @@ class DisplayOptionWidget : public BaseDockWidget
     Q_OBJECT
 public:
     explicit DisplayOptionWidget(QWidget* parent);
-    virtual ~DisplayOptionWidget();
+    virtual ~DisplayOptionWidget() override;
 
     void initUI() override;
     void updateUI() override;

--- a/app/src/doubleprogressdialog.cpp
+++ b/app/src/doubleprogressdialog.cpp
@@ -73,17 +73,17 @@ void DoubleProgressDialog::ProgressBarControl::setValue(float value)
 
 int DoubleProgressDialog::ProgressBarControl::getPrecision()
 {
-    return qLn(unitFactor) / qLn(10);
+    return static_cast<int>(qLn(unitFactor) / qLn(10));
 }
 
 void DoubleProgressDialog::ProgressBarControl::setPrecision(int e)
 {
     int oldFactor = unitFactor;
-    unitFactor = qPow(10, e);
+    unitFactor = static_cast<int>(qPow(10, e));
 
-    min *= unitFactor / (float)oldFactor;
-    max *= unitFactor / (float)oldFactor;
-    val *= unitFactor / (float)oldFactor;
+    min *= unitFactor / static_cast<float>(oldFactor);
+    max *= unitFactor / static_cast<float>(oldFactor);
+    val *= unitFactor / static_cast<float>(oldFactor);
 }
 
 int DoubleProgressDialog::ProgressBarControl::convertUnits(float value)

--- a/app/src/doubleprogressdialog.h
+++ b/app/src/doubleprogressdialog.h
@@ -30,7 +30,7 @@ class DoubleProgressDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit DoubleProgressDialog(QWidget *parent = 0);
+    explicit DoubleProgressDialog(QWidget *parent = nullptr);
     ~DoubleProgressDialog();
 
     QString getStatus();

--- a/app/src/errordialog.h
+++ b/app/src/errordialog.h
@@ -29,7 +29,7 @@ class ErrorDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ErrorDialog(QString title, QString description, QString details = QString(), QWidget *parent = 0 );
+    explicit ErrorDialog(QString title, QString description, QString details = QString(), QWidget *parent = nullptr);
     ~ErrorDialog();
 
 private:

--- a/app/src/exportmoviedialog.h
+++ b/app/src/exportmoviedialog.h
@@ -31,7 +31,7 @@ class ExportMovieDialog : public ImportExportDialog
     Q_OBJECT
 
 public:
-    explicit ExportMovieDialog(QWidget* parent = 0, Mode mode = ImportExportDialog::Export, FileType fileType = FileType::MOVIE);
+    explicit ExportMovieDialog(QWidget* parent = nullptr, Mode mode = ImportExportDialog::Export, FileType fileType = FileType::MOVIE);
     ~ExportMovieDialog();
 
     void setCamerasInfo(const std::vector<std::pair<QString, QSize>>);

--- a/app/src/importimageseqdialog.h
+++ b/app/src/importimageseqdialog.h
@@ -29,7 +29,7 @@ class ImportImageSeqDialog : public ImportExportDialog
     Q_OBJECT
 
 public:
-    explicit ImportImageSeqDialog(QWidget *parent = 0, Mode mode = ImportExportDialog::Import, FileType fileType = FileType::IMAGE_SEQUENCE);
+    explicit ImportImageSeqDialog(QWidget *parent = nullptr, Mode mode = ImportExportDialog::Import, FileType fileType = FileType::IMAGE_SEQUENCE);
     ~ImportImageSeqDialog();
 
     int getSpace();

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -304,6 +304,8 @@ void MainWindow2::createMenus()
     connect(pPlaybackManager, &PlaybackManager::playStateChanged, mTimeLine, &TimeLine::setPlaying);
     connect(pPlaybackManager, &PlaybackManager::playStateChanged, this, &MainWindow2::changePlayState);
     connect(pPlaybackManager, &PlaybackManager::playStateChanged, mEditor, &Editor::updateCurrentFrame);
+    connect(ui->actionFlip_Roll, &QAction::triggered, pPlaybackManager, &PlaybackManager::playFlipRoll);
+    connect(ui->actionFlip_InBetween, &QAction::triggered, pPlaybackManager, &PlaybackManager::playFlipBtwn);
 
     connect(ui->actionAdd_Frame, &QAction::triggered, mCommands, &ActionCommands::addNewKey);
     connect(ui->actionRemove_Frame, &QAction::triggered, mCommands, &ActionCommands::removeKey);

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -400,7 +400,7 @@ void MainWindow2::clearRecentFilesList()
     if (!recentFilesList.isEmpty())
     {
         mRecentFileMenu->clear();
-        QMessageBox::information(this, 0,
+        QMessageBox::information(this, nullptr,
                                  tr("\n\n You have successfully cleared the list"),
                                  QMessageBox::Ok);
     }
@@ -1265,7 +1265,7 @@ void MainWindow2::bindActionWithSetting(QAction* action, SETTING setting)
 void MainWindow2::updateZoomLabel()
 {
     float zoom = mEditor->view()->scaling() * 100.f;
-    statusBar()->showMessage(QString("Zoom: %0%1").arg(zoom, 0, 'f', 1).arg("%"));
+    statusBar()->showMessage(QString("Zoom: %0%1").arg(static_cast<double>(zoom), 0, 'f', 1).arg("%"));
 }
 
 void MainWindow2::changePlayState(bool isPlaying)

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -55,8 +55,8 @@ class MainWindow2 : public QMainWindow
     Q_OBJECT
 
 public:
-    explicit MainWindow2(QWidget* parent = 0);
-    ~MainWindow2();
+    explicit MainWindow2(QWidget* parent = nullptr);
+    ~MainWindow2() override;
 
     Editor* mEditor = nullptr;
 

--- a/app/src/preferencesdialog.h
+++ b/app/src/preferencesdialog.h
@@ -40,7 +40,7 @@ class PreferencesDialog : public QDialog
 
 public:
     PreferencesDialog(QWidget* parent);
-    ~PreferencesDialog();
+    ~PreferencesDialog() override;
 
     void init(PreferenceManager* m);
     void updateRecentListBtn(bool isEmpty);

--- a/app/src/preview.h
+++ b/app/src/preview.h
@@ -42,7 +42,7 @@ class PreviewWidget : public QDockWidget
 {
     Q_OBJECT
 public:
-    PreviewWidget(QWidget *parent = 0);
+    PreviewWidget(QWidget *parent = nullptr);
 	void setImage( BitmapImage* img ) { mCanvas->setImage( img ); }
 	void updateImage();
 

--- a/app/src/shortcutspage.h
+++ b/app/src/shortcutspage.h
@@ -38,7 +38,7 @@ class ShortcutsPage : public QWidget
 {
     Q_OBJECT
 public:
-    explicit ShortcutsPage(QWidget* parent = 0);
+    explicit ShortcutsPage(QWidget* parent = nullptr);
 
     void setManager( PreferenceManager* p ) { mManager = p; }
 

--- a/app/src/spinslider.cpp
+++ b/app/src/spinslider.cpp
@@ -34,7 +34,7 @@ void SpinSlider::init(QString text, GROWTH_TYPE type, VALUE_TYPE dataType, qreal
     if (type == LOG)
     {
         // important! dividing by zero is not acceptable.
-        Q_ASSERT_X(min > 0.f, "SpinSlider", "Real type value must larger than 0!!");
+        Q_ASSERT_X(min > 0.0, "SpinSlider", "Real type value must larger than 0!!");
     }
 
     mValue = 1.0;
@@ -96,15 +96,15 @@ void SpinSlider::setValue(qreal v)
     int value2 = 0;
     if (mGrowthType == LINEAR)
     {
-        value2 = std::round(mSlider->maximum() * (v - mMin) / (mMax - mMin));
+        value2 = static_cast<int>(std::round(mSlider->maximum() * (v - mMin) / (mMax - mMin)));
     }
     else if (mGrowthType == LOG)
     {
-        value2 = std::round(std::log(v / mMin) * mSlider->maximum() / std::log(mMax / mMin));
+        value2 = static_cast<int>(std::round(std::log(v / mMin) * mSlider->maximum() / std::log(mMax / mMin)));
     }
     else if (mGrowthType == EXPONENT)
     {
-        value2 = std::round(std::pow((v - mMin) * std::pow(mSlider->maximum(), mExp) / (mMax - mMin), 1 / mExp));
+        value2 = static_cast<int>(std::round(std::pow((v - mMin) * std::pow(mSlider->maximum(), mExp) / (mMax - mMin), 1 / mExp)));
     }
 
     changeValue(v);
@@ -113,7 +113,8 @@ void SpinSlider::setValue(qreal v)
 
 void SpinSlider::setPixelPos(qreal min, qreal max, int val, int space, bool upsideDown)
 {
-    mSlider->setSliderPosition(QStyle::sliderValueFromPosition(min, max, val, space, upsideDown));
+    mSlider->setSliderPosition(QStyle::sliderValueFromPosition(static_cast<int>(min),
+                                                               static_cast<int>(max), val, space, upsideDown));
 }
 
 void SpinSlider::setExponent(const qreal exp)

--- a/app/src/timeline2.h
+++ b/app/src/timeline2.h
@@ -30,8 +30,8 @@ class Timeline2 : public BaseDockWidget
     Q_OBJECT
 
 public:
-    explicit Timeline2(QWidget* parent = 0);
-    ~Timeline2();
+    explicit Timeline2(QWidget* parent = nullptr);
+    ~Timeline2() override;
 
     void initUI() override;
     void updateUI() override;

--- a/app/src/toolbox.h
+++ b/app/src/toolbox.h
@@ -38,7 +38,7 @@ class ToolBoxWidget : public BaseDockWidget
 
 public:
     ToolBoxWidget(QWidget* parent);
-    ~ToolBoxWidget();
+    ~ToolBoxWidget() override;
 
     void initUI() override;
     void updateUI() override;

--- a/app/src/tooloptionwidget.cpp
+++ b/app/src/tooloptionwidget.cpp
@@ -78,7 +78,7 @@ void ToolOptionWidget::updateUI()
     setVectorMergeEnabled(p.vectorMergeEnabled);
     setAA(p.useAA);
     setStabilizerLevel(p.stabilizerLevel);
-    setTolerance(p.tolerance);
+    setTolerance(static_cast<int>(p.tolerance));
     setFillContour(p.useFillContour);
 }
 
@@ -132,7 +132,7 @@ void ToolOptionWidget::onToolPropertyChanged(ToolType, ToolPropertyType ePropert
     case VECTORMERGE: setVectorMergeEnabled(p.vectorMergeEnabled); break;
     case ANTI_ALIASING: setAA(p.useAA); break;
     case STABILIZATION: setStabilizerLevel(p.stabilizerLevel); break;
-    case TOLERANCE: setTolerance(p.tolerance); break;
+    case TOLERANCE: setTolerance(static_cast<int>(p.tolerance)); break;
     case FILLCONTOUR: setFillContour(p.useFillContour); break;
     case BEZIER: setBezier(p.bezier_state); break;
     default:

--- a/app/src/tooloptionwidget.h
+++ b/app/src/tooloptionwidget.h
@@ -40,7 +40,7 @@ class ToolOptionWidget : public BaseDockWidget
     Q_OBJECT
 public:
     explicit ToolOptionWidget(QWidget* parent);
-    virtual ~ToolOptionWidget();
+    virtual ~ToolOptionWidget() override;
 
     void initUI() override;
     void updateUI() override;

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -49,7 +49,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>21</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -166,6 +166,9 @@
     <addaction name="separator"/>
     <addaction name="actionMove_Frame_Forward"/>
     <addaction name="actionMove_Frame_Backward"/>
+    <addaction name="separator"/>
+    <addaction name="actionFlip_Roll"/>
+    <addaction name="actionFlip_InBetween"/>
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
@@ -886,6 +889,22 @@
   <action name="actionExport_Animated_GIF">
    <property name="text">
     <string>Animated GIF...</string>
+   </property>
+  </action>
+  <action name="actionFlip_Roll">
+   <property name="text">
+    <string>Flip Roll</string>
+   </property>
+   <property name="shortcut">
+    <string>Alt+Z</string>
+   </property>
+  </action>
+  <action name="actionFlip_InBetween">
+   <property name="text">
+    <string>Flip InBetween</string>
+   </property>
+   <property name="shortcut">
+    <string>Alt+X</string>
    </property>
   </action>
  </widget>

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -231,7 +231,7 @@ void Editor::backup(int backupLayer, int backupFrame, QString undoText)
     }
 
     Layer* layer = mObject->getLayer(backupLayer);
-    if (layer != NULL)
+    if (layer != nullptr)
     {
         if (layer->type() == Layer::BITMAP)
         {
@@ -240,7 +240,7 @@ void Editor::backup(int backupLayer, int backupFrame, QString undoText)
                 int previous = layer->getPreviousKeyFramePosition(backupFrame);
                 bitmapImage = static_cast<LayerBitmap*>(layer)->getBitmapImageAtFrame(previous);
             }
-            if (bitmapImage != NULL)
+            if (bitmapImage != nullptr)
             {
                 BackupBitmapElement* element = new BackupBitmapElement(bitmapImage);
                 element->layer = backupLayer;
@@ -257,7 +257,7 @@ void Editor::backup(int backupLayer, int backupFrame, QString undoText)
         else if (layer->type() == Layer::VECTOR)
         {
             VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(backupFrame, 0);
-            if (vectorImage != NULL)
+            if (vectorImage != nullptr)
             {
                 BackupVectorElement* element = new BackupVectorElement(vectorImage);
                 element->layer = backupLayer;
@@ -312,7 +312,7 @@ void Editor::restoreKey()
     int layerIndex = 0;
     if (lastBackupElement->type() == BackupElement::BITMAP_MODIF)
     {
-        BackupBitmapElement* lastBackupBitmapElement = (BackupBitmapElement*)lastBackupElement;
+        BackupBitmapElement* lastBackupBitmapElement = static_cast<BackupBitmapElement*>(lastBackupElement);
         layerIndex = lastBackupBitmapElement->layer;
         frame = lastBackupBitmapElement->frame;
         layer = object()->getLayer(layerIndex);
@@ -321,7 +321,7 @@ void Editor::restoreKey()
     }
     if (lastBackupElement->type() == BackupElement::VECTOR_MODIF)
     {
-        BackupVectorElement* lastBackupVectorElement = (BackupVectorElement*)lastBackupElement;
+        BackupVectorElement* lastBackupVectorElement = static_cast<BackupVectorElement*>(lastBackupElement);
         layerIndex = lastBackupVectorElement->layer;
         frame = lastBackupVectorElement->frame;
         layer = object()->getLayer(layerIndex);
@@ -331,7 +331,7 @@ void Editor::restoreKey()
     if (lastBackupElement->type() == BackupElement::SOUND_MODIF)
     {
         QString strSoundFile;
-        BackupSoundElement* lastBackupSoundElement = (BackupSoundElement*)lastBackupElement;
+        BackupSoundElement* lastBackupSoundElement = static_cast<BackupSoundElement*>(lastBackupElement);
         layerIndex = lastBackupSoundElement->layer;
         frame = lastBackupSoundElement->frame;
 
@@ -367,7 +367,7 @@ void BackupBitmapElement::restore(Editor* editor)
     }
     else
     {
-        if (layer != NULL)
+        if (layer != nullptr)
         {
             if (layer->type() == Layer::BITMAP)
             {
@@ -391,7 +391,7 @@ void BackupVectorElement::restore(Editor* editor)
     }
     else
     {
-        if (layer != NULL)
+        if (layer != nullptr)
         {
             if (layer->type() == Layer::VECTOR)
             {
@@ -424,19 +424,19 @@ void Editor::undo()
             BackupElement* lastBackupElement = mBackupList[mBackupIndex];
             if (lastBackupElement->type() == BackupElement::BITMAP_MODIF)
             {
-                BackupBitmapElement* lastBackupBitmapElement = (BackupBitmapElement*)lastBackupElement;
+                BackupBitmapElement* lastBackupBitmapElement = static_cast<BackupBitmapElement*>(lastBackupElement);
                 backup(lastBackupBitmapElement->layer, lastBackupBitmapElement->frame, "NoOp");
                 mBackupIndex--;
             }
             if (lastBackupElement->type() == BackupElement::VECTOR_MODIF)
             {
-                BackupVectorElement* lastBackupVectorElement = (BackupVectorElement*)lastBackupElement;
+                BackupVectorElement* lastBackupVectorElement = static_cast<BackupVectorElement*>(lastBackupElement);
                 backup(lastBackupVectorElement->layer, lastBackupVectorElement->frame, "NoOp");
                 mBackupIndex--;
             }
             if (lastBackupElement->type() == BackupElement::SOUND_MODIF)
             {
-                BackupSoundElement* lastBackupSoundElement = (BackupSoundElement*)lastBackupElement;
+                BackupSoundElement* lastBackupSoundElement = static_cast<BackupSoundElement*>(lastBackupElement);
                 backup(lastBackupSoundElement->layer, lastBackupSoundElement->frame, "NoOp");
                 mBackupIndex--;
             }
@@ -495,14 +495,14 @@ void Editor::cut()
 void Editor::copy()
 {
     Layer* layer = mObject->getLayer(layers()->currentLayerIndex());
-    if (layer == NULL) 
+    if (layer == nullptr)
     {
         return;
     }
 
     if (layer->type() == Layer::BITMAP)
     {
-        LayerBitmap* layerBitmap = (LayerBitmap*)layer;
+        LayerBitmap* layerBitmap = static_cast<LayerBitmap*>(layer);
         if (mScribbleArea->isSomethingSelected())
         {
             g_clipboardBitmapImage = layerBitmap->getLastBitmapImageAtFrame(currentFrame(), 0)->copy(mScribbleArea->getSelection().toRect());  // copy part of the image
@@ -512,22 +512,22 @@ void Editor::copy()
             g_clipboardBitmapImage = layerBitmap->getLastBitmapImageAtFrame(currentFrame(), 0)->copy();  // copy the whole image
         }
         clipboardBitmapOk = true;
-        if (g_clipboardBitmapImage.image() != NULL)
+        if (g_clipboardBitmapImage.image() != nullptr)
             QApplication::clipboard()->setImage(*g_clipboardBitmapImage.image());
     }
     if (layer->type() == Layer::VECTOR)
     {
         clipboardVectorOk = true;
-        g_clipboardVectorImage = *(((LayerVector*)layer)->getLastVectorImageAtFrame(currentFrame(), 0));  // copy the image
+        g_clipboardVectorImage = *((static_cast<LayerVector*>(layer))->getLastVectorImageAtFrame(currentFrame(), 0));  // copy the image
     }
 }
 
 void Editor::paste()
 {
     Layer* layer = mObject->getLayer(layers()->currentLayerIndex());
-    if (layer != NULL)
+    if (layer != nullptr)
     {
-        if (layer->type() == Layer::BITMAP && g_clipboardBitmapImage.image() != NULL)
+        if (layer->type() == Layer::BITMAP && g_clipboardBitmapImage.image() != nullptr)
         {
             backup(tr("Paste"));
 
@@ -552,7 +552,7 @@ void Editor::paste()
         {
             backup(tr("Paste"));
             mScribbleArea->deselectAll();
-            VectorImage* vectorImage = ((LayerVector*)layer)->getLastVectorImageAtFrame(currentFrame(), 0);
+            VectorImage* vectorImage = (static_cast<LayerVector*>(layer))->getLastVectorImageAtFrame(currentFrame(), 0);
             vectorImage->paste(g_clipboardVectorImage);  // paste the clipboard
             mScribbleArea->setSelection(vectorImage->getSelectionRect());
         }
@@ -698,7 +698,7 @@ bool Editor::exportSeqCLI(QString filePath, LayerCamera *cameraLayer, QString fo
                           format,
                           transparency,
                           antialias,
-                          NULL,
+                          nullptr,
                           0);
     return true;
 }
@@ -794,11 +794,11 @@ bool Editor::importVectorImage(QString filePath)
 
     auto layer = static_cast<LayerVector*>(layers()->currentLayer());
 
-    VectorImage* vectorImage = ((LayerVector*)layer)->getVectorImageAtFrame(currentFrame());
-    if (vectorImage == NULL)
+    VectorImage* vectorImage = (static_cast<LayerVector*>(layer))->getVectorImageAtFrame(currentFrame());
+    if (vectorImage == nullptr)
     {
         addNewKey();
-        vectorImage = ((LayerVector*)layer)->getVectorImageAtFrame(currentFrame());
+        vectorImage = (static_cast<LayerVector*>(layer))->getVectorImageAtFrame(currentFrame());
     }
 
     VectorImage importedVectorImage;
@@ -910,7 +910,7 @@ KeyFrame* Editor::addNewKey()
 KeyFrame* Editor::addKeyFrame(int layerNumber, int frameIndex)
 {
     Layer* layer = mObject->getLayer(layerNumber);
-    if (layer == NULL)
+    if (layer == nullptr)
     {
         Q_ASSERT(false);
         return nullptr;
@@ -966,7 +966,7 @@ void Editor::scrubPreviousKeyFrame()
 void Editor::switchVisibilityOfLayer(int layerNumber)
 {
     Layer* layer = mObject->getLayer(layerNumber);
-    if (layer != NULL) layer->switchVisibility();
+    if (layer != nullptr) layer->switchVisibility();
     mScribbleArea->updateAllFrames();
 
     emit updateTimeLine();

--- a/core_lib/src/managers/playbackmanager.cpp
+++ b/core_lib/src/managers/playbackmanager.cpp
@@ -77,12 +77,11 @@ Status PlaybackManager::save(Object* o)
 
 bool PlaybackManager::isPlaying()
 {
-    return mTimer->isActive();
+    return (mTimer->isActive() || mFlipTimer->isActive());
 }
 
 void PlaybackManager::play()
 {
-    if (isPlaying()) { return; }
     updateStartFrame();
     updateEndFrame();
 

--- a/core_lib/src/managers/playbackmanager.cpp
+++ b/core_lib/src/managers/playbackmanager.cpp
@@ -82,6 +82,7 @@ bool PlaybackManager::isPlaying()
 
 void PlaybackManager::play()
 {
+    if (isPlaying()) { return; }
     updateStartFrame();
     updateEndFrame();
 
@@ -169,8 +170,6 @@ void PlaybackManager::playFlipBtwn()
 {
     if (isPlaying()) { return; }
     int start = editor()->currentFrame();
-    if (!editor()->layers()->currentLayer()->keyExists(start)) { return; }
-
     int prev = editor()->layers()->currentLayer()->getPreviousKeyFramePosition(start);
     int next = editor()->layers()->currentLayer()->getNextKeyFramePosition(start);
     if (editor()->layers()->currentLayer()->keyExists(prev) &&
@@ -178,7 +177,6 @@ void PlaybackManager::playFlipBtwn()
     {
         mFlipList.clear();
         mFlipList.append(QString::number(prev));
-        mFlipList.append(QString::number(next));
         mFlipList.append(QString::number(start));
         mFlipList.append(QString::number(next));
         mFlipList.append(QString::number(start));

--- a/core_lib/src/managers/playbackmanager.h
+++ b/core_lib/src/managers/playbackmanager.h
@@ -29,7 +29,7 @@ class PlaybackManager : public BaseManager
     Q_OBJECT
 public:
     explicit PlaybackManager(Editor* editor);
-    ~PlaybackManager();
+    ~PlaybackManager() override;
 
     bool init() override;
     Status load(Object*) override;
@@ -41,6 +41,8 @@ public:
 
     void play();
     void stop();
+    void playFlipRoll();
+    void playFlipBtwn();
 
     int fps() { return mFps; }
     int startFrame() { return mStartFrame; }
@@ -67,6 +69,7 @@ Q_SIGNALS:
 
 private:
     void timerTick();
+    void flipTimerTick();
     void playSounds(int frame);
     bool skipFrame();
 
@@ -87,11 +90,13 @@ private:
     int mFps = 12;
 
     QTimer* mTimer = nullptr;
+    QTimer* mFlipTimer = nullptr;
     QElapsedTimer* mElapsedTimer = nullptr;
     int mPlayingFrameCounter = 0; // how many frames has passed after pressing play
 
     bool mCheckForSoundsHalfway = false;
     QList<int> mListOfActiveSoundFrames;
+    QStringList mFlipList;
 };
 
 #endif // PLAYBACKMANAGER_H


### PR DESCRIPTION
This PR addresses issue #978 - the flip-requests.
Flip roll is triggered by Alt + Z, and flip InBetween is triggered by Alt + X. These shortcuts are not yet implemented in the preference manager.
When the flips are triggered, the keyframes are played at an even tempo of 200 msecs/frame. This number is hardcoded, but should be set by the user to a value between 100 and 500 msecs.
The number of drawings in the flip roll is hardcoded to up to ten. Here the user should be able to set a maximum number of frames as well - I think...
By accident, this branch is not checked out from 'master' as I usually do, but from a branch called 'master_resolvewarnings' that I have been working on. For that reason the PR also includes a lot of resolved warnings...