### PR TITLE
Master resolve warnings

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -309,7 +309,7 @@ Status ActionCommands::exportImageSequence()
     int endFrame  = dialog->getEndFrame();
 
     QString sCameraLayerName = dialog->getCameraLayerName();
-    LayerCamera* cameraLayer = (LayerCamera*)mEditor->layers()->findLayerByName(sCameraLayerName, Layer::CAMERA);
+    LayerCamera* cameraLayer = static_cast<LayerCamera*>(mEditor->layers()->findLayerByName(sCameraLayerName, Layer::CAMERA));
 
     // Show a progress dialog, as this can take a while if you have lots of frames.
     QProgressDialog progress(tr("Exporting image sequence..."), tr("Abort"), 0, 100, mParent);
@@ -376,7 +376,7 @@ Status ActionCommands::exportImage()
 
     // Export
     QString sCameraLayerName = dialog->getCameraLayerName();
-    LayerCamera* cameraLayer = (LayerCamera*)mEditor->layers()->findLayerByName(sCameraLayerName, Layer::CAMERA);
+    LayerCamera* cameraLayer = static_cast<LayerCamera*>(mEditor->layers()->findLayerByName(sCameraLayerName, Layer::CAMERA));
 
     QTransform view = cameraLayer->getViewAtFrame(mEditor->currentFrame());
 
@@ -536,7 +536,7 @@ void ActionCommands::removeKey()
 void ActionCommands::duplicateKey()
 {
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer == NULL) return;
+    if (layer == nullptr) return;
 
     KeyFrame* key = layer->getKeyFrameAt(mEditor->currentFrame());
     if (key == nullptr) return;

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -29,7 +29,7 @@ class ActionCommands : public QObject
     Q_OBJECT
 
 public:
-    explicit ActionCommands(QWidget* parent = 0);
+    explicit ActionCommands(QWidget* parent = nullptr);
     virtual ~ActionCommands();
 
     void setCore(Editor* e) { mEditor = e; }

--- a/app/src/colorbox.h
+++ b/app/src/colorbox.h
@@ -26,7 +26,7 @@ class ColorBox : public BaseDockWidget
 
 public:
     explicit ColorBox( QWidget* parent );
-    virtual ~ColorBox();
+    virtual ~ColorBox() override;
 
     void initUI() override;
     void updateUI() override;

--- a/app/src/colorinspector.cpp
+++ b/app/src/colorinspector.cpp
@@ -321,9 +321,9 @@ void ColorInspector::onColorChanged()
     } else {
         c.setHsv(
             ui->RedspinBox->value(),
-            ui->GreenspinBox->value()* 2.55,
-            ui->BluespinBox->value()* 2.55,
-            ui->AlphaspinBox->value()* 2.55);
+                    static_cast<int>(ui->GreenspinBox->value()* 2.55),
+                    static_cast<int>(ui->BluespinBox->value()* 2.55),
+                    static_cast<int>(ui->AlphaspinBox->value()* 2.55));
     }
 
     emit colorChanged(c);

--- a/app/src/colorinspector.cpp
+++ b/app/src/colorinspector.cpp
@@ -321,9 +321,9 @@ void ColorInspector::onColorChanged()
     } else {
         c.setHsv(
             ui->RedspinBox->value(),
-                    static_cast<int>(ui->GreenspinBox->value()* 2.55),
-                    static_cast<int>(ui->BluespinBox->value()* 2.55),
-                    static_cast<int>(ui->AlphaspinBox->value()* 2.55));
+            static_cast<int>(ui->GreenspinBox->value()* 2.55),
+            static_cast<int>(ui->BluespinBox->value()* 2.55),
+            static_cast<int>(ui->AlphaspinBox->value()* 2.55));
     }
 
     emit colorChanged(c);

--- a/app/src/colorinspector.h
+++ b/app/src/colorinspector.h
@@ -30,8 +30,8 @@ class ColorInspector : public BaseDockWidget
     friend class ColorSliders;
     
 public:
-    explicit ColorInspector(QWidget *parent = 0);
-    ~ColorInspector();
+    explicit ColorInspector(QWidget *parent = nullptr);
+    ~ColorInspector() override;
     QColor color();
 
     void initUI() override;

--- a/app/src/colorpalettewidget.h
+++ b/app/src/colorpalettewidget.h
@@ -43,7 +43,7 @@ class ColorPaletteWidget : public BaseDockWidget
 public:
 
     explicit ColorPaletteWidget(QWidget* parent);
-    ~ColorPaletteWidget();
+    ~ColorPaletteWidget() override;
 
     void initUI() override;
     void updateUI() override;

--- a/app/src/colorslider.cpp
+++ b/app/src/colorslider.cpp
@@ -19,12 +19,12 @@ ColorSlider::~ColorSlider()
 
 }
 
-void ColorSlider::init(ColorType type, QColor color, qreal min, float max)
+void ColorSlider::init(ColorType type, QColor color, qreal min, qreal max)
 {
     init(type, color, min, max, QSize(this->size()));
 }
 
-void ColorSlider::init(ColorType type, QColor color, qreal min, float max, QSize size)
+void ColorSlider::init(ColorType type, QColor color, qreal min, qreal max, QSize size)
 {
     mMin = min;
     mMax = max;
@@ -298,14 +298,14 @@ void ColorSlider::drawPicker(QColor color)
 
 
     painter.setPen(pen);
-    painter.drawRect(val, 0, mPickerSize.width(), mPickerSize.height());
+    painter.drawRect(static_cast<int>(val), 0, mPickerSize.width(), mPickerSize.height());
     painter.end();
 }
 
 void ColorSlider::colorPicked(QPoint point)
 {
     QColor colorPicked = mColor;
-    int colorMax = mMax;
+    int colorMax = static_cast<int>(mMax);
     int colorVal = 0;
 
     colorVal = point.x()*colorMax/mBoxPixmapSource.width();

--- a/app/src/colorslider.h
+++ b/app/src/colorslider.h
@@ -26,10 +26,10 @@ public:
     };
 
     explicit ColorSlider(QWidget* parent);
-    ~ColorSlider();
+    ~ColorSlider() override;
 
-    void init(ColorType type, QColor color, qreal min, float max);
-    void init(ColorType type, QColor color, qreal min, float max, QSize size);
+    void init(ColorType type, QColor color, qreal min, qreal max);
+    void init(ColorType type, QColor color, qreal min, qreal max, QSize size);
 
     QLinearGradient setColorSpec(QColor color);
 
@@ -50,8 +50,8 @@ public:
     void setColorSpecType(ColorSpecType newType) { this->mSpecType = newType; }
     void setColorType(ColorType newType) { this->mColorType = newType; }
 
-    void setMin(float min) { mMin = min; }
-    void setMax(float max) { mMax = max; }
+    void setMin(qreal min) { mMin = min; }
+    void setMax(qreal max) { mMax = max; }
 
 protected:
     void paintEvent(QPaintEvent* event) override;
@@ -78,8 +78,8 @@ private:
     QPixmap mBoxPixmapSource;
 
     QColor mColor;
-    float mMin = 0.0;
-    float mMax = 0.0;
+    qreal mMin = 0.0;
+    qreal mMax = 0.0;
 
     ColorType mColorType;
     ColorSpecType mSpecType;

--- a/app/src/colorwheel.cpp
+++ b/app/src/colorwheel.cpp
@@ -85,7 +85,7 @@ QColor ColorWheel::pickColor(const QPoint& point)
         hue = (hue > 359) ? 359 : hue;
         hue = (hue < 0) ? 0 : hue;
 
-        return QColor::fromHsv(hue,
+        return QColor::fromHsv(static_cast<int>(hue),
                                mCurrentColor.saturation(),
                                mCurrentColor.value());
     }
@@ -243,7 +243,8 @@ void ColorWheel::drawWheelImage(const QSize &newSize)
     qreal wheelWidth = 2 * ir / qSqrt(2);
 
     // Calculate wheel region
-    mWheelRegion = QRegion(m1, m2, wheelWidth, wheelWidth);
+    mWheelRegion = QRegion(static_cast<int>(m1), static_cast<int>(m2),
+                           static_cast<int>(wheelWidth), static_cast<int>(wheelWidth));
 }
 
 void ColorWheel::drawSquareImage(const int &hue)
@@ -280,8 +281,9 @@ void ColorWheel::drawSquareImage(const int &hue)
     painter.fillRect(square.rect(), blackGradiantBrush);
 
     qreal SquareWidth = 2 * ir / qSqrt(2.1);
-    mSquareImage = square.scaled(SquareWidth, SquareWidth);
-    mSquareRegion = QRegion(m1, m2, SquareWidth, SquareWidth);
+    mSquareImage = square.scaled(static_cast<int>(SquareWidth), static_cast<int>(SquareWidth));
+    mSquareRegion = QRegion(static_cast<int>(m1), static_cast<int>(m2),
+                            static_cast<int>(SquareWidth), static_cast<int>(SquareWidth));
 }
 
 void ColorWheel::drawHueIndicator(const int &hue)
@@ -334,7 +336,7 @@ void ColorWheel::drawPicker(const QColor& color)
     transform.translate(-ellipseSize/2,-ellipseSize/2);
     transform.translate(squareTopLeft.x()+2,squareTopLeft.y()+2);
     painter.setTransform(transform);
-    painter.drawEllipse(S, V, ellipseSize, ellipseSize);
+    painter.drawEllipse(static_cast<int>(S), static_cast<int>(V), ellipseSize, ellipseSize);
 }
 
 void ColorWheel::composeWheel(QPixmap& pixmap)

--- a/app/src/displayoptionwidget.h
+++ b/app/src/displayoptionwidget.h
@@ -32,7 +32,7 @@ class DisplayOptionWidget : public BaseDockWidget
     Q_OBJECT
 public:
     explicit DisplayOptionWidget(QWidget* parent);
-    virtual ~DisplayOptionWidget();
+    virtual ~DisplayOptionWidget() override;
 
     void initUI() override;
     void updateUI() override;

--- a/app/src/doubleprogressdialog.cpp
+++ b/app/src/doubleprogressdialog.cpp
@@ -73,17 +73,17 @@ void DoubleProgressDialog::ProgressBarControl::setValue(float value)
 
 int DoubleProgressDialog::ProgressBarControl::getPrecision()
 {
-    return qLn(unitFactor) / qLn(10);
+    return static_cast<int>(qLn(unitFactor) / qLn(10));
 }
 
 void DoubleProgressDialog::ProgressBarControl::setPrecision(int e)
 {
     int oldFactor = unitFactor;
-    unitFactor = qPow(10, e);
+    unitFactor = static_cast<int>(qPow(10, e));
 
-    min *= unitFactor / (float)oldFactor;
-    max *= unitFactor / (float)oldFactor;
-    val *= unitFactor / (float)oldFactor;
+    min *= unitFactor / static_cast<float>(oldFactor);
+    max *= unitFactor / static_cast<float>(oldFactor);
+    val *= unitFactor / static_cast<float>(oldFactor);
 }
 
 int DoubleProgressDialog::ProgressBarControl::convertUnits(float value)

--- a/app/src/doubleprogressdialog.h
+++ b/app/src/doubleprogressdialog.h
@@ -30,7 +30,7 @@ class DoubleProgressDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit DoubleProgressDialog(QWidget *parent = 0);
+    explicit DoubleProgressDialog(QWidget *parent = nullptr);
     ~DoubleProgressDialog();
 
     QString getStatus();

--- a/app/src/errordialog.h
+++ b/app/src/errordialog.h
@@ -29,7 +29,7 @@ class ErrorDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ErrorDialog(QString title, QString description, QString details = QString(), QWidget *parent = 0 );
+    explicit ErrorDialog(QString title, QString description, QString details = QString(), QWidget *parent = nullptr);
     ~ErrorDialog();
 
 private:

--- a/app/src/exportmoviedialog.h
+++ b/app/src/exportmoviedialog.h
@@ -31,7 +31,7 @@ class ExportMovieDialog : public ImportExportDialog
     Q_OBJECT
 
 public:
-    explicit ExportMovieDialog(QWidget* parent = 0, Mode mode = ImportExportDialog::Export, FileType fileType = FileType::MOVIE);
+    explicit ExportMovieDialog(QWidget* parent = nullptr, Mode mode = ImportExportDialog::Export, FileType fileType = FileType::MOVIE);
     ~ExportMovieDialog();
 
     void setCamerasInfo(const std::vector<std::pair<QString, QSize>>);

--- a/app/src/importimageseqdialog.h
+++ b/app/src/importimageseqdialog.h
@@ -29,7 +29,7 @@ class ImportImageSeqDialog : public ImportExportDialog
     Q_OBJECT
 
 public:
-    explicit ImportImageSeqDialog(QWidget *parent = 0, Mode mode = ImportExportDialog::Import, FileType fileType = FileType::IMAGE_SEQUENCE);
+    explicit ImportImageSeqDialog(QWidget *parent = nullptr, Mode mode = ImportExportDialog::Import, FileType fileType = FileType::IMAGE_SEQUENCE);
     ~ImportImageSeqDialog();
 
     int getSpace();

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -400,7 +400,7 @@ void MainWindow2::clearRecentFilesList()
     if (!recentFilesList.isEmpty())
     {
         mRecentFileMenu->clear();
-        QMessageBox::information(this, 0,
+        QMessageBox::information(this, nullptr,
                                  tr("\n\n You have successfully cleared the list"),
                                  QMessageBox::Ok);
     }
@@ -1265,7 +1265,7 @@ void MainWindow2::bindActionWithSetting(QAction* action, SETTING setting)
 void MainWindow2::updateZoomLabel()
 {
     float zoom = mEditor->view()->scaling() * 100.f;
-    statusBar()->showMessage(QString("Zoom: %0%1").arg(zoom, 0, 'f', 1).arg("%"));
+    statusBar()->showMessage(QString("Zoom: %0%1").arg(static_cast<double>(zoom), 0, 'f', 1).arg("%"));
 }
 
 void MainWindow2::changePlayState(bool isPlaying)

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -55,8 +55,8 @@ class MainWindow2 : public QMainWindow
     Q_OBJECT
 
 public:
-    explicit MainWindow2(QWidget* parent = 0);
-    ~MainWindow2();
+    explicit MainWindow2(QWidget* parent = nullptr);
+    ~MainWindow2() override;
 
     Editor* mEditor = nullptr;
 

--- a/app/src/preferencesdialog.h
+++ b/app/src/preferencesdialog.h
@@ -40,7 +40,7 @@ class PreferencesDialog : public QDialog
 
 public:
     PreferencesDialog(QWidget* parent);
-    ~PreferencesDialog();
+    ~PreferencesDialog() override;
 
     void init(PreferenceManager* m);
     void updateRecentListBtn(bool isEmpty);

--- a/app/src/preview.h
+++ b/app/src/preview.h
@@ -42,7 +42,7 @@ class PreviewWidget : public QDockWidget
 {
     Q_OBJECT
 public:
-    PreviewWidget(QWidget *parent = 0);
+    PreviewWidget(QWidget *parent = nullptr);
 	void setImage( BitmapImage* img ) { mCanvas->setImage( img ); }
 	void updateImage();
 

--- a/app/src/shortcutspage.h
+++ b/app/src/shortcutspage.h
@@ -38,7 +38,7 @@ class ShortcutsPage : public QWidget
 {
     Q_OBJECT
 public:
-    explicit ShortcutsPage(QWidget* parent = 0);
+    explicit ShortcutsPage(QWidget* parent = nullptr);
 
     void setManager( PreferenceManager* p ) { mManager = p; }
 

--- a/app/src/spinslider.cpp
+++ b/app/src/spinslider.cpp
@@ -96,15 +96,15 @@ void SpinSlider::setValue(qreal v)
     int value2 = 0;
     if (mGrowthType == LINEAR)
     {
-        value2 = static_cast<int>(std::round(mSlider->maximum() * (v - mMin) / (mMax - mMin)));
+        value2 =qRound((mSlider->maximum() * (v - mMin) / (mMax - mMin)));
     }
     else if (mGrowthType == LOG)
     {
-        value2 = static_cast<int>(std::round(std::log(v / mMin) * mSlider->maximum() / std::log(mMax / mMin)));
+        value2 = qRound(std::log(v / mMin) * mSlider->maximum() / std::log(mMax / mMin));
     }
     else if (mGrowthType == EXPONENT)
     {
-        value2 = static_cast<int>(std::round(std::pow((v - mMin) * std::pow(mSlider->maximum(), mExp) / (mMax - mMin), 1 / mExp)));
+        value2 = qRound(std::pow((v - mMin) * std::pow(mSlider->maximum(), mExp) / (mMax - mMin), 1 / mExp));
     }
 
     changeValue(v);

--- a/app/src/spinslider.cpp
+++ b/app/src/spinslider.cpp
@@ -34,7 +34,7 @@ void SpinSlider::init(QString text, GROWTH_TYPE type, VALUE_TYPE dataType, qreal
     if (type == LOG)
     {
         // important! dividing by zero is not acceptable.
-        Q_ASSERT_X(min > 0.f, "SpinSlider", "Real type value must larger than 0!!");
+        Q_ASSERT_X(min > 0.0, "SpinSlider", "Real type value must larger than 0!!");
     }
 
     mValue = 1.0;
@@ -96,15 +96,15 @@ void SpinSlider::setValue(qreal v)
     int value2 = 0;
     if (mGrowthType == LINEAR)
     {
-        value2 = std::round(mSlider->maximum() * (v - mMin) / (mMax - mMin));
+        value2 = static_cast<int>(std::round(mSlider->maximum() * (v - mMin) / (mMax - mMin)));
     }
     else if (mGrowthType == LOG)
     {
-        value2 = std::round(std::log(v / mMin) * mSlider->maximum() / std::log(mMax / mMin));
+        value2 = static_cast<int>(std::round(std::log(v / mMin) * mSlider->maximum() / std::log(mMax / mMin)));
     }
     else if (mGrowthType == EXPONENT)
     {
-        value2 = std::round(std::pow((v - mMin) * std::pow(mSlider->maximum(), mExp) / (mMax - mMin), 1 / mExp));
+        value2 = static_cast<int>(std::round(std::pow((v - mMin) * std::pow(mSlider->maximum(), mExp) / (mMax - mMin), 1 / mExp)));
     }
 
     changeValue(v);
@@ -113,7 +113,8 @@ void SpinSlider::setValue(qreal v)
 
 void SpinSlider::setPixelPos(qreal min, qreal max, int val, int space, bool upsideDown)
 {
-    mSlider->setSliderPosition(QStyle::sliderValueFromPosition(min, max, val, space, upsideDown));
+    mSlider->setSliderPosition(QStyle::sliderValueFromPosition(static_cast<int>(min),
+                                                               static_cast<int>(max), val, space, upsideDown));
 }
 
 void SpinSlider::setExponent(const qreal exp)

--- a/app/src/timeline2.h
+++ b/app/src/timeline2.h
@@ -30,8 +30,8 @@ class Timeline2 : public BaseDockWidget
     Q_OBJECT
 
 public:
-    explicit Timeline2(QWidget* parent = 0);
-    ~Timeline2();
+    explicit Timeline2(QWidget* parent = nullptr);
+    ~Timeline2() override;
 
     void initUI() override;
     void updateUI() override;

--- a/app/src/toolbox.h
+++ b/app/src/toolbox.h
@@ -38,7 +38,7 @@ class ToolBoxWidget : public BaseDockWidget
 
 public:
     ToolBoxWidget(QWidget* parent);
-    ~ToolBoxWidget();
+    ~ToolBoxWidget() override;
 
     void initUI() override;
     void updateUI() override;

--- a/app/src/tooloptionwidget.cpp
+++ b/app/src/tooloptionwidget.cpp
@@ -78,7 +78,7 @@ void ToolOptionWidget::updateUI()
     setVectorMergeEnabled(p.vectorMergeEnabled);
     setAA(p.useAA);
     setStabilizerLevel(p.stabilizerLevel);
-    setTolerance(p.tolerance);
+    setTolerance(static_cast<int>(p.tolerance));
     setFillContour(p.useFillContour);
 }
 
@@ -132,7 +132,7 @@ void ToolOptionWidget::onToolPropertyChanged(ToolType, ToolPropertyType ePropert
     case VECTORMERGE: setVectorMergeEnabled(p.vectorMergeEnabled); break;
     case ANTI_ALIASING: setAA(p.useAA); break;
     case STABILIZATION: setStabilizerLevel(p.stabilizerLevel); break;
-    case TOLERANCE: setTolerance(p.tolerance); break;
+    case TOLERANCE: setTolerance(static_cast<int>(p.tolerance)); break;
     case FILLCONTOUR: setFillContour(p.useFillContour); break;
     case BEZIER: setBezier(p.bezier_state); break;
     default:

--- a/app/src/tooloptionwidget.h
+++ b/app/src/tooloptionwidget.h
@@ -40,7 +40,7 @@ class ToolOptionWidget : public BaseDockWidget
     Q_OBJECT
 public:
     explicit ToolOptionWidget(QWidget* parent);
-    virtual ~ToolOptionWidget();
+    virtual ~ToolOptionWidget() override;
 
     void initUI() override;
     void updateUI() override;


### PR DESCRIPTION
This PR resolves most of the warnings in the app-directory.
Casts are changed from C to C++ style and '0' and 'NULL' is changed to 'nullptr'.
They are cast to the type the compiler would cast them to in the first place. 
Only in colorslider.h, I changed two member variables from 'float' to 'qreal'. This solved many warnings in itself.