### PR TITLE
Remove Show Tab Bar from the View menu on mac

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -30,7 +30,8 @@ INCLUDEPATH += \
     ../core_lib/src/tool \
     ../core_lib/src/util \
     ../core_lib/ui \
-    ../core_lib/src/managers
+    ../core_lib/src/managers \
+    ../core_lib/src/external
 
 HEADERS += \
     src/mainwindow2.h \
@@ -128,6 +129,8 @@ macx {
     FILE_ICONS.files = data/icons/mac_pcl_icon.icns data/icons/mac_pclx_icon.icns
     FILE_ICONS.path = Contents/Resources
     QMAKE_BUNDLE_DATA += FILE_ICONS
+
+    LIBS += -framework AppKit
 }
 
 win32 {

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -28,6 +28,7 @@ GNU General Public License for more details.
 #include "pencilapplication.h"
 #include "layermanager.h"
 #include "layercamera.h"
+#include "platformhandler.h"
 
 
 void installTranslator( PencilApplication& app )
@@ -223,6 +224,7 @@ int handleArguments( PencilApplication& app )
     // If there are no output paths, open up the GUI (to the input path if there is one)
     if ( outputPaths.isEmpty() )
     {
+        PlatformHandler::configurePlatformSpecificSettings();
         mainWindow.show();
         if( !inputPath.isEmpty() )
         {

--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -26,7 +26,8 @@ INCLUDEPATH += src \
     src/tool \
     src/util \
     ui \
-    src/managers
+    src/managers \
+    src/external
 
 # Input
 HEADERS +=  \
@@ -94,7 +95,9 @@ HEADERS +=  \
     src/movieexporter.h \
     src/miniz.h \
     src/qminiz.h \
-    src/activeframepool.h
+    src/activeframepool.h \
+    src/external/platformhandler.h \
+    src/external/macosx/macosxnative.h
 
 
 SOURCES +=  src/graphics/bitmap/bitmapimage.cpp \
@@ -170,7 +173,9 @@ win32 {
 
 macx {
     INCLUDEPATH += src/external/macosx
+    LIBS += -framework AppKit
     SOURCES += src/external/macosx/macosx.cpp
+    OBJECTIVE_SOURCES += src/external/macosx/macosxnative.mm
 }
 
 unix:!macx {

--- a/core_lib/src/external/linux/linux.cpp
+++ b/core_lib/src/external/linux/linux.cpp
@@ -28,9 +28,14 @@ GNU General Public License for more details.
 #include "editor.h"
 #include "layersound.h"
 #include "pencildef.h"
+#include "platformhandler.h"
 
 #define MIN(a,b) ((a)>(b)?(b):(a))
 
+namespace PlatformHandler
+{
+    void configurePlatformSpecificSettings() {}
+}
 
 qint16 safeSum ( qint16 a, qint16 b)
 {

--- a/core_lib/src/external/macosx/macosx.cpp
+++ b/core_lib/src/external/macosx/macosx.cpp
@@ -30,9 +30,19 @@ GNU General Public License for more details.
 #include "object.h"
 #include "editor.h"
 #include "pencildef.h"
+#include "macosxnative.h"
 
 #include <CoreFoundation/CoreFoundation.h>
 
+namespace PlatformHandler
+{
+
+    void configurePlatformSpecificSettings()
+    {
+        MacOSXNative::removeUnwantedMenuItems();
+    }
+
+}
 
 extern "C" {
 // this is not declared in Carbon.h anymore, but it's in the framework
@@ -59,11 +69,13 @@ void detectWhichOSX()
 void disableCoalescing()
 {
     SetMouseCoalescingEnabled(gIsMouseCoalecing, NULL);
+    //MacOSXNative::setMouseCoalescingEnabled(false);
 }
 
 void enableCoalescing()
 {
     SetMouseCoalescingEnabled(true, NULL);
+    //MacOSXNative::setMouseCoalescingEnabled(true);
 }
 
 void Editor::importMovie(QString filePath, int fps)

--- a/core_lib/src/external/macosx/macosxnative.h
+++ b/core_lib/src/external/macosx/macosxnative.h
@@ -1,0 +1,12 @@
+#ifndef MACOSXNATIVE_H
+#define MACOSXNATIVE_H
+
+namespace MacOSXNative
+{
+    void removeUnwantedMenuItems();
+
+    bool isMouseCoalescingEnabled();
+    void setMouseCoalescingEnabled(bool enabled);
+}
+
+#endif // MACOSXNATIVE_H

--- a/core_lib/src/external/macosx/macosxnative.mm
+++ b/core_lib/src/external/macosx/macosxnative.mm
@@ -1,0 +1,27 @@
+#include "macosxnative.h"
+
+#include <AppKit/NSWindow.h>
+#include <AppKit/Appkit.h>
+
+namespace MacOSXNative
+{
+    void removeUnwantedMenuItems()
+    {
+        // Remove "Show Tab Bar" option from the "View" menu if possible
+
+        if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)])
+        {
+            NSWindow.allowsAutomaticWindowTabbing = NO;
+        }
+    }
+
+    bool isMouseCoalescingEnabled()
+    {
+        return NSEvent.isMouseCoalescingEnabled;
+    }
+
+    void setMouseCoalescingEnabled(bool enabled)
+    {
+        NSEvent.mouseCoalescingEnabled = enabled;
+    }
+}

--- a/core_lib/src/external/platformhandler.h
+++ b/core_lib/src/external/platformhandler.h
@@ -1,0 +1,11 @@
+#ifndef PLATFORMHANDLER_H
+#define PLATFORMHANDLER_H
+
+namespace PlatformHandler
+{
+
+void configurePlatformSpecificSettings();
+
+}
+
+#endif // PLATFORMHANDLER_H

--- a/core_lib/src/external/win32/win32.cpp
+++ b/core_lib/src/external/win32/win32.cpp
@@ -30,7 +30,12 @@ GNU General Public License for more details.
 #include "object.h"
 #include "editor.h"
 #include "layersound.h"
+#include "platformhandler.h"
 
+namespace PlatformHandler
+{
+    void configurePlatformSpecificSettings() {}
+}
 
 void Editor::importMovie( QString filePath, int fps )
 {

--- a/pencil2d.pro
+++ b/pencil2d.pro
@@ -41,3 +41,5 @@ TRANSLATIONS += translations/pencil.ts \
                 translations/pencil_vi.ts \
                 translations/pencil_zh_CN.ts \
                 translations/pencil_zh_TW.ts
+
+macx: LIBS += -framework AppKit

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -54,3 +54,4 @@ else:win32:!win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PW
 else:win32:!win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core_lib/debug/core_lib.lib
 else:unix: PRE_TARGETDEPS += $$OUT_PWD/../core_lib/libcore_lib.a
 
+macx: LIBS += -framework AppKit


### PR DESCRIPTION
Newer versions of macOS add a "Show Tab Bar" option to the "View" menu automatically. Pressing it screws with the layout a little bit like this:
![double_titlebar](https://user-images.githubusercontent.com/3461051/49424139-e7065480-f756-11e8-80ab-195858035e70.png)
There is no way to remove the menu item with Qt, see [this bug report](https://bugreports.qt.io/browse/QTBUG-61707). To fix this I integrated a small amount of native objective-c code for mac builds.

This also enables us to easily add support for more native mac features in the future. I implemented mouse coalescing in this same way, but is currently not being used. It seems like what we are currently doing for setting mouse coalescing is not working, so when we actually disable it the brush stroke lags significantly similar to #1133. According to my event counter the peak number of events doubles from 128 to 256. This shouldn't cause a noticeable slowdown because we can process that many tablet events just fine. I've spent a few hours trying to debug this but am unsure exactly what the underlying problem is. I think it goes deeper than were just processing the events too slowly though. For now, we can just leave mouse coalescing enabled.