### PR TITLE
Export only keyframes possible in exportImageSequence

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -305,12 +305,14 @@ Status ActionCommands::exportImageSequence()
     QString strFilePath = dialog->getFilePath();
     QSize exportSize = dialog->getExportSize();
     QString exportFormat = dialog->getExportFormat();
+    bool exportKeyframesOnly = dialog->getExportKeyframesOnly();
     bool useTranparency = dialog->getTransparency();
     int startFrame = dialog->getStartFrame();
     int endFrame  = dialog->getEndFrame();
 
     QString sCameraLayerName = dialog->getCameraLayerName();
     LayerCamera* cameraLayer = (LayerCamera*)mEditor->layers()->findLayerByName(sCameraLayerName, Layer::CAMERA);
+    QString layerName = mEditor->layers()->currentLayer()->name();
 
     // Show a progress dialog, as this can take a while if you have lots of frames.
     QProgressDialog progress(tr("Exporting image sequence..."), tr("Abort"), 0, 100, mParent);
@@ -324,6 +326,8 @@ Status ActionCommands::exportImageSequence()
                                     strFilePath,
                                     exportFormat,
                                     useTranparency,
+                                    exportKeyframesOnly,
+                                    mEditor->layers()->currentLayer()->name(),
                                     true,
                                     &progress,
                                     100);

--- a/app/src/exportimagedialog.cpp
+++ b/app/src/exportimagedialog.cpp
@@ -105,6 +105,11 @@ bool ExportImageDialog::getTransparency() const
     return ui->cbTransparency->checkState() == Qt::Checked;
 }
 
+bool ExportImageDialog::getExportKeyframesOnly() const
+{
+    return ui->cbExportKeyframesOnly->checkState() == Qt::Checked;
+}
+
 QString ExportImageDialog::getExportFormat() const
 {
     return ui->formatComboBox->currentText();

--- a/app/src/exportimagedialog.h
+++ b/app/src/exportimagedialog.h
@@ -38,6 +38,7 @@ public:
     void  setExportSize( QSize size );
     QSize getExportSize() const;
     bool getTransparency() const;
+    bool getExportKeyframesOnly() const;
     QString getExportFormat() const;
 	QString getCameraLayerName() const;
 

--- a/app/ui/exportimageoptions.ui
+++ b/app/ui/exportimageoptions.ui
@@ -131,19 +131,6 @@
       <property name="spacing">
        <number>3</number>
       </property>
-      <item row="0" column="2">
-       <widget class="QSpinBox" name="startSpinBox">
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>99999</number>
-        </property>
-        <property name="value">
-         <number>1</number>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="1">
        <widget class="QLabel" name="endLabel">
         <property name="sizePolicy">
@@ -163,28 +150,6 @@
         </property>
         <property name="text">
          <string>End Frame</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="startLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>80</width>
-          <height>35</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>The first frame you want to include in the exported movie</string>
-        </property>
-        <property name="text">
-         <string>Start Frame</string>
         </property>
        </widget>
       </item>
@@ -219,6 +184,41 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="2">
+       <widget class="QSpinBox" name="startSpinBox">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>99999</number>
+        </property>
+        <property name="value">
+         <number>1</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="startLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>80</width>
+          <height>35</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The first frame you want to include in the exported movie</string>
+        </property>
+        <property name="text">
+         <string>Start Frame</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="2">
        <widget class="QSpinBox" name="endSpinBox">
         <property name="minimum">
@@ -229,6 +229,13 @@
         </property>
         <property name="value">
          <number>10</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QCheckBox" name="cbExportKeyframesOnly">
+        <property name="text">
+         <string>Export keyframes only</string>
         </property>
        </widget>
       </item>

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -231,7 +231,7 @@ void Editor::backup(int backupLayer, int backupFrame, QString undoText)
     }
 
     Layer* layer = mObject->getLayer(backupLayer);
-    if (layer != NULL)
+    if (layer != nullptr)
     {
         if (layer->type() == Layer::BITMAP)
         {
@@ -240,7 +240,7 @@ void Editor::backup(int backupLayer, int backupFrame, QString undoText)
                 int previous = layer->getPreviousKeyFramePosition(backupFrame);
                 bitmapImage = static_cast<LayerBitmap*>(layer)->getBitmapImageAtFrame(previous);
             }
-            if (bitmapImage != NULL)
+            if (bitmapImage != nullptr)
             {
                 BackupBitmapElement* element = new BackupBitmapElement(bitmapImage);
                 element->layer = backupLayer;
@@ -257,7 +257,7 @@ void Editor::backup(int backupLayer, int backupFrame, QString undoText)
         else if (layer->type() == Layer::VECTOR)
         {
             VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(backupFrame, 0);
-            if (vectorImage != NULL)
+            if (vectorImage != nullptr)
             {
                 BackupVectorElement* element = new BackupVectorElement(vectorImage);
                 element->layer = backupLayer;
@@ -367,7 +367,7 @@ void BackupBitmapElement::restore(Editor* editor)
     }
     else
     {
-        if (layer != NULL)
+        if (layer != nullptr)
         {
             if (layer->type() == Layer::BITMAP)
             {
@@ -391,7 +391,7 @@ void BackupVectorElement::restore(Editor* editor)
     }
     else
     {
-        if (layer != NULL)
+        if (layer != nullptr)
         {
             if (layer->type() == Layer::VECTOR)
             {
@@ -495,7 +495,7 @@ void Editor::cut()
 void Editor::copy()
 {
     Layer* layer = mObject->getLayer(layers()->currentLayerIndex());
-    if (layer == NULL) 
+    if (layer == nullptr)
     {
         return;
     }
@@ -512,7 +512,7 @@ void Editor::copy()
             g_clipboardBitmapImage = layerBitmap->getLastBitmapImageAtFrame(currentFrame(), 0)->copy();  // copy the whole image
         }
         clipboardBitmapOk = true;
-        if (g_clipboardBitmapImage.image() != NULL)
+        if (g_clipboardBitmapImage.image() != nullptr)
             QApplication::clipboard()->setImage(*g_clipboardBitmapImage.image());
     }
     if (layer->type() == Layer::VECTOR)
@@ -525,9 +525,9 @@ void Editor::copy()
 void Editor::paste()
 {
     Layer* layer = mObject->getLayer(layers()->currentLayerIndex());
-    if (layer != NULL)
+    if (layer != nullptr)
     {
-        if (layer->type() == Layer::BITMAP && g_clipboardBitmapImage.image() != NULL)
+        if (layer->type() == Layer::BITMAP && g_clipboardBitmapImage.image() != nullptr)
         {
             backup(tr("Paste"));
 
@@ -697,8 +697,10 @@ bool Editor::exportSeqCLI(QString filePath, LayerCamera *cameraLayer, QString fo
                           filePath,
                           format,
                           transparency,
+                          false,
+                          "",
                           antialias,
-                          NULL,
+                          nullptr,
                           0);
     return true;
 }
@@ -795,7 +797,7 @@ bool Editor::importVectorImage(QString filePath)
     auto layer = static_cast<LayerVector*>(layers()->currentLayer());
 
     VectorImage* vectorImage = ((LayerVector*)layer)->getVectorImageAtFrame(currentFrame());
-    if (vectorImage == NULL)
+    if (vectorImage == nullptr)
     {
         addNewKey();
         vectorImage = ((LayerVector*)layer)->getVectorImageAtFrame(currentFrame());
@@ -910,7 +912,7 @@ KeyFrame* Editor::addNewKey()
 KeyFrame* Editor::addKeyFrame(int layerNumber, int frameIndex)
 {
     Layer* layer = mObject->getLayer(layerNumber);
-    if (layer == NULL)
+    if (layer == nullptr)
     {
         Q_ASSERT(false);
         return nullptr;
@@ -966,7 +968,7 @@ void Editor::scrubPreviousKeyFrame()
 void Editor::switchVisibilityOfLayer(int layerNumber)
 {
     Layer* layer = mObject->getLayer(layerNumber);
-    if (layer != NULL) layer->switchVisibility();
+    if (layer != nullptr) layer->switchVisibility();
     mScribbleArea->updateAllFrames();
 
     emit updateTimeLine();

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -669,6 +669,8 @@ bool Object::exportFrames(int frameStart, int frameEnd,
                           QString filePath,
                           QString format,
                           bool transparency,
+                          bool exportKeyframesOnly,
+                          QString layerName,
                           bool antialiasing,
                           QProgressDialog* progress = nullptr,
                           int progressMax = 50)
@@ -737,8 +739,16 @@ bool Object::exportFrames(int frameStart, int frameEnd,
             frameNumberString.prepend("0");
         }
         QString sFileName = filePath + frameNumberString + extension;
-
-        exportIm(currentFrame, view, camSize, exportSize, sFileName, format, antialiasing, transparency);
+        Layer* layer = findLayerByName(layerName);
+        if (exportKeyframesOnly)
+        {
+            if (layer->keyExists(currentFrame))
+                exportIm(currentFrame, view, camSize, exportSize, sFileName, format, antialiasing, transparency);
+        }
+        else
+        {
+            exportIm(currentFrame, view, camSize, exportSize, sFileName, format, antialiasing, transparency);
+        }
     }
 
     return true;

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -132,7 +132,8 @@ public:
     }
 
     // these functions need to be moved to somewhere...
-    bool exportFrames(int frameStart, int frameEnd, LayerCamera* cameraLayer, QSize exportSize, QString filePath, QString format, bool transparency, bool antialiasing, QProgressDialog* progress, int progressMax);
+    bool exportFrames(int frameStart, int frameEnd, LayerCamera* cameraLayer, QSize exportSize, QString filePath, QString format,
+                      bool transparency, bool exportKeyframesOnly, QString layerName, bool antialiasing, QProgressDialog* progress, int progressMax);
     bool exportX(int frameStart, int frameEnd, QTransform view, QSize exportSize, QString filePath, bool antialiasing);
     bool exportIm(int frameStart, QTransform view, QSize cameraSize, QSize exportSize, QString filePath, QString format, bool antialiasing, bool transparency);
 


### PR DESCRIPTION
The possibility to import by filename has been merged.
The feature here will make it possible to only export the keyframes from a layer. Thus you can easily reuse animation from one scene to another.
There are also a few warning resolves. Only 'NULL' -> 'nullptr'