### PR TITLE
Resolved warnings for NULL and old-casts

### DIFF
--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -312,7 +312,7 @@ void Editor::restoreKey()
     int layerIndex = 0;
     if (lastBackupElement->type() == BackupElement::BITMAP_MODIF)
     {
-        BackupBitmapElement* lastBackupBitmapElement = (BackupBitmapElement*)lastBackupElement;
+        BackupBitmapElement* lastBackupBitmapElement = static_cast<BackupBitmapElement*>(lastBackupElement);
         layerIndex = lastBackupBitmapElement->layer;
         frame = lastBackupBitmapElement->frame;
         layer = object()->getLayer(layerIndex);
@@ -321,7 +321,7 @@ void Editor::restoreKey()
     }
     if (lastBackupElement->type() == BackupElement::VECTOR_MODIF)
     {
-        BackupVectorElement* lastBackupVectorElement = (BackupVectorElement*)lastBackupElement;
+        BackupVectorElement* lastBackupVectorElement = static_cast<BackupVectorElement*>(lastBackupElement);
         layerIndex = lastBackupVectorElement->layer;
         frame = lastBackupVectorElement->frame;
         layer = object()->getLayer(layerIndex);
@@ -331,7 +331,7 @@ void Editor::restoreKey()
     if (lastBackupElement->type() == BackupElement::SOUND_MODIF)
     {
         QString strSoundFile;
-        BackupSoundElement* lastBackupSoundElement = (BackupSoundElement*)lastBackupElement;
+        BackupSoundElement* lastBackupSoundElement = static_cast<BackupSoundElement*>(lastBackupElement);
         layerIndex = lastBackupSoundElement->layer;
         frame = lastBackupSoundElement->frame;
 
@@ -424,19 +424,19 @@ void Editor::undo()
             BackupElement* lastBackupElement = mBackupList[mBackupIndex];
             if (lastBackupElement->type() == BackupElement::BITMAP_MODIF)
             {
-                BackupBitmapElement* lastBackupBitmapElement = (BackupBitmapElement*)lastBackupElement;
+                BackupBitmapElement* lastBackupBitmapElement = static_cast<BackupBitmapElement*>(lastBackupElement);
                 backup(lastBackupBitmapElement->layer, lastBackupBitmapElement->frame, "NoOp");
                 mBackupIndex--;
             }
             if (lastBackupElement->type() == BackupElement::VECTOR_MODIF)
             {
-                BackupVectorElement* lastBackupVectorElement = (BackupVectorElement*)lastBackupElement;
+                BackupVectorElement* lastBackupVectorElement = static_cast<BackupVectorElement*>(lastBackupElement);
                 backup(lastBackupVectorElement->layer, lastBackupVectorElement->frame, "NoOp");
                 mBackupIndex--;
             }
             if (lastBackupElement->type() == BackupElement::SOUND_MODIF)
             {
-                BackupSoundElement* lastBackupSoundElement = (BackupSoundElement*)lastBackupElement;
+                BackupSoundElement* lastBackupSoundElement = static_cast<BackupSoundElement*>(lastBackupElement);
                 backup(lastBackupSoundElement->layer, lastBackupSoundElement->frame, "NoOp");
                 mBackupIndex--;
             }
@@ -502,7 +502,7 @@ void Editor::copy()
 
     if (layer->type() == Layer::BITMAP)
     {
-        LayerBitmap* layerBitmap = (LayerBitmap*)layer;
+        LayerBitmap* layerBitmap = static_cast<LayerBitmap*>(layer);
         if (mScribbleArea->isSomethingSelected())
         {
             g_clipboardBitmapImage = layerBitmap->getLastBitmapImageAtFrame(currentFrame(), 0)->copy(mScribbleArea->getSelection().toRect());  // copy part of the image
@@ -518,7 +518,7 @@ void Editor::copy()
     if (layer->type() == Layer::VECTOR)
     {
         clipboardVectorOk = true;
-        g_clipboardVectorImage = *(((LayerVector*)layer)->getLastVectorImageAtFrame(currentFrame(), 0));  // copy the image
+        g_clipboardVectorImage = *((static_cast<LayerVector*>(layer))->getLastVectorImageAtFrame(currentFrame(), 0));  // copy the image
     }
 }
 
@@ -552,7 +552,7 @@ void Editor::paste()
         {
             backup(tr("Paste"));
             mScribbleArea->deselectAll();
-            VectorImage* vectorImage = ((LayerVector*)layer)->getLastVectorImageAtFrame(currentFrame(), 0);
+            VectorImage* vectorImage = (static_cast<LayerVector*>(layer))->getLastVectorImageAtFrame(currentFrame(), 0);
             vectorImage->paste(g_clipboardVectorImage);  // paste the clipboard
             mScribbleArea->setSelection(vectorImage->getSelectionRect());
         }
@@ -796,11 +796,11 @@ bool Editor::importVectorImage(QString filePath)
 
     auto layer = static_cast<LayerVector*>(layers()->currentLayer());
 
-    VectorImage* vectorImage = ((LayerVector*)layer)->getVectorImageAtFrame(currentFrame());
+    VectorImage* vectorImage = (static_cast<LayerVector*>(layer))->getVectorImageAtFrame(currentFrame());
     if (vectorImage == nullptr)
     {
         addNewKey();
-        vectorImage = ((LayerVector*)layer)->getVectorImageAtFrame(currentFrame());
+        vectorImage = (static_cast<LayerVector*>(layer))->getVectorImageAtFrame(currentFrame());
     }
 
     VectorImage importedVectorImage;

--- a/core_lib/src/interface/recentfilemenu.cpp
+++ b/core_lib/src/interface/recentfilemenu.cpp
@@ -130,7 +130,7 @@ void RecentFileMenu::removeRecentFile( QString filename )
 
 void RecentFileMenu::onRecentFileTriggered()
 {
-    QAction* action = ( QAction* )QObject::sender();
+    QAction* action = static_cast<QAction*>(QObject::sender());
     QString filePath = action->data().toString();
 
     if ( !filePath.isEmpty() )

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -551,16 +551,16 @@ bool ScribbleArea::areLayersSane() const
 {
     Layer* layer = mEditor->layers()->currentLayer();
     // ---- checks ------
-    if (layer == NULL) { return false; }
+    if (layer == nullptr) { return false; }
     if (layer->type() == Layer::VECTOR)
     {
-        VectorImage *vectorImage = ((LayerVector*)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
-        if (vectorImage == NULL) { return false; }
+        VectorImage *vectorImage = (static_cast<LayerVector*>(layer))->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+        if (vectorImage == nullptr) { return false; }
     }
     if (layer->type() == Layer::BITMAP)
     {
-        BitmapImage *bitmapImage = ((LayerBitmap*)layer)->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0);
-        if (bitmapImage == NULL) { return false; }
+        BitmapImage *bitmapImage = (static_cast<LayerBitmap*>(layer))->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0);
+        if (bitmapImage == nullptr) { return false; }
     }
     // ---- end checks ------
 
@@ -822,7 +822,7 @@ void ScribbleArea::paintBitmapBuffer()
 
     // Clear the temporary pixel path
     BitmapImage* targetImage = layer->getLastBitmapImageAtFrame(mEditor->currentFrame());
-    if (targetImage != NULL)
+    if (targetImage != nullptr)
     {
         QPainter::CompositionMode cm = QPainter::CompositionMode_SourceOver;
         switch (currentTool()->type())
@@ -865,9 +865,9 @@ void ScribbleArea::paintBitmapBufferRect(const QRect& rect)
         Layer* layer = mEditor->layers()->currentLayer();
         Q_ASSERT(layer);
 
-        BitmapImage* targetImage = ((LayerBitmap*)layer)->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0);
+        BitmapImage* targetImage = (static_cast<LayerBitmap*>(layer))->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0);
 
-        if (targetImage != NULL)
+        if (targetImage != nullptr)
         {
             QPainter::CompositionMode cm = QPainter::CompositionMode_SourceOver;
             switch (currentTool()->type())
@@ -1099,7 +1099,7 @@ void ScribbleArea::paintEvent(QPaintEvent* event)
     {
         if (layer->type() == Layer::VECTOR)
         {
-            VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+            VectorImage *vectorImage = (static_cast<LayerVector*>(layer))->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
             switch (currentTool()->type())
             {
             case SMUDGE:
@@ -1164,7 +1164,7 @@ void ScribbleArea::paintEvent(QPaintEvent* event)
         }
 
         // paints the  buffer image
-        if (mEditor->layers()->currentLayer() != NULL)
+        if (mEditor->layers()->currentLayer() != nullptr)
         {
             painter.setOpacity(1.0);
             if (mEditor->layers()->currentLayer()->type() == Layer::BITMAP)
@@ -1212,7 +1212,7 @@ void ScribbleArea::paintSelectionVisuals(QPainter& painter)
     mLastTransformSelection = mEditor->view()->getView().mapToPolygon(myTransformedSelection.toAlignedRect());
 
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer != NULL)
+    if (layer != nullptr)
     {
         if (layer->type() == Layer::BITMAP)
         {
@@ -1483,10 +1483,10 @@ void ScribbleArea::calculateSelectionRect()
 {
     selectionTransformation.reset();
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer == NULL) { return; }
+    if (layer == nullptr) { return; }
     if (layer->type() == Layer::VECTOR)
     {
-        VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+        VectorImage *vectorImage = (static_cast<LayerVector*>(layer))->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
         vectorImage->calculateSelectionRect();
         setSelection(vectorImage->getSelectionRect());
     }
@@ -1707,7 +1707,7 @@ void ScribbleArea::calculateSelectionTransformation()
 void ScribbleArea::paintTransformedSelection()
 {
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer == NULL)
+    if (layer == nullptr)
     {
         return;
     }
@@ -1721,7 +1721,7 @@ void ScribbleArea::paintTransformedSelection()
         else if (layer->type() == Layer::VECTOR)
         {
             // vector transformation
-            LayerVector* layerVector = (LayerVector*)layer;
+            LayerVector* layerVector = static_cast<LayerVector*>(layer);
             VectorImage* vectorImage = layerVector->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
             vectorImage->setSelectionTransformation(selectionTransformation);
 
@@ -1761,7 +1761,7 @@ void ScribbleArea::applyTransformedSelection()
     mCanvasPainter.ignoreTransformedSelection();
 
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer == NULL)
+    if (layer == nullptr)
     {
         return;
     }
@@ -1780,7 +1780,7 @@ void ScribbleArea::applyTransformedSelection()
         }
         else if (layer->type() == Layer::VECTOR)
         {
-            VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+            VectorImage *vectorImage = (static_cast<LayerVector*>(layer))->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
                 vectorImage->applySelectionTransformation();
 
         }
@@ -1798,14 +1798,14 @@ void ScribbleArea::cancelTransformedSelection()
     if (mSomethingSelected) {
 
         Layer* layer = mEditor->layers()->currentLayer();
-        if (layer == NULL)
+        if (layer == nullptr)
         {
             return;
         }
 
         if (layer->type() == Layer::VECTOR) {
 
-            VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+            VectorImage *vectorImage = (static_cast<LayerVector*>(layer))->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
             vectorImage->setSelectionTransformation(QTransform());
         }
 
@@ -1880,10 +1880,10 @@ void ScribbleArea::manageSelectionOrigin(QPointF currentPoint, QPointF originPoi
 void ScribbleArea::displaySelectionProperties()
 {
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer == NULL) { return; }
+    if (layer == nullptr) { return; }
     if (layer->type() == Layer::VECTOR)
     {
-        LayerVector *layerVector = (LayerVector *)layer;
+        LayerVector *layerVector = static_cast<LayerVector*>(layer);
         VectorImage *vectorImage = layerVector->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
         //vectorImage->applySelectionTransformation();
         if (currentTool()->type() == MOVE)
@@ -1914,7 +1914,7 @@ void ScribbleArea::selectAll()
     Layer* layer = mEditor->layers()->currentLayer();
 
     Q_ASSERT(layer);
-    if (layer == NULL) { return; }
+    if (layer == nullptr) { return; }
 
     if (layer->type() == Layer::BITMAP)
     {
@@ -1924,14 +1924,14 @@ void ScribbleArea::selectAll()
         // Selects the drawn area (bigger or smaller than the screen). It may be more accurate to select all this way
         // as the drawing area is not limited
         //
-        BitmapImage *bitmapImage = ((LayerBitmap *)layer)->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0);
+        BitmapImage *bitmapImage = (static_cast<LayerBitmap*>(layer))->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0);
         setSelection(bitmapImage->bounds());
 
 
     }
     else if (layer->type() == Layer::VECTOR)
     {
-        VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+        VectorImage *vectorImage = (static_cast<LayerVector*>(layer))->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
         vectorImage->selectAll();
         setSelection(vectorImage->getSelectionRect());
     }
@@ -1958,10 +1958,10 @@ void ScribbleArea::deselectAll()
     myTempTransformedSelection = QRectF();
 
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer == NULL) { return; }
+    if (layer == nullptr) { return; }
     if (layer->type() == Layer::VECTOR)
     {
-        ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0)->deselectAll();
+        (static_cast<LayerVector*>(layer))->getLastVectorImageAtFrame(mEditor->currentFrame(), 0)->deselectAll();
     }
     mSomethingSelected = false;
 
@@ -2014,7 +2014,7 @@ BaseTool* ScribbleArea::getTool(ToolType eToolType)
 // TODO: check this method
 void ScribbleArea::setCurrentTool(ToolType eToolMode)
 {
-    if (currentTool() != NULL && eToolMode != currentTool()->type())
+    if (currentTool() != nullptr && eToolMode != currentTool()->type())
     {
         qDebug() << "Set Current Tool" << BaseTool::TypeName(eToolMode);
         if (BaseTool::TypeName(eToolMode) == "")
@@ -2060,13 +2060,13 @@ void ScribbleArea::deleteSelection()
     if (mSomethingSelected)      // there is something selected
     {
         Layer* layer = mEditor->layers()->currentLayer();
-        if (layer == NULL) { return; }
+        if (layer == nullptr) { return; }
 
         mEditor->backup(tr("Delete Selection", "Undo Step: clear the selection area."));
 
         mClosestCurves.clear();
-        if (layer->type() == Layer::VECTOR) { ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0)->deleteSelection(); }
-        if (layer->type() == Layer::BITMAP) { ((LayerBitmap *)layer)->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0)->clear(mySelection); }
+        if (layer->type() == Layer::VECTOR) { (static_cast<LayerVector*>(layer))->getLastVectorImageAtFrame(mEditor->currentFrame(), 0)->deleteSelection(); }
+        if (layer->type() == Layer::BITMAP) { (static_cast<LayerBitmap*>(layer))->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0)->clear(mySelection); }
         updateAllFrames();
     }
 }
@@ -2074,13 +2074,13 @@ void ScribbleArea::deleteSelection()
 void ScribbleArea::clearImage()
 {
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer == NULL) { return; }
+    if (layer == nullptr) { return; }
 
     if (layer->type() == Layer::VECTOR)
     {
         mEditor->backup(tr("Clear Image", "Undo step text"));
 
-        ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0)->clear();
+        (static_cast<LayerVector*>(layer))->getLastVectorImageAtFrame(mEditor->currentFrame(), 0)->clear();
         mClosestCurves.clear();
         mClosestVertices.clear();
     }
@@ -2088,7 +2088,7 @@ void ScribbleArea::clearImage()
     {
         mEditor->backup(tr("Clear Image", "Undo step text"));
 
-        ((LayerBitmap *)layer)->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0)->clear();
+        (static_cast<LayerBitmap*>(layer))->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0)->clear();
     }
     else
     {


### PR DESCRIPTION
This PR resolved many of the warnings in the Interface folder, in core_lib.
Some warnings remain. In scribblearea.cpp alone there are 59 warnings concerning 'implicit conversions'. Someone should look at this one day. I'm not sure it's within my reach to decide whether Penci2D should use floats, doubles, qreals or what...