### PR TITLE
Force light theme on mac os

### DIFF
--- a/app/data/Info.plist
+++ b/app/data/Info.plist
@@ -45,6 +45,8 @@
 			</array>
 		</dict>
 	</array>
+        <key>NSRequiresAquaSystemAppearance</key>
+        <string>True</string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>

--- a/core_lib/src/external/macosx/macosxnative.mm
+++ b/core_lib/src/external/macosx/macosxnative.mm
@@ -28,11 +28,12 @@ namespace MacOSXNative
 
     bool isDarkMode()
     {
-        NSAppearance* apperance = NSAppearance.currentAppearance;
-
-        #ifdef __MAC_10_14
-            return apperance.name == NSAppearanceNameDarkAqua;
-        #endif
+//        #ifdef __MAC_10_14
+//            #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_14
+//            NSAppearance* apperance = NSAppearance.currentAppearance;
+//            return apperance.name == NSAppearanceNameDarkAqua;
+//            #endif
+//        #endif
 
         return false;
     }


### PR DESCRIPTION
This change comes from a discussion on Discord:
the story is that this commit https://github.com/pencil2d/pencil/commit/d6157526854b7f9cdb53528ec152f83b5010b86d
tried to fix some styling regarding Mojave dark mode. What I failed to see however is that the flag apparently already exists from Mac OS 10.13 and thus will throw this error if compiled on that target
>'NSAppearanceNameDarkAqua' is only available on macOS 10_14 or newer [-Wunguarded-availability-new]
            return apperance.name == NSAppearanceNameDarkAqua;
                                     ^~~~~~ 

Thus my conclusion is that since there's no reliable way to determine whether the OS runs AquaDark aka. dark mode, and that it still has various layout bugs regarding it, we should force the standard light theme for now to make the experience as pleasant as possible.

it's still possible to change to dark mode by setting the parameter through info.plist though so if you still want it, it can be enabled again.