### PR TITLE
Renable dark mode on macOS

### DIFF
--- a/app/data/Info.plist
+++ b/app/data/Info.plist
@@ -45,8 +45,6 @@
 			</array>
 		</dict>
 	</array>
-        <key>NSRequiresAquaSystemAppearance</key>
-        <string>True</string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>

--- a/core_lib/src/external/macosx/macosxnative.mm
+++ b/core_lib/src/external/macosx/macosxnative.mm
@@ -6,6 +6,10 @@
 
 namespace MacOSXNative
 {
+    #if !defined(MAC_OS_X_VERSION_10_14) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_14
+        NSString* const NSAppearanceNameDarkAqua = @"NSAppearanceNameDarkAqua";
+    #endif
+
     void removeUnwantedMenuItems()
     {
         // Remove "Show Tab Bar" option from the "View" menu if possible
@@ -28,13 +32,14 @@ namespace MacOSXNative
 
     bool isDarkMode()
     {
-//        #ifdef __MAC_10_14
-//            #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_14
-//            NSAppearance* apperance = NSAppearance.currentAppearance;
-//            return apperance.name == NSAppearanceNameDarkAqua;
-//            #endif
-//        #endif
-
+        if (@available(macOS 10.14, *))
+        {
+            NSAppearanceName appearance =
+                [[NSApp effectiveAppearance] bestMatchFromAppearancesWithNames:@[
+                  NSAppearanceNameAqua, NSAppearanceNameDarkAqua
+                ]];
+            return [appearance isEqual:NSAppearanceNameDarkAqua];
+        }
         return false;
     }
 }


### PR DESCRIPTION
Compiles and runs just fine on macOS 10.13, still needs to be tested on macOS 10.14 with and without dark mode. Based on code from Chromium.