### PR TITLE
Layers swap place as they pass each other

### DIFF
--- a/core_lib/src/interface/timelinecells.h
+++ b/core_lib/src/interface/timelinecells.h
@@ -103,6 +103,8 @@ private:
     int mStartY = 0;
     int mEndY   = 0;
 
+    int fromLayer = 0;
+    int toLayer   = 1;
     int mStartLayerNumber = -1;
     int mStartFrameNumber = 0;
     int mLastFrameNumber = -1;


### PR DESCRIPTION
This PR concerns issue #1080. 
When you rearrange the layers, the layer you drag and the layer you drop it on, has until now swapped place. This has been considered against logical and expected behavior.
With this change the the layer you drag, will swap place with the layer it is passing, and thus not rearringing the order like before.
I know it is a change to the timeline, but I think we should make life easier for our users, while we wait for the new timeline.