### PR TITLE
issue #926: Scrubber moves to start of range, if outside range

### DIFF
--- a/core_lib/src/managers/playbackmanager.cpp
+++ b/core_lib/src/managers/playbackmanager.cpp
@@ -87,7 +87,7 @@ void PlaybackManager::play()
     updateEndFrame();
 
     int frame = editor()->currentFrame();
-    if (frame >= mEndFrame)
+    if (frame >= mEndFrame || frame < mStartFrame)
     {
         editor()->scrubTo(mStartFrame);
     }


### PR DESCRIPTION
If current frame is outside of range, it scrubs to first frame in range.