### PR TITLE
#940 - Fix XML fields corrupting because of locale decimal types.

### DIFF
--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -17,6 +17,7 @@ GNU General Public License for more details.
 
 #include "filemanager.h"
 
+#include <clocale>
 #include <ctime>
 #include <QDir>
 #include "pencildef.h"
@@ -207,6 +208,11 @@ bool FileManager::isOldForamt(const QString& fileName) const
 
 Status FileManager::save(Object* object, QString sFileName)
 {
+    // It's important that we save the file as En_US to avoid decimals being changed.
+    // issue: #940
+
+    std::setlocale(LC_NUMERIC, "En_US");
+
     DebugDetails dd;
     dd << "FileManager::save";
     dd << ("sFileName = " + sFileName);
@@ -333,6 +339,7 @@ Status FileManager::save(Object* object, QString sFileName)
 
     // -------- save main XML file -----------
     QFile file(sMainXMLFile);
+    std::setlocale(LC_ALL, "");
     if (!file.open(QFile::WriteOnly | QFile::Text))
     {
         return Status(Status::ERROR_FILE_CANNOT_OPEN, dd);


### PR DESCRIPTION
Because the decimal character can be different depending on the locale of your system for certain languages, we set the locale before saving and resetting afterwards to make sure that the xml data is generated consistently across languages.