### PR TITLE
Fix tablet events and cleanup events handling

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -563,7 +563,7 @@ void ActionCommands::duplicateKey()
     }
     else
     {
-        key->setFileName(""); // don't share filename
+        dupKey->setFileName(""); // don't share filename
     }
 
     mEditor->layers()->notifyAnimationLengthChanged();

--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -97,7 +97,8 @@ HEADERS +=  \
     src/qminiz.h \
     src/activeframepool.h \
     src/external/platformhandler.h \
-    src/external/macosx/macosxnative.h
+    src/external/macosx/macosxnative.h \
+    src/util/pointerevent.h
 
 
 SOURCES +=  src/graphics/bitmap/bitmapimage.cpp \
@@ -159,7 +160,8 @@ SOURCES +=  src/graphics/bitmap/bitmapimage.cpp \
     src/movieexporter.cpp \
     src/miniz.cpp \
     src/qminiz.cpp \
-    src/activeframepool.cpp
+    src/activeframepool.cpp \
+    src/util/pointerevent.cpp
 
 FORMS += \
     ui/camerapropertiesdialog.ui

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -646,11 +646,11 @@ void ScribbleArea::mousePressEvent(QMouseEvent* e)
 
 void ScribbleArea::mouseMoveEvent(QMouseEvent* e)
 {
-    if (mStrokeManager->isTabletInUse() || !isMouseInUse()) { e->ignore(); return; }
+    // Workaround for tablet issue (#677 part 2)
+    if (mStrokeManager->isTabletInUse()
+        || (!isMouseInUse() && currentTool()->type() != POLYLINE)) { e->ignore(); return; }
     PointerEvent* event = new PointerEvent(e);
 
-    // Workaround for tablet issue (#677 part 2)
-    if (mStrokeManager->isTabletInUse()) { event->ignore(); return; }
     mStrokeManager->pointerMoveEvent(event);
 
     pointerMoveEvent(event);
@@ -689,7 +689,7 @@ void ScribbleArea::mouseReleaseEvent(QMouseEvent* e)
 
 void ScribbleArea::mouseDoubleClickEvent(QMouseEvent *e)
 {
-    if (mStrokeManager->isTabletInUse() || !isMouseInUse()) { e->ignore(); return; }
+    if (mStrokeManager->isTabletInUse()) { e->ignore(); return; }
     PointerEvent* event = new PointerEvent(e);
     mStrokeManager->pointerPressEvent(event);
 

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -433,6 +433,7 @@ void ScribbleArea::tabletEvent(QTabletEvent *e)
     {
         if (event->type() == QTabletEvent::TabletPress)
         {
+            mStrokeManager->setTabletinUse(true);
             mStrokeManager->pointerPressEvent(event);
             if (isFirstClick)
             {
@@ -463,6 +464,7 @@ void ScribbleArea::tabletEvent(QTabletEvent *e)
         {
             mStrokeManager->pointerReleaseEvent(event);
             pointerReleaseEvent(event);
+            mStrokeManager->setTabletinUse(false);
         }
 
     }
@@ -633,7 +635,10 @@ bool ScribbleArea::allowSmudging()
 
 void ScribbleArea::mousePressEvent(QMouseEvent* e)
 {
+    if (mStrokeManager->isTabletInUse() || !isMouseInUse()) { e->ignore(); return; }
     PointerEvent* event = new PointerEvent(e);
+    mMouseInUse = true;
+
     mStrokeManager->pointerPressEvent(event);
 
     pointerPressEvent(event);
@@ -641,7 +646,11 @@ void ScribbleArea::mousePressEvent(QMouseEvent* e)
 
 void ScribbleArea::mouseMoveEvent(QMouseEvent* e)
 {
+    if (mStrokeManager->isTabletInUse() || !isMouseInUse()) { e->ignore(); return; }
     PointerEvent* event = new PointerEvent(e);
+
+    // Workaround for tablet issue (#677 part 2)
+    if (mStrokeManager->isTabletInUse()) { event->ignore(); return; }
     mStrokeManager->pointerMoveEvent(event);
 
     pointerMoveEvent(event);
@@ -669,14 +678,18 @@ void ScribbleArea::mouseMoveEvent(QMouseEvent* e)
 
 void ScribbleArea::mouseReleaseEvent(QMouseEvent* e)
 {
+    if (mStrokeManager->isTabletInUse() || !isMouseInUse()) { e->ignore(); return; }
     PointerEvent* event = new PointerEvent(e);
+
     mStrokeManager->pointerReleaseEvent(event);
 
     pointerReleaseEvent(event);
+    mMouseInUse = false;
 }
 
 void ScribbleArea::mouseDoubleClickEvent(QMouseEvent *e)
 {
+    if (mStrokeManager->isTabletInUse() || !isMouseInUse()) { e->ignore(); return; }
     PointerEvent* event = new PointerEvent(e);
     mStrokeManager->pointerPressEvent(event);
 

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -417,7 +417,7 @@ void ScribbleArea::wheelEvent(QWheelEvent* event)
 
 void ScribbleArea::tabletEvent(QTabletEvent *e)
 {
-    PointerEvent* event = new PointerEvent(e);
+    PointerEvent* event = new PointerEvent(e, e->posF());
     updateCanvasCursor();
 
     if (event->pointerType() == QTabletEvent::Eraser)
@@ -635,7 +635,7 @@ bool ScribbleArea::allowSmudging()
 
 void ScribbleArea::mousePressEvent(QMouseEvent* e)
 {
-    if (mStrokeManager->isTabletInUse() || !isMouseInUse()) { e->ignore(); return; }
+    if (mStrokeManager->isTabletInUse()) { e->ignore(); return; }
     PointerEvent* event = new PointerEvent(e);
     mMouseInUse = true;
 

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -43,7 +43,7 @@ class Layer;
 class Editor;
 class BaseTool;
 class StrokeManager;
-
+class PointerEvent;
 
 class ScribbleArea : public QWidget
 {
@@ -194,6 +194,10 @@ public:
     void refreshVector( const QRectF& rect, int rad );
     void setGaussianGradient( QGradient &gradient, QColor colour, qreal opacity, qreal offset );
 
+    void pointerPressEvent(PointerEvent*);
+    void pointerMoveEvent(PointerEvent*);
+    void pointerReleaseEvent(PointerEvent*);
+
     void updateCanvasCursor();
 
     /// Call this when starting to use a paint tool. Checks whether we are drawing
@@ -212,9 +216,6 @@ private:
     void drawCanvas( int frame, QRect rect );
     void settingUpdated(SETTING setting);
     void paintSelectionVisuals(QPainter& painter);
-    void tabletPressEvent(QTabletEvent* event);
-    void tabletMoveEvent(QTabletEvent* event);
-    void tabletReleaseEvent(QTabletEvent* event);
 
     MoveMode mMoveMode = MoveMode::NONE;
     ToolType mPrevTemporalToolType = ERASER;
@@ -245,10 +246,16 @@ private:
     bool mMouseInUse    = false;
     bool mMouseRightButtonInUse = false;
     bool mPenHeldDown = false;
-    QPointF mLastPixel;
-    QPointF mCurrentPixel;
-    QPointF mLastPoint;
-    QPointF mCurrentPoint;
+
+
+    // Double click handling for tablet input
+    void handleDoubleClick();
+    bool isFirstClick = true;
+    int doubleClickMillis = 0;
+    // Microsoft suggests that a double click action should be no more than 500 ms
+    int DOUBLE_CLICK_THRESHOLD = 500;
+    QTimer* doubleClickTimer;
+
 
     qreal selectionTolerance = 8.0;
     QList<VertexRef> mClosestVertices;

--- a/core_lib/src/tool/basetool.cpp
+++ b/core_lib/src/tool/basetool.cpp
@@ -117,19 +117,6 @@ void BaseTool::pointerDoubleClickEvent(PointerEvent *event)
 {
     pointerPressEvent(event);
 }
-//void BaseTool::tabletPressEvent(QTabletEvent* event) {
-//    event->accept();
-//}
-
-//void BaseTool::tabletReleaseEvent(QTabletEvent* event) {
-//    event->accept();
-//}
-
-//void BaseTool::mouseDoubleClickEvent(QMouseEvent* event)
-//{
-//    mousePressEvent(event);
-//}
-
 
 /**
  * @brief BaseTool::isDrawingTool - A drawing tool is anything that applies something to the canvas.

--- a/core_lib/src/tool/basetool.cpp
+++ b/core_lib/src/tool/basetool.cpp
@@ -17,6 +17,7 @@ GNU General Public License for more details.
 
 #include "basetool.h"
 
+#include "pointerevent.h"
 #include <array>
 #include <QtMath>
 #include "editor.h"
@@ -97,22 +98,37 @@ void BaseTool::initialize(Editor* editor)
     loadSettings();
 }
 
-void BaseTool::tabletMoveEvent(QTabletEvent* event) {
-    event->accept();
-}
-
-void BaseTool::tabletPressEvent(QTabletEvent* event) {
-    event->accept();
-}
-
-void BaseTool::tabletReleaseEvent(QTabletEvent* event) {
-    event->accept();
-}
-
-void BaseTool::mouseDoubleClickEvent(QMouseEvent* event)
+void BaseTool::pointerPressEvent(PointerEvent *event)
 {
-    mousePressEvent(event);
+    event->accept();
 }
+
+void BaseTool::pointerMoveEvent(PointerEvent *event)
+{
+    event->accept();
+}
+
+void BaseTool::pointerReleaseEvent(PointerEvent *event)
+{
+    event->accept();
+}
+
+void BaseTool::pointerDoubleClickEvent(PointerEvent *event)
+{
+    pointerPressEvent(event);
+}
+//void BaseTool::tabletPressEvent(QTabletEvent* event) {
+//    event->accept();
+//}
+
+//void BaseTool::tabletReleaseEvent(QTabletEvent* event) {
+//    event->accept();
+//}
+
+//void BaseTool::mouseDoubleClickEvent(QMouseEvent* event)
+//{
+//    mousePressEvent(event);
+//}
 
 
 /**
@@ -365,10 +381,14 @@ void BaseTool::adjustCursor(qreal argOffsetX, Qt::KeyboardModifiers keyMod) //of
     };
 }
 
-void BaseTool::adjustPressureSensitiveProperties(qreal pressure, bool mouseDevice)
+QPointF BaseTool::getCurrentPressPixel()
 {
-    Q_UNUSED(pressure);
-    Q_UNUSED(mouseDevice);
+    return m_pStrokeManager->getCurrentPressPixel();
+}
+
+QPointF BaseTool::getCurrentPressPoint()
+{
+    return mEditor->view()->mapScreenToCanvas(m_pStrokeManager->getCurrentPressPixel());
 }
 
 QPointF BaseTool::getCurrentPixel()

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -33,6 +33,7 @@ class QKeyEvent;
 class QMouseEvent;
 class QTabletEvent;
 class StrokeManager;
+class PointerEvent;
 
 class Properties
 {
@@ -76,13 +77,10 @@ public:
     virtual void loadSettings() = 0;
     virtual QCursor cursor();
 
-    virtual void mousePressEvent(QMouseEvent*) = 0;
-    virtual void mouseMoveEvent(QMouseEvent*) = 0;
-    virtual void mouseReleaseEvent(QMouseEvent*) = 0;
-    virtual void mouseDoubleClickEvent(QMouseEvent*);
-    virtual void tabletMoveEvent(QTabletEvent*);
-    virtual void tabletPressEvent(QTabletEvent*);
-    virtual void tabletReleaseEvent(QTabletEvent*);
+    virtual void pointerPressEvent(PointerEvent*) = 0;
+    virtual void pointerMoveEvent(PointerEvent*) = 0;
+    virtual void pointerReleaseEvent(PointerEvent*) = 0;
+    virtual void pointerDoubleClickEvent(PointerEvent*);
 
     // return true if handled
     virtual bool keyPressEvent(QKeyEvent*) { return false; }
@@ -92,8 +90,6 @@ public:
     virtual void startAdjusting(ToolPropertyType argSettingType, qreal argStep);
     virtual void stopAdjusting();
     virtual void adjustCursor(qreal argOffsetX, Qt::KeyboardModifiers keyMod);
-
-    virtual void adjustPressureSensitiveProperties(qreal pressure, bool mouseDevice);
 
     virtual void clear() {}
 
@@ -120,6 +116,8 @@ public:
 
     Properties properties;
 
+    QPointF getCurrentPressPixel();
+    QPointF getCurrentPressPoint();
     QPointF getCurrentPixel();
     QPointF getCurrentPoint();
     QPointF getLastPixel();

--- a/core_lib/src/tool/brushtool.cpp
+++ b/core_lib/src/tool/brushtool.cpp
@@ -170,12 +170,6 @@ void BrushTool::pointerPressEvent(PointerEvent *)
     mMouseDownPoint = getCurrentPoint();
     mLastBrushPoint = getCurrentPoint();
 
-    qreal distance = QLineF( getCurrentPoint(), mMouseDownPoint ).length();
-    if (distance < 1)
-    {
-        paintAt(mMouseDownPoint);
-    }
-
     startStroke();
 }
 void BrushTool::pointerMoveEvent(PointerEvent *)
@@ -188,6 +182,17 @@ void BrushTool::pointerMoveEvent(PointerEvent *)
 void BrushTool::pointerReleaseEvent(PointerEvent *)
 {
     Layer* layer = mEditor->layers()->currentLayer();
+
+    qreal distance = QLineF(getCurrentPoint(), mMouseDownPoint).length();
+    if (distance < 1)
+    {
+        paintAt(mMouseDownPoint);
+    }
+    else
+    {
+        drawStroke();
+    }
+
     if (layer->type() == Layer::BITMAP)
         paintBitmapStroke();
     else if (layer->type() == Layer::VECTOR)

--- a/core_lib/src/tool/brushtool.cpp
+++ b/core_lib/src/tool/brushtool.cpp
@@ -164,105 +164,36 @@ QCursor BrushTool::cursor()
     return Qt::CrossCursor;
 }
 
-void BrushTool::adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice )
-{
-//    Layer* layer = mEditor->layers()->currentLayer();
-
-//    // In Bitmap mode, the brush tool pressure only handles opacity while the Pen tool
-//    // only handles size. Pencil tool handles both.
-
-//    QColor currentColor = mEditor->color()->frontColor();
-//    currentPressuredColor = currentColor;
-
-//    if ( layer->type() == Layer::BITMAP && properties.pressure && !mouseDevice )
-//    {
-//        currentPressuredColor.setAlphaF( currentColor.alphaF() * pressure * pressure );
-//    }
-
-//    mCurrentWidth = properties.width;
-
-    if ( properties.pressure && !mouseDevice )
-    {
-        mCurrentPressure = pressure;
-    }
-    else
-    {
-        mCurrentPressure = 1.0;
-    }
-}
-
-void BrushTool::tabletPressEvent(QTabletEvent *)
+void BrushTool::pointerPressEvent(PointerEvent *)
 {
     mScribbleArea->setAllDirty();
     mMouseDownPoint = getCurrentPoint();
     mLastBrushPoint = getCurrentPoint();
-    startStroke();
-}
 
-void BrushTool::tabletMoveEvent(QTabletEvent *)
-{
-    drawStroke();
-    if (properties.stabilizerLevel != m_pStrokeManager->getStabilizerLevel())
-        m_pStrokeManager->setStabilizerLevel(properties.stabilizerLevel);
-}
-
-void BrushTool::tabletReleaseEvent(QTabletEvent *)
-{
-    mEditor->backup(typeName());
-
-    Layer* layer = mEditor->layers()->currentLayer();
     qreal distance = QLineF( getCurrentPoint(), mMouseDownPoint ).length();
     if (distance < 1)
     {
         paintAt(mMouseDownPoint);
     }
-    else
-    {
-        drawStroke();
-    }
 
-    if ( layer->type() == Layer::BITMAP )
-        paintBitmapStroke();
-    else if (layer->type() == Layer::VECTOR )
-        paintVectorStroke();
-    endStroke();
-}
-
-void BrushTool::mousePressEvent( QMouseEvent *)
-{
-    mScribbleArea->setAllDirty();
-    mMouseDownPoint = getCurrentPoint();
-    mLastBrushPoint = getCurrentPoint();
     startStroke();
 }
-
-void BrushTool::mouseReleaseEvent( QMouseEvent *)
+void BrushTool::pointerMoveEvent(PointerEvent *)
 {
-    mEditor->backup(typeName());
-
-    Layer* layer = mEditor->layers()->currentLayer();
-    qreal distance = QLineF( getCurrentPoint(), mMouseDownPoint ).length();
-    if (distance < 1)
-    {
-        paintAt(mMouseDownPoint);
-    }
-    else
-    {
-        drawStroke();
-    }
-
-    if ( layer->type() == Layer::BITMAP )
-        paintBitmapStroke();
-    else if (layer->type() == Layer::VECTOR )
-        paintVectorStroke();
-    endStroke();
-}
-
-void BrushTool::mouseMoveEvent( QMouseEvent *)
-{
+    mCurrentPressure = m_pStrokeManager->getPressure();
     drawStroke();
     if (properties.stabilizerLevel != m_pStrokeManager->getStabilizerLevel())
         m_pStrokeManager->setStabilizerLevel(properties.stabilizerLevel);
+}
+void BrushTool::pointerReleaseEvent(PointerEvent *)
+{
+    Layer* layer = mEditor->layers()->currentLayer();
+    if (layer->type() == Layer::BITMAP)
+        paintBitmapStroke();
+    else if (layer->type() == Layer::VECTOR)
+        paintVectorStroke();
+
+    endStroke();
 }
 
 // draw a single paint dab at the given location

--- a/core_lib/src/tool/brushtool.h
+++ b/core_lib/src/tool/brushtool.h
@@ -30,15 +30,9 @@ public:
     void loadSettings() override;
     QCursor cursor() override;
 
-    void mouseMoveEvent( QMouseEvent* ) override;
-    void mousePressEvent( QMouseEvent* ) override;
-    void mouseReleaseEvent( QMouseEvent* ) override;
-
-    void tabletMoveEvent( QTabletEvent* ) override;
-    void tabletPressEvent( QTabletEvent* ) override;
-    void tabletReleaseEvent( QTabletEvent* ) override;
-
-    void adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice ) override;
+    void pointerMoveEvent( PointerEvent* ) override;
+    void pointerPressEvent( PointerEvent* ) override;
+    void pointerReleaseEvent( PointerEvent* ) override;
 
     void drawStroke();
     void paintVectorStroke();

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -18,7 +18,7 @@ GNU General Public License for more details.
 
 #include <QPixmap>
 #include <QPainter>
-#include <QMouseEvent>
+#include "pointerevent.h"
 
 #include "layer.h"
 #include "layervector.h"
@@ -96,64 +96,34 @@ void BucketTool::setTolerance(const int tolerance)
     settings.sync();
 }
 
-void BucketTool::mousePressEvent(QMouseEvent* evt)
-{
-    pressEventInternal(evt->button());
-}
-
-void BucketTool::mouseReleaseEvent(QMouseEvent* evt)
-{
-    releaseEventInternal(evt->button());
-}
-
-void BucketTool::mouseMoveEvent(QMouseEvent* evt)
-{
-    moveEventInternal(evt->buttons());
-}
-
-void BucketTool::tabletPressEvent(QTabletEvent* evt)
-{
-    pressEventInternal(evt->button());
-}
-
-void BucketTool::tabletReleaseEvent(QTabletEvent* evt)
-{
-    releaseEventInternal(evt->button());
-}
-
-void BucketTool::tabletMoveEvent(QTabletEvent* evt)
-{
-    moveEventInternal(evt->buttons());
-}
-
-void BucketTool::pressEventInternal(Qt::MouseButton mouseButton)
+void BucketTool::pointerPressEvent(PointerEvent *event)
 {
     startStroke();
-    if (mouseButton == Qt::LeftButton)
+    if (event->button() == Qt::LeftButton)
     {
         mScribbleArea->setAllDirty();
     }
     startStroke();
 }
 
-void BucketTool::moveEventInternal(Qt::MouseButtons mouseButton)
+void BucketTool::pointerMoveEvent(PointerEvent *event)
 {
     Layer* layer = mEditor->layers()->currentLayer();
     if (layer->type() == Layer::VECTOR)
     {
-        if (mouseButton & Qt::LeftButton)
+        if (event->buttons() & Qt::LeftButton)
         {
             drawStroke();
         }
     }
 }
 
-void BucketTool::releaseEventInternal(Qt::MouseButton mouseButton)
+void BucketTool::pointerReleaseEvent(PointerEvent *event)
 {
     Layer* layer = editor()->layers()->currentLayer();
     if (layer == nullptr) { return; }
 
-    if (mouseButton == Qt::LeftButton)
+    if (event->button() == Qt::LeftButton)
     {
         mEditor->backup(typeName());
 

--- a/core_lib/src/tool/buckettool.h
+++ b/core_lib/src/tool/buckettool.h
@@ -23,7 +23,6 @@ GNU General Public License for more details.
 class Layer;
 class VectorImage;
 
-
 class BucketTool : public StrokeTool
 {
     Q_OBJECT
@@ -33,13 +32,9 @@ public:
     void loadSettings() override;
     QCursor cursor() override;
 
-    void mousePressEvent(QMouseEvent*) override;
-    void mouseMoveEvent(QMouseEvent*) override;
-    void mouseReleaseEvent(QMouseEvent*) override;
-
-    void tabletPressEvent(QTabletEvent*) override;
-    void tabletMoveEvent(QTabletEvent*) override;
-    void tabletReleaseEvent(QTabletEvent*) override;
+    void pointerPressEvent(PointerEvent*) override;
+    void pointerMoveEvent(PointerEvent*) override;
+    void pointerReleaseEvent(PointerEvent*) override;
 
     void setTolerance(const int tolerance) override;
     void setWidth(const qreal width) override;
@@ -51,10 +46,6 @@ public:
     void applyChanges();
 
 private:
-    void pressEventInternal(Qt::MouseButton);
-    void releaseEventInternal(Qt::MouseButton);
-    void moveEventInternal(Qt::MouseButtons);
-    
 
     VectorImage* vectorImage = nullptr;
 };

--- a/core_lib/src/tool/buckettool.h
+++ b/core_lib/src/tool/buckettool.h
@@ -23,30 +23,39 @@ GNU General Public License for more details.
 class Layer;
 class VectorImage;
 
+
 class BucketTool : public StrokeTool
 {
     Q_OBJECT
 public:
-    explicit BucketTool( QObject *parent = 0 );
+    explicit BucketTool(QObject* parent = nullptr);
     ToolType type() override;
     void loadSettings() override;
     QCursor cursor() override;
 
-    void mousePressEvent( QMouseEvent * ) override;
-    void mouseMoveEvent( QMouseEvent * ) override;
-    void mouseReleaseEvent( QMouseEvent * ) override;
+    void mousePressEvent(QMouseEvent*) override;
+    void mouseMoveEvent(QMouseEvent*) override;
+    void mouseReleaseEvent(QMouseEvent*) override;
+
+    void tabletPressEvent(QTabletEvent*) override;
+    void tabletMoveEvent(QTabletEvent*) override;
+    void tabletReleaseEvent(QTabletEvent*) override;
 
     void setTolerance(const int tolerance) override;
     void setWidth(const qreal width) override;
 
-    void paintBitmap(Layer *layer);
-    void paintVector(QMouseEvent *event, Layer *layer);
+    void paintBitmap(Layer* layer);
+    void paintVector(Layer* layer);
     void drawStroke();
-    void getBrushWidth();
 
     void applyChanges();
 
 private:
+    void pressEventInternal(Qt::MouseButton);
+    void releaseEventInternal(Qt::MouseButton);
+    void moveEventInternal(Qt::MouseButtons);
+    
+
     VectorImage* vectorImage = nullptr;
 };
 

--- a/core_lib/src/tool/erasertool.cpp
+++ b/core_lib/src/tool/erasertool.cpp
@@ -115,19 +115,7 @@ QCursor EraserTool::cursor()
     return Qt::CrossCursor;
 }
 
-void EraserTool::adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice )
-{
-    if ( properties.pressure && !mouseDevice )
-    {
-        mCurrentPressure = pressure;
-    }
-    else
-    {
-        mCurrentPressure = 1.0;
-    }
-}
-
-void EraserTool::tabletPressEvent(QTabletEvent *)
+void EraserTool::pointerPressEvent(PointerEvent *)
 {
     mScribbleArea->setAllDirty();
 
@@ -136,14 +124,15 @@ void EraserTool::tabletPressEvent(QTabletEvent *)
     mMouseDownPoint = getCurrentPoint();
 }
 
-void EraserTool::tabletMoveEvent(QTabletEvent *)
+void EraserTool::pointerMoveEvent(PointerEvent *)
 {
+    mCurrentPressure = m_pStrokeManager->getPressure();
     updateStrokes();
     if (properties.stabilizerLevel != m_pStrokeManager->getStabilizerLevel())
         m_pStrokeManager->setStabilizerLevel(properties.stabilizerLevel);
 }
 
-void EraserTool::tabletReleaseEvent(QTabletEvent *)
+void EraserTool::pointerReleaseEvent(PointerEvent *)
 {
     mEditor->backup(typeName());
 
@@ -158,39 +147,6 @@ void EraserTool::tabletReleaseEvent(QTabletEvent *)
     }
     removeVectorPaint();
     endStroke();
-}
-
-void EraserTool::mousePressEvent( QMouseEvent *)
-{
-    mScribbleArea->setAllDirty();
-
-    startStroke();
-    mLastBrushPoint = getCurrentPoint();
-    mMouseDownPoint = getCurrentPoint();
-}
-
-void EraserTool::mouseReleaseEvent(QMouseEvent *)
-{
-    mEditor->backup(typeName());
-
-    qreal distance = QLineF( getCurrentPoint(), mMouseDownPoint ).length();
-    if (distance < 1)
-    {
-        paintAt(mMouseDownPoint);
-    }
-    else
-    {
-        drawStroke();
-    }
-    removeVectorPaint();
-    endStroke();
-}
-
-void EraserTool::mouseMoveEvent(QMouseEvent *)
-{
-    updateStrokes();
-    if (properties.stabilizerLevel != m_pStrokeManager->getStabilizerLevel())
-        m_pStrokeManager->setStabilizerLevel(properties.stabilizerLevel);
 }
 
 // draw a single paint dab at the given location

--- a/core_lib/src/tool/erasertool.h
+++ b/core_lib/src/tool/erasertool.h
@@ -30,15 +30,9 @@ public:
     void loadSettings() override;
     QCursor cursor() override;
 
-    void mouseMoveEvent( QMouseEvent* ) override;
-    void mousePressEvent( QMouseEvent* ) override;
-    void mouseReleaseEvent( QMouseEvent* ) override;
-
-    void tabletPressEvent( QTabletEvent* ) override;
-    void tabletMoveEvent( QTabletEvent* ) override;
-    void tabletReleaseEvent( QTabletEvent* ) override;
-
-    void adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice ) override;
+    void pointerMoveEvent( PointerEvent* ) override;
+    void pointerPressEvent( PointerEvent* ) override;
+    void pointerReleaseEvent( PointerEvent* ) override;
 
     void drawStroke();
     void paintAt( QPointF point );

--- a/core_lib/src/tool/eyedroppertool.cpp
+++ b/core_lib/src/tool/eyedroppertool.cpp
@@ -20,7 +20,7 @@ GNU General Public License for more details.
 #include <QPainter>
 #include <QPixmap>
 #include <QBitmap>
-#include <QMouseEvent>
+#include "pointerevent.h"
 
 #include "vectorimage.h"
 #include "layervector.h"
@@ -74,49 +74,11 @@ QCursor EyedropperTool::cursor(const QColor colour)
     return QCursor(pixmap, 0, 15);
 }
 
-void EyedropperTool::mousePressEvent(QMouseEvent *event)
+void EyedropperTool::pointerPressEvent(PointerEvent *)
+{}
+
+void EyedropperTool::pointerMoveEvent(PointerEvent *)
 {
-    Q_UNUSED(event);
-}
-
-void EyedropperTool::mouseReleaseEvent(QMouseEvent *event)
-{
-    Layer* layer = mEditor->layers()->currentLayer();
-    if (layer == NULL) { return; }
-
-    if (event->button() == Qt::LeftButton)
-    {
-        if (layer->type() == Layer::BITMAP)
-        {
-            BitmapImage* targetImage = ((LayerBitmap *)layer)->getLastBitmapImageAtFrame( mEditor->currentFrame(), 0);
-            //QColor pickedColour = targetImage->pixel(getLastPoint().x(), getLastPoint().y());
-            QColor pickedColour;
-            pickedColour.setRgba( targetImage->pixel( getLastPoint().x(), getLastPoint().y() ) );
-            int transp = 255 - pickedColour.alpha();
-            pickedColour.setRed( pickedColour.red() + transp );
-            pickedColour.setGreen( pickedColour.green() + transp );
-            pickedColour.setBlue( pickedColour.blue() + transp );
-            if (pickedColour.alpha() != 0)
-            {
-                mEditor->color()->setColor(pickedColour);
-            }
-        }
-        else if (layer->type() == Layer::VECTOR)
-        {
-            VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
-            int colourNumber = vectorImage->getColourNumber(getLastPoint());
-            if (colourNumber != -1)
-            {
-                mEditor->color()->setColorNumber(colourNumber);
-            }
-        }
-    }
-}
-
-void EyedropperTool::mouseMoveEvent(QMouseEvent *event)
-{
-    Q_UNUSED(event);
-
     Layer* layer = mEditor->layers()->currentLayer();
     if (layer == NULL) { return; }
 
@@ -157,6 +119,41 @@ void EyedropperTool::mouseMoveEvent(QMouseEvent *event)
         else
         {
             mScribbleArea->setCursor(cursor());
+        }
+    }
+}
+
+void EyedropperTool::pointerReleaseEvent(PointerEvent *event)
+{
+    Layer* layer = mEditor->layers()->currentLayer();
+    if (layer == NULL) { return; }
+
+    if (event->button() == Qt::LeftButton)
+    {
+        qDebug() << "was left button or tablet button";
+        if (layer->type() == Layer::BITMAP)
+        {
+            BitmapImage* targetImage = ((LayerBitmap *)layer)->getLastBitmapImageAtFrame( mEditor->currentFrame(), 0);
+            //QColor pickedColour = targetImage->pixel(getLastPoint().x(), getLastPoint().y());
+            QColor pickedColour;
+            pickedColour.setRgba( targetImage->pixel( getLastPoint().x(), getLastPoint().y() ) );
+            int transp = 255 - pickedColour.alpha();
+            pickedColour.setRed( pickedColour.red() + transp );
+            pickedColour.setGreen( pickedColour.green() + transp );
+            pickedColour.setBlue( pickedColour.blue() + transp );
+            if (pickedColour.alpha() != 0)
+            {
+                mEditor->color()->setColor(pickedColour);
+            }
+        }
+        else if (layer->type() == Layer::VECTOR)
+        {
+            VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+            int colourNumber = vectorImage->getColourNumber(getLastPoint());
+            if (colourNumber != -1)
+            {
+                mEditor->color()->setColorNumber(colourNumber);
+            }
         }
     }
 }

--- a/core_lib/src/tool/eyedroppertool.h
+++ b/core_lib/src/tool/eyedroppertool.h
@@ -35,8 +35,8 @@ public:
     void pointerReleaseEvent( PointerEvent* event ) override;
     void pointerMoveEvent( PointerEvent* ) override;
 
-    void moveEventInternal();
-    void releaseEventInternal(Qt::MouseButton mouseButton);
+    /** Updates front color for bitmap and color index for vector */
+    void updateFrontColor();
 };
 
 #endif // EYEDROPPERTOOL_H

--- a/core_lib/src/tool/eyedroppertool.h
+++ b/core_lib/src/tool/eyedroppertool.h
@@ -31,9 +31,12 @@ public:
     QCursor cursor() override;
     QCursor cursor( const QColor colour );
 
-    void mousePressEvent( QMouseEvent* ) override;
-    void mouseReleaseEvent( QMouseEvent* ) override;
-    void mouseMoveEvent( QMouseEvent* ) override;
+    void pointerPressEvent( PointerEvent* ) override;
+    void pointerReleaseEvent( PointerEvent* event ) override;
+    void pointerMoveEvent( PointerEvent* ) override;
+
+    void moveEventInternal();
+    void releaseEventInternal(Qt::MouseButton mouseButton);
 };
 
 #endif // EYEDROPPERTOOL_H

--- a/core_lib/src/tool/handtool.cpp
+++ b/core_lib/src/tool/handtool.cpp
@@ -21,7 +21,7 @@ GNU General Public License for more details.
 #include <QtMath>
 #include <QPixmap>
 #include <QVector2D>
-#include <QMouseEvent>
+#include <pointerevent.h>
 
 #include "layer.h"
 #include "layercamera.h"
@@ -50,28 +50,7 @@ QCursor HandTool::cursor()
     return mIsHeld ? Qt::ClosedHandCursor : Qt::OpenHandCursor;
 }
 
-void HandTool::tabletPressEvent(QTabletEvent *)
-{
-    mLastPixel = getLastPressPixel();
-    mScribbleArea->updateToolCursor();
-    mIsHeld = true;
-}
-
-void HandTool::tabletMoveEvent(QTabletEvent * event)
-{
-    if (m_pStrokeManager->isPenPressed()) {
-        transformView(event->modifiers(), event->buttons());
-        mLastPixel = getCurrentPixel();
-    }
-}
-
-void HandTool::tabletReleaseEvent(QTabletEvent *)
-{
-    mScribbleArea->updateToolCursor();
-    mIsHeld = false;
-}
-
-void HandTool::mousePressEvent( QMouseEvent* )
+void HandTool::pointerPressEvent(PointerEvent *)
 {
     mLastPixel = getLastPressPixel();
     mIsHeld = true;
@@ -79,19 +58,7 @@ void HandTool::mousePressEvent( QMouseEvent* )
     mScribbleArea->updateToolCursor();
 }
 
-void HandTool::mouseReleaseEvent( QMouseEvent* event )
-{
-    //---- stop the hand tool if this was mid button
-    if ( event->button() == Qt::MidButton )
-    {
-        qDebug( "[HandTool] Stop Hand Tool" );
-        mScribbleArea->setPrevTool();
-    }
-    mIsHeld = false;
-    mScribbleArea->updateToolCursor();
-}
-
-void HandTool::mouseMoveEvent( QMouseEvent* event )
+void HandTool::pointerMoveEvent(PointerEvent *event)
 {
     if ( event->buttons() == Qt::NoButton )
     {
@@ -103,7 +70,19 @@ void HandTool::mouseMoveEvent( QMouseEvent* event )
     mLastPixel = getCurrentPixel();
 }
 
-void HandTool::mouseDoubleClickEvent( QMouseEvent *event )
+void HandTool::pointerReleaseEvent(PointerEvent *event)
+{
+    //---- stop the hand tool if this was mid button
+    if ( event->button() == Qt::MidButton )
+    {
+        qDebug( "[HandTool] Stop Hand Tool" );
+        mScribbleArea->setPrevTool();
+    }
+    mIsHeld = false;
+    mScribbleArea->updateToolCursor();
+}
+
+void HandTool::pointerDoubleClickEvent(PointerEvent *event)
 {
     if ( event->button() == Qt::RightButton )
     {

--- a/core_lib/src/tool/handtool.h
+++ b/core_lib/src/tool/handtool.h
@@ -30,14 +30,10 @@ public:
     void loadSettings() override;
     QCursor cursor() override;
 
-    void mousePressEvent(QMouseEvent *) override;
-    void mouseReleaseEvent(QMouseEvent *) override;
-    void mouseMoveEvent(QMouseEvent *) override;
-    void mouseDoubleClickEvent(QMouseEvent *) override;
-
-    void tabletPressEvent(QTabletEvent*) override;
-    void tabletMoveEvent(QTabletEvent*) override;
-    void tabletReleaseEvent(QTabletEvent*) override;
+    void pointerPressEvent(PointerEvent *) override;
+    void pointerReleaseEvent(PointerEvent *) override;
+    void pointerMoveEvent(PointerEvent *) override;
+    void pointerDoubleClickEvent(PointerEvent *) override;
 
 private:
 

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -18,7 +18,7 @@ GNU General Public License for more details.
 #include "movetool.h"
 
 #include <cassert>
-#include <QMouseEvent>
+#include "pointerevent.h"
 #include <QMessageBox>
 
 #include "editor.h"
@@ -56,69 +56,15 @@ QCursor MoveTool::cursor()
     return mScribbleArea->currentTool()->selectMoveCursor(mode, type());
 }
 
-void MoveTool::tabletPressEvent(QTabletEvent *event)
+void MoveTool::pointerPressEvent(PointerEvent *event)
 {
-    mCurrentLayer = currentPaintableLayer();
-    beginInteraction(event->modifiers(), mCurrentLayer);
-
-}
-
-void MoveTool::tabletMoveEvent(QTabletEvent *event)
-{
-    mCurrentLayer = currentPaintableLayer();
-
-    if (m_pStrokeManager->isPenPressed())   // the user is also pressing the mouse (dragging)
-    {
-        transformSelection(event->modifiers(), mCurrentLayer);
-    }
-    else
-    {
-        // the user is hovering the pen over the tablet
-        // update cursor to reflect selection corner interaction
-        mScribbleArea->updateToolCursor();
-
-        if (mCurrentLayer->type() == Layer::VECTOR)
-        {
-            storeClosestVectorCurve(mCurrentLayer);
-        }
-    }
-    mScribbleArea->updateCurrentFrame();
-}
-
-void MoveTool::tabletReleaseEvent(QTabletEvent*)
-{
-    if (!mScribbleArea->isSomethingSelected())
-        return;
-
-    mRotatedAngle = mScribbleArea->myRotatedAngle;
-    updateTransformation();
-
-    mScribbleArea->updateToolCursor();
-    mScribbleArea->updateCurrentFrame();
-}
-
-void MoveTool::mousePressEvent(QMouseEvent* event)
-{
-
     mCurrentLayer = currentPaintableLayer();
     if (mCurrentLayer == nullptr) return;
     setAnchorToLastPoint();
     beginInteraction(event->modifiers(), mCurrentLayer);
 }
 
-void MoveTool::mouseReleaseEvent(QMouseEvent*)
-{
-    if (!mScribbleArea->isSomethingSelected())
-        return;
-
-    mRotatedAngle = mScribbleArea->myRotatedAngle;
-    updateTransformation();
-
-    mScribbleArea->updateToolCursor();
-    mScribbleArea->updateCurrentFrame();
-}
-
-void MoveTool::mouseMoveEvent(QMouseEvent* event)
+void MoveTool::pointerMoveEvent(PointerEvent *event)
 {
     mCurrentLayer = currentPaintableLayer();
     if (mCurrentLayer == nullptr) return;
@@ -138,6 +84,18 @@ void MoveTool::mouseMoveEvent(QMouseEvent* event)
             storeClosestVectorCurve(mCurrentLayer);
         }
     }
+    mScribbleArea->updateCurrentFrame();
+}
+
+void MoveTool::pointerReleaseEvent(PointerEvent *)
+{
+    if (!mScribbleArea->isSomethingSelected())
+        return;
+
+    mRotatedAngle = mScribbleArea->myRotatedAngle;
+    updateTransformation();
+
+    mScribbleArea->updateToolCursor();
     mScribbleArea->updateCurrentFrame();
 }
 

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -34,13 +34,9 @@ public:
     void loadSettings() override;
     QCursor cursor() override;
 
-    void mousePressEvent(QMouseEvent*) override;
-    void mouseReleaseEvent(QMouseEvent*) override;
-    void mouseMoveEvent(QMouseEvent*) override;
-
-    void tabletMoveEvent( QTabletEvent* ) override;
-    void tabletPressEvent( QTabletEvent* ) override;
-    void tabletReleaseEvent( QTabletEvent* ) override;
+    void pointerPressEvent(PointerEvent*) override;
+    void pointerReleaseEvent(PointerEvent*) override;
+    void pointerMoveEvent(PointerEvent*) override;
 
     bool leavingThisTool() override;
     bool switchingLayer() override;

--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -18,7 +18,7 @@ GNU General Public License for more details.
 
 #include <QSettings>
 #include <QPixmap>
-#include <QMouseEvent>
+#include "pointerevent.h"
 
 #include "layermanager.h"
 #include "colormanager.h"
@@ -146,34 +146,13 @@ QCursor PencilTool::cursor()
     return Qt::CrossCursor;
 }
 
-void PencilTool::tabletPressEvent(QTabletEvent*)
+void PencilTool::pointerPressEvent(PointerEvent *)
 {
     mScribbleArea->setAllDirty();
 
     mMouseDownPoint = getCurrentPoint();
     mLastBrushPoint = getCurrentPoint();
 
-    startStroke();
-
-    // note: why are we doing this on device press event?
-    if ( !mEditor->preference()->isOn(SETTING::INVISIBLE_LINES) )
-    {
-        mScribbleArea->toggleThinLines();
-    }
-}
-
-void PencilTool::tabletMoveEvent(QTabletEvent*)
-{
-    drawStroke();
-    if (properties.stabilizerLevel != m_pStrokeManager->getStabilizerLevel())
-        m_pStrokeManager->setStabilizerLevel(properties.stabilizerLevel);
-}
-
-void PencilTool::tabletReleaseEvent(QTabletEvent*)
-{
-    mEditor->backup(typeName());
-
-    Layer* layer = mEditor->layers()->currentLayer();
     qreal distance = QLineF(getCurrentPoint(), mMouseDownPoint).length();
     if (distance < 1)
     {
@@ -184,20 +163,6 @@ void PencilTool::tabletReleaseEvent(QTabletEvent*)
         drawStroke();
     }
 
-    if (layer->type() == Layer::BITMAP)
-        paintBitmapStroke();
-    else if (layer->type() == Layer::VECTOR)
-        paintVectorStroke(layer);
-    endStroke();
-}
-
-void PencilTool::mousePressEvent(QMouseEvent *)
-{
-    mScribbleArea->setAllDirty();
-
-    mMouseDownPoint = getCurrentPoint();
-    mLastBrushPoint = getCurrentPoint();
-
     startStroke();
 
     // note: why are we doing this on device press event?
@@ -207,47 +172,25 @@ void PencilTool::mousePressEvent(QMouseEvent *)
     }
 }
 
-void PencilTool::mouseReleaseEvent(QMouseEvent *)
+void PencilTool::pointerMoveEvent(PointerEvent *)
+{
+    mCurrentPressure = m_pStrokeManager->getPressure();
+    drawStroke();
+    if (properties.stabilizerLevel != m_pStrokeManager->getStabilizerLevel())
+        m_pStrokeManager->setStabilizerLevel(properties.stabilizerLevel);
+}
+
+void PencilTool::pointerReleaseEvent(PointerEvent *)
 {
     mEditor->backup(typeName());
 
     Layer* layer = mEditor->layers()->currentLayer();
-    qreal distance = QLineF(getCurrentPoint(), mMouseDownPoint).length();
-    if (distance < 1)
-    {
-        paintAt(mMouseDownPoint);
-    }
-    else
-    {
-        drawStroke();
-    }
 
     if (layer->type() == Layer::BITMAP)
         paintBitmapStroke();
     else if (layer->type() == Layer::VECTOR)
         paintVectorStroke(layer);
     endStroke();
-}
-
-void PencilTool::mouseMoveEvent( QMouseEvent *)
-{
-    drawStroke();
-    if (properties.stabilizerLevel != m_pStrokeManager->getStabilizerLevel())
-        m_pStrokeManager->setStabilizerLevel(properties.stabilizerLevel);
-}
-
-void PencilTool::adjustPressureSensitiveProperties(qreal pressure, bool mouseDevice)
-{
-    mCurrentWidth = properties.width;
-
-    if (properties.pressure && !mouseDevice)
-    {
-        mCurrentPressure = pressure;
-    }
-    else
-    {
-        mCurrentPressure = 1.0;
-    }
 }
 
 // draw a single paint dab at the given location

--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -153,16 +153,6 @@ void PencilTool::pointerPressEvent(PointerEvent *)
     mMouseDownPoint = getCurrentPoint();
     mLastBrushPoint = getCurrentPoint();
 
-    qreal distance = QLineF(getCurrentPoint(), mMouseDownPoint).length();
-    if (distance < 1)
-    {
-        paintAt(mMouseDownPoint);
-    }
-    else
-    {
-        drawStroke();
-    }
-
     startStroke();
 
     // note: why are we doing this on device press event?
@@ -185,6 +175,16 @@ void PencilTool::pointerReleaseEvent(PointerEvent *)
     mEditor->backup(typeName());
 
     Layer* layer = mEditor->layers()->currentLayer();
+
+    qreal distance = QLineF(getCurrentPoint(), mMouseDownPoint).length();
+    if (distance < 1)
+    {
+        paintAt(mMouseDownPoint);
+    }
+    else
+    {
+        drawStroke();
+    }
 
     if (layer->type() == Layer::BITMAP)
         paintBitmapStroke();

--- a/core_lib/src/tool/penciltool.h
+++ b/core_lib/src/tool/penciltool.h
@@ -32,20 +32,14 @@ public:
     void loadSettings() override;
     QCursor cursor() override;
 
-    void mousePressEvent( QMouseEvent* ) override;
-    void mouseMoveEvent( QMouseEvent* ) override;
-    void mouseReleaseEvent( QMouseEvent* ) override;
-
-    void tabletPressEvent( QTabletEvent* ) override;
-    void tabletMoveEvent( QTabletEvent* ) override;
-    void tabletReleaseEvent( QTabletEvent* ) override;
+    void pointerPressEvent( PointerEvent* ) override;
+    void pointerMoveEvent( PointerEvent* ) override;
+    void pointerReleaseEvent( PointerEvent* ) override;
 
     void drawStroke();
     void paintAt( QPointF point );
     void paintVectorStroke(Layer* layer);
     void paintBitmapStroke();
-
-    void adjustPressureSensitiveProperties( qreal pressure, bool mouseDevice ) override;
 
     void setWidth( const qreal width ) override;
     void setFeather( const qreal feather ) override;

--- a/core_lib/src/tool/pentool.cpp
+++ b/core_lib/src/tool/pentool.cpp
@@ -111,35 +111,13 @@ QCursor PenTool::cursor()
     return Qt::CrossCursor;
 }
 
-void PenTool::adjustPressureSensitiveProperties(qreal pressure, bool mouseDevice)
-{
-    mCurrentWidth = properties.width;
-
-    if (properties.pressure && !mouseDevice)
-    {
-        mCurrentPressure = pressure;
-    }
-    else
-    {
-        mCurrentPressure = 1.0;
-    }
-}
-
-void PenTool::tabletPressEvent(QTabletEvent *)
+void PenTool::pointerPressEvent(PointerEvent *)
 {
     mScribbleArea->setAllDirty();
 
     mMouseDownPoint = getCurrentPoint();
     mLastBrushPoint = getCurrentPoint();
 
-    startStroke();
-}
-
-void PenTool::tabletReleaseEvent(QTabletEvent *)
-{
-    mEditor->backup(typeName());
-
-    Layer* layer = mEditor->layers()->currentLayer();
     qreal distance = QLineF(getCurrentPoint(), mMouseDownPoint).length();
     if (distance < 1)
     {
@@ -150,58 +128,28 @@ void PenTool::tabletReleaseEvent(QTabletEvent *)
         drawStroke();
     }
 
-    if (layer->type() == Layer::BITMAP)
-        paintBitmapStroke();
-    else if (layer->type() == Layer::VECTOR)
-        paintVectorStroke(layer);
-    endStroke();
+    startStroke();
 }
 
-void PenTool::tabletMoveEvent(QTabletEvent *)
+void PenTool::pointerMoveEvent(PointerEvent *)
 {
+    mCurrentPressure = m_pStrokeManager->getPressure();
     drawStroke();
     if (properties.stabilizerLevel != m_pStrokeManager->getStabilizerLevel())
         m_pStrokeManager->setStabilizerLevel(properties.stabilizerLevel);
 }
 
-
-void PenTool::mousePressEvent(QMouseEvent *)
-{
-    mScribbleArea->setAllDirty();
-
-    mMouseDownPoint = getCurrentPoint();
-    mLastBrushPoint = getCurrentPoint();
-
-    startStroke();
-}
-
-void PenTool::mouseReleaseEvent(QMouseEvent *)
+void PenTool::pointerReleaseEvent(PointerEvent *)
 {
     mEditor->backup(typeName());
 
     Layer* layer = mEditor->layers()->currentLayer();
-    qreal distance = QLineF(getCurrentPoint(), mMouseDownPoint).length();
-    if (distance < 1)
-    {
-        paintAt(mMouseDownPoint);
-    }
-    else
-    {
-        drawStroke();
-    }
 
     if (layer->type() == Layer::BITMAP)
         paintBitmapStroke();
     else if (layer->type() == Layer::VECTOR)
         paintVectorStroke(layer);
     endStroke();
-}
-
-void PenTool::mouseMoveEvent( QMouseEvent *)
-{
-    drawStroke();
-    if (properties.stabilizerLevel != m_pStrokeManager->getStabilizerLevel())
-        m_pStrokeManager->setStabilizerLevel(properties.stabilizerLevel);
 }
 
 // draw a single paint dab at the given location

--- a/core_lib/src/tool/pentool.cpp
+++ b/core_lib/src/tool/pentool.cpp
@@ -118,16 +118,6 @@ void PenTool::pointerPressEvent(PointerEvent *)
     mMouseDownPoint = getCurrentPoint();
     mLastBrushPoint = getCurrentPoint();
 
-    qreal distance = QLineF(getCurrentPoint(), mMouseDownPoint).length();
-    if (distance < 1)
-    {
-        paintAt(mMouseDownPoint);
-    }
-    else
-    {
-        drawStroke();
-    }
-
     startStroke();
 }
 
@@ -144,6 +134,16 @@ void PenTool::pointerReleaseEvent(PointerEvent *)
     mEditor->backup(typeName());
 
     Layer* layer = mEditor->layers()->currentLayer();
+
+    qreal distance = QLineF(getCurrentPoint(), mMouseDownPoint).length();
+    if (distance < 1)
+    {
+        paintAt(mMouseDownPoint);
+    }
+    else
+    {
+        drawStroke();
+    }
 
     if (layer->type() == Layer::BITMAP)
         paintBitmapStroke();

--- a/core_lib/src/tool/pentool.h
+++ b/core_lib/src/tool/pentool.h
@@ -31,20 +31,14 @@ public:
     void loadSettings() override;
     QCursor cursor() override;
 
-    void mousePressEvent(QMouseEvent*) override;
-    void mouseMoveEvent(QMouseEvent*) override;
-    void mouseReleaseEvent(QMouseEvent*) override;
-
-    void tabletPressEvent(QTabletEvent*) override;
-    void tabletMoveEvent(QTabletEvent*) override;
-    void tabletReleaseEvent(QTabletEvent*) override;
+    void pointerPressEvent(PointerEvent*) override;
+    void pointerMoveEvent(PointerEvent*) override;
+    void pointerReleaseEvent(PointerEvent*) override;
 
     void drawStroke();
     void paintAt(QPointF point);
     void paintVectorStroke(Layer *layer);
     void paintBitmapStroke();
-
-    void adjustPressureSensitiveProperties(qreal pressure, bool mouseDevice) override;
 
     void setWidth(const qreal width) override;
     void setPressure(const bool pressure) override;

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -17,6 +17,8 @@ GNU General Public License for more details.
 
 #include "polylinetool.h"
 
+#include "pointerevent.h"
+
 #include "editor.h"
 #include "scribblearea.h"
 
@@ -101,7 +103,7 @@ void PolylineTool::clear()
     mPoints.clear();
 }
 
-void PolylineTool::mousePressEvent( QMouseEvent *event )
+void PolylineTool::pointerPressEvent(PointerEvent *event)
 {
     Layer* layer = mEditor->layers()->currentLayer();
 
@@ -125,10 +127,7 @@ void PolylineTool::mousePressEvent( QMouseEvent *event )
     }
 }
 
-void PolylineTool::mouseReleaseEvent(QMouseEvent*)
-{}
-
-void PolylineTool::mouseMoveEvent(QMouseEvent*)
+void PolylineTool::pointerMoveEvent(PointerEvent*)
 {
     Layer* layer = mEditor->layers()->currentLayer();
     if ( layer->type() == Layer::BITMAP || layer->type() == Layer::VECTOR )
@@ -137,16 +136,20 @@ void PolylineTool::mouseMoveEvent(QMouseEvent*)
     }
 }
 
-void PolylineTool::mouseDoubleClickEvent(QMouseEvent* event)
+void PolylineTool::pointerReleaseEvent(PointerEvent *)
+{}
+
+void PolylineTool::pointerDoubleClickEvent(PointerEvent*)
 {
+    // include the current point before ending the line.
+    mPoints << getCurrentPoint();
+
     mEditor->backup(typeName());
 
-    if ( BezierCurve::eLength( m_pStrokeManager->getLastPressPixel() - event->pos() ) < 2.0 )
-    {
-        endPolyline( mPoints );
-        clear();
-    }
+    endPolyline( mPoints );
+    clear();
 }
+
 
 bool PolylineTool::keyPressEvent(QKeyEvent* event)
 {

--- a/core_lib/src/tool/polylinetool.h
+++ b/core_lib/src/tool/polylinetool.h
@@ -31,10 +31,11 @@ public:
     void loadSettings() override;
     QCursor cursor() override;
 
-    void mousePressEvent( QMouseEvent* ) override;
-    void mouseReleaseEvent( QMouseEvent* ) override;
-    void mouseMoveEvent( QMouseEvent* ) override;
-    void mouseDoubleClickEvent( QMouseEvent* ) override;
+    void pointerPressEvent(PointerEvent*) override;
+    void pointerReleaseEvent(PointerEvent*) override;
+    void pointerMoveEvent(PointerEvent* event) override;
+    void pointerDoubleClickEvent(PointerEvent*) override;
+
     bool keyPressEvent( QKeyEvent* event ) override;
 
     void clear() override;

--- a/core_lib/src/tool/selecttool.cpp
+++ b/core_lib/src/tool/selecttool.cpp
@@ -128,6 +128,13 @@ void SelectTool::pointerReleaseEvent(PointerEvent *event)
     if (mCurrentLayer == NULL) return;
     if (event->button() != Qt::LeftButton) return;
 
+    // if there's a small very small distance between current and last point
+    // discard the selection...
+    // TODO: improve by adding a timer to check if the user is deliberately selecting
+    if (qSqrt(qPow(mAnchorOriginPoint.x()-getCurrentPoint().x(),2) +
+              qPow(mAnchorOriginPoint.y()-getCurrentPoint().y(),2)) < 5.0) {
+        mScribbleArea->deselectAll();
+    }
     if (maybeDeselect())
     {
         mScribbleArea->deselectAll();

--- a/core_lib/src/tool/selecttool.cpp
+++ b/core_lib/src/tool/selecttool.cpp
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 */
 #include "selecttool.h"
 
-#include <QMouseEvent>
+#include "pointerevent.h"
 
 #include "vectorimage.h"
 #include "editor.h"
@@ -44,61 +44,6 @@ QCursor SelectTool::cursor()
 {
     MoveMode mode = mScribbleArea->getMoveModeForSelectionAnchor();
     return mScribbleArea->currentTool()->selectMoveCursor(mode, type());
-}
-
-bool first = false;
-void SelectTool::tabletPressEvent(QTabletEvent *)
-{
-    mCurrentLayer = mEditor->layers()->currentLayer();
-    beginSelection();
-}
-
-void SelectTool::tabletMoveEvent(QTabletEvent *)
-{
-    mCurrentLayer = mEditor->layers()->currentLayer();
-    if (!mScribbleArea->isSomethingSelected()) { return; }
-
-    mScribbleArea->updateToolCursor();
-
-    if (m_pStrokeManager->isPenPressed())
-    {
-        controlOffsetOrigin();
-
-        if (mCurrentLayer->type() == Layer::VECTOR)
-        {
-            static_cast<LayerVector*>(mCurrentLayer)->
-                    getLastVectorImageAtFrame(mEditor->currentFrame(), 0)->
-                    select(mScribbleArea->myTempTransformedSelection);
-        }
-    }
-
-    mScribbleArea->updateCurrentFrame();
-}
-
-void SelectTool::tabletReleaseEvent(QTabletEvent *)
-{
-    mCurrentLayer = mEditor->layers()->currentLayer();
-    if (maybeDeselect())
-    {
-        mScribbleArea->deselectAll();
-    } else {
-        keepSelection();
-    }
-
-    mScribbleArea->updateToolCursor();
-    mScribbleArea->updateCurrentFrame();
-    mScribbleArea->setAllDirty();
-}
-
-void SelectTool::mousePressEvent(QMouseEvent* event)
-{
-
-    mCurrentLayer = mEditor->layers()->currentLayer();
-    if (mCurrentLayer == NULL) return;
-    if (!mCurrentLayer->isPaintable()) { return; }
-    if (event->button() != Qt::LeftButton) { return; }
-
-    beginSelection();
 }
 
 void SelectTool::beginSelection()
@@ -143,26 +88,17 @@ QPointF SelectTool::whichAnchorPoint()
     return mScribbleArea->whichAnchorPoint(mAnchorOriginPoint);
 }
 
-void SelectTool::mouseReleaseEvent(QMouseEvent* event)
+void SelectTool::pointerPressEvent(PointerEvent *event)
 {
     mCurrentLayer = mEditor->layers()->currentLayer();
     if (mCurrentLayer == NULL) return;
-    if (event->button() != Qt::LeftButton) return;
+    if (!mCurrentLayer->isPaintable()) { return; }
+    if (event->button() != Qt::LeftButton) { return; }
 
-    if (maybeDeselect())
-    {
-        mScribbleArea->deselectAll();
-    } else {
-        keepSelection();
-    }
-
-    mScribbleArea->updateToolCursor();
-
-    mScribbleArea->updateCurrentFrame();
-    mScribbleArea->setAllDirty();
+    beginSelection();
 }
 
-void SelectTool::mouseMoveEvent(QMouseEvent* event)
+void SelectTool::pointerMoveEvent(PointerEvent *event)
 {
     mCurrentLayer = mEditor->layers()->currentLayer();
     if (mCurrentLayer == NULL) { return; }
@@ -184,6 +120,25 @@ void SelectTool::mouseMoveEvent(QMouseEvent* event)
     }
 
     mScribbleArea->updateCurrentFrame();
+}
+
+void SelectTool::pointerReleaseEvent(PointerEvent *event)
+{
+    mCurrentLayer = mEditor->layers()->currentLayer();
+    if (mCurrentLayer == NULL) return;
+    if (event->button() != Qt::LeftButton) return;
+
+    if (maybeDeselect())
+    {
+        mScribbleArea->deselectAll();
+    } else {
+        keepSelection();
+    }
+
+    mScribbleArea->updateToolCursor();
+
+    mScribbleArea->updateCurrentFrame();
+    mScribbleArea->setAllDirty();
 }
 
 bool SelectTool::maybeDeselect()

--- a/core_lib/src/tool/selecttool.h
+++ b/core_lib/src/tool/selecttool.h
@@ -34,14 +34,11 @@ public:
 
 private:
 
-    void mousePressEvent(QMouseEvent*) override;
-    void mouseReleaseEvent(QMouseEvent*) override;
-    void mouseMoveEvent(QMouseEvent*) override;
-    bool keyPressEvent(QKeyEvent *event) override;
+    void pointerPressEvent(PointerEvent*) override;
+    void pointerReleaseEvent(PointerEvent*) override;
+    void pointerMoveEvent(PointerEvent*) override;
 
-    void tabletPressEvent(QTabletEvent*) override;
-    void tabletMoveEvent(QTabletEvent*) override;
-    void tabletReleaseEvent(QTabletEvent*) override;
+    bool keyPressEvent(QKeyEvent *event) override;
 
     QPointF whichAnchorPoint();
     void controlOffsetOrigin();

--- a/core_lib/src/tool/smudgetool.cpp
+++ b/core_lib/src/tool/smudgetool.cpp
@@ -16,6 +16,8 @@ GNU General Public License for more details.
 */
 #include "smudgetool.h"
 
+#include "pointerevent.h"
+
 #include <QPixmap>
 #include "vectorimage.h"
 #include "editor.h"
@@ -110,19 +112,6 @@ QCursor SmudgeTool::cursor()
     }
 }
 
-void SmudgeTool::adjustPressureSensitiveProperties(qreal pressure, bool mouseDevice)
-{
-    mCurrentWidth = properties.width;
-    if (properties.pressure && !mouseDevice)
-    {
-        mCurrentPressure = pressure;
-    }
-    else
-    {
-        mCurrentPressure = 1.0;
-    }
-}
-
 bool SmudgeTool::keyPressEvent(QKeyEvent *event)
 {
     if (event->key() == Qt::Key_Alt)
@@ -143,7 +132,7 @@ bool SmudgeTool::keyReleaseEvent(QKeyEvent*)
     return true;
 }
 
-void SmudgeTool::mousePressEvent(QMouseEvent *event)
+void SmudgeTool::pointerPressEvent(PointerEvent *event)
 {
     //qDebug() << "smudgetool: mousePressEvent";
 
@@ -199,37 +188,7 @@ void SmudgeTool::mousePressEvent(QMouseEvent *event)
     }
 }
 
-void SmudgeTool::mouseReleaseEvent(QMouseEvent *event)
-{
-    Layer* layer = mEditor->layers()->currentLayer();
-    if (layer == NULL) { return; }
-
-    if (event->button() == Qt::LeftButton)
-    {
-        mEditor->backup(typeName());
-
-        if (layer->type() == Layer::BITMAP)
-        {
-            drawStroke();
-            mScribbleArea->setAllDirty();
-            endStroke();
-        }
-        else if (layer->type() == Layer::VECTOR)
-        {
-            VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
-            vectorImage->applySelectionTransformation();
-            mScribbleArea->selectionTransformation.reset();
-            for (int k = 0; k < mScribbleArea->vectorSelection.curve.size(); k++)
-            {
-                int curveNumber = mScribbleArea->vectorSelection.curve.at(k);
-                vectorImage->curve(curveNumber).smoothCurve();
-            }
-            mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
-        }
-    }
-}
-
-void SmudgeTool::mouseMoveEvent(QMouseEvent *event)
+void SmudgeTool::pointerMoveEvent(PointerEvent *event)
 {
     Layer* layer = mEditor->layers()->currentLayer();
     if (layer == NULL) { return; }
@@ -263,6 +222,36 @@ void SmudgeTool::mouseMoveEvent(QMouseEvent *event)
         }
         mScribbleArea->update();
         mScribbleArea->setAllDirty();
+    }
+}
+
+void SmudgeTool::pointerReleaseEvent(PointerEvent *event)
+{
+    Layer* layer = mEditor->layers()->currentLayer();
+    if (layer == NULL) { return; }
+
+    if (event->button() == Qt::LeftButton)
+    {
+        mEditor->backup(typeName());
+
+        if (layer->type() == Layer::BITMAP)
+        {
+            drawStroke();
+            mScribbleArea->setAllDirty();
+            endStroke();
+        }
+        else if (layer->type() == Layer::VECTOR)
+        {
+            VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+            vectorImage->applySelectionTransformation();
+            mScribbleArea->selectionTransformation.reset();
+            for (int k = 0; k < mScribbleArea->vectorSelection.curve.size(); k++)
+            {
+                int curveNumber = mScribbleArea->vectorSelection.curve.at(k);
+                vectorImage->curve(curveNumber).smoothCurve();
+            }
+            mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
+        }
     }
 }
 

--- a/core_lib/src/tool/smudgetool.h
+++ b/core_lib/src/tool/smudgetool.h
@@ -30,13 +30,13 @@ public:
     void loadSettings() override;
     QCursor cursor() override;
 
-    void mousePressEvent(QMouseEvent *) override;
-    void mouseReleaseEvent(QMouseEvent *) override;
-    void mouseMoveEvent(QMouseEvent *) override;
+    void pointerPressEvent(PointerEvent *) override;
+    void pointerReleaseEvent(PointerEvent *) override;
+    void pointerMoveEvent(PointerEvent *) override;
+
     bool keyPressEvent(QKeyEvent *) override;
     bool keyReleaseEvent(QKeyEvent *) override;
 
-    void adjustPressureSensitiveProperties(qreal pressure, bool mouseDevice) override;
     void drawStroke();
 
     void setWidth( const qreal width ) override;

--- a/core_lib/src/tool/strokemanager.cpp
+++ b/core_lib/src/tool/strokemanager.cpp
@@ -26,7 +26,7 @@
 #include <QLineF>
 #include <QPainterPath>
 #include "object.h"
-
+#include "pointerevent.h"
 
 StrokeManager::StrokeManager()
 {
@@ -72,44 +72,90 @@ void StrokeManager::setPressure(float pressure)
     mTabletPressure = pressure;
 }
 
-void StrokeManager::mousePressEvent(QMouseEvent* event)
+void StrokeManager::pointerPressEvent(PointerEvent *event)
 {
     reset();
     if ( !(event->button() == Qt::NoButton) ) // if the user is pressing the left/right button
     {
-        mLastPressPixel = event->localPos();
+        qDebug() << "press";
+        mLastPressPixel = mCurrentPressPixel;
+        mCurrentPressPixel = event->posF();
     }
-    mLastPixel = mCurrentPixel = event->localPos();
+
+    mLastPixel = mCurrentPixel = event->posF();
 
     mStrokeStarted = true;
+    setPressure(event->pressure());
 }
 
-void StrokeManager::mouseReleaseEvent(QMouseEvent* event)
+void StrokeManager::pointerMoveEvent(PointerEvent *event)
+{
+    // only applied to drawing tools.
+    if (mStabilizerLevel != -1)
+    {
+        smoothMousePos(event->posF());
+    }
+    else
+    {
+        // No smoothing
+        mLastPixel = mCurrentPixel;
+        mCurrentPixel = event->posF();
+        mLastInterpolated = mCurrentPixel;
+    }
+        setPressure(event->pressure());
+}
+
+void StrokeManager::pointerReleaseEvent(PointerEvent *event)
 {
     // flush out stroke
+    // TODO: events refactoring WIP... reassemble moue events and make sure everything is working
+    // will probably also to add is using tablet bool again...
     if ( mStrokeStarted )
     {
-        mouseMoveEvent(event);
+        pointerMoveEvent(event);
     }
 
     mStrokeStarted = false;
 }
 
+void StrokeManager::mousePressEvent(QMouseEvent* event)
+{
+//    reset();
+//    if ( !(event->button() == Qt::NoButton) ) // if the user is pressing the left/right button
+//    {
+//        mLastPressPixel = event->localPos();
+//    }
+//    mLastPixel = mCurrentPixel = event->localPos();
+
+//    mStrokeStarted = true;
+}
+
+void StrokeManager::mouseReleaseEvent(QMouseEvent* event)
+{
+//    // flush out stroke
+//    if ( mStrokeStarted )
+//    {
+//        mouseMoveEvent(event);
+//    }
+
+//    mStrokeStarted = false;
+}
+
 void StrokeManager::tabletEvent(QTabletEvent* event)
 {
-    if (event->type() == QEvent::TabletPress) {
-        mTabletInUse = true;
-        mPenIsHeld = true;
-        mLastPressPixel = event->posF();
-    }
-    if (event->type() == QEvent::TabletRelease) { mTabletInUse = false; mPenIsHeld = false; }
+//    if (event->type() == QEvent::TabletPress) {
+//        mTabletInUse = true;
+//        mPenIsHeld = true;
+//        mLastPressPixel = event->posF();
+//    }
+//    if (event->type() == QEvent::TabletRelease) { mTabletInUse = false; mPenIsHeld = false; }
 
-    setPressure(event->pressure());
+//    setPressure(event->pressure());
 
-    if(event->type() == QEvent::TabletMove)
-    {
-        genericMoveEvent(event->posF());
-    }
+//    if(event->type() == QEvent::TabletMove)
+//    {
+//        genericMoveEvent(event->posF());
+//    }
 }
 
 void StrokeManager::setStabilizerLevel(int level)
@@ -119,7 +165,7 @@ void StrokeManager::setStabilizerLevel(int level)
 
 void StrokeManager::mouseMoveEvent(QMouseEvent* event)
 {
-    genericMoveEvent(event->localPos());
+//    genericMoveEvent(event->localPos());
 }
 
 void StrokeManager::smoothMousePos(QPointF pos)

--- a/core_lib/src/tool/strokemanager.cpp
+++ b/core_lib/src/tool/strokemanager.cpp
@@ -40,22 +40,6 @@ StrokeManager::StrokeManager()
     connect(&timer, &QTimer::timeout, this, &StrokeManager::interpolatePollAndPaint);
 }
 
-void StrokeManager::genericMoveEvent(QPointF pos)
-{
-    // only applied to drawing tools.
-    if (mStabilizerLevel != -1)
-    {
-        smoothMousePos(pos);
-    }
-    else
-    {
-        // No smoothing
-        mLastPixel = mCurrentPixel;
-        mCurrentPixel = pos;
-        mLastInterpolated = mCurrentPixel;
-    }
-}
-
 void StrokeManager::reset()
 {
     mStrokeStarted = false;
@@ -108,8 +92,6 @@ void StrokeManager::pointerMoveEvent(PointerEvent *event)
 void StrokeManager::pointerReleaseEvent(PointerEvent *event)
 {
     // flush out stroke
-    // TODO: events refactoring WIP... reassemble moue events and make sure everything is working
-    // will probably also to add is using tablet bool again...
     if ( mStrokeStarted )
     {
         pointerMoveEvent(event);
@@ -118,54 +100,9 @@ void StrokeManager::pointerReleaseEvent(PointerEvent *event)
     mStrokeStarted = false;
 }
 
-void StrokeManager::mousePressEvent(QMouseEvent* event)
-{
-//    reset();
-//    if ( !(event->button() == Qt::NoButton) ) // if the user is pressing the left/right button
-//    {
-//        mLastPressPixel = event->localPos();
-//    }
-//    mLastPixel = mCurrentPixel = event->localPos();
-
-//    mStrokeStarted = true;
-}
-
-void StrokeManager::mouseReleaseEvent(QMouseEvent* event)
-{
-//    // flush out stroke
-//    if ( mStrokeStarted )
-//    {
-//        mouseMoveEvent(event);
-//    }
-
-//    mStrokeStarted = false;
-}
-
-void StrokeManager::tabletEvent(QTabletEvent* event)
-{
-//    if (event->type() == QEvent::TabletPress) {
-//        mTabletInUse = true;
-//        mPenIsHeld = true;
-//        mLastPressPixel = event->posF();
-//    }
-//    if (event->type() == QEvent::TabletRelease) { mTabletInUse = false; mPenIsHeld = false; }
-
-//    setPressure(event->pressure());
-
-//    if(event->type() == QEvent::TabletMove)
-//    {
-//        genericMoveEvent(event->posF());
-//    }
-}
-
 void StrokeManager::setStabilizerLevel(int level)
 {
     mStabilizerLevel = level;
-}
-
-void StrokeManager::mouseMoveEvent(QMouseEvent* event)
-{
-//    genericMoveEvent(event->localPos());
 }
 
 void StrokeManager::smoothMousePos(QPointF pos)

--- a/core_lib/src/tool/strokemanager.h
+++ b/core_lib/src/tool/strokemanager.h
@@ -51,6 +51,7 @@ public:
     float getPressure() { return mTabletPressure; }
     int getStabilizerLevel() { return mStabilizerLevel; }
     bool isTabletInUse() { return mTabletInUse; }
+    void setTabletinUse(bool inUse) { mTabletInUse = inUse; }
 
     QList<QPointF> interpolateStroke();
     void interpolatePoll();

--- a/core_lib/src/tool/strokemanager.h
+++ b/core_lib/src/tool/strokemanager.h
@@ -29,6 +29,8 @@ GNU General Public License for more details.
 #include "object.h"
 #include "assert.h"
 
+class PointerEvent;
+
 class StrokeManager : public QObject
 {
 public:
@@ -39,6 +41,10 @@ public:
     void mousePressEvent(QMouseEvent* event);
     void mouseMoveEvent(QMouseEvent* event);
     void mouseReleaseEvent(QMouseEvent* event);
+
+    void pointerPressEvent(PointerEvent* event);
+    void pointerMoveEvent(PointerEvent* event);
+    void pointerReleaseEvent(PointerEvent* event);
     void setPressure(float pressure);
     void setStabilizerLevel(int level);
 
@@ -61,6 +67,7 @@ public:
     QPointF getLastPixel() const { return mLastPixel; }
     QPointF getLastMeanPixel() const { return mLastInterpolated; }
     QPointF getMousePos() const { return mousePos; }
+    QPointF getCurrentPressPixel() const { return mCurrentPressPixel; }
     bool isPenPressed() const { return mPenIsHeld; }
 
 private:
@@ -76,6 +83,7 @@ private:
     QTimer timer;
 
     QTime mSingleshotTime;
+    QPointF mCurrentPressPixel = { 0, 0 };
     QPointF mLastPressPixel2 = { 0, 0 };
     QPointF mLastPressPixel = { 0, 0 };
     QPointF mCurrentPixel   = { 0, 0 };

--- a/core_lib/src/tool/strokemanager.h
+++ b/core_lib/src/tool/strokemanager.h
@@ -36,12 +36,6 @@ class StrokeManager : public QObject
 public:
     StrokeManager();
 
-    void genericMoveEvent(QPointF pos);
-    void tabletEvent(QTabletEvent* event);
-    void mousePressEvent(QMouseEvent* event);
-    void mouseMoveEvent(QMouseEvent* event);
-    void mouseReleaseEvent(QMouseEvent* event);
-
     void pointerPressEvent(PointerEvent* event);
     void pointerMoveEvent(PointerEvent* event);
     void pointerReleaseEvent(PointerEvent* event);

--- a/core_lib/src/util/pointerevent.cpp
+++ b/core_lib/src/util/pointerevent.cpp
@@ -1,0 +1,247 @@
+#include "pointerevent.h"
+
+PointerEvent::PointerEvent(QMouseEvent* event)
+{
+    this->mouseEvent = event;
+}
+
+PointerEvent::PointerEvent(QTabletEvent* event)
+{
+    this->tabletEvent = event;
+}
+
+PointerEvent::~PointerEvent()
+{
+}
+
+QPoint PointerEvent::pos() const
+{
+    if (this->mouseEvent)
+    {
+        return mouseEvent->pos();
+    }
+    else if (this->tabletEvent)
+    {
+        return this->tabletEvent->pos();
+    }
+    else
+    {
+        // if we land here... the incoming input was
+        // neither tablet nor mouse
+        Q_ASSERT(false);
+        return QPoint(0,0);
+    }
+}
+
+QPointF PointerEvent::posF() const
+{
+    if (this->mouseEvent)
+    {
+        return mouseEvent->localPos();
+    }
+    else if (this->tabletEvent)
+    {
+        return this->tabletEvent->posF();
+    }
+    else
+    {
+        // if we land here... the incoming input was
+        // neither tablet nor mouse
+        Q_ASSERT(false);
+        return QPoint(0,0);
+    }
+}
+
+Qt::MouseButton PointerEvent::button() const
+{
+    if (this->mouseEvent)
+    {
+        return this->mouseEvent->button();
+    }
+    else if (this->tabletEvent)
+    {
+        return this->tabletEvent->button();
+    }
+    else
+    {
+        // if we land here... the incoming input was
+        // neither tablet nor mouse
+        Q_ASSERT(false);
+        return Qt::NoButton;
+    }
+}
+
+Qt::MouseButtons PointerEvent::buttons() const
+{
+    if (this->mouseEvent)
+    {
+        return this->mouseEvent->buttons();
+    }
+    else if (this->tabletEvent)
+    {
+        return this->tabletEvent->buttons();
+    }
+    else
+    {
+        // if we land here... the incoming input was
+        // neither tablet nor mouse
+        Q_ASSERT(false);
+        return Qt::NoButton;
+    }
+}
+
+qreal PointerEvent::pressure() const
+{
+    if (this->tabletEvent)
+    {
+        return this->tabletEvent->pressure();
+    }
+    return 1.0;
+}
+
+qreal PointerEvent::rotation() const
+{
+    if (this->tabletEvent)
+    {
+        return this->tabletEvent->rotation();
+    }
+    return 0.0;
+}
+
+qreal PointerEvent::tangentialPressure() const
+{
+    if (this->tabletEvent)
+    {
+        return this->tabletEvent->tangentialPressure();
+    }
+    return 0.0;
+}
+
+int PointerEvent::x() const
+{
+    if (this->mouseEvent)
+    {
+        return this->mouseEvent->x();
+    }
+    else if (this->tabletEvent)
+    {
+        return this->tabletEvent->x();
+    }
+    else
+    {
+        Q_ASSERT(false);
+        return 0;
+    }
+
+}
+
+int PointerEvent::y() const
+{
+    if (this->mouseEvent)
+    {
+        return this->mouseEvent->y();
+    }
+    else if (this->tabletEvent)
+    {
+        return this->tabletEvent->y();
+    }
+    else
+    {
+        Q_ASSERT(false);
+        return 0;
+    }
+}
+
+bool PointerEvent::isTabletEvent() const
+{
+    if (this->tabletEvent)
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+Qt::KeyboardModifiers PointerEvent::modifiers() const
+{
+    if (this->mouseEvent)
+    {
+        return this->mouseEvent->modifiers();
+    }
+    else if (this->tabletEvent)
+    {
+        return this->tabletEvent->modifiers();
+    }
+    else
+    {
+        Q_ASSERT(false);
+        return Qt::NoModifier;
+    }
+}
+
+void PointerEvent::accept()
+{
+    if (this->mouseEvent)
+    {
+        this->mouseEvent->accept();
+    }
+    else if (this->tabletEvent)
+    {
+        this->tabletEvent->accept();
+    }
+    else
+    {
+        Q_ASSERT(false);
+    }
+}
+
+void PointerEvent::ignore()
+{
+    if (this->mouseEvent)
+    {
+        this->mouseEvent->ignore();
+    }
+    else if (this->tabletEvent)
+    {
+        this->tabletEvent->ignore();
+    }
+    else
+    {
+        Q_ASSERT(false);
+    }
+}
+
+QEvent::Type PointerEvent::type() const
+{
+    if (this->mouseEvent)
+    {
+        return this->mouseEvent->type();
+    }
+    else if (this->tabletEvent)
+    {
+        return this->tabletEvent->type();
+    }
+    return QEvent::None;
+}
+
+QTabletEvent::TabletDevice PointerEvent::device() const
+{
+    if (this->tabletEvent)
+    {
+        return this->tabletEvent->device();
+    }
+    return QTabletEvent::TabletDevice::NoDevice;
+}
+
+QTabletEvent::PointerType PointerEvent::pointerType() const
+{
+    if (this->tabletEvent)
+    {
+        return this->tabletEvent->pointerType();
+    }
+    return QTabletEvent::PointerType::UnknownPointer;
+}
+
+//QEvent::device

--- a/core_lib/src/util/pointerevent.cpp
+++ b/core_lib/src/util/pointerevent.cpp
@@ -5,9 +5,10 @@ PointerEvent::PointerEvent(QMouseEvent* event)
     this->mouseEvent = event;
 }
 
-PointerEvent::PointerEvent(QTabletEvent* event)
+PointerEvent::PointerEvent(QTabletEvent* event, QPointF widgetPos)
 {
     this->tabletEvent = event;
+    mWidgetPos = this->widgetPos();
 }
 
 PointerEvent::~PointerEvent()
@@ -28,8 +29,7 @@ QPoint PointerEvent::pos() const
     {
         // if we land here... the incoming input was
         // neither tablet nor mouse
-        Q_ASSERT(false);
-        return QPoint(0,0);
+        return mWidgetPos.toPoint();
     }
 }
 
@@ -45,10 +45,7 @@ QPointF PointerEvent::posF() const
     }
     else
     {
-        // if we land here... the incoming input was
-        // neither tablet nor mouse
-        Q_ASSERT(false);
-        return QPoint(0,0);
+        return mWidgetPos;
     }
 }
 

--- a/core_lib/src/util/pointerevent.h
+++ b/core_lib/src/util/pointerevent.h
@@ -8,7 +8,7 @@ class PointerEvent
 {
 public:
     PointerEvent(QMouseEvent* event);
-    PointerEvent(QTabletEvent* event);
+    PointerEvent(QTabletEvent* event, QPointF hiDefPos);
     ~PointerEvent();
 
     /**
@@ -20,6 +20,11 @@ public:
      * Returns pos() if used on mouse event
      */
     QPointF posF() const;
+
+    /**
+     * returns QPointF of current position in the given widget.
+     */
+    inline QPointF widgetPos() { return mWidgetPos; }
 
     /**
      * Returns a value between 0 and 1 for tablet events,
@@ -71,6 +76,7 @@ public:
 
 private:
 
+    QPointF mWidgetPos;
 
 };
 

--- a/core_lib/src/util/pointerevent.h
+++ b/core_lib/src/util/pointerevent.h
@@ -1,0 +1,77 @@
+#ifndef POINTEREVENT_H
+#define POINTEREVENT_H
+
+#include <QTabletEvent>
+#include <QMouseEvent>
+
+class PointerEvent
+{
+public:
+    PointerEvent(QMouseEvent* event);
+    PointerEvent(QTabletEvent* event);
+    ~PointerEvent();
+
+    /**
+     * Returns QPoint of the device */
+    QPoint pos() const;
+
+    /**
+     * Returns the QPointF of the device
+     * Returns pos() if used on mouse event
+     */
+    QPointF posF() const;
+
+    /**
+     * Returns a value between 0 and 1 for tablet events,
+     * otherwise 1.0
+     */
+    qreal pressure() const;
+
+    /**
+     * Returns rotation value if any, otherwise 0 */
+    qreal rotation() const;
+
+    /**
+     * Returns the tangential pressure of a tablet's that support it
+     * This is typically given by a finger wheel on an airbrush tool. The range
+     * is from -1.0 to 1.0. 0.0 indicates a neutral position. Current airbrushes can
+     * only move in the positive direction from the neutral position. If the device
+     * does not support tangential pressure, this value is always 0.0.
+     */
+    qreal tangentialPressure() const;
+
+    /** Returns the x position of the input device in the widget */
+    int x() const;
+
+    /** Returns the y position of the input device in the widget */
+    int y() const;
+
+    /** Returns true if the device was tablet, otherwise false */
+    bool isTabletEvent() const;
+
+    /** Returns the modifier created by keyboard while a device was in use */
+    Qt::KeyboardModifiers modifiers() const;
+
+    /** Returns Qt::MouseButton() */
+    Qt::MouseButton button() const;
+
+    /** Returns Qt::MouseButtons() */
+    Qt::MouseButtons buttons() const;
+
+    void accept();
+    void ignore();
+
+    QEvent::Type type() const;
+
+    QTabletEvent::TabletDevice device() const;
+    QTabletEvent::PointerType pointerType() const;
+
+    QTabletEvent* tabletEvent = nullptr;
+    QMouseEvent* mouseEvent = nullptr;
+
+private:
+
+
+};
+
+#endif // POINTEREVENT_H


### PR DESCRIPTION
We now have a specific PointerEvent class that should take care of all the mouse and tablet events and get rid of a so much duplicate code.

The PR however also fixes:
#1165
#1162

Additional fixes:
* Eyedropper icon resetting when the release event is done
* Select tool leaves a small selection piece when trying to tab to deselect.
 - This is WIP solution...

I've tested it with my mouse and tablet and it works here but I've come to learn that, that measurement is not good enough so please test it with a mouse and tablet yourself to make sure it doesn't break anything.