### PR TITLE
Issue flip

### DIFF
--- a/core_lib/src/managers/playbackmanager.cpp
+++ b/core_lib/src/managers/playbackmanager.cpp
@@ -193,7 +193,9 @@ void PlaybackManager::playFlipInBetween()
     {
         mFlipList.clear();
         mFlipList.append(prev);
+        mFlipList.append(prev);
         mFlipList.append(start);
+        mFlipList.append(next);
         mFlipList.append(next);
         mFlipList.append(start);
     }

--- a/core_lib/src/managers/playbackmanager.cpp
+++ b/core_lib/src/managers/playbackmanager.cpp
@@ -187,8 +187,9 @@ void PlaybackManager::playFlipInBetween()
     int prev = layerMgr->currentLayer()->getPreviousKeyFramePosition(start);
     int next = layerMgr->currentLayer()->getNextKeyFramePosition(start);
 
-    if (layerMgr->currentLayer()->keyExists(prev) &&
-        layerMgr->currentLayer()->keyExists(next))
+    if (prev < start && next > start &&
+            layerMgr->currentLayer()->keyExists(prev) &&
+            layerMgr->currentLayer()->keyExists(next))
     {
         mFlipList.clear();
         mFlipList.append(prev);
@@ -392,7 +393,7 @@ void PlaybackManager::timerTick()
 
 void PlaybackManager::flipTimerTick()
 {
-    int curr = editor()->currentFrame();
+    int curr = mFlipList[0];
     int pos = mFlipList.indexOf(curr);
     if (pos == mFlipList.count() - 1)
     {
@@ -402,7 +403,7 @@ void PlaybackManager::flipTimerTick()
     else
     {
         editor()->scrubTo(mFlipList[pos + 1]);
-        mFlipList.removeAt(pos);
+        mFlipList.removeFirst();
     }
 }
 

--- a/core_lib/src/managers/playbackmanager.cpp
+++ b/core_lib/src/managers/playbackmanager.cpp
@@ -393,16 +393,14 @@ void PlaybackManager::timerTick()
 
 void PlaybackManager::flipTimerTick()
 {
-    int curr = mFlipList[0];
-    int pos = mFlipList.indexOf(curr);
-    if (pos == mFlipList.count() - 1)
+    if (mFlipList.count() < 2)
     {
         mFlipTimer->stop();
         emit playStateChanged(false);
     }
     else
     {
-        editor()->scrubTo(mFlipList[pos + 1]);
+        editor()->scrubTo(mFlipList[1]);
         mFlipList.removeFirst();
     }
 }

--- a/core_lib/src/managers/playbackmanager.cpp
+++ b/core_lib/src/managers/playbackmanager.cpp
@@ -395,9 +395,10 @@ void PlaybackManager::timerTick()
 
 void PlaybackManager::flipTimerTick()
 {
-    if (mFlipList.count() < 2)
+    if (mFlipList.count() < 2 || editor()->currentFrame() != mFlipList[0])
     {
         mFlipTimer->stop();
+        editor()->scrubTo(mFlipList.last());
         emit playStateChanged(false);
     }
     else


### PR DESCRIPTION
Fixes a bug that made Pencil2D to crash, if you pressed the timeline digits while a flipping was performed.
Changed the timing in flip inbetween slightly, while I was at it. It's better now.