### PR TITLE
Layer merge

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -60,7 +60,8 @@ HEADERS += \
     src/spinslider.h \
     src/doubleprogressdialog.h \
     src/colorslider.h \
-    src/checkupdatesdialog.h
+    src/checkupdatesdialog.h \
+    src/mergelayers.h
 
 SOURCES += \
     src/main.cpp \
@@ -89,7 +90,8 @@ SOURCES += \
     src/spinslider.cpp \
     src/doubleprogressdialog.cpp \
     src/colorslider.cpp \
-    src/checkupdatesdialog.cpp
+    src/checkupdatesdialog.cpp \
+    src/mergelayers.cpp
 
 FORMS += \
     ui/mainwindow2.ui \
@@ -111,7 +113,8 @@ FORMS += \
     ui/timelinepage.ui \
     ui/filespage.ui \
     ui/toolspage.ui \
-    ui/toolboxwidget.ui
+    ui/toolboxwidget.ui \
+    ui/mergelayers.ui
 
 
 

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -661,6 +661,20 @@ Status ActionCommands::mergeLayers()
         return Status::NOT_SUPPORTED;
     }
 
+    int type = mEditor->layers()->currentLayer()->type();
+    int layers = 0;
+    for (int i = 0; i < mEditor->layers()->count(); i++)
+    {
+        if (mEditor->layers()->getLayer(i)->type() == type)
+            layers++;
+    }
+    if (layers < 2)
+    {
+        QMessageBox::information(nullptr, tr("Merge not possible"),
+                                 tr("Only one layer of that type!"));
+        return Status::NOT_SUPPORTED;
+    }
+
     MergeLayers* merge = new MergeLayers();
     if (merge == nullptr)
         return Status::FAIL;

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -49,6 +49,7 @@ GNU General Public License for more details.
 #include "aboutdialog.h"
 #include "doubleprogressdialog.h"
 #include "checkupdatesdialog.h"
+#include "mergelayers.h"
 
 
 ActionCommands::ActionCommands(QWidget* parent) : QObject(parent)
@@ -646,6 +647,25 @@ Status ActionCommands::addNewSoundLayer()
         Layer* layer = mEditor->layers()->createSoundLayer(strLayerName);
         mEditor->layers()->setCurrentLayer(layer);
    }
+    return Status::OK;
+}
+
+Status ActionCommands::mergeLayers()
+{
+    if (!(mEditor->layers()->currentLayer()->type() == Layer::BITMAP ||
+          mEditor->layers()->currentLayer()->type() == Layer::VECTOR))
+    {
+        QMessageBox::information(nullptr, nullptr,
+                                 tr("Only Bitmap and Vector Layers\n"
+                                    "can be merged."));
+        return Status::NOT_SUPPORTED;
+    }
+
+    MergeLayers* merge = new MergeLayers();
+    if (merge == nullptr)
+        return Status::FAIL;
+    merge->initDialog(mEditor);
+    merge->exec();
     return Status::OK;
 }
 

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -72,6 +72,7 @@ public:
     Status addNewVectorLayer();
     Status addNewCameraLayer();
     Status addNewSoundLayer();
+    Status mergeLayers();
     Status deleteCurrentLayer();
     QString nameSuggest(QString s);
 

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -268,6 +268,7 @@ void MainWindow2::createMenus()
     connect(ui->actionNew_Vector_Layer, &QAction::triggered, mCommands, &ActionCommands::addNewVectorLayer);
     connect(ui->actionNew_Sound_Layer, &QAction::triggered, mCommands, &ActionCommands::addNewSoundLayer);
     connect(ui->actionNew_Camera_Layer, &QAction::triggered, mCommands, &ActionCommands::addNewCameraLayer);
+    connect(ui->actionMerge_Layer, &QAction::triggered, mCommands, &ActionCommands::mergeLayers);
     connect(ui->actionDelete_Current_Layer, &QAction::triggered, mCommands, &ActionCommands::deleteCurrentLayer);
 
     //--- View Menu ---

--- a/app/src/mergelayers.cpp
+++ b/app/src/mergelayers.cpp
@@ -1,0 +1,88 @@
+#include "mergelayers.h"
+#include "ui_mergelayers.h"
+
+#include "layerbitmap.h"
+#include "layervector.h"
+
+MergeLayers::MergeLayers(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::MergeLayers)
+{
+    ui->setupUi(this);
+    connect(ui->cbFromLayer, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &MergeLayers::layerSelectionChanged);
+    connect(ui->cbToLayer, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &MergeLayers::layerSelectionChanged);
+    connect(ui->btnMerge, &QPushButton::clicked, this, &MergeLayers::mergeLayers);
+    connect(ui->btnClose, &QPushButton::clicked, this, &MergeLayers::close);
+}
+
+MergeLayers::~MergeLayers()
+{
+    delete ui;
+}
+
+void MergeLayers::initDialog(Editor *editor)
+{
+    mEditor = editor;
+    mLayerType = mEditor->layers()->currentLayer()->type();
+    ui->cbFromLayer->clear();
+    ui->cbToLayer->clear();
+    for (int i = 0; i < mEditor->layers()->count(); i++)
+    {
+        if (mEditor->layers()->getLayer(i)->type() == mLayerType)
+        {
+            ui->cbFromLayer->addItem(mEditor->layers()->getLayer(i)->name());
+            ui->cbToLayer->addItem(mEditor->layers()->getLayer(i)->name());
+        }
+    }
+    if (ui->cbFromLayer->currentText() == ui->cbToLayer->currentText())
+    {
+        ui->btnMerge->setEnabled(false);
+    }
+}
+
+void MergeLayers::layerSelectionChanged()
+{
+    if (ui->cbFromLayer->currentText() == ui->cbToLayer->currentText())
+    {
+        ui->btnMerge->setEnabled(false);
+    }
+    else {
+        ui->btnMerge->setEnabled(true);
+    }
+}
+
+void MergeLayers::mergeLayers()
+{
+    if (mLayerType == Layer::BITMAP)
+    {
+        mFromLayer = static_cast<LayerBitmap*>(mEditor->layers()->findLayerByName(ui->cbFromLayer->currentText()));
+        mToLayer   = static_cast<LayerBitmap*>(mEditor->layers()->findLayerByName(ui->cbToLayer->currentText()));
+    }
+    else
+    {
+        mFromLayer = static_cast<LayerVector*>(mEditor->layers()->findLayerByName(ui->cbFromLayer->currentText()));
+        mToLayer   = static_cast<LayerVector*>(mEditor->layers()->findLayerByName(ui->cbToLayer->currentText()));
+    }
+
+    for (int i = mFromLayer->firstKeyFramePosition(); i <= mFromLayer->getMaxKeyFramePosition(); i++)
+    {
+        mEditor->scrubTo(i);
+        if (mFromLayer->keyExists(i))
+        {
+            mEditor->layers()->setCurrentLayer(mFromLayer);
+            mEditor->copy();
+            mEditor->layers()->setCurrentLayer(mToLayer);
+            if (!mToLayer->keyExists(i))
+                mToLayer->addNewKeyFrameAt(i);
+            mEditor->paste();
+        }
+    }
+    mEditor->layers()->setCurrentLayer(mFromLayer);
+    if (ui->cbDeleteLayer->isChecked())
+        mEditor->layers()->deleteLayer(mEditor->layers()->currentLayerIndex());
+}
+
+void MergeLayers::closeUi()
+{
+    close();
+}

--- a/app/src/mergelayers.h
+++ b/app/src/mergelayers.h
@@ -1,0 +1,36 @@
+#ifndef MERGELAYERS_H
+#define MERGELAYERS_H
+
+#include <QDialog>
+#include "editor.h"
+#include "layermanager.h"
+
+namespace Ui {
+class MergeLayers;
+}
+
+class MergeLayers : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit MergeLayers(QWidget *parent = nullptr);
+    ~MergeLayers();
+
+    void initDialog(Editor* editor);
+
+private slots:
+    void layerSelectionChanged();
+    void mergeLayers();
+    void closeUi();
+
+private:
+    Ui::MergeLayers *ui;
+
+    Editor* mEditor = nullptr;
+    Layer* mFromLayer = nullptr;
+    Layer* mToLayer = nullptr;
+    int mLayerType;
+};
+
+#endif // MERGELAYERS_H

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -49,7 +49,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>21</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -210,6 +210,8 @@
     <addaction name="actionNew_Vector_Layer"/>
     <addaction name="actionNew_Sound_Layer"/>
     <addaction name="actionNew_Camera_Layer"/>
+    <addaction name="separator"/>
+    <addaction name="actionMerge_Layer"/>
     <addaction name="separator"/>
     <addaction name="actionDelete_Current_Layer"/>
    </widget>
@@ -972,6 +974,11 @@
   <action name="actionFlip_rolling">
    <property name="text">
     <string>Flip Rolling</string>
+   </property>
+  </action>
+  <action name="actionMerge_Layer">
+   <property name="text">
+    <string>Merge Layers</string>
    </property>
   </action>
  </widget>

--- a/app/ui/mergelayers.ui
+++ b/app/ui/mergelayers.ui
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MergeLayers</class>
+ <widget class="QDialog" name="MergeLayers">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>364</width>
+    <height>157</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Merge Layers</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Merge layers</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>2</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="labFroLayer">
+          <property name="text">
+           <string>Merge Layer...</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="cbFromLayer"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="labToLayer">
+          <property name="text">
+           <string>...to Layer</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="cbToLayer"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="cbDeleteLayer">
+        <property name="text">
+         <string>Delete layer after merge</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Line" name="line">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnMerge">
+          <property name="text">
+           <string>Merge Layers</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnClose">
+          <property name="text">
+           <string>Close</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This feature adresses an issue in the Official Roadmap #540.
It is possible to merge bitmap and vector layers. It is only tested with bitmap layers, and maybe vector layers should be commented out in the code, until the vector layers are useable again.
The feature is only available if there are at least two layers of the correct type in the timeline.