### PR TITLE
Fail to open a pclx with Unicode filenames on Windows

### DIFF
--- a/core_lib/src/miniz.cpp
+++ b/core_lib/src/miniz.cpp
@@ -2976,7 +2976,7 @@ void tinfl_decompressor_free(tinfl_decompressor *pDecomp)
 #ifndef MINIZ_NO_ARCHIVE_APIS
 
 #ifdef __cplusplus
-extern "C" {
+//extern "C" {
 #endif
 
 /* ------------------- .ZIP archive reading */
@@ -2987,10 +2987,16 @@ extern "C" {
 #include <sys/stat.h>
 
 #if defined(_MSC_VER) || defined(__MINGW64__)
+#include <codecvt>
+#include <string>
 static FILE *mz_fopen(const char *pFilename, const char *pMode)
 {
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    std::wstring sWideFilename = converter.from_bytes(pFilename);
+    std::wstring sWideMode = converter.from_bytes(pMode);
+
     FILE *pFile = NULL;
-    fopen_s(&pFile, pFilename, pMode);
+    _wfopen_s(&pFile, sWideFilename.c_str(), sWideMode.c_str());
     return pFile;
 }
 static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream)
@@ -7651,7 +7657,7 @@ mz_bool mz_zip_end(mz_zip_archive *pZip)
 }
 
 #ifdef __cplusplus
-}
+//}
 #endif
 
 #endif /*#ifndef MINIZ_NO_ARCHIVE_APIS*/

--- a/core_lib/src/miniz.h
+++ b/core_lib/src/miniz.h
@@ -125,7 +125,7 @@
 /* If MINIZ_NO_TIME is specified then the ZIP archive functions will not be able to get the current time, or */
 /* get/set file times, and the C run-time funcs that get/set times won't be called. */
 /* The current downside is the times written to your archives will be from 1979. */
-/*#define MINIZ_NO_TIME */
+#define MINIZ_NO_TIME
 
 /* Define MINIZ_NO_ARCHIVE_APIS to disable all ZIP archive API's. */
 /*#define MINIZ_NO_ARCHIVE_APIS */


### PR DESCRIPTION
Just got a bug report from the user forum
https://discuss.pencil2d.org/t/miniz-error-doesnt-let-me-record/3755/11

I can confirm the current v0.6.4 will fail to open any .pclx if the filename contains Unicode characters.

The issue is caused by the miniz update. We used to use a modified version of miniz to handle Unicode on Windows (Opening a file by `_wfopen_s()` rather than `fopen_s()`). But the change was overwritten when updating to miniz 2.1.0.

We might need to prepare a hot-fix release as soon as possible for that.

If anyone needs an example, please download this pclx:
https://www.dropbox.com/s/zgzp1vbscykspsb/%E8%A8%B1%E5%8A%9F%E8%93%8B.pclx?dl=0
