### PR TITLE
Add function to fill non alpha pixels

### DIFF
--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -541,7 +541,7 @@ void BitmapImage::setPixel(QPoint p, QRgb colour)
     modification();
 }
 
-void BitmapImage::setAllAlteredPixels(QRgb color)
+void BitmapImage::fillNonAlpha(QRgb color)
 {
     if (mBounds.isEmpty()) { return; }
 

--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -541,7 +541,7 @@ void BitmapImage::setPixel(QPoint p, QRgb colour)
     modification();
 }
 
-void BitmapImage::fillNonAlpha(const QRgb &color)
+void BitmapImage::fillNonAlphaPixels(const QRgb color)
 {
     if (mBounds.isEmpty()) { return; }
 

--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -541,14 +541,12 @@ void BitmapImage::setPixel(QPoint p, QRgb colour)
     modification();
 }
 
-void BitmapImage::fillNonAlpha(QRgb color)
+void BitmapImage::fillNonAlpha(const QRgb &color)
 {
     if (mBounds.isEmpty()) { return; }
 
     BitmapImage fill(bounds(), color);
     paste(&fill, QPainter::CompositionMode_SourceIn);
-
-    modification();
 }
 
 void BitmapImage::drawLine(QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm, bool antialiasing)

--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -541,6 +541,15 @@ void BitmapImage::setPixel(QPoint p, QRgb colour)
     modification();
 }
 
+void BitmapImage::setAllAlteredPixels(QRgb color)
+{
+    if (mBounds.isEmpty()) { return; }
+
+    BitmapImage fill(bounds(), color);
+    paste(&fill, QPainter::CompositionMode_SourceIn);
+
+    modification();
+}
 
 void BitmapImage::drawLine(QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm, bool antialiasing)
 {

--- a/core_lib/src/graphics/bitmap/bitmapimage.h
+++ b/core_lib/src/graphics/bitmap/bitmapimage.h
@@ -65,6 +65,8 @@ public:
     QRgb pixel(QPoint p);
     void setPixel(int x, int y, QRgb colour);
     void setPixel(QPoint p, QRgb colour);
+    void setAllAlteredPixels(QRgb color);
+
     QRgb constScanLine(int x, int y);
     void scanLine(int x, int y, QRgb colour);
     void clear();

--- a/core_lib/src/graphics/bitmap/bitmapimage.h
+++ b/core_lib/src/graphics/bitmap/bitmapimage.h
@@ -65,7 +65,7 @@ public:
     QRgb pixel(QPoint p);
     void setPixel(int x, int y, QRgb colour);
     void setPixel(QPoint p, QRgb colour);
-    void fillNonAlpha(QRgb color);
+    void fillNonAlpha(const QRgb& color);
 
     QRgb constScanLine(int x, int y);
     void scanLine(int x, int y, QRgb colour);

--- a/core_lib/src/graphics/bitmap/bitmapimage.h
+++ b/core_lib/src/graphics/bitmap/bitmapimage.h
@@ -65,7 +65,7 @@ public:
     QRgb pixel(QPoint p);
     void setPixel(int x, int y, QRgb colour);
     void setPixel(QPoint p, QRgb colour);
-    void setAllAlteredPixels(QRgb color);
+    void fillNonAlpha(QRgb color);
 
     QRgb constScanLine(int x, int y);
     void scanLine(int x, int y, QRgb colour);

--- a/core_lib/src/graphics/bitmap/bitmapimage.h
+++ b/core_lib/src/graphics/bitmap/bitmapimage.h
@@ -65,7 +65,7 @@ public:
     QRgb pixel(QPoint p);
     void setPixel(int x, int y, QRgb colour);
     void setPixel(QPoint p, QRgb colour);
-    void fillNonAlpha(const QRgb& color);
+    void fillNonAlphaPixels(const QRgb color);
 
     QRgb constScanLine(int x, int y);
     void scanLine(int x, int y, QRgb colour);


### PR DESCRIPTION
This PR is rather simple. It adds a function to BitmapImage, that replaces all pixels inside mBounds with a chosen color.
I think it is a good general-purpose function, and I know I can use it in one of the features I'm working on, + the bitmap-coloring feature + two more features I plan to work on.
Could it be merged right away, it would be easier for me, since I don't have to wait for a more complex PR to be accepted and merged, before the function is in the code base.