### PR TITLE
Autosave & Grid preference settings adjustment

### DIFF
--- a/app/ui/filespage.ui
+++ b/app/ui/filespage.ui
@@ -46,10 +46,13 @@
          </size>
         </property>
         <property name="minimum">
-         <number>5</number>
+         <number>4</number>
         </property>
         <property name="maximum">
-         <number>200</number>
+         <number>8192</number>
+        </property>
+        <property name="value">
+         <number>256</number>
         </property>
        </widget>
       </item>

--- a/app/ui/generalpage.ui
+++ b/app/ui/generalpage.ui
@@ -38,9 +38,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-173</y>
-        <width>300</width>
-        <height>618</height>
+        <y>-184</y>
+        <width>299</width>
+        <height>627</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="lay">
@@ -256,7 +256,7 @@
           <item row="2" column="1">
            <widget class="QSpinBox" name="gridSizeInputH">
             <property name="minimum">
-             <number>5</number>
+             <number>1</number>
             </property>
             <property name="maximum">
              <number>9999</number>
@@ -281,7 +281,7 @@
              </size>
             </property>
             <property name="minimum">
-             <number>5</number>
+             <number>1</number>
             </property>
             <property name="maximum">
              <number>9999</number>

--- a/core_lib/src/managers/preferencemanager.cpp
+++ b/core_lib/src/managers/preferencemanager.cpp
@@ -81,7 +81,7 @@ void PreferenceManager::loadPrefs()
 
     // Files
     set(SETTING::AUTO_SAVE,                settings.value(SETTING_AUTO_SAVE,              true ).toBool());
-    set(SETTING::AUTO_SAVE_NUMBER,         settings.value(SETTING_AUTO_SAVE_NUMBER,       25).toInt());
+    set(SETTING::AUTO_SAVE_NUMBER,         settings.value(SETTING_AUTO_SAVE_NUMBER,       256).toInt());
 
     // Timeline
     set(SETTING::SHORT_SCRUB,              settings.value(SETTING_SHORT_SCRUB,            false ).toBool());


### PR DESCRIPTION
- Autosave max. value set to 8192 in filespage.ui
- Autosave initial value set to 256 in preferencemanager.cpp (this will provide an average of about 5~7 minutes of uninterrupted drawing before the autosave alert kicks in)
- Grid W & Grid H minimum values set to 1px in generalpage.ui

If there's a mistake or a missing alteration that needs to be made please point it out descriptively as usual. Thanks :relaxed: 