### PR TITLE
Fix onion skin rendering and behavior

### DIFF
--- a/core_lib/src/canvaspainter.cpp
+++ b/core_lib/src/canvaspainter.cpp
@@ -88,7 +88,6 @@ void CanvasPainter::paint(const Object* object, int layer, int frame, QRect rect
     Q_UNUSED(rect);
 
     paintBackground();
-    paintOnionSkin(painter);
 
     //painter.setClipRect(aligned); // this aligned rect is valid only for bitmap images.
     paintCurrentFrame(painter);
@@ -127,7 +126,13 @@ void CanvasPainter::paintOnionSkin(QPainter& painter)
         qreal prevOpacityIncrement = (maxOpacity - minOpacity) / mOptions.nPrevOnionSkinCount;
         qreal opacity = maxOpacity;
 
-        int onionFrameNumber = layer->getPreviousFrameNumber(mFrameNumber, mOptions.bIsOnionAbsolute);
+        int onionFrameNumber = mFrameNumber;
+        if (mOptions.bIsOnionAbsolute)
+        {
+            onionFrameNumber = layer->getPreviousFrameNumber(onionFrameNumber+1, true);
+        }
+        onionFrameNumber = layer->getPreviousFrameNumber(onionFrameNumber, mOptions.bIsOnionAbsolute);
+
         int onionPosition = 0;
 
         while (onionPosition < mOptions.nPrevOnionSkinCount && onionFrameNumber > 0)
@@ -361,6 +366,11 @@ void CanvasPainter::paintCurrentFrame(QPainter& painter)
 
         if (layer->visible() == false)
             continue;
+
+        if (i == mCurrentLayerIndex) {
+            paintOnionSkin(painter);
+            painter.setOpacity(1.0);
+        }
 
         if (i == mCurrentLayerIndex || mOptions.nShowAllLayers > 0)
         {

--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -360,7 +360,12 @@ void TimeLineCells::paintOnionSkin(QPainter& painter)
 
     if (mEditor->preference()->isOn(SETTING::PREV_ONION) && prevOnionSkinCount > 0)
     {
-        int onionFrameNumber = layer->getPreviousFrameNumber(frameNumber, isAbsolute);
+        int onionFrameNumber = frameNumber;
+        if (isAbsolute)
+        {
+            onionFrameNumber = layer->getPreviousFrameNumber(onionFrameNumber+1, true);
+        }
+        onionFrameNumber = layer->getPreviousFrameNumber(onionFrameNumber, isAbsolute);
         int onionPosition = 0;
 
         while (onionPosition < prevOnionSkinCount && onionFrameNumber > 0)

--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -99,6 +99,13 @@ int Layer::getPreviousKeyFramePosition(int position) const
 
 int Layer::getNextKeyFramePosition(int position) const
 {
+    // workaround: bug with lower_bound?
+    // when position is before the first frame it == mKeyFrames.end() for some reason
+    if (position < firstKeyFramePosition())
+    {
+       return firstKeyFramePosition();
+    }
+
     auto it = mKeyFrames.lower_bound(position);
     if (it == mKeyFrames.end())
     {
@@ -121,7 +128,7 @@ int Layer::getPreviousFrameNumber(int position, bool isAbsolute) const
     else
         prevNumber = position - 1;
 
-    if (prevNumber == position)
+    if (prevNumber >= position)
     {
         return -1; // There is no previous keyframe
     }
@@ -137,7 +144,7 @@ int Layer::getNextFrameNumber(int position, bool isAbsolute) const
     else
         nextNumber = position + 1;
 
-    if (nextNumber == position)
+    if (nextNumber <= position)
         return -1; // There is no next keyframe
 
     return nextNumber;


### PR DESCRIPTION
- Fix onion skin rendering below lower layers
- Fix previous onion skin display when on a held frame in absolute mode
- Fix next onion skin behavior when before the first frame in absolute mode

Fixes #989