### PR TITLE
Move onion skin mode selector to the preferences window

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1343,7 +1343,6 @@ void MainWindow2::makeConnections(Editor* pEditor, TimeLine* pTimeline)
     connect(pTimeline, &TimeLine::newSoundLayer, mCommands, &ActionCommands::addNewSoundLayer);
     connect(pTimeline, &TimeLine::newCameraLayer, mCommands, &ActionCommands::addNewCameraLayer);
 
-    connect(pTimeline, &TimeLine::toogleAbsoluteOnionClick, pEditor, &Editor::toogleOnionSkinType);
     connect(mTimeLine, &TimeLine::playButtonTriggered, mCommands, &ActionCommands::PlayStop);
 
     connect(pEditor->layers(), &LayerManager::currentLayerChanged, pTimeline, &TimeLine::updateUI);

--- a/app/src/preferencesdialog.cpp
+++ b/app/src/preferencesdialog.cpp
@@ -468,6 +468,7 @@ ToolsPage::ToolsPage()
     connect(ui->onionMinOpacityBox, spinBoxChanged, this, &ToolsPage::onionMinOpacityChange);
     connect(ui->onionPrevFramesNumBox, spinBoxChanged, this, &ToolsPage::onionPrevFramesNumChange);
     connect(ui->onionNextFramesNumBox, spinBoxChanged, this, &ToolsPage::onionNextFramesNumChange);
+    connect(ui->onionSkinMode, &QCheckBox::stateChanged, this, &ToolsPage::onionSkinModeChange);
     connect(ui->useQuickSizingBox, &QCheckBox::stateChanged, this, &ToolsPage::quickSizingChange);
     connect(ui->rotationIncrementSlider, &QSlider::valueChanged, this, &ToolsPage::rotationIncrementChange);
 }
@@ -483,6 +484,7 @@ void ToolsPage::updateValues()
     ui->onionMinOpacityBox->setValue(mManager->getInt(SETTING::ONION_MIN_OPACITY));
     ui->onionPrevFramesNumBox->setValue(mManager->getInt(SETTING::ONION_PREV_FRAMES_NUM));
     ui->onionNextFramesNumBox->setValue(mManager->getInt(SETTING::ONION_NEXT_FRAMES_NUM));
+    ui->onionSkinMode->setChecked(mManager->getString(SETTING::ONION_TYPE) == "absolute");
     ui->useQuickSizingBox->setChecked(mManager->isOn(SETTING::QUICK_SIZING));
     setRotationIncrement(mManager->getInt(SETTING::ROTATION_INCREMENT));
 }
@@ -490,6 +492,18 @@ void ToolsPage::updateValues()
 void ToolsPage::onionMaxOpacityChange(int value)
 {
     mManager->set(SETTING::ONION_MAX_OPACITY, value);
+}
+
+void ToolsPage::onionSkinModeChange(int value)
+{
+    if (value == Qt::Checked)
+    {
+        mManager->set(SETTING::ONION_TYPE, QString("absolute"));
+    }
+    else
+    {
+        mManager->set(SETTING::ONION_TYPE, QString("relative"));
+    }
 }
 
 void ToolsPage::quickSizingChange(int b)

--- a/app/src/preferencesdialog.h
+++ b/app/src/preferencesdialog.h
@@ -163,6 +163,7 @@ public slots:
     void onionMinOpacityChange(int);
     void onionPrevFramesNumChange(int);
     void onionNextFramesNumChange(int);
+    void onionSkinModeChange(int);
     void quickSizingChange(int);
     void setRotationIncrement(int);
     void rotationIncrementChange(int);

--- a/app/ui/toolspage.ui
+++ b/app/ui/toolspage.ui
@@ -33,15 +33,15 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>299</width>
-        <height>560</height>
+        <width>313</width>
+        <height>566</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
         <widget class="QGroupBox" name="onionSkinBox">
          <property name="title">
-          <string>Onion skin</string>
+          <string>Onion Skin</string>
          </property>
          <layout class="QVBoxLayout" name="lay">
           <item>
@@ -151,6 +151,13 @@
             </property>
             <property name="maximum">
              <number>60</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="onionSkinMode">
+            <property name="text">
+             <string>Skip empty frames</string>
             </property>
            </widget>
           </item>

--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -142,13 +142,6 @@ void TimeLine::initUI()
     zoomSlider->setToolTip(tr("Adjust frame width"));
     zoomSlider->setOrientation(Qt::Horizontal);
 
-    QLabel* onionLabel = new QLabel(tr("Onion skin:"));
-
-    QToolButton* onionTypeButton = new QToolButton(this);
-    onionTypeButton->setIcon(QIcon(":icons/onion_type.png"));
-    onionTypeButton->setToolTip(tr("Toggle match keyframes"));
-    onionTypeButton->setFixedSize(24, 24);
-
     timelineButtons->addWidget(keyLabel);
     timelineButtons->addWidget(addKeyButton);
     timelineButtons->addWidget(removeKeyButton);
@@ -157,8 +150,6 @@ void TimeLine::initUI()
     timelineButtons->addWidget(zoomLabel);
     timelineButtons->addWidget(zoomSlider);
     timelineButtons->addSeparator();
-    timelineButtons->addWidget(onionLabel);
-    timelineButtons->addWidget(onionTypeButton);
     timelineButtons->addSeparator();
     timelineButtons->setFixedHeight(30);
 
@@ -213,7 +204,6 @@ void TimeLine::initUI()
     connect(removeKeyButton, &QToolButton::clicked, this, &TimeLine::removeKeyClick);
     connect(duplicateKeyButton, &QToolButton::clicked, this, &TimeLine::duplicateKeyClick);
     connect(zoomSlider, &QSlider::valueChanged, mTracks, &TimeLineCells::setFrameSize);
-    connect(onionTypeButton, &QToolButton::clicked, this, &TimeLine::toogleAbsoluteOnionClick);
 
     connect(mTimeControls, &TimeControls::soundToggled, this, &TimeLine::soundClick);
     connect(mTimeControls, &TimeControls::fpsChanged, this, &TimeLine::fpsChanged);

--- a/core_lib/src/interface/timeline.h
+++ b/core_lib/src/interface/timeline.h
@@ -59,7 +59,6 @@ Q_SIGNALS:
     void addKeyClick();
     void removeKeyClick();
     void duplicateKeyClick();
-    void toogleAbsoluteOnionClick();
 
     void newBitmapLayer();
     void newVectorLayer();


### PR DESCRIPTION
We all should be well aware by now of how much confusion that "onion skin" button in the timeline is. Well now it's in the preferences with the other onion skin options and has been better described so there should be no more confusion.

Eventually this will be superceded by #1125, but I think this is a good short- to mid-term solution until an onion skin panel is implemented.