### PR TITLE
Fix all spin boxes maintaining focus after returning

### DIFF
--- a/app/src/colorinspector.cpp
+++ b/app/src/colorinspector.cpp
@@ -26,6 +26,7 @@ GNU General Public License for more details.
 #include "pencildef.h"
 #include "editor.h"
 #include "colormanager.h"
+#include "util/util.h"
 
 
 ColorInspector::ColorInspector(QWidget *parent) :
@@ -87,9 +88,13 @@ void ColorInspector::initUI()
 
     auto spinBoxChanged = static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged);
     connect(ui->RedspinBox, spinBoxChanged, this, &ColorInspector::onColorChanged);
+    clearFocusOnFinished(ui->RedspinBox);
     connect(ui->GreenspinBox, spinBoxChanged, this, &ColorInspector::onColorChanged);
+    clearFocusOnFinished(ui->GreenspinBox);
     connect(ui->BluespinBox, spinBoxChanged, this, &ColorInspector::onColorChanged);
+    clearFocusOnFinished(ui->BluespinBox);
     connect(ui->AlphaspinBox, spinBoxChanged, this, &ColorInspector::onColorChanged);
+    clearFocusOnFinished(ui->AlphaspinBox);
     connect(ui->rgbButton, &QPushButton::clicked, this, &ColorInspector::onModeChanged);
     connect(ui->hsvButton, &QPushButton::clicked, this, &ColorInspector::onModeChanged);
 

--- a/app/src/tooloptionwidget.cpp
+++ b/app/src/tooloptionwidget.cpp
@@ -99,7 +99,9 @@ void ToolOptionWidget::makeConnectionToEditor(Editor* editor)
 
     auto spinboxValueChanged = static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged);
     connect(ui->brushSpinBox, spinboxValueChanged, toolManager, &ToolManager::setWidth);
+    clearFocusOnFinished(ui->brushSpinBox);
     connect(ui->featherSpinBox, spinboxValueChanged, toolManager, &ToolManager::setFeather);
+    clearFocusOnFinished(ui->featherSpinBox);
 
     connect(ui->useFeatherBox, &QCheckBox::clicked, toolManager, &ToolManager::setUseFeather);
 
@@ -110,6 +112,7 @@ void ToolOptionWidget::makeConnectionToEditor(Editor* editor)
 
     connect(ui->toleranceSlider, &SpinSlider::valueChanged, toolManager, &ToolManager::setTolerance);
     connect(ui->toleranceSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), toolManager, &ToolManager::setTolerance);
+    clearFocusOnFinished(ui->toleranceSpinBox);
 
     connect(ui->fillContourBox, &QCheckBox::clicked, toolManager, &ToolManager::setUseFillContour);
 

--- a/core_lib/src/interface/timecontrols.cpp
+++ b/core_lib/src/interface/timecontrols.cpp
@@ -162,19 +162,18 @@ void TimeControls::makeConnections()
 
     auto spinBoxValueChanged = static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged);
     connect(mLoopStartSpinBox, spinBoxValueChanged, this, &TimeControls::loopStartValueChanged);
+    clearFocusOnFinished(mLoopStartSpinBox);
     connect(mLoopEndSpinBox, spinBoxValueChanged, this, &TimeControls::loopEndValueChanged);
+    clearFocusOnFinished(mLoopEndSpinBox);
 
     connect(mPlaybackRangeCheckBox, &QCheckBox::toggled, mLoopStartSpinBox, &QSpinBox::setEnabled);
     connect(mPlaybackRangeCheckBox, &QCheckBox::toggled, mLoopEndSpinBox, &QSpinBox::setEnabled);
 
     connect(mSoundButton, &QPushButton::clicked, this, &TimeControls::soundToggled);
     connect(mSoundButton, &QPushButton::clicked, this, &TimeControls::updateSoundIcon);
-    auto connection = connect(mFpsBox, spinBoxValueChanged, this, &TimeControls::fpsChanged);
-    if(!connection)
-    {
-        // Use "editingFinished" if the "spinBoxValueChanged" signal doesn't work...
-        connect(mFpsBox, &QSpinBox::editingFinished, this, &TimeControls::onFpsEditingFinished);
-    }
+
+    connect(mFpsBox, spinBoxValueChanged, this, &TimeControls::fpsChanged);
+    connect(mFpsBox, &QSpinBox::editingFinished, this, &TimeControls::onFpsEditingFinished);
 }
 
 void TimeControls::playButtonClicked()
@@ -264,6 +263,7 @@ void TimeControls::updateSoundIcon(bool soundEnabled)
 
 void TimeControls::onFpsEditingFinished()
 {
+    mFpsBox->clearFocus();
     emit fpsChanged(mFpsBox->value());
 }
 

--- a/core_lib/src/util/util.cpp
+++ b/core_lib/src/util/util.cpp
@@ -15,7 +15,7 @@ GNU General Public License for more details.
 
 */
 #include "util.h"
-
+#include <QAbstractSpinBox>
 
 QTransform RectMapTransform( QRectF source, QRectF target )
 {
@@ -54,4 +54,9 @@ SignalBlocker::~SignalBlocker()
 {
     if ( mObject )
         mObject->blockSignals( mBlocked );
+}
+
+void clearFocusOnFinished(QAbstractSpinBox *spinBox)
+{
+    QObject::connect(spinBox, &QAbstractSpinBox::editingFinished, spinBox, &QAbstractSpinBox::clearFocus);
 }

--- a/core_lib/src/util/util.h
+++ b/core_lib/src/util/util.h
@@ -21,8 +21,11 @@ GNU General Public License for more details.
 #include <functional>
 #include <QTransform>
 
+class QAbstractSpinBox;
 
 QTransform RectMapTransform( QRectF source, QRectF target );
+
+void clearFocusOnFinished(QAbstractSpinBox *spinBox);
 
 class ScopeGuard
 {


### PR DESCRIPTION
Created a helper function to connect the signal that spin boxes emit when enter is pressed to a function that removes their focus. Should allow all keyboard shortcuts to work after pressing typing in any of the spin boxes and pressing enter.

Fixes #1230 