### PR TITLE
#1105 Added checks on timelinecells, so scrub is tracked

### DIFF
--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -781,7 +781,10 @@ void TimeLineCells::trackScrubber()
     else if (width() < (mEditor->currentFrame() - mFrameOffset + 1) * mFrameSize)
     {
         // Move timeline forward if the scrubber is offscreen to the right
-        mFrameOffset = mFrameOffset + ((mEditor->currentFrame() - mFrameOffset) / 2);
+        if (mEditor->playback()->isPlaying())
+            mFrameOffset = mFrameOffset + ((mEditor->currentFrame() - mFrameOffset) / 2);
+        else
+            mFrameOffset = mEditor->currentFrame() - width() / mFrameSize;
         emit offsetChanged(mFrameOffset);
         mTimeLine->updateContent();
     }

--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -425,7 +425,7 @@ void TimeLineCells::paintEvent(QPaintEvent*)
             paintOnionSkin(painter);
         }
 
-        if (mPrevFrame != mEditor->currentFrame())
+        if (mPrevFrame != mEditor->currentFrame()  || mEditor->playback()->isPlaying())
         {
             mPrevFrame = mEditor->currentFrame();
             trackScrubber();
@@ -771,7 +771,7 @@ void TimeLineCells::setMouseMoveY(int x)
 
 void TimeLineCells::trackScrubber()
 {
-    if (mEditor->currentFrame() < mFrameOffset)
+    if (mEditor->currentFrame() <= mFrameOffset)
     {
         // Move the timeline back if the scrubber is offscreen to the left
         mFrameOffset = mEditor->currentFrame() - 1;

--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -424,21 +424,14 @@ void TimeLineCells::paintEvent(QPaintEvent*)
             paintOnionSkin(painter);
         }
 
-        // --- draw the position of the current frame
-        if (mEditor->playback()->isPlaying() && mEditor->currentFrame() < mFrameOffset)
+        if (mEditor->playback()->isPlaying())
         {
-            mFrameOffset = mEditor->currentFrame() - 1;
-            emit offsetChanged(mFrameOffset);
-            mTimeLine->updateContent();
+            trackScrubber();
         }
-        else
+
+        // --- draw the position of the current frame
+        if (mEditor->currentFrame() > mFrameOffset)
         {
-            if (mEditor->playback()->isPlaying() && width() < (mEditor->currentFrame() - mFrameOffset + 1) * mFrameSize)
-            {
-                mFrameOffset = mFrameOffset + ((mEditor->currentFrame() - mFrameOffset) / 2);
-                emit offsetChanged(mFrameOffset);
-                mTimeLine->updateContent();
-            }
             painter.setBrush(QColor(255, 0, 0, 128));
             painter.setPen(Qt::NoPen);
             //painter.setCompositionMode(QPainter::CompositionMode_Source); // this causes the message: QPainter::setCompositionMode: PorterDuff modes not supported on device
@@ -771,5 +764,24 @@ void TimeLineCells::setMouseMoveY(int x)
     if (x == 0)
     {
         update();
+    }
+}
+
+void TimeLineCells::trackScrubber()
+{
+    if (mEditor->currentFrame() < mFrameOffset)
+    {
+        mFrameOffset = mEditor->currentFrame() - 1;
+        emit offsetChanged(mFrameOffset);
+        mTimeLine->updateContent();
+    }
+    else
+    {
+        if (width() < (mEditor->currentFrame() - mFrameOffset + 1) * mFrameSize)
+        {
+            mFrameOffset = mFrameOffset + ((mEditor->currentFrame() - mFrameOffset) / 2);
+            emit offsetChanged(mFrameOffset);
+            mTimeLine->updateContent();
+        }
     }
 }

--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -425,8 +425,20 @@ void TimeLineCells::paintEvent(QPaintEvent*)
         }
 
         // --- draw the position of the current frame
-        if (mEditor->currentFrame() > mFrameOffset)
+        if (mEditor->playback()->isPlaying() && mEditor->currentFrame() < mFrameOffset)
         {
+            mFrameOffset = mEditor->currentFrame() - 1;
+            emit offsetChanged(mFrameOffset);
+            mTimeLine->updateContent();
+        }
+        else
+        {
+            if (mEditor->playback()->isPlaying() && width() < (mEditor->currentFrame() - mFrameOffset + 1) * mFrameSize)
+            {
+                mFrameOffset = mFrameOffset + ((mEditor->currentFrame() - mFrameOffset) / 2);
+                emit offsetChanged(mFrameOffset);
+                mTimeLine->updateContent();
+            }
             painter.setBrush(QColor(255, 0, 0, 128));
             painter.setPen(Qt::NoPen);
             //painter.setCompositionMode(QPainter::CompositionMode_Source); // this causes the message: QPainter::setCompositionMode: PorterDuff modes not supported on device

--- a/core_lib/src/interface/timelinecells.h
+++ b/core_lib/src/interface/timelinecells.h
@@ -76,6 +76,7 @@ public slots:
     void setMouseMoveY(int x);
 
 protected:
+    void trackScrubber();
     void drawContent();
     void paintOnionSkin(QPainter& painter);
     void paintEvent(QPaintEvent* event);


### PR DESCRIPTION
This PR see to it, that the scrubber always is visible during playback.
It is a rather simple solution, since we shouldn't do too complicated things on the timeline, while we wait for the Timeline rewrite.
This one has bugged me (and @Jose-Moreno) and possible others for some time, so here is a solution.
![1105_scrubPlaybackTracking](https://user-images.githubusercontent.com/1292931/63711305-6a169000-c83b-11e9-9686-22ac065b20a9.gif)
