### PR TITLE
Layer import, from *.pclx to active project

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -34,6 +34,7 @@ INCLUDEPATH += \
     ../core_lib/src/external
 
 HEADERS += \
+    src/importlayersdialog.h \
     src/mainwindow2.h \
     src/pegbaralignmentdialog.h \
     src/shortcutfilter.h \
@@ -64,6 +65,7 @@ HEADERS += \
     src/checkupdatesdialog.h
 
 SOURCES += \
+    src/importlayersdialog.cpp \
     src/main.cpp \
     src/mainwindow2.cpp \
     src/pegbaralignmentdialog.cpp \
@@ -94,6 +96,7 @@ SOURCES += \
     src/checkupdatesdialog.cpp
 
 FORMS += \
+    ui/importlayersdialog.ui \
     ui/mainwindow2.ui \
     ui/pegbaralignmentdialog.ui \
     ui/timeline2.ui \

--- a/app/src/importlayersdialog.cpp
+++ b/app/src/importlayersdialog.cpp
@@ -1,0 +1,14 @@
+#include "importlayersdialog.h"
+#include "ui_importlayersdialog.h"
+
+ImportLayersDialog::ImportLayersDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::ImportLayersDialog)
+{
+    ui->setupUi(this);
+}
+
+ImportLayersDialog::~ImportLayersDialog()
+{
+    delete ui;
+}

--- a/app/src/importlayersdialog.cpp
+++ b/app/src/importlayersdialog.cpp
@@ -45,7 +45,7 @@ void ImportLayersDialog::getFileName()
     FileDialog fd(this);
     mFileName = QFileDialog::getOpenFileName(this, tr("Choose file"),
                                              fd.getLastOpenPath(FileType::ANIMATION),
-                                             tr("Pencil Animation file (*.pclx))"));
+                                             tr("Pencil Animation file (*.pclx)"));
     if (mFileName.isEmpty()) { return; }
     getLayers();
     for (int i = 0; i < mImportObject->getLayerCount(); i++)

--- a/app/src/importlayersdialog.cpp
+++ b/app/src/importlayersdialog.cpp
@@ -40,11 +40,13 @@ void ImportLayersDialog::setCore(Editor *editor)
 
 void ImportLayersDialog::getFileName()
 {
+    mFileName.clear();
     ui->lwLayers->clear();
     FileDialog fd(this);
     mFileName = QFileDialog::getOpenFileName(this, tr("Choose file"),
                                              fd.getLastOpenPath(FileType::ANIMATION),
                                              tr("Pencil Animation file (*.pclx))"));
+    if (mFileName.isEmpty()) { return; }
     getLayers();
     for (int i = 0; i < mImportObject->getLayerCount(); i++)
         ui->lwLayers->addItem(mImportObject->getLayer(i)->name());

--- a/app/src/importlayersdialog.cpp
+++ b/app/src/importlayersdialog.cpp
@@ -1,14 +1,127 @@
 #include "importlayersdialog.h"
 #include "ui_importlayersdialog.h"
 
+#include <QFileDialog>
+#include <QProgressDialog>
+
+#include "app_util.h"
+#include "filemanager.h"
+#include "filedialogex.h"
+#include "layermanager.h"
+#include "layer.h"
+#include "layerbitmap.h"
+#include "layervector.h"
+#include "layercamera.h"
+#include "layersound.h"
+
+#include <QDebug>
+
 ImportLayersDialog::ImportLayersDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::ImportLayersDialog)
 {
     ui->setupUi(this);
+    connect(ui->btnSelectFile, &QPushButton::clicked, this, &ImportLayersDialog::getFileName);
+    connect(ui->btnImportLayers, &QPushButton::clicked, this, &ImportLayersDialog::importLayers);
+    connect(ui->lwLayers, &QListWidget::itemSelectionChanged, this, &ImportLayersDialog::listWidgetChanged);
+    connect(ui->btnCancel, &QPushButton::clicked, this, &ImportLayersDialog::cancel);
+    ui->lwLayers->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    ui->btnImportLayers->setEnabled(false);
 }
 
 ImportLayersDialog::~ImportLayersDialog()
 {
     delete ui;
+}
+
+void ImportLayersDialog::setCore(Editor *editor)
+{
+    mEditor = editor;
+}
+
+void ImportLayersDialog::getFileName()
+{
+    FileDialog fd(this);
+    mFileName = QFileDialog::getOpenFileName(this, tr("Choose file"),
+                                             fd.getLastOpenPath(FileType::ANIMATION) , tr("Project files (*.pclx))"));
+    getLayers();
+    for (int i = 0; i < mObject->getLayerCount(); i++)
+        ui->lwLayers->addItem(mObject->getLayer(i)->name());
+}
+
+void ImportLayersDialog::listWidgetChanged()
+{
+    if (ui->lwLayers->count() > 0)
+        ui->btnImportLayers->setEnabled(true);
+    else
+        ui->btnImportLayers->setEnabled(false);
+}
+
+void ImportLayersDialog::importLayers()
+{
+//    if (mLayerList.isEmpty()) { return; }
+
+    for (int i = 0; i < mObject->getLayerCount(); i++ )
+    {
+        if (ui->lwLayers->item(i)->isSelected())
+        {
+            Layer *tmpLayer = mObject->findLayerByName(ui->lwLayers->item(i)->text());
+            Layer *newLayer = nullptr;
+            switch (tmpLayer->type()) {
+            case Layer::BITMAP:
+                newLayer = static_cast<LayerBitmap*>(mEditor->layers()->createBitmapLayer(tmpLayer->name()));
+                break;
+            case Layer::VECTOR:
+                newLayer = static_cast<LayerVector*>(mEditor->layers()->createVectorLayer(tmpLayer->name()));
+                break;
+            case Layer::CAMERA:
+                newLayer = static_cast<LayerCamera*>(mEditor->layers()->createCameraLayer(tmpLayer->name()));
+                break;
+            case Layer::SOUND:
+                newLayer = static_cast<LayerSound*>(mEditor->layers()->createSoundLayer(tmpLayer->name()));
+                break;
+            default:
+                newLayer = nullptr;
+            }
+            qDebug() << "Layer: " << tmpLayer->name();
+            for (int j = 1; j <= tmpLayer->getMaxKeyFramePosition(); j++)
+            {
+                if (tmpLayer->keyExists(j))
+                {
+                    qDebug() << "Key at: " << j;
+                }
+            }
+        }
+    }
+    close();
+}
+
+void ImportLayersDialog::cancel()
+{
+    close();
+}
+
+void ImportLayersDialog::getLayers()
+{
+    QProgressDialog progress(tr("Opening document..."), tr("Abort"), 0, 100, this);
+
+    // Don't show progress bar if running without a GUI (aka. when rendering from command line)
+    if (isVisible())
+    {
+        hideQuestionMark(progress);
+        progress.setWindowModality(Qt::WindowModal);
+        progress.show();
+    }
+
+    FileManager fm;
+    connect(&fm, &FileManager::progressChanged, [&progress](int p)
+    {
+        progress.setValue(p);
+        QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+    });
+    connect(&fm, &FileManager::progressRangeChanged, [&progress](int max)
+    {
+        progress.setRange(0, max + 3);
+    });
+    mObject = fm.load(mFileName);
 }

--- a/app/src/importlayersdialog.cpp
+++ b/app/src/importlayersdialog.cpp
@@ -8,11 +8,11 @@
 #include "filemanager.h"
 #include "filedialogex.h"
 #include "layermanager.h"
+#include "soundmanager.h"
 #include "layer.h"
 #include "layersound.h"
 #include "soundclip.h"
 
-#include <QDebug>
 
 ImportLayersDialog::ImportLayersDialog(QWidget *parent) :
     QDialog(parent),
@@ -44,7 +44,7 @@ void ImportLayersDialog::getFileName()
     FileDialog fd(this);
     mFileName = QFileDialog::getOpenFileName(this, tr("Choose file"),
                                              fd.getLastOpenPath(FileType::ANIMATION),
-                                             tr("Project files (*.pclx))"));
+                                             tr("Pencil Animation file (*.pclx))"));
     getLayers();
     for (int i = 0; i < mImportObject->getLayerCount(); i++)
         ui->lwLayers->addItem(mImportObject->getLayer(i)->name());
@@ -75,11 +75,7 @@ void ImportLayersDialog::importLayers()
                     int newKeyPos = layerSound->getNextKeyFramePosition(count);
                     SoundClip* clip = new SoundClip;
                     clip = layerSound->getSoundClipWhichCovers(newKeyPos);
-                    qDebug() << "Soundclipname: " << clip->soundClipName() << ".\nFilename: " << clip->fileName();
-                    Status st = layerSound->loadSoundClipAtFrame(clip->soundClipName(),
-                                                                 clip->fileName(),
-                                                                 newKeyPos);
-                    qDebug() << "Status: " << st.msg();
+                    Status st = mEditor->sound()->loadSound(clip, clip->fileName());
                     count = newKeyPos;
                 }
                 mObject->addLayer(layerSound);

--- a/app/src/importlayersdialog.h
+++ b/app/src/importlayersdialog.h
@@ -1,0 +1,22 @@
+#ifndef IMPORTLAYERSDIALOG_H
+#define IMPORTLAYERSDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class ImportLayersDialog;
+}
+
+class ImportLayersDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ImportLayersDialog(QWidget *parent = nullptr);
+    ~ImportLayersDialog();
+
+private:
+    Ui::ImportLayersDialog *ui;
+};
+
+#endif // IMPORTLAYERSDIALOG_H

--- a/app/src/importlayersdialog.h
+++ b/app/src/importlayersdialog.h
@@ -31,6 +31,7 @@ private:
     void getLayers();
 
     Object *mObject = nullptr;
+    Object *mImportObject = nullptr;
     Editor *mEditor = nullptr;
     QString mFileName = "";
 };

--- a/app/src/importlayersdialog.h
+++ b/app/src/importlayersdialog.h
@@ -2,6 +2,8 @@
 #define IMPORTLAYERSDIALOG_H
 
 #include <QDialog>
+#include "object.h"
+#include "editor.h"
 
 namespace Ui {
 class ImportLayersDialog;
@@ -15,8 +17,22 @@ public:
     explicit ImportLayersDialog(QWidget *parent = nullptr);
     ~ImportLayersDialog();
 
+    void setCore(Editor *editor);
+
+public slots:
+    void getFileName();
+    void listWidgetChanged();
+    void importLayers();
+    void cancel();
+
 private:
     Ui::ImportLayersDialog *ui;
+
+    void getLayers();
+
+    Object *mObject = nullptr;
+    Editor *mEditor = nullptr;
+    QString mFileName = "";
 };
 
 #endif // IMPORTLAYERSDIALOG_H

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -64,6 +64,7 @@ GNU General Public License for more details.
 #include "timeline2.h"
 #include "errordialog.h"
 #include "importimageseqdialog.h"
+#include "importlayersdialog.h"
 #include "recentfilemenu.h"
 #include "shortcutfilter.h"
 #include "app_util.h"
@@ -975,7 +976,9 @@ void MainWindow2::addLayerByFilename(QString strFilePath)
 
 void MainWindow2::importLayers()
 {
-
+    ImportLayersDialog *importLayers = new ImportLayersDialog(this);
+    importLayers->setCore(mEditor);
+    importLayers->exec();
 }
 
 void MainWindow2::importGIF()

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -243,6 +243,7 @@ void MainWindow2::createMenus()
     connect(ui->actionImport_Image, &QAction::triggered, this, &MainWindow2::importImage);
     connect(ui->actionImport_ImageSeq, &QAction::triggered, this, &MainWindow2::importImageSequence);
     connect(ui->actionImport_ImageSeqNum, &QAction::triggered, this, &MainWindow2::importImageSequenceNumbered);
+    connect(ui->actionImportLayers_from_pclx, &QAction::triggered, this, &MainWindow2::importLayers);
     connect(ui->actionImport_Gif, &QAction::triggered, this, &MainWindow2::importGIF);
     connect(ui->actionImport_Movie, &QAction::triggered, this, &MainWindow2::importMovie);
 
@@ -970,6 +971,11 @@ void MainWindow2::addLayerByFilename(QString strFilePath)
     }
     ui->scribbleArea->updateCurrentFrame();
     mTimeLine->updateContent();
+}
+
+void MainWindow2::importLayers()
+{
+
 }
 
 void MainWindow2::importGIF()

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -83,6 +83,7 @@ public:
     void importImageSequence();
     void importImageSequenceNumbered();
     void addLayerByFilename(QString strFilePath);
+    void importLayers();
     void importMovie();
     void importGIF();
 

--- a/app/ui/importlayersdialog.ui
+++ b/app/ui/importlayersdialog.ui
@@ -19,7 +19,7 @@
      <item>
       <widget class="QLabel" name="labSelectFile">
        <property name="text">
-        <string>Select *.pclx file:</string>
+        <string>1. Select *.pclx file:</string>
        </property>
       </widget>
      </item>
@@ -48,7 +48,7 @@
    <item>
     <widget class="QLabel" name="labSelectLayers">
      <property name="text">
-      <string>Select layers from file:</string>
+      <string>2. Select layers from file:</string>
      </property>
     </widget>
    </item>

--- a/app/ui/importlayersdialog.ui
+++ b/app/ui/importlayersdialog.ui
@@ -71,9 +71,9 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="btnCancel">
+      <widget class="QPushButton" name="btnClose">
        <property name="text">
-        <string>Cancel</string>
+        <string>Close</string>
        </property>
       </widget>
      </item>

--- a/app/ui/importlayersdialog.ui
+++ b/app/ui/importlayersdialog.ui
@@ -53,7 +53,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QListView" name="lvLayers"/>
+    <widget class="QListWidget" name="lwLayers"/>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">

--- a/app/ui/importlayersdialog.ui
+++ b/app/ui/importlayersdialog.ui
@@ -19,7 +19,7 @@
      <item>
       <widget class="QLabel" name="labSelectFile">
        <property name="text">
-        <string>1. Select *.pclx file:</string>
+        <string>1. Select PCLX file:</string>
        </property>
       </widget>
      </item>

--- a/app/ui/importlayersdialog.ui
+++ b/app/ui/importlayersdialog.ui
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ImportLayersDialog</class>
+ <widget class="QDialog" name="ImportLayersDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>267</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Import Layers from other *.pclx files</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="labSelectFile">
+       <property name="text">
+        <string>Select *.pclx file:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnSelectFile">
+       <property name="text">
+        <string>Select File</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="labSelectLayers">
+     <property name="text">
+      <string>Select layers from file:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListView" name="lvLayers"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnCancel">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnImportLayers">
+       <property name="text">
+        <string>Import layers</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -984,7 +984,7 @@
   </action>
   <action name="actionImportLayers_from_pclx">
    <property name="text">
-    <string>Layers from *.pclx</string>
+    <string>Layers from PCLX...</string>
    </property>
   </action>
  </widget>

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -49,7 +49,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>22</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -66,6 +66,7 @@
      <addaction name="actionImport_Movie"/>
      <addaction name="actionImport_ImageSeqNum"/>
      <addaction name="actionImport_Gif"/>
+     <addaction name="actionImportLayers_from_pclx"/>
      <addaction name="actionImport_Sound"/>
      <addaction name="separator"/>
      <addaction name="actionImport_Palette"/>
@@ -979,6 +980,11 @@
   <action name="actionPegbarAlignment">
    <property name="text">
     <string>Peg bar Alignment</string>
+   </property>
+  </action>
+  <action name="actionImportLayers_from_pclx">
+   <property name="text">
+    <string>Layers from *.pclx</string>
    </property>
   </action>
  </widget>

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -281,6 +281,14 @@ void Object::deleteLayer(Layer* layer)
     }
 }
 
+void Object::addLayer(Layer *layer)
+{
+    if (layer != nullptr)
+    {
+        mLayers.append(layer);
+    }
+}
+
 ColourRef Object::getColour(int index) const
 {
     ColourRef result(Qt::white, "error");

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -117,6 +117,7 @@ public:
     bool swapLayers(int i, int j);
     void deleteLayer(int i);
     void deleteLayer(Layer*);
+    void addLayer(Layer* layer);
 
     template<typename T>
     std::vector<T*> getLayersByType() const


### PR DESCRIPTION
The ability to reuse animation is essential today. Not just characters, but also rain, snow and other effects can be reused.
This PR makes it possible to import layers from whatever *.pclx file you want.
I don't think the import should be in the undo/redo, since it doesn't affect the other layers, and it's easy to delete layers if you want.
It's not a huge PR, but I think it's impact will be...