### PR TITLE
#1193 Changing feather range to 1-99

### DIFF
--- a/app/src/tooloptionwidget.cpp
+++ b/app/src/tooloptionwidget.cpp
@@ -49,7 +49,7 @@ void ToolOptionWidget::initUI()
     ui->sizeSlider->setValue(settings.value("brushWidth", "3").toDouble());
     ui->brushSpinBox->setValue(settings.value("brushWidth", "3").toDouble());
 
-    ui->featherSlider->init(tr("Feather"), SpinSlider::LOG, SpinSlider::INTEGER, 1, 100);
+    ui->featherSlider->init(tr("Feather"), SpinSlider::LOG, SpinSlider::INTEGER, 1, 99);
     ui->featherSlider->setValue(settings.value("brushFeather", "5").toDouble());
     ui->featherSpinBox->setValue(settings.value("brushFeather", "5").toDouble());
 

--- a/app/src/tooloptionwidget.cpp
+++ b/app/src/tooloptionwidget.cpp
@@ -49,7 +49,7 @@ void ToolOptionWidget::initUI()
     ui->sizeSlider->setValue(settings.value("brushWidth", "3").toDouble());
     ui->brushSpinBox->setValue(settings.value("brushWidth", "3").toDouble());
 
-    ui->featherSlider->init(tr("Feather"), SpinSlider::LOG, SpinSlider::INTEGER, 2, 200);
+    ui->featherSlider->init(tr("Feather"), SpinSlider::LOG, SpinSlider::INTEGER, 1, 100);
     ui->featherSlider->setValue(settings.value("brushFeather", "5").toDouble());
     ui->featherSpinBox->setValue(settings.value("brushFeather", "5").toDouble());
 

--- a/app/ui/tooloptions.ui
+++ b/app/ui/tooloptions.ui
@@ -77,7 +77,7 @@
         <double>0.100000000000000</double>
        </property>
        <property name="maximum">
-        <double>100.000000000000000</double>
+        <double>99.000000000000000</double>
        </property>
        <property name="value">
         <double>5.000000000000000</double>

--- a/app/ui/tooloptions.ui
+++ b/app/ui/tooloptions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>164</width>
-    <height>341</height>
+    <height>361</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -77,7 +77,7 @@
         <double>0.100000000000000</double>
        </property>
        <property name="maximum">
-        <double>80.000000000000000</double>
+        <double>100.000000000000000</double>
        </property>
        <property name="value">
         <double>5.000000000000000</double>


### PR DESCRIPTION
This closes #1193 and #1194 .
Since the value indicates the alpha-value of the feathering, 100 = invisible. For this reason it could be argued that we should have 99 as maximum. Right now it is set to 100.