### PR TITLE
#1177 Import drawings on wanted position

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -35,6 +35,7 @@ INCLUDEPATH += \
 
 HEADERS += \
     src/importlayersdialog.h \
+    src/importpositiondialog.h \
     src/mainwindow2.h \
     src/predefinedsetmodel.h \
     src/pegbaralignmentdialog.h \
@@ -67,6 +68,7 @@ HEADERS += \
 
 SOURCES += \
     src/importlayersdialog.cpp \
+    src/importpositiondialog.cpp \
     src/main.cpp \
     src/mainwindow2.cpp \
     src/predefinedsetmodel.cpp \
@@ -100,6 +102,7 @@ SOURCES += \
 FORMS += \
     ui/importimageseqpreview.ui \
     ui/importlayersdialog.ui \
+    ui/importpositiondialog.ui \
     ui/mainwindow2.ui \
     ui/pegbaralignmentdialog.ui \
     ui/timeline2.ui \

--- a/app/src/importexportdialog.cpp
+++ b/app/src/importexportdialog.cpp
@@ -28,8 +28,13 @@ ImportExportDialog::ImportExportDialog(QWidget* parent, Mode eMode, FileType eFi
     ui = new Ui::ImportExportDialog;
     ui->setupUi(this);
     m_fileDialog = new FileDialog(this);
+    ui->cbImportPosition->addItem("Current view and position");
+    ui->cbImportPosition->addItem("Canvas center");
+    ui->cbImportPosition->addItem("Active camera");
 
     connect(ui->browseButton, &QPushButton::clicked, this, &ImportExportDialog::browse);
+    connect(ui->cbImportPosition, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &ImportExportDialog::setPosIndex);
 
     Qt::WindowFlags eFlags = Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint;
     setWindowFlags(eFlags);

--- a/app/src/importexportdialog.cpp
+++ b/app/src/importexportdialog.cpp
@@ -28,13 +28,7 @@ ImportExportDialog::ImportExportDialog(QWidget* parent, Mode eMode, FileType eFi
     ui = new Ui::ImportExportDialog;
     ui->setupUi(this);
     m_fileDialog = new FileDialog(this);
-    ui->cbImportPosition->addItem("Current view and position");
-    ui->cbImportPosition->addItem("Canvas center");
-    ui->cbImportPosition->addItem("Active camera");
-
     connect(ui->browseButton, &QPushButton::clicked, this, &ImportExportDialog::browse);
-    connect(ui->cbImportPosition, QOverload<int>::of(&QComboBox::currentIndexChanged),
-            this, &ImportExportDialog::setPosIndex);
 
     Qt::WindowFlags eFlags = Qt::Dialog | Qt::WindowTitleHint | Qt::WindowCloseButtonHint;
     setWindowFlags(eFlags);

--- a/app/src/importexportdialog.h
+++ b/app/src/importexportdialog.h
@@ -42,6 +42,7 @@ public:
     QString getFilePath() const;
     QString getAbsolutePath();
     QStringList getFilePaths();
+    int getPosIndex() { return mPosIndex; }
 
 signals:
     void filePathsChanged(QStringList filePaths);
@@ -60,6 +61,7 @@ protected:
 
 private slots:
     void browse();
+    void setPosIndex(int index) { mPosIndex = index; }
 
 private:
     Ui::ImportExportDialog* ui = nullptr;
@@ -69,6 +71,7 @@ private:
 
     FileType mFileType = FileType::ANIMATION;
     Mode mMode = Import;
+    int mPosIndex = 0;
 };
 
 #endif // IMPORTEXPORTDIALOG_H

--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -158,8 +158,18 @@ void ImportImageSeqDialog::setSpace(int number)
     uiOptionsBox->spaceSpinBox->setValue(number);
 }
 
-void ImportImageSeqDialog::importArbitrarySequence()
+void ImportImageSeqDialog::importArbitrarySequence(int index)
 {
+    QPointF currentView = mEditor->view()->translation();
+    if (index == 1)
+    {
+        mEditor->view()->resetView();
+    }
+    else if (index == 2)
+    {
+        mEditor->view()->translate(mEditor->view()->getCameraView());
+    }
+
     QStringList files = getFilePaths();
     int number = getSpace();
 
@@ -219,6 +229,8 @@ void ImportImageSeqDialog::importArbitrarySequence()
                              QMessageBox::Ok,
                              QMessageBox::Ok);
     }
+
+    mEditor->view()->translate(currentView);
 
     emit notifyAnimationLengthChanged();
     progress.close();

--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -22,6 +22,7 @@ GNU General Public License for more details.
 
 #include "editor.h"
 #include "predefinedsetmodel.h"
+#include "viewmanager.h"
 
 #include <QProgressDialog>
 #include <QMessageBox>
@@ -294,8 +295,17 @@ const PredefinedKeySetParams ImportImageSeqDialog::predefinedKeySetParams() cons
     return setParams;
 }
 
-void ImportImageSeqDialog::importPredefinedSet()
+void ImportImageSeqDialog::importPredefinedSet(int index)
 {
+    qDebug() << "map canvas to screen: " << mEditor->view()->mapCanvasToScreen(mEditor->view()->translation());
+    if (index == 1)
+    {
+        mEditor->view()->resetView();
+    }
+    else if (index == 2)
+    {
+        mEditor->view()->translate(mEditor->view()->translation());
+    }
     PredefinedKeySet keySet = generatePredefinedKeySet();
 
     // Show a progress dialog, as this can take a while if you have lots of images.

--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -90,7 +90,7 @@ int ImportImageSeqDialog::getSpace()
 
 void ImportImageSeqDialog::updatePreviewList(const QStringList& list)
 {
-    Q_UNUSED(list);
+    Q_UNUSED(list)
     if (mImportCriteria == ImportCriteria::PredefinedSet)
     {
         const PredefinedKeySet& keySet = generatePredefinedKeySet();
@@ -297,14 +297,14 @@ const PredefinedKeySetParams ImportImageSeqDialog::predefinedKeySetParams() cons
 
 void ImportImageSeqDialog::importPredefinedSet(int index)
 {
-    qDebug() << "map canvas to screen: " << mEditor->view()->mapCanvasToScreen(mEditor->view()->translation());
+    QPointF currentView = mEditor->view()->translation();
     if (index == 1)
     {
         mEditor->view()->resetView();
     }
     else if (index == 2)
     {
-        mEditor->view()->translate(mEditor->view()->translation());
+        mEditor->view()->translate(mEditor->view()->getCameraView());
     }
     PredefinedKeySet keySet = generatePredefinedKeySet();
 
@@ -338,6 +338,8 @@ void ImportImageSeqDialog::importPredefinedSet(int index)
 
         if (!ok) { return;}
     }
+
+    mEditor->view()->translate(currentView);
 
     emit notifyAnimationLengthChanged();
 }

--- a/app/src/importimageseqdialog.h
+++ b/app/src/importimageseqdialog.h
@@ -54,7 +54,7 @@ public:
     ~ImportImageSeqDialog() override;
 
     void importArbitrarySequence();
-    void importPredefinedSet();
+    void importPredefinedSet(int index);
     int getSpace();
 
     void setCore(Editor* editor) { mEditor = editor; }

--- a/app/src/importimageseqdialog.h
+++ b/app/src/importimageseqdialog.h
@@ -76,7 +76,6 @@ private:
     int keyFramePosFromFilePath(const QString& path);
 
 private:
-
     const PredefinedKeySet generatePredefinedKeySet() const;
     void setPreviewModel(const PredefinedKeySet& predefinedKeySet);
     void setupLayout();

--- a/app/src/importimageseqdialog.h
+++ b/app/src/importimageseqdialog.h
@@ -53,7 +53,7 @@ public:
                                   ImportCriteria importCriteria = ImportCriteria::Arbitrary);
     ~ImportImageSeqDialog() override;
 
-    void importArbitrarySequence();
+    void importArbitrarySequence(int index);
     void importPredefinedSet(int index);
     int getSpace();
 

--- a/app/src/importpositiondialog.cpp
+++ b/app/src/importpositiondialog.cpp
@@ -1,0 +1,20 @@
+#include "importpositiondialog.h"
+#include "ui_importpositiondialog.h"
+
+ImportPositionDialog::ImportPositionDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::ImportPositionDialog)
+{
+    ui->setupUi(this);
+
+    ui->cbImagePosition->addItem("Current view and position");
+    ui->cbImagePosition->addItem("Canvas centre");
+    ui->cbImagePosition->addItem("Current camera view");
+
+    connect(ui->cbImagePosition, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ImportPositionDialog::setPosIndex);
+}
+
+ImportPositionDialog::~ImportPositionDialog()
+{
+    delete ui;
+}

--- a/app/src/importpositiondialog.h
+++ b/app/src/importpositiondialog.h
@@ -1,0 +1,27 @@
+#ifndef IMPORTPOSITIONDIALOG_H
+#define IMPORTPOSITIONDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class ImportPositionDialog;
+}
+
+class ImportPositionDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ImportPositionDialog(QWidget *parent = nullptr);
+    ~ImportPositionDialog();
+
+    int getPosIndex() { return mPosIndex; }
+    void setPosIndex(int index) { mPosIndex = index; }
+
+private:
+    Ui::ImportPositionDialog *ui;
+
+    int mPosIndex = 0;
+};
+
+#endif // IMPORTPOSITIONDIALOG_H

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -808,7 +808,7 @@ void MainWindow2::importImageSequence()
     mIsImportingImageSequence = true;
 
     ImportImageSeqDialog* imageSeqDialog = new ImportImageSeqDialog(this);
-    OnScopeExit(delete imageSeqDialog);
+    OnScopeExit(delete imageSeqDialog)
     imageSeqDialog->setCore(mEditor);
 
     connect(imageSeqDialog, &ImportImageSeqDialog::notifyAnimationLengthChanged, mEditor, &Editor::notifyAnimationLengthChanged);
@@ -818,7 +818,8 @@ void MainWindow2::importImageSequence()
     {
         return;
     }
-    imageSeqDialog->importArbitrarySequence();
+    int index = imageSeqDialog->getPosIndex();
+    imageSeqDialog->importArbitrarySequence(index);
 
     mIsImportingImageSequence = false;
 }

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -833,9 +833,11 @@ void MainWindow2::importImageSequence()
     }
 
     ImportPositionDialog* positionDialog = new ImportPositionDialog(this);
+    OnScopeExit(delete positionDialog)
+
     positionDialog->setCore(mEditor);
     positionDialog->exec();
-    if (positionDialog->result() == QDialog::Rejected)
+    if (positionDialog->result() != QDialog::Accepted)
     {
         return;
     }
@@ -861,6 +863,9 @@ void MainWindow2::importPredefinedImageSet()
     }
 
     ImportPositionDialog* positionDialog = new  ImportPositionDialog(this);
+    OnScopeExit(delete positionDialog)
+
+    positionDialog->setCore(mEditor);
     positionDialog->exec();
     if (positionDialog->result() != QDialog::Accepted)
     {
@@ -889,6 +894,16 @@ void MainWindow2::importGIF()
 
     // Flag this so we don't prompt the user about auto-save in the middle of the import.
     mIsImportingImageSequence = true;
+
+    ImportPositionDialog* positionDialog = new  ImportPositionDialog(this);
+    OnScopeExit(delete positionDialog)
+
+    positionDialog->setCore(mEditor);
+    positionDialog->exec();
+    if (positionDialog->result() != QDialog::Accepted)
+    {
+        return;
+    }
 
     int space = gifDialog->getSpace();
 

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -826,7 +826,7 @@ void MainWindow2::importImageSequence()
 void MainWindow2::importPredefinedImageSet()
 {
     ImportImageSeqDialog* imageSeqDialog = new ImportImageSeqDialog(this, ImportExportDialog::Import, FileType::IMAGE, ImportCriteria::PredefinedSet);
-    OnScopeExit(delete imageSeqDialog);
+    OnScopeExit(delete imageSeqDialog)
     imageSeqDialog->setCore(mEditor);
 
     connect(imageSeqDialog, &ImportImageSeqDialog::notifyAnimationLengthChanged, mEditor, &Editor::notifyAnimationLengthChanged);
@@ -838,7 +838,8 @@ void MainWindow2::importPredefinedImageSet()
         return;
     }
 
-    imageSeqDialog->importPredefinedSet();
+    int index = imageSeqDialog->getPosIndex();
+    imageSeqDialog->importPredefinedSet(index);
     mIsImportingImageSequence = false;
 }
 

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -79,6 +79,7 @@ public:
     bool autoSave();
 
     // import
+    int getImportPosition();
     void importImage();
     void importImageSequence();
     void importPredefinedImageSet();

--- a/app/ui/importexportdialog.ui
+++ b/app/ui/importexportdialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>455</width>
-    <height>263</height>
+    <height>244</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -96,33 +96,6 @@
       <string>Imports</string>
      </property>
     </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="labImportRelativeTo">
-       <property name="text">
-        <string>Import relative to: </string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="cbImportPosition"/>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/app/ui/importexportdialog.ui
+++ b/app/ui/importexportdialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>455</width>
-    <height>218</height>
+    <height>263</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -23,18 +23,6 @@
    <bool>true</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="spacing">
-    <number>2</number>
-   </property>
-   <property name="leftMargin">
-    <number>9</number>
-   </property>
-   <property name="topMargin">
-    <number>9</number>
-   </property>
-   <property name="rightMargin">
-    <number>9</number>
-   </property>
    <item>
     <widget class="QLabel" name="instructionsLabel">
      <property name="minimumSize">
@@ -108,6 +96,33 @@
       <string>Imports</string>
      </property>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="labImportRelativeTo">
+       <property name="text">
+        <string>Import relative to: </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="cbImportPosition"/>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/app/ui/importpositiondialog.ui
+++ b/app/ui/importpositiondialog.ui
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ImportPositionDialog</class>
+ <widget class="QDialog" name="ImportPositionDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>304</width>
+    <height>101</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Import position</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="labImagePosition">
+       <property name="text">
+        <string>Import image(-s) relative to:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QComboBox" name="cbImagePosition"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ImportPositionDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ImportPositionDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/core_lib/src/managers/viewmanager.cpp
+++ b/core_lib/src/managers/viewmanager.cpp
@@ -360,3 +360,12 @@ void ViewManager::resetView()
         Q_EMIT viewFlipped();
     }
 }
+
+QPointF ViewManager::getCameraView()
+{
+    if (mCurrentCamera)
+    {
+        return mCurrentCamera->translation();
+    }
+    return QPointF(0.0 , 0.0);
+}

--- a/core_lib/src/managers/viewmanager.h
+++ b/core_lib/src/managers/viewmanager.h
@@ -42,6 +42,8 @@ public:
     QTransform getViewInverse();
     void resetView();
 
+    QPointF getCameraView();
+
     QPointF mapCanvasToScreen(QPointF p);
     QPointF mapScreenToCanvas(QPointF p);
 


### PR DESCRIPTION
This addresses #1177, but I won't say it closes it.
There are 3 kinds oh image imports:
(1) image - (2) image sequence - (3) predefined set.
With this PR, you can select whether you you want to import (2) and (3) relative to: 
(a) current view - (b) canvas centre - (c) current camera view. 
The selection is done in a combobox on the filedialog.
You can't select where you want to import a single image (1), because we use the ordinary fileopen dialog in that case, and it's not possible to (for me at least) to place a combobox on that dialog. It could be solved by agreeing that all single image imports are done to canvas centre. Or - what do you think?
You can't select camera either, if you have multiple cameras. The importExportDialog doesn't know of layers or editors, and I'm not convinced that this possibility is necessary.