### PR TITLE
Miscellaneous compiler warning fixes

### DIFF
--- a/app/src/colorwheel.cpp
+++ b/app/src/colorwheel.cpp
@@ -71,7 +71,6 @@ QColor ColorWheel::pickColor(const QPoint& point)
     if (mIsInWheel)
     {
         qreal hue = 0;
-        int r = qMin(width(), height()) / 2;
         QPoint center(width() / 2, height() / 2);
         QPoint diff = point - center;
 

--- a/core_lib/src/tool/selecttool.cpp
+++ b/core_lib/src/tool/selecttool.cpp
@@ -94,7 +94,7 @@ void SelectTool::pointerPressEvent(PointerEvent* event)
     beginSelection();
 }
 
-void SelectTool::pointerMoveEvent(PointerEvent* event)
+void SelectTool::pointerMoveEvent(PointerEvent*)
 {
     mCurrentLayer = mEditor->layers()->currentLayer();
     if (mCurrentLayer == nullptr) { return; }


### PR DESCRIPTION
Just a fix of some compiler warnings (unused variable/arguments).

The only remaining warnings are in `miniz.h` and `miniz.cpp`, but these look to be third party.