### PR TITLE
Issue1288 Comments to frames

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -67,7 +67,8 @@ HEADERS += \
     src/spinslider.h \
     src/doubleprogressdialog.h \
     src/colorslider.h \
-    src/checkupdatesdialog.h
+    src/checkupdatesdialog.h \
+    src/framecommentwidget.h
 
 SOURCES += \
     src/importlayersdialog.cpp \
@@ -99,7 +100,8 @@ SOURCES += \
     src/spinslider.cpp \
     src/doubleprogressdialog.cpp \
     src/colorslider.cpp \
-    src/checkupdatesdialog.cpp
+    src/checkupdatesdialog.cpp \
+    src/framecommentwidget.cpp
 
 FORMS += \
     ui/importimageseqpreview.ui \
@@ -124,7 +126,8 @@ FORMS += \
     ui/timelinepage.ui \
     ui/filespage.ui \
     ui/toolspage.ui \
-    ui/toolboxwidget.ui
+    ui/toolboxwidget.ui \
+    ui/framecommentwidget.ui
 
 
 

--- a/app/src/framecommentwidget.cpp
+++ b/app/src/framecommentwidget.cpp
@@ -1,6 +1,10 @@
 #include "framecommentwidget.h"
 #include "ui_framecommentwidget.h"
 
+#include "editor.h"
+#include "layermanager.h"
+#include "keyframe.h"
+
 FrameCommentWidget::FrameCommentWidget(QWidget *parent) :
     BaseDockWidget(parent)
 {
@@ -22,6 +26,9 @@ void FrameCommentWidget::initUI()
     connect(ui->leDialogue, &QLineEdit::textChanged, this, &FrameCommentWidget::dialogueTextChanged);
     connect(ui->leAction, &QLineEdit::textChanged, this, &FrameCommentWidget::actionTextChanged);
     connect(ui->leNotes, &QLineEdit::textChanged, this, &FrameCommentWidget::notesTextChanged);
+    connect(editor(), &Editor::currentFrameChanged, this, &FrameCommentWidget::currentFrameChanged);
+    connect(ui->btnClearFields, &QPushButton::clicked, this, &FrameCommentWidget::clearFrameCommentsFields);
+    connect(ui->btnApplyComments, &QPushButton::clicked, this, &FrameCommentWidget::updateFrameComments);
     dialogueTextChanged("");
     actionTextChanged("");
     notesTextChanged("");
@@ -49,3 +56,43 @@ void FrameCommentWidget::notesTextChanged(QString text)
     int len = text.length();
     ui->labNotesCount->setText(tr("%1 chars").arg(QString::number(len)));
 }
+
+void FrameCommentWidget::currentFrameChanged(int frame)
+{
+    if (editor()->layers()->currentLayer()->keyExists(frame))
+    {
+        fillFrameComments();
+        ui->btnApplyComments->setEnabled(true);
+    }
+    else
+    {
+        clearFrameCommentsFields();
+        ui->btnApplyComments->setEnabled(false);
+    }
+}
+
+void FrameCommentWidget::clearFrameCommentsFields()
+{
+    ui->leDialogue->clear();
+    ui->leAction->clear();
+    ui->leNotes->clear();
+}
+
+void FrameCommentWidget::updateFrameComments()
+{
+    KeyFrame* key = editor()->layers()->currentLayer()->getKeyFrameAt(editor()->currentFrame());
+    if (key == nullptr) { return; }
+    key->setDialogueComment(ui->leDialogue->text());
+    key->setActionComment(ui->leAction->text());
+    key->setNotesComment(ui->leNotes->text());
+}
+
+void FrameCommentWidget::fillFrameComments()
+{
+    KeyFrame* key = editor()->layers()->currentLayer()->getKeyFrameAt(editor()->currentFrame());
+    if (key == nullptr) { return; }
+    ui->leDialogue->setText(key->getDialogueComment());
+    ui->leAction->setText(key->getActionComment());
+    ui->leNotes->setText(key->getNotesComment());
+}
+

--- a/app/src/framecommentwidget.cpp
+++ b/app/src/framecommentwidget.cpp
@@ -1,0 +1,51 @@
+#include "framecommentwidget.h"
+#include "ui_framecommentwidget.h"
+
+FrameCommentWidget::FrameCommentWidget(QWidget *parent) :
+    BaseDockWidget(parent)
+{
+    QWidget* innerWidget = new QWidget;
+    setWindowTitle(tr("Frame Comments"));
+
+    ui = new Ui::FrameComment;
+    ui->setupUi(innerWidget);
+    setWidget(innerWidget);
+}
+
+FrameCommentWidget::~FrameCommentWidget()
+{
+    delete ui;
+}
+
+void FrameCommentWidget::initUI()
+{
+    connect(ui->leDialogue, &QLineEdit::textChanged, this, &FrameCommentWidget::dialogueTextChanged);
+    connect(ui->leAction, &QLineEdit::textChanged, this, &FrameCommentWidget::actionTextChanged);
+    connect(ui->leNotes, &QLineEdit::textChanged, this, &FrameCommentWidget::notesTextChanged);
+    dialogueTextChanged("");
+    actionTextChanged("");
+    notesTextChanged("");
+}
+
+void FrameCommentWidget::updateUI()
+{
+
+}
+
+void FrameCommentWidget::dialogueTextChanged(QString text)
+{
+    int len = text.length();
+    ui->labDialogueCount->setText(tr("%1 chars").arg(QString::number(len)));
+}
+
+void FrameCommentWidget::actionTextChanged(QString text)
+{
+    int len = text.length();
+    ui->labActionCount->setText(tr("%1 chars").arg(QString::number(len)));
+}
+
+void FrameCommentWidget::notesTextChanged(QString text)
+{
+    int len = text.length();
+    ui->labNotesCount->setText(tr("%1 chars").arg(QString::number(len)));
+}

--- a/app/src/framecommentwidget.cpp
+++ b/app/src/framecommentwidget.cpp
@@ -26,6 +26,9 @@ FrameCommentWidget::~FrameCommentWidget()
 void FrameCommentWidget::initUI()
 {
     connect(this, &FrameCommentWidget::visibilityChanged, this, &FrameCommentWidget::updateConnections);
+    dialogueTextChanged("");
+    actionTextChanged("");
+    notesTextChanged("");
     updateConnections();
 }
 
@@ -103,6 +106,10 @@ void FrameCommentWidget::applyFrameComments()
 void FrameCommentWidget::playStateChanged(bool isPlaying)
 {
     mIsPlaying = isPlaying;
+    if (!mIsPlaying)
+    {
+        currentFrameChanged(mEditor->currentFrame());
+    }
 }
 
 void FrameCommentWidget::updateConnections()

--- a/app/src/framecommentwidget.cpp
+++ b/app/src/framecommentwidget.cpp
@@ -3,7 +3,9 @@
 
 #include "editor.h"
 #include "layermanager.h"
+#include "playbackmanager.h"
 #include "keyframe.h"
+#include <QDebug>
 
 FrameCommentWidget::FrameCommentWidget(QWidget *parent) :
     BaseDockWidget(parent)
@@ -23,20 +25,19 @@ FrameCommentWidget::~FrameCommentWidget()
 
 void FrameCommentWidget::initUI()
 {
-    connect(ui->leDialogue, &QLineEdit::textChanged, this, &FrameCommentWidget::dialogueTextChanged);
-    connect(ui->leAction, &QLineEdit::textChanged, this, &FrameCommentWidget::actionTextChanged);
-    connect(ui->leNotes, &QLineEdit::textChanged, this, &FrameCommentWidget::notesTextChanged);
-    connect(editor(), &Editor::currentFrameChanged, this, &FrameCommentWidget::currentFrameChanged);
-    connect(ui->btnClearFields, &QPushButton::clicked, this, &FrameCommentWidget::clearFrameCommentsFields);
-    connect(ui->btnApplyComments, &QPushButton::clicked, this, &FrameCommentWidget::updateFrameComments);
-    dialogueTextChanged("");
-    actionTextChanged("");
-    notesTextChanged("");
+    connect(this, &FrameCommentWidget::visibilityChanged, this, &FrameCommentWidget::updateConnections);
+    updateConnections();
 }
 
 void FrameCommentWidget::updateUI()
 {
 
+}
+
+void FrameCommentWidget::setCore(Editor *editor)
+{
+    mEditor = editor;
+    currentFrameChanged(mEditor->currentFrame());
 }
 
 void FrameCommentWidget::dialogueTextChanged(QString text)
@@ -59,16 +60,25 @@ void FrameCommentWidget::notesTextChanged(QString text)
 
 void FrameCommentWidget::currentFrameChanged(int frame)
 {
-    if (editor()->layers()->currentLayer()->keyExists(frame))
+    if (!mIsPlaying)
     {
-        fillFrameComments();
-        ui->btnApplyComments->setEnabled(true);
+        if (mEditor->layers()->currentLayer()->keyExists(frame))
+        {
+            fillFrameComments();
+            ui->btnApplyComments->setEnabled(true);
+        }
+        else
+        {
+            clearFrameCommentsFields();
+            ui->btnApplyComments->setEnabled(false);
+        }
     }
-    else
-    {
-        clearFrameCommentsFields();
-        ui->btnApplyComments->setEnabled(false);
-    }
+}
+
+void FrameCommentWidget::currentLayerChanged(int index)
+{
+    Q_UNUSED(index)
+    currentFrameChanged(mEditor->currentFrame());
 }
 
 void FrameCommentWidget::clearFrameCommentsFields()
@@ -76,23 +86,70 @@ void FrameCommentWidget::clearFrameCommentsFields()
     ui->leDialogue->clear();
     ui->leAction->clear();
     ui->leNotes->clear();
+    if (!mEditor->layers()->currentLayer()->keyExists(mEditor->currentFrame()))
+        ui->labLayerFrame->setText("");
 }
 
-void FrameCommentWidget::updateFrameComments()
+void FrameCommentWidget::applyFrameComments()
 {
-    KeyFrame* key = editor()->layers()->currentLayer()->getKeyFrameAt(editor()->currentFrame());
+    KeyFrame* key = mEditor->layers()->currentLayer()->getKeyFrameAt(mEditor->currentFrame());
     if (key == nullptr) { return; }
     key->setDialogueComment(ui->leDialogue->text());
     key->setActionComment(ui->leAction->text());
     key->setNotesComment(ui->leNotes->text());
+    mEditor->layers()->currentLayer()->setModified(key->pos(), true);
+}
+
+void FrameCommentWidget::playStateChanged(bool isPlaying)
+{
+    mIsPlaying = isPlaying;
+}
+
+void FrameCommentWidget::updateConnections()
+{
+    if (isVisible())
+    {
+        connectAll();
+    }
+    else
+    {
+        disconnectAll();
+    }
 }
 
 void FrameCommentWidget::fillFrameComments()
 {
-    KeyFrame* key = editor()->layers()->currentLayer()->getKeyFrameAt(editor()->currentFrame());
+    KeyFrame* key = mEditor->layers()->currentLayer()->getKeyFrameAt(mEditor->currentFrame());
     if (key == nullptr) { return; }
     ui->leDialogue->setText(key->getDialogueComment());
     ui->leAction->setText(key->getActionComment());
     ui->leNotes->setText(key->getNotesComment());
+    ui->labLayerFrame->setText(tr("%1 #%2 :").arg(mEditor->layers()->currentLayer()->name()).arg(QString::number(mEditor->currentFrame())));
+}
+
+void FrameCommentWidget::connectAll()
+{
+    connect(ui->leDialogue, &QLineEdit::textChanged, this, &FrameCommentWidget::dialogueTextChanged);
+    connect(ui->leAction, &QLineEdit::textChanged, this, &FrameCommentWidget::actionTextChanged);
+    connect(ui->leNotes, &QLineEdit::textChanged, this, &FrameCommentWidget::notesTextChanged);
+    connect(mEditor, &Editor::currentFrameChanged, this, &FrameCommentWidget::currentFrameChanged);
+    connect(mEditor->layers(), &LayerManager::currentLayerChanged, this, &FrameCommentWidget::currentLayerChanged);
+    connect(ui->btnClearFields, &QPushButton::clicked, this, &FrameCommentWidget::clearFrameCommentsFields);
+    connect(ui->btnApplyComments, &QPushButton::clicked, this, &FrameCommentWidget::applyFrameComments);
+    connect(mEditor, &Editor::objectLoaded, this, &FrameCommentWidget::fillFrameComments);
+    connect(mEditor->playback(), &PlaybackManager::playStateChanged, this, &FrameCommentWidget::playStateChanged);
+}
+
+void FrameCommentWidget::disconnectAll()
+{
+    disconnect(ui->leDialogue, &QLineEdit::textChanged, this, &FrameCommentWidget::dialogueTextChanged);
+    disconnect(ui->leAction, &QLineEdit::textChanged, this, &FrameCommentWidget::actionTextChanged);
+    disconnect(ui->leNotes, &QLineEdit::textChanged, this, &FrameCommentWidget::notesTextChanged);
+    disconnect(mEditor, &Editor::currentFrameChanged, this, &FrameCommentWidget::currentFrameChanged);
+    disconnect(mEditor->layers(), &LayerManager::currentLayerChanged, this, &FrameCommentWidget::currentLayerChanged);
+    disconnect(ui->btnClearFields, &QPushButton::clicked, this, &FrameCommentWidget::clearFrameCommentsFields);
+    disconnect(ui->btnApplyComments, &QPushButton::clicked, this, &FrameCommentWidget::applyFrameComments);
+    disconnect(mEditor, &Editor::objectLoaded, this, &FrameCommentWidget::fillFrameComments);
+    disconnect(mEditor->playback(), &PlaybackManager::playStateChanged, this, &FrameCommentWidget::playStateChanged);
 }
 

--- a/app/src/framecommentwidget.h
+++ b/app/src/framecommentwidget.h
@@ -1,0 +1,31 @@
+#ifndef FRAMECOMMENTWIDGET_H
+#define FRAMECOMMENTWIDGET_H
+
+#include <QWidget>
+#include "basedockwidget.h"
+
+namespace Ui {
+    class FrameComment;
+}
+
+class FrameCommentWidget : public BaseDockWidget
+{
+    Q_OBJECT
+
+public:
+    explicit FrameCommentWidget(QWidget *parent = nullptr);
+    ~FrameCommentWidget() override;
+
+    void initUI() override;
+    void updateUI() override;
+
+public slots:
+    void dialogueTextChanged(QString text);
+    void actionTextChanged(QString text);
+    void notesTextChanged(QString text);
+
+private:
+    Ui::FrameComment *ui;
+};
+
+#endif // FRAMECOMMENTWIDGET_H

--- a/app/src/framecommentwidget.h
+++ b/app/src/framecommentwidget.h
@@ -19,19 +19,29 @@ public:
 
     void initUI() override;
     void updateUI() override;
+    void setCore(Editor* editor);
 
 public slots:
     void dialogueTextChanged(QString text);
     void actionTextChanged(QString text);
     void notesTextChanged(QString text);
     void currentFrameChanged(int frame);
+    void currentLayerChanged(int index);
     void clearFrameCommentsFields();
-    void updateFrameComments();
+    void applyFrameComments();
+    void playStateChanged(bool isPlaying);
+    void updateConnections();
 
 private:
     Ui::FrameComment *ui;
 
     void fillFrameComments();
+    void connectAll();
+    void disconnectAll();
+
+    bool mIsPlaying = false;
+
+    Editor* mEditor = nullptr;
 };
 
 #endif // FRAMECOMMENTWIDGET_H

--- a/app/src/framecommentwidget.h
+++ b/app/src/framecommentwidget.h
@@ -3,6 +3,7 @@
 
 #include <QWidget>
 #include "basedockwidget.h"
+#include "editor.h"
 
 namespace Ui {
     class FrameComment;
@@ -23,9 +24,14 @@ public slots:
     void dialogueTextChanged(QString text);
     void actionTextChanged(QString text);
     void notesTextChanged(QString text);
+    void currentFrameChanged(int frame);
+    void clearFrameCommentsFields();
+    void updateFrameComments();
 
 private:
     Ui::FrameComment *ui;
+
+    void fillFrameComments();
 };
 
 #endif // FRAMECOMMENTWIDGET_H

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -55,6 +55,7 @@ GNU General Public License for more details.
 #include "colorinspector.h"
 #include "colorpalettewidget.h"
 #include "displayoptionwidget.h"
+#include "framecommentwidget.h"
 #include "tooloptionwidget.h"
 #include "preferencesdialog.h"
 #include "timeline.h"
@@ -154,6 +155,9 @@ void MainWindow2::createDockWidgets()
     mDisplayOptionWidget = new DisplayOptionWidget(this);
     mDisplayOptionWidget->setObjectName("DisplayOption");
 
+    mFrameComments = new FrameCommentWidget(this);
+    mFrameComments->setObjectName("FrameComments");
+
     mToolOptions = new ToolOptionWidget(this);
     mToolOptions->setObjectName("ToolOption");
 
@@ -172,6 +176,7 @@ void MainWindow2::createDockWidgets()
         << mColorInspector
         << mColorPalette
         << mDisplayOptionWidget
+        << mFrameComments
         << mToolOptions
         << mToolBox;
 
@@ -193,6 +198,8 @@ void MainWindow2::createDockWidgets()
     addDockWidget(Qt::RightDockWidgetArea, mColorBox);
     addDockWidget(Qt::RightDockWidgetArea, mColorInspector);
     addDockWidget(Qt::RightDockWidgetArea, mColorPalette);
+    addDockWidget(Qt::RightDockWidgetArea, mFrameComments);
+    mFrameComments->hide();
     addDockWidget(Qt::LeftDockWidgetArea, mToolBox);
     addDockWidget(Qt::LeftDockWidgetArea, mToolOptions);
     addDockWidget(Qt::LeftDockWidgetArea, mDisplayOptionWidget);
@@ -348,7 +355,8 @@ void MainWindow2::createMenus()
         mColorPalette->toggleViewAction(),
         mTimeLine->toggleViewAction(),
         mDisplayOptionWidget->toggleViewAction(),
-        mColorInspector->toggleViewAction()
+        mColorInspector->toggleViewAction(),
+        mFrameComments->toggleViewAction()
     };
 
     for (QAction* action : actions)

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -157,6 +157,7 @@ void MainWindow2::createDockWidgets()
 
     mFrameComments = new FrameCommentWidget(this);
     mFrameComments->setObjectName("FrameComments");
+    mFrameComments->setCore(mEditor);
 
     mToolOptions = new ToolOptionWidget(this);
     mToolOptions->setObjectName("ToolOption");

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -31,6 +31,7 @@ class ScribbleArea;
 class BaseDockWidget;
 class ColorPaletteWidget;
 class DisplayOptionWidget;
+class FrameCommentWidget;
 class ToolOptionWidget;
 class TimeLine;
 class ToolBoxWidget;
@@ -142,6 +143,7 @@ private:
     ColorBox*           mColorBox = nullptr;
     ColorPaletteWidget*   mColorPalette = nullptr;
     DisplayOptionWidget*  mDisplayOptionWidget = nullptr;
+    FrameCommentWidget*   mFrameComments = nullptr;
     ToolOptionWidget*     mToolOptions = nullptr;
     ToolBoxWidget*        mToolBox = nullptr;
     Timeline2*            mTimeline2 = nullptr;

--- a/app/ui/framecommentwidget.ui
+++ b/app/ui/framecommentwidget.ui
@@ -179,6 +179,54 @@
        </property>
       </spacer>
      </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <item>
+      <widget class="QLabel" name="labLayerFrame">
+       <property name="text">
+        <string>TextLabel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_6">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <spacer name="horizontalSpacer_5">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
      <item>
       <widget class="QPushButton" name="btnApplyComments">
        <property name="text">

--- a/app/ui/framecommentwidget.ui
+++ b/app/ui/framecommentwidget.ui
@@ -30,7 +30,7 @@
     <number>4</number>
    </property>
    <item>
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="labMax100chars">
      <property name="text">
       <string>Max 100 chars each!</string>
      </property>
@@ -158,18 +158,11 @@
     </widget>
    </item>
    <item>
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
-      <widget class="QPushButton" name="pushButton">
+      <widget class="QPushButton" name="btnClearFields">
        <property name="text">
-        <string>Clear all</string>
+        <string>Clear fields</string>
        </property>
       </widget>
      </item>
@@ -187,9 +180,9 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="pushButton_2">
+      <widget class="QPushButton" name="btnApplyComments">
        <property name="text">
-        <string>Apply comments!</string>
+        <string>Apply comments</string>
        </property>
       </widget>
      </item>

--- a/app/ui/framecommentwidget.ui
+++ b/app/ui/framecommentwidget.ui
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FrameComment</class>
+ <widget class="QWidget" name="FrameComment">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>379</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Frame Comments</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>2</number>
+   </property>
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
+    <number>4</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Max 100 chars each!</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="labDialogue">
+       <property name="text">
+        <string>Dialogue:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="labDialogueCount">
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="leDialogue">
+     <property name="maxLength">
+      <number>100</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="labAction">
+       <property name="text">
+        <string>Action:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="labActionCount">
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="leAction">
+     <property name="maxLength">
+      <number>100</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="labNotes">
+       <property name="text">
+        <string>Notes:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="labNotesCount">
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="leNotes">
+     <property name="maxLength">
+      <number>100</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QPushButton" name="pushButton">
+       <property name="text">
+        <string>Clear all</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_2">
+       <property name="text">
+        <string>Apply comments!</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>117</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/core_lib/src/structure/filemanager.h
+++ b/core_lib/src/structure/filemanager.h
@@ -36,7 +36,7 @@ class FileManager : public QObject
     Q_OBJECT
 
 public:
-    FileManager(QObject* parent = 0);
+    FileManager(QObject* parent = nullptr);
 
     Object* load(QString sFilenNme);
     Status  save(Object*, QString sFileName);
@@ -59,6 +59,9 @@ private:
 
     ObjectData* loadProjectData(const QDomElement& element);
     QDomElement saveProjectData(ObjectData*, QDomDocument& xmlDoc);
+
+    void loadFrameComments(Object* obj, QDomElement &element);
+    QDomElement saveFrameComments(Object* obj, QDomDocument& xmlDoc);
 
     void extractProjectData(const QDomElement& element, ObjectData* data);
     Object* cleanUpWithErrorCode(Status);

--- a/core_lib/src/structure/keyframe.cpp
+++ b/core_lib/src/structure/keyframe.cpp
@@ -39,6 +39,13 @@ KeyFrame::~KeyFrame()
     }
 }
 
+bool KeyFrame::frameHasComments()
+{
+    if (mDialogueComment.isEmpty() && mActionComment.isEmpty() && mNotesComment.isEmpty())
+        return false;
+    return true;
+}
+
 void KeyFrame::addEventListener(KeyFrameEventListener* listener)
 {
     auto it = std::find(mEventListeners.begin(), mEventListeners.end(), listener);

--- a/core_lib/src/structure/keyframe.h
+++ b/core_lib/src/structure/keyframe.h
@@ -46,6 +46,13 @@ public:
     void setSelected(bool b) { mIsSelected = b; }
     bool isSelected() const { return mIsSelected; }
 
+    void setDialogueComment(QString comment) { mDialogueComment = comment; }
+    QString getDialogueComment() { return mDialogueComment; }
+    void setActionComment(QString comment) { mActionComment = comment; }
+    QString getActionComment() { return mActionComment; }
+    void setNotesComment(QString comment) { mNotesComment = comment; }
+    QString getNotesComment() { return mNotesComment; }
+
     QString fileName() const { return mAttachedFileName; }
     void    setFileName(QString strFileName) { mAttachedFileName = strFileName; }
 
@@ -63,6 +70,11 @@ private:
     bool mIsModified = true;
     bool mIsSelected = false;
     QString mAttachedFileName;
+
+    // comments
+    QString mDialogueComment = "";
+    QString mActionComment = "";
+    QString mNotesComment = "";
 
     std::vector<KeyFrameEventListener*> mEventListeners;
 };

--- a/core_lib/src/structure/keyframe.h
+++ b/core_lib/src/structure/keyframe.h
@@ -52,6 +52,7 @@ public:
     QString getActionComment() { return mActionComment; }
     void setNotesComment(QString comment) { mNotesComment = comment; }
     QString getNotesComment() { return mNotesComment; }
+    bool frameHasComments();
 
     QString fileName() const { return mAttachedFileName; }
     void    setFileName(QString strFileName) { mAttachedFileName = strFileName; }

--- a/core_lib/src/structure/layermultiplanecamera.cpp
+++ b/core_lib/src/structure/layermultiplanecamera.cpp
@@ -1,0 +1,6 @@
+#include "layermultiplanecamera.h"
+
+LayerMultiPlaneCamera::LayerMultiPlaneCamera(Object *object) :Layer(object, LAYER_TYPE::MULTIPLANCAMERA)
+{
+    setName(tr("Multiplane Camera"));
+}

--- a/core_lib/src/structure/layermultiplanecamera.h
+++ b/core_lib/src/structure/layermultiplanecamera.h
@@ -1,0 +1,39 @@
+#ifndef LAYERMULTIPLANECAMERA_H
+#define LAYERMULTIPLANECAMERA_H
+
+#include "layer.h"
+
+struct Campoint {
+    int frame;
+    QTransform transform;
+    QPainterPath path;
+};
+
+class LayerMultiPlaneCamera : public Layer
+{
+    Q_OBJECT
+
+public:
+    LayerMultiPlaneCamera(Object* object);
+
+    void setViewRect(QRect viewrect) { mViewRect = viewrect; }
+    QRect getViewRect() { return mViewRect; }
+
+private:
+    QList<Campoint> mCampointList;
+    QRect mViewRect;
+};
+
+#endif // LAYERMULTIPLANECAMERA_H
+/*
+Hver frame har sin egen Campoint.
+DVS:
+Frame 1 har altid et Campoint. Er der ikke nogen kamerabevægelser, bruges
+Campoint fra frame 1 i hele scenen.
+Laver man en pan fra frame 50 til 80 i en 300 frames lang scene vil følgende ske:
+Frame 1 har et Campoint.
+Idet frame 50 tildeles en transform, udregnes transforms for frame 1 til 50. Hvis
+der ikke er forskel på fielden i frame 1 og 50, har alle 50 samme transform.
+Idet frame 80 får en transform sker det samme. 50 til 80 udregnes. Når frame
+80 ændres, vil 50 til 80 igen blive beregnet.
+*/


### PR DESCRIPTION
This addresses #1288, or at least part of it.
Writing comments to keyframes has been an old wish, and this PR solves it.
@Jose-Moreno suggested that there should be markers on the timeline, to show which keys had comments, but I think that should wait for the timeline rewrite.

https://youtu.be/6iypzTRL2pw
I've made a short video to show how it works, and is saved.