### PR TITLE
Rewrite the windows after-build tasks by Powershell

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,6 @@ skip_commits:
   files:
     - '*.md'
     - docs/*
-    - util/*
 
 install:
   - set PYTHON3="%PYTHON%\python.exe"
@@ -41,13 +40,14 @@ install:
   - set PATH=%PATH%;%QTDIR%;%QTDIR%\bin;C:\MinGW\bin
 
 before_build:
+  - echo %PLATFORM_%
   - qmake --version
   - md build
   - cd build
   - call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %PLATFORM_%
   - if NOT %APPVEYOR_REPO_BRANCH%==release call qmake ..\ -tp vc -r "%APPVEYOR_BUILD_FOLDER%\pencil2d.pro" CONFIG+=GIT CONFIG+=NIGHTLY
   - if %APPVEYOR_REPO_BRANCH%==release call qmake ..\ -tp vc -r "%APPVEYOR_BUILD_FOLDER%\pencil2d.pro" DEFINES+=QT_NO_DEBUG_OUTPUT DEFINES+=PENCIL2D_RELEASE
-  - echo %PLATFORM_%
+
 
 build_script:
   - set BUILDTYPE=/t:Build
@@ -63,53 +63,4 @@ after_build:
   - if %APPVEYOR_REPO_BRANCH%==master set upload=yes
   - if %APPVEYOR_REPO_BRANCH%==release set upload=yes
   - if "%FORCE_NIGHTLY_UPLOAD%"=="yes" set upload=yes
-  - if %PLATFORM_%==x86 (
-    echo "-----Deploying 32 Bit Version-----" &
-    dir /s &
-    md bin\plugins\ &
-    echo "Copying ffmpeg plugin" &
-    call curl.exe -o bin\plugins\ffmpeg-4.1.1-win32-static.zip "https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-4.1.1-win32-static.zip" &
-    call 7z.exe x bin\plugins\ffmpeg-4.1.1-win32-static.zip -o"bin\plugins" &
-    echo "move ffmpeg.exe and delete ffmpeg leftovers" &
-    del bin\plugins\ffmpeg-4.1.1-win32-static.zip &
-    move /y bin\plugins\ffmpeg-4.1.1-win32-static\bin\ffmpeg.exe bin\plugins &
-    rmdir /q /s bin\plugins\ffmpeg-4.1.1-win32-static &
-    echo "copying qt libraries" &
-    windeployqt bin\pencil2d.exe &
-    echo "zipping" &
-    Rename bin Pencil2D &
-    call 7z.exe a "pencil2d-win32-%date:~-4,4%"-"%date:~-10,2%"-"%date:~7,2%.zip" Pencil2D\ &
-    echo "zipping done" &
-    echo "what's inside?" &
-    call 7z.exe l "pencil2d-win32-%date:~-4,4%"-"%date:~-10,2%"-"%date:~7,2%.zip" &
-    if %upload%==yes (
-    echo "deploying to google drive" &
-    cd %APPVEYOR_BUILD_FOLDER%\util &
-    call %PYTHON%\\python.exe nightly-build-upload.py "%WIN32_NIGHTLY_PARENT%" "%APPVEYOR_BUILD_FOLDER%\build\pencil2d-win32-%date:~-4,4%"-"%date:~-10,2%"-"%date:~7,2%.zip" &
-    echo "32 Bit deployed" ) )
-
-  - if %PLATFORM_%==amd64 (
-    echo "----- Deploying 64 Bit Version -----" &
-    echo "rename and zip folder" &
-    dir /s &
-    md bin\plugins\ &
-    echo "Copying ffmpeg plugin" &
-    call curl.exe -o bin\plugins\ffmpeg-4.1.1-win64-static.zip "https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.1.1-win64-static.zip" &
-    call 7z.exe x bin\plugins\ffmpeg-4.1.1-win64-static.zip -o"bin\plugins" &
-    echo "move ffmpeg.exe and delete ffmpeg leftovers" &
-    del bin\plugins\ffmpeg-4.1.1-win64-static.zip &
-    move /y bin\plugins\ffmpeg-4.1.1-win64-static\bin\ffmpeg.exe bin\plugins &
-    rmdir /q /s bin\plugins\ffmpeg-4.1.1-win64-static &
-    echo "copying qt libraries" &
-    windeployqt bin\pencil2d.exe &
-    echo "zipping" &
-    Rename bin Pencil2D &
-    call 7z.exe a "pencil2d-win64-%date:~-4,4%"-"%date:~-10,2%"-"%date:~7,2%.zip" Pencil2D\ &
-    echo "zipping done" &
-    echo "what's inside?" &
-    call 7z.exe l "pencil2d-win64-%date:~-4,4%"-"%date:~-10,2%"-"%date:~7,2%.zip" &
-    if %upload%==yes (
-    echo "deploying to google drive" &
-    cd %APPVEYOR_BUILD_FOLDER%\util &
-    call %PYTHON%\\python.exe nightly-build-upload.py "%WIN64_NIGHTLY_PARENT%" "%APPVEYOR_BUILD_FOLDER%\build\pencil2d-win64-%date:~-4,4%"-"%date:~-10,2%"-"%date:~7,2%.zip" &
-    echo "64 Bit Deployed" ) )
+  - powershell ..\util\after-build.ps1 -upload %upload% -platform %PLATFORM_% -branch %APPVEYOR_REPO_BRANCH%

--- a/util/after-build.ps1
+++ b/util/after-build.ps1
@@ -1,0 +1,85 @@
+Param(
+  [string]$platform = "amd64",  # amd64/x86
+  [string]$branch = "master",   # branch names: master, release
+  [string]$upload = "no"        # yes/no
+)
+
+echo ">>> Upload?", $upload
+echo ">>> Branch:", $branch
+echo ">>> Platform:", $platform
+
+$arch = switch ($platform) {
+  "x86" {"win32"; break}
+  "amd64" {"win64"; break}
+  default {"Unknown"; break}
+}
+
+[string]$ffmpegFileName = "ffmpeg-4.1.1-$arch-static"
+[string]$ffmpegUrl = "https://ffmpeg.zeranoe.com/builds/$arch/static/$ffmpegFileName.zip"
+
+
+echo $PSScriptRoot
+cd $PSScriptRoot
+cd ../build
+
+echo ">>> Current working directory:"
+Get-Location # print the current working directory
+
+New-Item -ItemType 'directory' -Path './bin/plugins' -ErrorAction Continue
+
+echo ">>> Downloading ffmpeg: $ffmpegUrl"
+ 
+wget -Uri $ffmpegUrl -OutFile "$ffmpegFileName.zip" -ErrorAction Stop
+Expand-Archive -Path "$ffmpegFileName.zip" -DestinationPath "."
+
+echo ">>> Move ffmpeg.exe to plugin folder"
+
+Move-Item -Path "./$ffmpegFileName/bin/ffmpeg.exe" -Destination "./bin/plugins"
+
+echo ">>> Clean up ffmpeg"
+
+Remove-Item -Path "./$ffmpegFileName.zip"
+Remove-Item -Path "./$ffmpegFileName" -Recurse
+
+Remove-Item -Path "./Pencil2D" -Recurse -ErrorAction SilentlyContinue
+Copy-Item -Path "./bin" -Destination "./Pencil2D" -Recurse
+
+echo ">>> Deploying Qt libraries"
+
+& "windeployqt" @("Pencil2D/pencil2d.exe")
+
+echo ">>> Zipping bin folder"
+
+Remove-Item -Path "./Pencil2D/*.pdb"
+Remove-Item -Path "./Pencil2D/*.ilk"
+Compress-Archive -Path "./Pencil2D" -DestinationPath "./Pencil2D.zip"
+
+$today = Get-Date -Format "yyyy-MM-dd"
+$zipFileName = "pencil2d-$arch-$today.zip"
+
+echo ">>> Zip filename: $zipFileName"
+Rename-Item -Path "./Pencil2D.zip" -NewName $zipFileName
+
+echo ">>> Zip ok?"
+Test-Path $zipFileName
+
+if ($upload -ne "yes") {
+  echo ">>> Done. No need to upload binaries."
+  exit 0
+}
+
+echo ">>> Uplaod to Google drive"
+cd $PSScriptRoot
+
+$python3 = if (Test-Path env:PYTHON) { "$env:PYTHON\python.exe" } else { "python.exe" }
+
+$GDriveFolderId = switch($platform) {
+  "x86" {$env:WIN32_NIGHTLY_PARENT; break}
+  "amd64" {$env:WIN64_NIGHTLY_PARENT; break}
+}
+
+$fullPath = Convert-Path "..\build\$zipFileName"
+
+& $python3 @("nightly-build-upload.py", $GDriveFolderId, $fullPath)
+
+echo ">>> Done!"


### PR DESCRIPTION
I rewrote the Appveyor after-build tasks by Powershell.
The behaviour is exactly the same as the previous packing process:
1. Download FFmpeg
2. Pack and zip binaries
3. Uploading to Google drive

A few benefits of using PowerShell scripts:
1. I can run and test the script locally on my machine without AppVeyor environment.
2. It's easier to implement features with a decent script language.
3. Built-in zip & wget, so we don't need 3party programs like`curl.exe` and `7z.exe` to pack binaries.

The next step I will implement internal PR builds for windows, which was once implemented and then was reverted.


