### PR TITLE
1177 extended import position possibilities

### DIFF
--- a/app/src/filedialogex.cpp
+++ b/app/src/filedialogex.cpp
@@ -135,7 +135,8 @@ QString FileDialog::openDialogTitle( FileType fileType )
         case FileType::GIF: return tr( "Import Animated GIF" );
         case FileType::MOVIE: return tr( "Import movie" );
         case FileType::SOUND: return tr( "Import sound" );
-        case FileType::PALETTE: return tr( "Import palette" );
+        case FileType::PALETTE: return tr( "Open palette" );
+        case FileType::PALETTE_XML: return tr( "Open palette" );
         default: Q_ASSERT( false );
     }
     return "";
@@ -152,6 +153,7 @@ QString FileDialog::saveDialogTitle( FileType fileType )
         case FileType::MOVIE: return tr( "Export movie" );
         case FileType::SOUND: return tr( "Export sound" );
         case FileType::PALETTE: return tr( "Export palette" );
+        case FileType::PALETTE_XML: return tr( "Save palette" );
         default: Q_ASSERT( false );
     }
     return "";
@@ -172,7 +174,10 @@ QString FileDialog::openFileFilters( FileType fileType )
                 .arg(tr("Palette"))
                 .arg(tr("Pencil2D Palette"))
                 .arg(tr("GIMP Palette"));
-        default: Q_ASSERT( false );
+        case FileType::PALETTE_XML:
+            return QString("%1 (*.xml)")
+                .arg(tr("Pencil2D Palette"));
+    default: Q_ASSERT( false );
     }
     return "";
 }
@@ -192,6 +197,9 @@ QString FileDialog::saveFileFilters( FileType fileType )
                 .arg(tr("Palette"))
                 .arg(tr("Pencil2D Palette"))
                 .arg(tr("GIMP Palette"));
+    case FileType::PALETTE_XML:
+        return QString("%1 (*.xml)")
+            .arg(tr("Pencil2D Palette"));
         default: Q_ASSERT( false );
     }
     return "";
@@ -238,6 +246,7 @@ QString FileDialog::defaultFileName( FileType fileType )
         case FileType::MOVIE: return "untitled.mp4";
         case FileType::SOUND: return "untitled.wav";
         case FileType::PALETTE: return "untitled.xml";
+        case FileType::PALETTE_XML: return "untitled.xml";
         default: Q_ASSERT( false );
     }
     return "";
@@ -254,6 +263,7 @@ QString FileDialog::toSettingKey( FileType fileType )
         case FileType::MOVIE: return "Movie";
         case FileType::SOUND: return "Sound";
         case FileType::PALETTE: return "Palette";
+        case FileType::PALETTE_XML: return "Palette";
         default: Q_ASSERT( false );
     }
     return "";

--- a/app/src/filedialogex.h
+++ b/app/src/filedialogex.h
@@ -28,7 +28,8 @@ enum class FileType
     GIF,
     MOVIE,
     SOUND,
-    PALETTE
+    PALETTE,
+    PALETTE_XML
 };
 
 class FileDialog : public QObject

--- a/app/src/importpositiondialog.cpp
+++ b/app/src/importpositiondialog.cpp
@@ -39,6 +39,7 @@ void ImportPositionDialog::didChangeComboBoxIndex(const int index)
 
 void ImportPositionDialog::changeImportView()
 {
+    mEditor->view()->setImportFollowsCamera(false);
     QTransform transform;
     if (mImportOption == ImportPosition::Type::CenterOfView)
     {
@@ -67,6 +68,7 @@ void ImportPositionDialog::changeImportView()
         return;
     }
 
+    mEditor->view()->setImportFollowsCamera(true);
     QSettings settings(PENCIL2D, PENCIL2D);
     settings.setValue(IMPORT_REPOSITION_TYPE, ui->cbImagePosition->currentIndex());
 }

--- a/app/src/importpositiondialog.cpp
+++ b/app/src/importpositiondialog.cpp
@@ -12,8 +12,10 @@ ImportPositionDialog::ImportPositionDialog(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    ui->cbImagePosition->addItem(tr("Center of canvas"));
-    ui->cbImagePosition->addItem(tr("Center of active camera"));
+    ui->cbImagePosition->addItem(tr("Center of current view"));
+    ui->cbImagePosition->addItem(tr("Center of canvas (0,0)"));
+    ui->cbImagePosition->addItem(tr("Center of camera, current frame"));
+    ui->cbImagePosition->addItem(tr("Center of camera, follow camera"));
 
     connect(ui->cbImagePosition, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ImportPositionDialog::didChangeComboBoxIndex);
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ImportPositionDialog::changeImportView);
@@ -38,17 +40,32 @@ void ImportPositionDialog::didChangeComboBoxIndex(const int index)
 void ImportPositionDialog::changeImportView()
 {
     QTransform transform;
-    if (mImportOption == ImportPosition::Type::CenterOfCanvas)
+    if (mImportOption == ImportPosition::Type::CenterOfView)
     {
         QPointF centralPoint = mEditor->getScribbleArea()->getCentralPoint();
         transform = transform.fromTranslate(centralPoint.x(), centralPoint.y());
+        mEditor->view()->setImportView(transform);
+        QSettings settings(PENCIL2D, PENCIL2D);
+        settings.setValue(IMPORT_REPOSITION_TYPE, ui->cbImagePosition->currentIndex());
+        return;
+    }
+    else if (mImportOption == ImportPosition::Type::CenterOfCanvas)
+    {
+        transform = transform.fromTranslate(0, 0);
+        mEditor->view()->setImportView(transform);
+        QSettings settings(PENCIL2D, PENCIL2D);
+        settings.setValue(IMPORT_REPOSITION_TYPE, ui->cbImagePosition->currentIndex());
+        return;
     }
     else if (mImportOption == ImportPosition::Type::CenterOfCamera)
     {
         QRectF cameraRect = mEditor->getScribbleArea()->getCameraRect();
         transform = transform.fromTranslate(cameraRect.center().x(), cameraRect.center().y());
+        mEditor->view()->setImportView(transform);
+        QSettings settings(PENCIL2D, PENCIL2D);
+        settings.setValue(IMPORT_REPOSITION_TYPE, ui->cbImagePosition->currentIndex());
+        return;
     }
-    mEditor->view()->setImportView(transform);
 
     QSettings settings(PENCIL2D, PENCIL2D);
     settings.setValue(IMPORT_REPOSITION_TYPE, ui->cbImagePosition->currentIndex());

--- a/app/src/importpositiondialog.h
+++ b/app/src/importpositiondialog.h
@@ -16,19 +16,25 @@ class ImportPositionDialog : public QDialog
     struct ImportPosition {
 
         enum Type {
-            CenterOfCamera,
+            CenterOfView,
             CenterOfCanvas,
+            CenterOfCamera,
+            CenterOfCameraFollowed,
             None
         };
 
         static Type getTypeFromIndex(int index) {
             switch (index) {
-                case 0:
-                    return CenterOfCanvas;
-                case 1:
-                    return CenterOfCamera;
-                default:
-                    return None;
+            case 0:
+                return CenterOfView;
+            case 1:
+                return CenterOfCanvas;
+            case 2:
+                return CenterOfCamera;
+            case 3:
+                return CenterOfCameraFollowed;
+            default:
+                return None;
             }
         }
     };

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -236,7 +236,8 @@ void MainWindow2::createMenus()
     connect(ui->actionExport_Movie, &QAction::triggered, mCommands, &ActionCommands::exportMovie);
     connect(ui->actionExport_Animated_GIF, &QAction::triggered, mCommands, &ActionCommands::exportGif);
 
-    connect(ui->actionExport_Palette, &QAction::triggered, this, &MainWindow2::exportPalette);
+    connect(ui->actionExport_Palette, &QAction::triggered, this, &MainWindow2::savePalette);
+    connect(ui->actionExport_Other_Palette_formats, &QAction::triggered, this, &MainWindow2::exportPalette);
 
     //--- Import Menu ---
     //connect( ui->actionExport_Svg_Image, &QAction::triggered, editor, &Editor::saveSvg );
@@ -1296,6 +1297,16 @@ void MainWindow2::importPalette()
     }
 }
 
+void MainWindow2::savePalette()
+{
+    FileDialog FileDialog(this);
+    QString filePath = FileDialog.saveFile(FileType::PALETTE_XML);
+    if (!filePath.isEmpty())
+    {
+        mEditor->object()->exportPalette(filePath);
+    }
+}
+
 void MainWindow2::openPalette()
 {
     FileDialog fileDialog(this);
@@ -1436,31 +1447,7 @@ void MainWindow2::changePlayState(bool isPlaying)
     }
     update();
 }
-/*
-void MainWindow2::alignPegs()
-{
-    QStringList bitmaplayers;
-    bitmaplayers = mPegreg->getLayerList();
-    if (bitmaplayers.isEmpty())
-    {
-        QMessageBox::information(this, nullptr,
-                                 tr("No layers selected!"),
-                                 QMessageBox::Ok);
-    }
-    else
-    {
-        Status::StatusInt statusint = mEditor->pegBarAlignment(bitmaplayers);
-        if (statusint.errorcode == Status::FAIL)
-        {
-            QMessageBox::information(this, nullptr,
-                                     tr("Peg bar alignment failed!"),
-                                     QMessageBox::Ok);
-            return;
-        }
-        closePegReg();
-    }
-}
-*/
+
 void MainWindow2::displayMessageBox(const QString& title, const QString& body)
 {
     QMessageBox::information(this, tr(qPrintable(title)), tr(qPrintable(body)), QMessageBox::Ok);

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -240,8 +240,7 @@ void MainWindow2::createMenus()
     connect(ui->actionExport_Movie, &QAction::triggered, mCommands, &ActionCommands::exportMovie);
     connect(ui->actionExport_Animated_GIF, &QAction::triggered, mCommands, &ActionCommands::exportGif);
 
-    connect(ui->actionExport_Palette, &QAction::triggered, this, &MainWindow2::savePalette);
-    connect(ui->actionExport_Other_Palette_formats, &QAction::triggered, this, &MainWindow2::exportPalette);
+    connect(ui->actionExport_Palette, &QAction::triggered, this, &MainWindow2::exportPalette);
 
     //--- Import Menu ---
     //connect( ui->actionExport_Svg_Image, &QAction::triggered, editor, &Editor::saveSvg );
@@ -1232,7 +1231,7 @@ void MainWindow2::openPalette()
 {
     int count = 0;
     int maxNumber = mEditor->object()->getColourCount();
-    bool openPalet = true;
+    bool openPalette = true;
     while (count < maxNumber)
     {
         if (mEditor->object()->isColourInUse(count))
@@ -1246,14 +1245,14 @@ void MainWindow2::openPalette()
             int ret = msgBox.exec();
             if (ret == QMessageBox::RejectRole)
             {
-                openPalet = false;
+                openPalette = false;
             }
             count = maxNumber;
         }
         count++;
     }
 
-    if (openPalet)
+    if (openPalette)
     {
         FileDialog fileDialog(this);
         QString filePath = fileDialog.openFile(FileType::PALETTE);

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1309,13 +1309,39 @@ void MainWindow2::savePalette()
 
 void MainWindow2::openPalette()
 {
-    FileDialog fileDialog(this);
-    QString filePath = fileDialog.openFile(FileType::PALETTE);
-    if (!filePath.isEmpty())
+    int count = 0;
+    int maxNumber = mEditor->object()->getColourCount();
+    bool openPalet = true;
+    while (count < maxNumber)
     {
-        mEditor->object()->openPalette(filePath);
-        mColorPalette->refreshColorList();
-        mEditor->color()->setColorNumber(0);
+        if (mEditor->object()->isColourInUse(count))
+        {
+            QMessageBox msgBox;
+            msgBox.setText(tr("Opening palette, will replace the old palette.\n"
+                              "Color(s) in strokes will be altered by this action!\n"));
+            msgBox.addButton(tr("Open Palette"), QMessageBox::AcceptRole);
+            msgBox.addButton(tr("Cancel"), QMessageBox::RejectRole);
+
+            int ret = msgBox.exec();
+            if (ret == QMessageBox::RejectRole)
+            {
+                openPalet = false;
+            }
+            count = maxNumber;
+        }
+        count++;
+    }
+
+    if (openPalet)
+    {
+        FileDialog fileDialog(this);
+        QString filePath = fileDialog.openFile(FileType::PALETTE);
+        if (!filePath.isEmpty())
+        {
+            mEditor->object()->openPalette(filePath);
+            mColorPalette->refreshColorList();
+            mEditor->color()->setColorNumber(0);
+        }
     }
 }
 

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1201,7 +1201,11 @@ void MainWindow2::exportPalette()
     QString filePath = FileDialog.saveFile(FileType::PALETTE);
     if (!filePath.isEmpty())
     {
-        mEditor->object()->exportPalette(filePath);
+        if (!filePath.endsWith(PENCIL2D_PALETTE_EXT) && !filePath.endsWith(GIMP_PALETTE_EXT))
+        {
+            filePath = filePath + PENCIL2D_PALETTE_EXT;
+        }
+            mEditor->object()->exportPalette(filePath);
     }
 }
 
@@ -1214,16 +1218,6 @@ void MainWindow2::importPalette()
         mEditor->object()->importPalette(filePath);
         mColorPalette->refreshColorList();
         mEditor->color()->setColorNumber(0);
-    }
-}
-
-void MainWindow2::savePalette()
-{
-    FileDialog FileDialog(this);
-    QString filePath = FileDialog.saveFile(FileType::PALETTE_XML);
-    if (!filePath.isEmpty())
-    {
-        mEditor->object()->exportPalette(filePath);
     }
 }
 

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -247,7 +247,8 @@ void MainWindow2::createMenus()
     connect(ui->actionImport_Movie, &QAction::triggered, this, &MainWindow2::importMovie);
 
     connect(ui->actionImport_Sound, &QAction::triggered, mCommands, &ActionCommands::importSound);
-    connect(ui->actionImport_Palette, &QAction::triggered, this, &MainWindow2::importPalette);
+    connect(ui->actionImport_Append_Palette, &QAction::triggered, this, &MainWindow2::importPalette);
+    connect(ui->actionOpen_Replace_Palette, &QAction::triggered, this, &MainWindow2::openPalette);
 
     //--- Edit Menu ---
     connect(ui->actionUndo, &QAction::triggered, mEditor, &Editor::undo);
@@ -1131,7 +1132,7 @@ void MainWindow2::setupKeyboardShortcuts()
     ui->actionImport_Image->setShortcut(cmdKeySeq(CMD_IMPORT_IMAGE));
     ui->actionImport_ImageSeq->setShortcut(cmdKeySeq(CMD_IMPORT_IMAGE_SEQ));
     ui->actionImport_Movie->setShortcut(cmdKeySeq(CMD_IMPORT_MOVIE));
-    ui->actionImport_Palette->setShortcut(cmdKeySeq(CMD_IMPORT_PALETTE));
+    ui->actionImport_Append_Palette->setShortcut(cmdKeySeq(CMD_IMPORT_PALETTE));
     ui->actionImport_Sound->setShortcut(cmdKeySeq(CMD_IMPORT_SOUND));
 
     ui->actionExport_Image->setShortcut(cmdKeySeq(CMD_EXPORT_IMAGE));
@@ -1290,6 +1291,18 @@ void MainWindow2::importPalette()
     if (!filePath.isEmpty())
     {
         mEditor->object()->importPalette(filePath);
+        mColorPalette->refreshColorList();
+        mEditor->color()->setColorNumber(0);
+    }
+}
+
+void MainWindow2::openPalette()
+{
+    FileDialog fileDialog(this);
+    QString filePath = fileDialog.openFile(FileType::PALETTE);
+    if (!filePath.isEmpty())
+    {
+        mEditor->object()->openPalette(filePath);
         mColorPalette->refreshColorList();
         mEditor->color()->setColorNumber(0);
     }

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -120,6 +120,7 @@ private:
 
     void openPalette();
     void importPalette();
+    void savePalette();
     void exportPalette();
 
     void readSettings();

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -118,6 +118,7 @@ private:
     void clearKeyboardShortcuts();
     void updateZoomLabel();
 
+    void openPalette();
     void importPalette();
     void exportPalette();
 

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -121,7 +121,6 @@ private:
 
     void openPalette();
     void importPalette();
-    void savePalette();
     void exportPalette();
 
     void readSettings();

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -82,6 +82,7 @@
      <addaction name="actionExport_Animated_GIF"/>
      <addaction name="separator"/>
      <addaction name="actionExport_Palette"/>
+     <addaction name="actionExport_Other_Palette_formats"/>
     </widget>
     <addaction name="actionNew"/>
     <addaction name="actionOpen"/>
@@ -312,7 +313,7 @@
   </action>
   <action name="actionExport_Palette">
    <property name="text">
-    <string>Palette...</string>
+    <string>Pencil2D Palette...</string>
    </property>
   </action>
   <action name="actionImport_Image">
@@ -985,6 +986,11 @@
   <action name="actionOpen_Replace_Palette">
    <property name="text">
     <string>Open (Replace) Palette...</string>
+   </property>
+  </action>
+  <action name="actionExport_Other_Palette_formats">
+   <property name="text">
+    <string>Other Palette format...</string>
    </property>
   </action>
  </widget>

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -49,7 +49,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>22</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -68,7 +68,8 @@
      <addaction name="actionImport_Gif"/>
      <addaction name="actionImport_Sound"/>
      <addaction name="separator"/>
-     <addaction name="actionImport_Palette"/>
+     <addaction name="actionOpen_Replace_Palette"/>
+     <addaction name="actionImport_Append_Palette"/>
     </widget>
     <widget class="QMenu" name="menuExport">
      <property name="title">
@@ -335,11 +336,6 @@
   <action name="actionImport_Sound">
    <property name="text">
     <string>Sound...</string>
-   </property>
-  </action>
-  <action name="actionImport_Palette">
-   <property name="text">
-    <string>Palette...</string>
    </property>
   </action>
   <action name="actionImport_ImageSeqNum">
@@ -979,6 +975,16 @@
   <action name="actionPegbarAlignment">
    <property name="text">
     <string>Peg bar Alignment</string>
+   </property>
+  </action>
+  <action name="actionImport_Append_Palette">
+   <property name="text">
+    <string>Import (Append) Palette...</string>
+   </property>
+  </action>
+  <action name="actionOpen_Replace_Palette">
+   <property name="text">
+    <string>Open (Replace) Palette...</string>
    </property>
   </action>
  </widget>

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -49,7 +49,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>26</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -83,7 +83,6 @@
      <addaction name="actionExport_Animated_GIF"/>
      <addaction name="separator"/>
      <addaction name="actionExport_Palette"/>
-     <addaction name="actionExport_Other_Palette_formats"/>
     </widget>
     <addaction name="actionNew"/>
     <addaction name="actionOpen"/>
@@ -314,7 +313,7 @@
   </action>
   <action name="actionExport_Palette">
    <property name="text">
-    <string>Pencil2D Palette...</string>
+    <string>Export Palette</string>
    </property>
   </action>
   <action name="actionImport_Image">

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -49,6 +49,7 @@ GNU General Public License for more details.
 #include "timeline.h"
 #include "util.h"
 #include "movieexporter.h"
+#include "qsettings.h"
 
 #define MIN(a,b) ((a)>(b)?(b):(a))
 
@@ -876,6 +877,15 @@ void Editor::createNewCameraLayer(const QString& name)
 bool Editor::importImage(QString filePath)
 {
     Layer* layer = layers()->currentLayer();
+    QSettings settings(PENCIL2D, PENCIL2D);
+    int index = settings.value("ImportRepositionType").toInt();
+
+    if (index == 3)
+    {
+        LayerCamera* camera = static_cast<LayerCamera*>(layers()->getLastCameraLayer());
+        QTransform transform = camera->getViewAtFrame(currentFrame());
+        view()->setImportView(transform);
+    }
 
     switch (layer->type())
     {

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -877,10 +877,8 @@ void Editor::createNewCameraLayer(const QString& name)
 bool Editor::importImage(QString filePath)
 {
     Layer* layer = layers()->currentLayer();
-    QSettings settings(PENCIL2D, PENCIL2D);
-    int index = settings.value("ImportRepositionType").toInt();
 
-    if (index == 3)
+    if (view()->getImportFollowsCamera())
     {
         LayerCamera* camera = static_cast<LayerCamera*>(layers()->getLastCameraLayer());
         QTransform transform = camera->getViewAtFrame(currentFrame());

--- a/core_lib/src/managers/viewmanager.h
+++ b/core_lib/src/managers/viewmanager.h
@@ -79,6 +79,9 @@ public:
     bool isFlipHorizontal() { return mIsFlipHorizontal; }
     bool isFlipVertical() { return mIsFlipVertical; }
 
+    void setImportFollowsCamera(bool b) { mImportFollowsCamera = b; }
+    bool getImportFollowsCamera() { return mImportFollowsCamera; }
+
     void setCanvasSize(QSize size);
     void setCameraLayer(Layer* layer);
 
@@ -108,6 +111,7 @@ private:
 
     bool mIsFlipHorizontal = false;
     bool mIsFlipVertical = false;
+    bool mImportFollowsCamera = false;
 
     LayerCamera* mCameraLayer = nullptr;
 };

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -524,7 +524,6 @@ void Object::importPalettePencil(QFile& file)
     QDomDocument doc;
     doc.setContent(&file);
 
-//    mPalette.clear();
     QDomElement docElem = doc.documentElement();
     QDomNode tag = docElem.firstChild();
     while (!tag.isNull())

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -516,7 +516,7 @@ void Object::importPalettePencil(QFile& file)
     QDomDocument doc;
     doc.setContent(&file);
 
-    mPalette.clear();
+//    mPalette.clear();
     QDomElement docElem = doc.documentElement();
     QDomNode tag = docElem.firstChild();
     while (!tag.isNull())
@@ -535,6 +535,20 @@ void Object::importPalettePencil(QFile& file)
     }
 }
 
+void Object::openPalette(QString filePath)
+{
+    if (!QFile::exists(filePath))
+    {
+        return;
+    }
+
+    mPalette.clear();
+    importPalette(filePath);
+}
+
+/*
+ * Imports palette, e.g. appends to palette
+*/
 bool Object::importPalette(QString filePath)
 {
     QFile file(filePath);

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -97,6 +97,7 @@ public:
     bool importPalette(QString filePath);
     void importPaletteGPL(QFile& file);
     void importPalettePencil(QFile& file);
+    void openPalette(QString filePath);
 
     bool exportPalette(QString filePath);
     void exportPaletteGPL(QFile& file);

--- a/core_lib/src/util/fileformat.h
+++ b/core_lib/src/util/fileformat.h
@@ -36,6 +36,10 @@ GNU General Public License for more details.
 #define PFF_TMP_DECOMPRESS_EXT 	"Y2xD"
 #define PFF_PALETTE_FILE        "palette.xml"
 
+// Palette formats
+#define PENCIL2D_PALETTE_EXT    ".xml"
+#define GIMP_PALETTE_EXT        ".gpl"
+
 
 bool removePFFTmpDirectory (const QString& dirName);
 QString uniqueString(int len);


### PR DESCRIPTION
I've made this extension to the much discussed import feature.
Here you can import relative to four positions, as shown in the screenshot below.
Whether my naming for the four possibilities are precise enough is up to you. Let's discuss it.
![importpos](https://user-images.githubusercontent.com/1292931/68992020-e088c400-0865-11ea-8cc1-5d228f909deb.png)

When importing to follow camera, we have to set the viewManagers importView for each image, which called for 6 lines of code in the Editor::importImage() function. If any of you know a smarter way, please tell me how.
Finally, this only addresses the urgent problem of the merged feature, that could be more precise. We should have a feature where we could import to whatever position we want. That must be another time.