### PR TITLE
#1177 Added possibilities for import positions

### DIFF
--- a/app/src/importpositiondialog.h
+++ b/app/src/importpositiondialog.h
@@ -16,19 +16,25 @@ class ImportPositionDialog : public QDialog
     struct ImportPosition {
 
         enum Type {
-            CenterOfCamera,
+            CenterOfView,
             CenterOfCanvas,
+            CenterOfCamera,
+            CenterOfCameraFollowed,
             None
         };
 
         static Type getTypeFromIndex(int index) {
             switch (index) {
-                case 0:
-                    return CenterOfCanvas;
-                case 1:
-                    return CenterOfCamera;
-                default:
-                    return None;
+            case 0:
+                return CenterOfView;
+            case 1:
+                return CenterOfCanvas;
+            case 2:
+                return CenterOfCamera;
+            case 3:
+                return CenterOfCameraFollowed;
+            default:
+                return None;
             }
         }
     };

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -877,6 +877,12 @@ bool Editor::importImage(QString filePath)
 {
     Layer* layer = layers()->currentLayer();
 
+    if (view()->getImportFollowsCamera())
+    {
+        LayerCamera* camera = static_cast<LayerCamera*>(layers()->getLastCameraLayer());
+        QTransform transform = camera->getViewAtFrame(currentFrame());
+        view()->setImportView(transform);
+    }
     switch (layer->type())
     {
     case Layer::BITMAP:

--- a/core_lib/src/managers/viewmanager.h
+++ b/core_lib/src/managers/viewmanager.h
@@ -85,6 +85,9 @@ public:
     QTransform getImportView() { return mImportView; }
     void setImportView(const QTransform& newView) { mImportView = newView; }
 
+    void setImportFollowsCamera(bool b) { mImportFollowsCamera = b; }
+    bool getImportFollowsCamera() { return mImportFollowsCamera; }
+
     void updateViewTransforms();
 
     Q_SIGNAL void viewChanged();
@@ -108,6 +111,7 @@ private:
 
     bool mIsFlipHorizontal = false;
     bool mIsFlipVertical = false;
+    bool mImportFollowsCamera = false;
 
     LayerCamera* mCameraLayer = nullptr;
 };


### PR DESCRIPTION
"Tredje gang er lykkens gang" (Danish proverb)
I've made this extension to the much discussed import feature.
Here you can import relative to four positions, as shown in the screenshot below.
Whether my naming for the four possibilities are precise enough is up to you. Let's discuss it.
![importpos](https://user-images.githubusercontent.com/1292931/68992376-d2897200-086a-11ea-8078-4a4d6cfa0f2f.png)
When importing to follow camera, we have to set the viewManagers importView for each image, which called for 4 lines of code in the Editor::importImage() function. If any of you know a smarter way, please tell me how.
Finally, this only addresses the urgent problem of the merged feature, that could be more precise. We should have a feature where we could import to whatever position we want. That must be another time.