### PR TITLE
Remove extensions from translations and tweak some strings

### DIFF
--- a/app/src/filedialogex.cpp
+++ b/app/src/filedialogex.cpp
@@ -79,17 +79,38 @@ QString FileDialog::saveFile( FileType fileType )
     QString strFilter = saveFileFilters( fileType );
     QString strSelectedFilter = getFilterForFile(strFilter, strInitialFilePath);
 
-    QString filePath = QFileDialog::getSaveFileName( mRoot,
-                                                     strTitle,
-                                                     strInitialFilePath,
-                                                     strFilter,
-                                                     strSelectedFilter.isNull() ? Q_NULLPTR : &strSelectedFilter );
+    QString filePath = QFileDialog::getSaveFileName(mRoot,
+                           strTitle,
+                           strInitialFilePath,
+                           strFilter,
+                           strSelectedFilter.isNull() ? Q_NULLPTR : &strSelectedFilter);
+
     if ( !filePath.isEmpty() )
     {
         setLastSavePath( fileType, filePath );
     }
 
+    QFileInfo info(filePath);
+    if (info.suffix().isEmpty() || strSelectedFilter.isEmpty()) {
+
+        filePath += addDefaultExtensionSuffix(fileType);
+    }
+
     return filePath;
+}
+
+QString FileDialog::addDefaultExtensionSuffix(const FileType fileType)
+{
+    switch(fileType)
+    {
+    case FileType::ANIMATION: return PFF_DEFAULT_PROJECT_EXT;
+    case FileType::IMAGE: return PFF_DEFAULT_IMAGE_EXT;
+    case FileType::IMAGE_SEQUENCE: return PFF_DEFAULT_IMAGE_SEQ_EXT;
+    case FileType::GIF: return PFF_DEFAULT_ANIMATED_EXT;
+    case FileType::PALETTE: return PFF_DEFAULT_PALETTE_EXT;
+    default:
+        return "";
+    }
 }
 
 QString FileDialog::getLastOpenPath( FileType fileType )

--- a/app/src/filedialogex.cpp
+++ b/app/src/filedialogex.cpp
@@ -135,8 +135,7 @@ QString FileDialog::openDialogTitle( FileType fileType )
         case FileType::GIF: return tr( "Import Animated GIF" );
         case FileType::MOVIE: return tr( "Import movie" );
         case FileType::SOUND: return tr( "Import sound" );
-        case FileType::PALETTE: return tr( "Import palette" );
-        default: Q_ASSERT( false );
+        case FileType::PALETTE: return tr( "Open palette" );
     }
     return "";
 }
@@ -152,7 +151,6 @@ QString FileDialog::saveDialogTitle( FileType fileType )
         case FileType::MOVIE: return tr( "Export movie" );
         case FileType::SOUND: return tr( "Export sound" );
         case FileType::PALETTE: return tr( "Export palette" );
-        default: Q_ASSERT( false );
     }
     return "";
 }
@@ -161,18 +159,13 @@ QString FileDialog::openFileFilters( FileType fileType )
 {
     switch ( fileType )
     {
-        case FileType::ANIMATION: return PFF_OPEN_ALL_FILE_FILTER;
-        case FileType::IMAGE: return PENCIL_IMAGE_FILTER;
-        case FileType::IMAGE_SEQUENCE: return PENCIL_IMAGE_SEQ_FILTER;
-        case FileType::GIF: return QString("%1 (*.gif)").arg(tr("Animated GIF"));
-        case FileType::MOVIE: { Q_ASSERT(false); return PENCIL_MOVIE_EXT; } // currently not supported
-        case FileType::SOUND: return QString("%1 (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)").arg("Sounds");
-        case FileType::PALETTE:
-            return QString("%1 (*.xml *.gpl);;%2 (*.xml);;%3 (*.gpl)")
-                .arg(tr("Palette"))
-                .arg(tr("Pencil2D Palette"))
-                .arg(tr("GIMP Palette"));
-        default: Q_ASSERT( false );
+        case FileType::ANIMATION: return PFF_PROJECT_EXT_FILTER;
+        case FileType::IMAGE: return PFF_IMAGE_FILTER;
+        case FileType::IMAGE_SEQUENCE: return PFF_IMAGE_SEQ_FILTER;
+        case FileType::GIF: return PFF_GIF_EXT_FILTER;
+        case FileType::MOVIE: { Q_ASSERT(false); return PFF_MOVIE_EXT; } // currently not supported
+        case FileType::SOUND: return PFF_SOUND_EXT_FILTER;
+        case FileType::PALETTE: return PFF_PALETTE_EXT_FILTER;
     }
     return "";
 }
@@ -181,18 +174,13 @@ QString FileDialog::saveFileFilters( FileType fileType )
 {
     switch ( fileType )
     {
-        case FileType::ANIMATION: return PFF_SAVE_ALL_FILE_FILTER;
+        case FileType::ANIMATION: return PFF_PROJECT_EXT_FILTER;
         case FileType::IMAGE: return "";
         case FileType::IMAGE_SEQUENCE: return "";
         case FileType::GIF: return QString("%1 (*.gif)").arg(tr("Animated GIF"));
         case FileType::MOVIE: return "MP4 (*.mp4);; AVI (*.avi);; WebM (*.webm);; APNG (*.apng)";
         case FileType::SOUND: return "";
-        case FileType::PALETTE:
-            return QString("%1 (*.xml *.gpl);;%2 (*.xml);;%3 (*.gpl)")
-                .arg(tr("Palette"))
-                .arg(tr("Pencil2D Palette"))
-                .arg(tr("GIMP Palette"));
-        default: Q_ASSERT( false );
+        case FileType::PALETTE: return PFF_PALETTE_EXT_FILTER;
     }
     return "";
 }
@@ -238,7 +226,6 @@ QString FileDialog::defaultFileName( FileType fileType )
         case FileType::MOVIE: return "untitled.mp4";
         case FileType::SOUND: return "untitled.wav";
         case FileType::PALETTE: return "untitled.xml";
-        default: Q_ASSERT( false );
     }
     return "";
 }
@@ -254,7 +241,6 @@ QString FileDialog::toSettingKey( FileType fileType )
         case FileType::MOVIE: return "Movie";
         case FileType::SOUND: return "Sound";
         case FileType::PALETTE: return "Palette";
-        default: Q_ASSERT( false );
     }
     return "";
 }

--- a/app/src/filedialogex.h
+++ b/app/src/filedialogex.h
@@ -55,6 +55,8 @@ private:
     QString getFilterForFile( QString fileType, QString filePath );
     QString defaultFileName( FileType fileType );
 
+    QString addDefaultExtensionSuffix(const FileType fileType);
+
     QString toSettingKey( FileType fileType);
 
     QWidget* mRoot = nullptr;

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -522,11 +522,6 @@ bool MainWindow2::saveAsNewDocument()
     {
         return false;
     }
-
-    if (!fileName.endsWith(PFF_OLD_EXTENSION) && !fileName.endsWith(PFF_EXTENSION))
-    {
-        fileName = fileName + PFF_EXTENSION;
-    }
     return saveObject(fileName);
 }
 

--- a/core_lib/src/util/fileformat.h
+++ b/core_lib/src/util/fileformat.h
@@ -27,25 +27,25 @@ GNU General Public License for more details.
 #define PFF_BIG_LETTER_EXTENSION	    "PCLX"
 
 #define PFF_PROJECT_EXT_FILTER \
-    QObject::tr("Supported Pencil formats") + " (*.pclx *.pcl);;" + QObject::tr("Pencil Project") + " (*.pclx);;" + QObject::tr("Legacy Pencil Project") + " (*.pcl)"
+    QObject::tr("Pencil formats") + " (*.pclx *.pcl);;" + QObject::tr("Pencil Project") + " (*.pclx);;" + QObject::tr("Legacy Pencil Project") + " (*.pcl)"
 
 #define PFF_MOVIE_EXT \
-    QObject::tr("Supported Movie formats") + " AVI (*.avi);;MPEG(*.mpg);;MOV(*.mov);;MP4(*.mp4);;SWF(*.swf);;FLV(*.flv);;WMV(*.wmv)"
+    QObject::tr("Movie formats") + " AVI (*.avi);;MPEG(*.mpg);;MOV(*.mov);;MP4(*.mp4);;SWF(*.swf);;FLV(*.flv);;WMV(*.wmv)"
 
 #define PFF_IMAGE_FILTER \
-   QObject::tr( "Supported Image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)"
+   QObject::tr( "Image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)"
 
 #define PFF_IMAGE_SEQ_FILTER \
-    QObject::tr( "Supported Image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)"
+    QObject::tr( "Image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)"
 
 #define PFF_PALETTE_EXT_FILTER \
-    QObject::tr("Supported Palette formats") + " (*.xml *.gpl);;" + QObject::tr("Pencil Palette") + " (*.xml);;" + QObject::tr("GIMP Palette") + " (*.gpl)"
+    QObject::tr("Palette formats") + " (*.xml *.gpl);;" + QObject::tr("Pencil Palette") + " (*.xml);;" + QObject::tr("GIMP Palette") + " (*.gpl)"
 
 #define PFF_GIF_EXT_FILTER \
     QObject::tr("Animated GIF") + " (*.gif)"
 
 #define PFF_SOUND_EXT_FILTER \
-    QObject::tr("Supported Sound formats") + " (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)"
+    QObject::tr("Sound formats") + " (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)"
 
 
 #define PFF_DEFAULT_PROJECT_EXT \

--- a/core_lib/src/util/fileformat.h
+++ b/core_lib/src/util/fileformat.h
@@ -26,8 +26,26 @@ GNU General Public License for more details.
 #define PFF_EXTENSION				    ".pclx"
 #define PFF_BIG_LETTER_EXTENSION	    "PCLX"
 
-#define PFF_OPEN_ALL_FILE_FILTER	QObject::tr( "All Pencil Files PCLX & PCL(*.pclx *.pcl);;Pencil Animation File PCLX(*.pclx);;Old Pencil Animation File PCL(*.pcl);;Any files (*)" )
-#define PFF_SAVE_ALL_FILE_FILTER	QObject::tr( "Pencil Animation File PCLX(*.pclx);;Old Pencil Animation File PCL(*.pcl)" )
+#define PFF_PROJECT_EXT_FILTER \
+    QObject::tr("Supported Pencil formats") + " (*.pclx *.pcl);;" + QObject::tr("Pencil Project") + " (*.pclx);;" + QObject::tr("Legacy Pencil Project") + " (*.pcl)"
+
+#define PFF_MOVIE_EXT \
+    QObject::tr("Supported movie formats") + "AVI (*.avi);;MPEG(*.mpg);;MOV(*.mov);;MP4(*.mp4);;SWF(*.swf);;FLV(*.flv);;WMV(*.wmv)"
+
+#define PFF_IMAGE_FILTER \
+   QObject::tr( "Supported image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)"
+
+#define PFF_IMAGE_SEQ_FILTER \
+    QObject::tr( "Supported image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)"
+
+#define PFF_PALETTE_EXT_FILTER \
+    QObject::tr("Supported Palette formats") + " (*.xml *.gpl);;" + QObject::tr("Pencil Palette") + " (*.xml);;" + QObject::tr("GIMP Palette") + " (*.gpl)"
+
+#define PFF_GIF_EXT_FILTER \
+    QObject::tr("Animated GIF") + " (*.gif)"
+
+#define PFF_SOUND_EXT_FILTER \
+    QObject::tr("Supported sound formats") + " (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)"
 
 
 #define PFF_OLD_DATA_DIR 		"data"
@@ -35,7 +53,6 @@ GNU General Public License for more details.
 #define PFF_XML_FILE_NAME 		"main.xml"
 #define PFF_TMP_DECOMPRESS_EXT 	"Y2xD"
 #define PFF_PALETTE_FILE        "palette.xml"
-
 
 bool removePFFTmpDirectory (const QString& dirName);
 QString uniqueString(int len);

--- a/core_lib/src/util/fileformat.h
+++ b/core_lib/src/util/fileformat.h
@@ -48,6 +48,22 @@ GNU General Public License for more details.
     QObject::tr("Supported Sound formats") + " (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)"
 
 
+#define PFF_DEFAULT_PROJECT_EXT \
+    QString(".pclx")
+
+#define PFF_DEFAULT_IMAGE_EXT \
+   QString(".png")
+
+#define PFF_DEFAULT_IMAGE_SEQ_EXT \
+    QString(".png")
+
+#define PFF_DEFAULT_ANIMATED_EXT \
+    QString(".gif")
+
+#define PFF_DEFAULT_PALETTE_EXT \
+    QString(".xml")
+
+
 #define PFF_OLD_DATA_DIR 		"data"
 #define PFF_DATA_DIR            "data"
 #define PFF_XML_FILE_NAME 		"main.xml"

--- a/core_lib/src/util/fileformat.h
+++ b/core_lib/src/util/fileformat.h
@@ -30,13 +30,13 @@ GNU General Public License for more details.
     QObject::tr("Supported Pencil formats") + " (*.pclx *.pcl);;" + QObject::tr("Pencil Project") + " (*.pclx);;" + QObject::tr("Legacy Pencil Project") + " (*.pcl)"
 
 #define PFF_MOVIE_EXT \
-    QObject::tr("Supported movie formats") + "AVI (*.avi);;MPEG(*.mpg);;MOV(*.mov);;MP4(*.mp4);;SWF(*.swf);;FLV(*.flv);;WMV(*.wmv)"
+    QObject::tr("Supported Movie formats") + " AVI (*.avi);;MPEG(*.mpg);;MOV(*.mov);;MP4(*.mp4);;SWF(*.swf);;FLV(*.flv);;WMV(*.wmv)"
 
 #define PFF_IMAGE_FILTER \
-   QObject::tr( "Supported image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)"
+   QObject::tr( "Supported Image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)"
 
 #define PFF_IMAGE_SEQ_FILTER \
-    QObject::tr( "Supported image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)"
+    QObject::tr( "Supported Image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)"
 
 #define PFF_PALETTE_EXT_FILTER \
     QObject::tr("Supported Palette formats") + " (*.xml *.gpl);;" + QObject::tr("Pencil Palette") + " (*.xml);;" + QObject::tr("GIMP Palette") + " (*.gpl)"
@@ -45,7 +45,7 @@ GNU General Public License for more details.
     QObject::tr("Animated GIF") + " (*.gif)"
 
 #define PFF_SOUND_EXT_FILTER \
-    QObject::tr("Supported sound formats") + " (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)"
+    QObject::tr("Supported Sound formats") + " (*.wav *.mp3);;WAV (*.wav);;MP3 (*.mp3)"
 
 
 #define PFF_OLD_DATA_DIR 		"data"

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -22,15 +22,6 @@ GNU General Public License for more details.
 #define M_PI 3.14159265358979323846
 #endif
 
-#define PENCIL_MOVIE_EXT \
-    QObject::tr( "AVI (*.avi);;MPEG(*.mpg);;MOV(*.mov);;MP4(*.mp4);;SWF(*.swf);;FLV(*.flv);;WMV(*.wmv)" )
-
-#define PENCIL_IMAGE_FILTER \
-   QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)" )
-
-#define PENCIL_IMAGE_SEQ_FILTER \
-    QObject::tr( "Images (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);; TIFF(*.tif *.tiff)" )
-
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
 #define S__GIT_TIMESTAMP TOSTRING(GIT_TIMESTAMP)


### PR DESCRIPTION
This removes extensions from translations, only text that could be interpreted otherwise is translatable now.

I've also tweaked the strings.
This means that it's not up to the translator now to write the extension, thus we should see no more of those bugs where an extension is not added because of wrong format.

Should not be merged before #1262 