### PR TITLE
#1314: Fix save dialog ignores if path is empty

### DIFF
--- a/app/src/filedialogex.cpp
+++ b/app/src/filedialogex.cpp
@@ -88,6 +88,8 @@ QString FileDialog::saveFile( FileType fileType )
     if ( !filePath.isEmpty() )
     {
         setLastSavePath( fileType, filePath );
+    } else {
+        return QString();
     }
 
     QFileInfo info(filePath);


### PR DESCRIPTION
This is a quick fix for now, we should consider not opening the filedialog static, as there's no way to get the return codes this way... The save methods could also make use of Status instead for more error handling.

closes #1314 