### PR TITLE
Layout tweaks

### DIFF
--- a/app/src/displayoptionwidget.cpp
+++ b/app/src/displayoptionwidget.cpp
@@ -43,7 +43,14 @@ DisplayOptionWidget::~DisplayOptionWidget()
 void DisplayOptionWidget::resizeEvent(QResizeEvent *event)
 {
     BaseDockWidget::resizeEvent(event);
-    int minHeight = ui->innerWidget->layout()->heightForWidth(event->size().width()) + layout()->margin()*2;
+    int margins = layout()->margin()*2;
+#ifdef __APPLE__
+    // For some reason the behavior of minimumSize and the margin changes on mac when floating, so we need to do this
+    if (isFloating()) {
+        margins = 0;
+    }
+#endif
+    int minHeight = ui->innerWidget->layout()->heightForWidth(event->size().width()) + margins;
     setMinimumSize(QSize(layout()->minimumSize().width(), minHeight));
 }
 

--- a/app/src/displayoptionwidget.cpp
+++ b/app/src/displayoptionwidget.cpp
@@ -25,6 +25,7 @@ GNU General Public License for more details.
 #include "scribblearea.h"
 #include "editor.h"
 #include "util.h"
+#include "flowlayout.h"
 
 
 DisplayOptionWidget::DisplayOptionWidget(QWidget *parent) :
@@ -39,10 +40,31 @@ DisplayOptionWidget::~DisplayOptionWidget()
     delete ui;
 }
 
+void DisplayOptionWidget::resizeEvent(QResizeEvent *event)
+{
+    BaseDockWidget::resizeEvent(event);
+    int minHeight = ui->innerWidget->layout()->heightForWidth(event->size().width()) + layout()->margin()*2;
+    setMinimumSize(QSize(layout()->minimumSize().width(), minHeight));
+}
+
 void DisplayOptionWidget::initUI()
 {
     updateUI();
     makeConnections();
+
+    delete ui->innerWidget->layout();
+
+    FlowLayout *layout = new FlowLayout;
+    layout->addWidget(ui->mirrorButton);
+    layout->addWidget(ui->mirrorVButton);
+    layout->addWidget(ui->outLinesButton);
+    layout->addWidget(ui->thinLinesButton);
+    layout->addWidget(ui->overlayCenterButton);
+    layout->addWidget(ui->overlayGoldenRatioButton);
+    layout->addWidget(ui->overlaySafeAreaButton);
+    layout->addWidget(ui->overlayThirdsButton);
+
+    ui->innerWidget->setLayout(layout);
 
 #ifdef __APPLE__
     // Mac only style. ToolButtons are naturally borderless on Win/Linux.

--- a/app/src/displayoptionwidget.cpp
+++ b/app/src/displayoptionwidget.cpp
@@ -58,12 +58,12 @@ void DisplayOptionWidget::initUI()
     layout->setAlignment(Qt::AlignHCenter);
     layout->addWidget(ui->mirrorButton);
     layout->addWidget(ui->mirrorVButton);
-    layout->addWidget(ui->outLinesButton);
     layout->addWidget(ui->thinLinesButton);
+    layout->addWidget(ui->outLinesButton);
     layout->addWidget(ui->overlayCenterButton);
+    layout->addWidget(ui->overlayThirdsButton);
     layout->addWidget(ui->overlayGoldenRatioButton);
     layout->addWidget(ui->overlaySafeAreaButton);
-    layout->addWidget(ui->overlayThirdsButton);
 
     ui->innerWidget->setLayout(layout);
 

--- a/app/src/displayoptionwidget.cpp
+++ b/app/src/displayoptionwidget.cpp
@@ -50,7 +50,8 @@ void DisplayOptionWidget::resizeEvent(QResizeEvent *event)
         margins = 0;
     }
 #endif
-    int minHeight = ui->innerWidget->layout()->heightForWidth(event->size().width()) + margins;
+    // Not sure where the -2 comes from, but the event width is always 2 more than what is passed to FlowLayout::setGeometry
+    int minHeight = ui->innerWidget->layout()->heightForWidth(event->size().width() - 2) + margins;
     setMinimumSize(QSize(layout()->minimumSize().width(), minHeight));
 }
 

--- a/app/src/displayoptionwidget.cpp
+++ b/app/src/displayoptionwidget.cpp
@@ -40,21 +40,6 @@ DisplayOptionWidget::~DisplayOptionWidget()
     delete ui;
 }
 
-void DisplayOptionWidget::resizeEvent(QResizeEvent *event)
-{
-    BaseDockWidget::resizeEvent(event);
-    int margins = layout()->margin()*2;
-#ifdef __APPLE__
-    // For some reason the behavior of minimumSize and the margin changes on mac when floating, so we need to do this
-    if (isFloating()) {
-        margins = 0;
-    }
-#endif
-    // Not sure where the -2 comes from, but the event width is always 2 more than what is passed to FlowLayout::setGeometry
-    int minHeight = ui->innerWidget->layout()->heightForWidth(event->size().width() - 2) + margins;
-    setMinimumSize(QSize(layout()->minimumSize().width(), minHeight));
-}
-
 void DisplayOptionWidget::initUI()
 {
     updateUI();
@@ -149,6 +134,11 @@ void DisplayOptionWidget::updateUI()
 
     SignalBlocker b4(ui->mirrorVButton);
     ui->mirrorVButton->setChecked(view->isFlipVertical());
+}
+
+int DisplayOptionWidget::getMinHeightForWidth(int width)
+{
+    return ui->innerWidget->layout()->heightForWidth(width);
 }
 
 void DisplayOptionWidget::toggleMirror(bool isOn)

--- a/app/src/displayoptionwidget.cpp
+++ b/app/src/displayoptionwidget.cpp
@@ -55,6 +55,7 @@ void DisplayOptionWidget::initUI()
     delete ui->innerWidget->layout();
 
     FlowLayout *layout = new FlowLayout;
+    layout->setAlignment(Qt::AlignHCenter);
     layout->addWidget(ui->mirrorButton);
     layout->addWidget(ui->mirrorVButton);
     layout->addWidget(ui->outLinesButton);

--- a/app/src/displayoptionwidget.cpp
+++ b/app/src/displayoptionwidget.cpp
@@ -80,7 +80,15 @@ void DisplayOptionWidget::initUI()
         "QToolButton { border: 0px; } "
         "QToolButton:pressed{ border: 1px solid #FFADAD; border-radius: 2px; background-color: #D5D5D5; }"
         "QToolButton:checked{ border: 1px solid #ADADAD; border-radius: 2px; background-color: #D5D5D5; }";
-    setStyleSheet(this->styleSheet().append(stylesheet));
+
+    ui->mirrorButton->setStyleSheet(stylesheet);
+    ui->mirrorVButton->setStyleSheet(stylesheet);
+    ui->thinLinesButton->setStyleSheet(stylesheet);
+    ui->outLinesButton->setStyleSheet(stylesheet);
+    ui->overlayCenterButton->setStyleSheet(stylesheet);
+    ui->overlayThirdsButton->setStyleSheet(stylesheet);
+    ui->overlayGoldenRatioButton->setStyleSheet(stylesheet);
+    ui->overlaySafeAreaButton->setStyleSheet(stylesheet);
 #endif
 }
 

--- a/app/src/displayoptionwidget.h
+++ b/app/src/displayoptionwidget.h
@@ -34,6 +34,8 @@ public:
     explicit DisplayOptionWidget(QWidget* parent);
     virtual ~DisplayOptionWidget() override;
 
+    void resizeEvent(QResizeEvent *event) override;
+
     void initUI() override;
     void updateUI() override;
 

--- a/app/src/displayoptionwidget.h
+++ b/app/src/displayoptionwidget.h
@@ -34,10 +34,11 @@ public:
     explicit DisplayOptionWidget(QWidget* parent);
     virtual ~DisplayOptionWidget() override;
 
-    void resizeEvent(QResizeEvent *event) override;
-
     void initUI() override;
     void updateUI() override;
+
+protected:
+    int getMinHeightForWidth(int width) override;
 
 private slots:
     void toggleMirror(bool);

--- a/app/src/toolbox.cpp
+++ b/app/src/toolbox.cpp
@@ -63,7 +63,8 @@ void ToolBoxWidget::resizeEvent(QResizeEvent *event)
         margins = 0;
     }
 #endif
-    int minHeight = ui->toolGroup->layout()->heightForWidth(event->size().width()) + margins;
+    // Not sure where the -2 comes from, but the event width is always 2 more than what is passed to FlowLayout::setGeometry
+    int minHeight = ui->toolGroup->layout()->heightForWidth(event->size().width() - 2) + margins;
     setMinimumSize(QSize(layout()->minimumSize().width(), minHeight));
 }
 

--- a/app/src/toolbox.cpp
+++ b/app/src/toolbox.cpp
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 #include <QToolButton>
 #include <QGridLayout>
 #include <QKeySequence>
+#include <QResizeEvent>
 
 #include "flowlayout.h"
 #include "spinslider.h"
@@ -55,7 +56,14 @@ ToolBoxWidget::~ToolBoxWidget()
 void ToolBoxWidget::resizeEvent(QResizeEvent *event)
 {
     BaseDockWidget::resizeEvent(event);
-    int minHeight = ui->toolGroup->layout()->heightForWidth(event->size().width()) + layout()->margin()*2;
+    int margins = layout()->margin()*2;
+#ifdef __APPLE__
+    // For some reason the behavior of minimumSize and the margin changes on mac when floating, so we need to do this
+    if (isFloating()) {
+        margins = 0;
+    }
+#endif
+    int minHeight = ui->toolGroup->layout()->heightForWidth(event->size().width()) + margins;
     setMinimumSize(QSize(layout()->minimumSize().width(), minHeight));
 }
 

--- a/app/src/toolbox.cpp
+++ b/app/src/toolbox.cpp
@@ -52,6 +52,13 @@ ToolBoxWidget::~ToolBoxWidget()
     delete ui;
 }
 
+void ToolBoxWidget::resizeEvent(QResizeEvent *event)
+{
+    BaseDockWidget::resizeEvent(event);
+    int minHeight = ui->toolGroup->layout()->heightForWidth(event->size().width()) + layout()->margin()*2;
+    setMinimumSize(QSize(layout()->minimumSize().width(), minHeight));
+}
+
 void ToolBoxWidget::initUI()
 {
 #ifdef __APPLE__

--- a/app/src/toolbox.cpp
+++ b/app/src/toolbox.cpp
@@ -53,21 +53,6 @@ ToolBoxWidget::~ToolBoxWidget()
     delete ui;
 }
 
-void ToolBoxWidget::resizeEvent(QResizeEvent *event)
-{
-    BaseDockWidget::resizeEvent(event);
-    int margins = layout()->margin()*2;
-#ifdef __APPLE__
-    // For some reason the behavior of minimumSize and the margin changes on mac when floating, so we need to do this
-    if (isFloating()) {
-        margins = 0;
-    }
-#endif
-    // Not sure where the -2 comes from, but the event width is always 2 more than what is passed to FlowLayout::setGeometry
-    int minHeight = ui->toolGroup->layout()->heightForWidth(event->size().width() - 2) + margins;
-    setMinimumSize(QSize(layout()->minimumSize().width(), minHeight));
-}
-
 void ToolBoxWidget::initUI()
 {
 #ifdef __APPLE__
@@ -286,6 +271,11 @@ void ToolBoxWidget::smudgeOn()
 
     deselectAllTools();
     ui->smudgeButton->setChecked(true);
+}
+
+int ToolBoxWidget::getMinHeightForWidth(int width)
+{
+    return ui->toolGroup->layout()->heightForWidth(width);
 }
 
 void ToolBoxWidget::deselectAllTools()

--- a/app/src/toolbox.h
+++ b/app/src/toolbox.h
@@ -40,8 +40,6 @@ public:
     ToolBoxWidget(QWidget* parent);
     ~ToolBoxWidget() override;
 
-    void resizeEvent(QResizeEvent *event) override;
-
     void initUI() override;
     void updateUI() override;
 
@@ -57,6 +55,9 @@ public slots:
     void eyedropperOn();
     void brushOn();
     void smudgeOn();
+
+protected:
+    int getMinHeightForWidth(int width) override;
 
 signals:
     void clearButtonClicked();

--- a/app/src/toolbox.h
+++ b/app/src/toolbox.h
@@ -40,6 +40,8 @@ public:
     ToolBoxWidget(QWidget* parent);
     ~ToolBoxWidget() override;
 
+    void resizeEvent(QResizeEvent *event) override;
+
     void initUI() override;
     void updateUI() override;
 

--- a/app/ui/displayoption.ui
+++ b/app/ui/displayoption.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>204</width>
-    <height>204</height>
+    <height>329</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,249 +16,228 @@
   <widget class="QWidget" name="innerWidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QToolButton" name="mirrorButton">
-        <property name="toolTip">
-         <string>Horizontal flip</string>
-        </property>
-        <property name="text">
-         <string notr="true"/>
-        </property>
-        <property name="icon">
-         <iconset resource="../data/app.qrc">
-          <normaloff>:/app/icons/mirror.png</normaloff>:/app/icons/mirror.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>24</width>
-          <height>24</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="popupMode">
-         <enum>QToolButton::DelayedPopup</enum>
-        </property>
-        <property name="toolButtonStyle">
-         <enum>Qt::ToolButtonIconOnly</enum>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="QToolButton" name="outLinesButton">
-        <property name="toolTip">
-         <string>Show outlines only</string>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../data/app.qrc">
-          <normaloff>:/app/icons/outlines5.png</normaloff>:/app/icons/outlines5.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>24</width>
-          <height>24</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QToolButton" name="thinLinesButton">
-        <property name="mouseTracking">
-         <bool>false</bool>
-        </property>
-        <property name="acceptDrops">
-         <bool>true</bool>
-        </property>
-        <property name="toolTip">
-         <string>Show invisible lines</string>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../data/app.qrc">
-          <normaloff>:/app/icons/thinlines5.png</normaloff>:/app/icons/thinlines5.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>24</width>
-          <height>24</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QToolButton" name="mirrorVButton">
-        <property name="toolTip">
-         <string>Vertical flip</string>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../data/app.qrc">
-          <normaloff>:/app/icons/mirrorV.png</normaloff>:/app/icons/mirrorV.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>24</width>
-          <height>24</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QToolButton" name="overlayCenterButton">
-        <property name="toolTip">
-         <string>Overlay shows field center</string>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../data/app.qrc">
-          <normaloff>:/icons/overlay_center.png</normaloff>:/icons/overlay_center.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>24</width>
-          <height>24</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QToolButton" name="overlayThirdsButton">
-        <property name="toolTip">
-         <string>Overlay shows field in thirds</string>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../data/app.qrc">
-          <normaloff>:/icons/overlay_third.png</normaloff>:/icons/overlay_third.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>24</width>
-          <height>24</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QToolButton" name="overlayGoldenRatioButton">
-        <property name="toolTip">
-         <string>Overlay shows field in Golden Ratio</string>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../data/app.qrc">
-          <normaloff>:/icons/overlay_godenratio.png</normaloff>:/icons/overlay_godenratio.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>24</width>
-          <height>24</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="3">
-       <widget class="QToolButton" name="overlaySafeAreaButton">
-        <property name="toolTip">
-         <string>Overlay shows field safe areas</string>
-        </property>
-        <property name="text">
-         <string>...</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../data/app.qrc">
-          <normaloff>:/icons/overlay_safe.png</normaloff>:/icons/overlay_safe.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>24</width>
-          <height>24</height>
-         </size>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <spacer name="verticalSpacer">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
+     <widget class="QToolButton" name="mirrorVButton">
+      <property name="toolTip">
+       <string>Vertical flip</string>
       </property>
-      <property name="sizeHint" stdset="0">
+      <property name="text">
+       <string>...</string>
+      </property>
+      <property name="icon">
+       <iconset resource="../data/app.qrc">
+        <normaloff>:/app/icons/mirrorV.png</normaloff>:/app/icons/mirrorV.png</iconset>
+      </property>
+      <property name="iconSize">
        <size>
-        <width>20</width>
-        <height>40</height>
+        <width>24</width>
+        <height>24</height>
        </size>
       </property>
-     </spacer>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="autoRaise">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QToolButton" name="mirrorButton">
+      <property name="toolTip">
+       <string>Horizontal flip</string>
+      </property>
+      <property name="text">
+       <string notr="true"/>
+      </property>
+      <property name="icon">
+       <iconset resource="../data/app.qrc">
+        <normaloff>:/app/icons/mirror.png</normaloff>:/app/icons/mirror.png</iconset>
+      </property>
+      <property name="iconSize">
+       <size>
+        <width>24</width>
+        <height>24</height>
+       </size>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="popupMode">
+       <enum>QToolButton::DelayedPopup</enum>
+      </property>
+      <property name="toolButtonStyle">
+       <enum>Qt::ToolButtonIconOnly</enum>
+      </property>
+      <property name="autoRaise">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QToolButton" name="thinLinesButton">
+      <property name="mouseTracking">
+       <bool>false</bool>
+      </property>
+      <property name="acceptDrops">
+       <bool>true</bool>
+      </property>
+      <property name="toolTip">
+       <string>Show invisible lines</string>
+      </property>
+      <property name="text">
+       <string>...</string>
+      </property>
+      <property name="icon">
+       <iconset resource="../data/app.qrc">
+        <normaloff>:/app/icons/thinlines5.png</normaloff>:/app/icons/thinlines5.png</iconset>
+      </property>
+      <property name="iconSize">
+       <size>
+        <width>24</width>
+        <height>24</height>
+       </size>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="autoRaise">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QToolButton" name="outLinesButton">
+      <property name="toolTip">
+       <string>Show outlines only</string>
+      </property>
+      <property name="text">
+       <string>...</string>
+      </property>
+      <property name="icon">
+       <iconset resource="../data/app.qrc">
+        <normaloff>:/app/icons/outlines5.png</normaloff>:/app/icons/outlines5.png</iconset>
+      </property>
+      <property name="iconSize">
+       <size>
+        <width>24</width>
+        <height>24</height>
+       </size>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="autoRaise">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QToolButton" name="overlayGoldenRatioButton">
+      <property name="toolTip">
+       <string>Overlay shows field in Golden Ratio</string>
+      </property>
+      <property name="text">
+       <string>...</string>
+      </property>
+      <property name="icon">
+       <iconset resource="../data/app.qrc">
+        <normaloff>:/icons/overlay_godenratio.png</normaloff>:/icons/overlay_godenratio.png</iconset>
+      </property>
+      <property name="iconSize">
+       <size>
+        <width>24</width>
+        <height>24</height>
+       </size>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="autoRaise">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QToolButton" name="overlayThirdsButton">
+      <property name="toolTip">
+       <string>Overlay shows field in thirds</string>
+      </property>
+      <property name="text">
+       <string>...</string>
+      </property>
+      <property name="icon">
+       <iconset resource="../data/app.qrc">
+        <normaloff>:/icons/overlay_third.png</normaloff>:/icons/overlay_third.png</iconset>
+      </property>
+      <property name="iconSize">
+       <size>
+        <width>24</width>
+        <height>24</height>
+       </size>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="autoRaise">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QToolButton" name="overlayCenterButton">
+      <property name="toolTip">
+       <string>Overlay shows field center</string>
+      </property>
+      <property name="text">
+       <string>...</string>
+      </property>
+      <property name="icon">
+       <iconset resource="../data/app.qrc">
+        <normaloff>:/icons/overlay_center.png</normaloff>:/icons/overlay_center.png</iconset>
+      </property>
+      <property name="iconSize">
+       <size>
+        <width>24</width>
+        <height>24</height>
+       </size>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="autoRaise">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QToolButton" name="overlaySafeAreaButton">
+      <property name="toolTip">
+       <string>Overlay shows field safe areas</string>
+      </property>
+      <property name="text">
+       <string>...</string>
+      </property>
+      <property name="icon">
+       <iconset resource="../data/app.qrc">
+        <normaloff>:/icons/overlay_safe.png</normaloff>:/icons/overlay_safe.png</iconset>
+      </property>
+      <property name="iconSize">
+       <size>
+        <width>24</width>
+        <height>24</height>
+       </size>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <property name="autoRaise">
+       <bool>true</bool>
+      </property>
+     </widget>
     </item>
    </layout>
   </widget>
  </widget>
- <tabstops>
-  <tabstop>mirrorButton</tabstop>
-  <tabstop>thinLinesButton</tabstop>
- </tabstops>
  <resources>
   <include location="../data/app.qrc"/>
  </resources>

--- a/app/ui/displayoption.ui
+++ b/app/ui/displayoption.ui
@@ -16,32 +16,6 @@
   <widget class="QWidget" name="innerWidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <widget class="QToolButton" name="mirrorVButton">
-      <property name="toolTip">
-       <string>Vertical flip</string>
-      </property>
-      <property name="text">
-       <string>...</string>
-      </property>
-      <property name="icon">
-       <iconset resource="../data/app.qrc">
-        <normaloff>:/app/icons/mirrorV.png</normaloff>:/app/icons/mirrorV.png</iconset>
-      </property>
-      <property name="iconSize">
-       <size>
-        <width>24</width>
-        <height>24</height>
-       </size>
-      </property>
-      <property name="checkable">
-       <bool>true</bool>
-      </property>
-      <property name="autoRaise">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item>
      <widget class="QToolButton" name="mirrorButton">
       <property name="toolTip">
        <string>Horizontal flip</string>
@@ -67,6 +41,32 @@
       </property>
       <property name="toolButtonStyle">
        <enum>Qt::ToolButtonIconOnly</enum>
+      </property>
+      <property name="autoRaise">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QToolButton" name="mirrorVButton">
+      <property name="toolTip">
+       <string>Vertical flip</string>
+      </property>
+      <property name="text">
+       <string>...</string>
+      </property>
+      <property name="icon">
+       <iconset resource="../data/app.qrc">
+        <normaloff>:/app/icons/mirrorV.png</normaloff>:/app/icons/mirrorV.png</iconset>
+      </property>
+      <property name="iconSize">
+       <size>
+        <width>24</width>
+        <height>24</height>
+       </size>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
       </property>
       <property name="autoRaise">
        <bool>true</bool>
@@ -132,16 +132,16 @@
      </widget>
     </item>
     <item>
-     <widget class="QToolButton" name="overlayGoldenRatioButton">
+     <widget class="QToolButton" name="overlayCenterButton">
       <property name="toolTip">
-       <string>Overlay shows field in Golden Ratio</string>
+       <string>Overlay shows field center</string>
       </property>
       <property name="text">
        <string>...</string>
       </property>
       <property name="icon">
        <iconset resource="../data/app.qrc">
-        <normaloff>:/icons/overlay_godenratio.png</normaloff>:/icons/overlay_godenratio.png</iconset>
+        <normaloff>:/icons/overlay_center.png</normaloff>:/icons/overlay_center.png</iconset>
       </property>
       <property name="iconSize">
        <size>
@@ -184,16 +184,16 @@
      </widget>
     </item>
     <item>
-     <widget class="QToolButton" name="overlayCenterButton">
+     <widget class="QToolButton" name="overlayGoldenRatioButton">
       <property name="toolTip">
-       <string>Overlay shows field center</string>
+       <string>Overlay shows field in Golden Ratio</string>
       </property>
       <property name="text">
        <string>...</string>
       </property>
       <property name="icon">
        <iconset resource="../data/app.qrc">
-        <normaloff>:/icons/overlay_center.png</normaloff>:/icons/overlay_center.png</iconset>
+        <normaloff>:/icons/overlay_godenratio.png</normaloff>:/icons/overlay_godenratio.png</iconset>
       </property>
       <property name="iconSize">
        <size>
@@ -238,6 +238,16 @@
    </layout>
   </widget>
  </widget>
+ <tabstops>
+  <tabstop>mirrorButton</tabstop>
+  <tabstop>mirrorVButton</tabstop>
+  <tabstop>thinLinesButton</tabstop>
+  <tabstop>outLinesButton</tabstop>
+  <tabstop>overlayCenterButton</tabstop>
+  <tabstop>overlayThirdsButton</tabstop>
+  <tabstop>overlayGoldenRatioButton</tabstop>
+  <tabstop>overlaySafeAreaButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../data/app.qrc"/>
  </resources>

--- a/app/ui/onionskin.ui
+++ b/app/ui/onionskin.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>160</width>
-    <height>300</height>
+    <width>193</width>
+    <height>317</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>160</width>
-    <height>280</height>
+    <width>193</width>
+    <height>317</height>
    </size>
   </property>
   <property name="floating">
@@ -332,6 +332,19 @@
        <string>Show During Playback</string>
       </property>
      </widget>
+    </item>
+    <item>
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
     </item>
    </layout>
   </widget>

--- a/core_lib/src/interface/basedockwidget.cpp
+++ b/core_lib/src/interface/basedockwidget.cpp
@@ -15,6 +15,8 @@ GNU General Public License for more details.
 
 */
 
+#include <QLayout>
+#include <QResizeEvent>
 
 #include "basedockwidget.h"
 #include "platformhandler.h"
@@ -37,4 +39,30 @@ BaseDockWidget::BaseDockWidget(QWidget* pParent)
 
 BaseDockWidget::~BaseDockWidget()
 {
+}
+
+void BaseDockWidget::resizeEvent(QResizeEvent *event)
+{
+    QDockWidget::resizeEvent(event);
+
+    // Not sure where the -2 comes from, but the event width is always 2 more than what is passed to FlowLayout::setGeometry
+    int minHeight = getMinHeightForWidth(event->size().width() - 2);
+
+    if (minHeight < 0) return;
+
+#ifdef __APPLE__
+    // For some reason the behavior of minimumSize and the margin changes on mac when floating, so we need to do this
+    if (isFloating()) {
+        margins = 0;
+    }
+#else
+    minHeight += layout()->margin()*2;
+#endif
+    setMinimumSize(QSize(layout()->minimumSize().width(), minHeight));
+}
+
+int BaseDockWidget::getMinHeightForWidth(int width)
+{
+    Q_UNUSED(width);
+    return -1;
 }

--- a/core_lib/src/interface/basedockwidget.h
+++ b/core_lib/src/interface/basedockwidget.h
@@ -30,12 +30,17 @@ protected:
     explicit BaseDockWidget(QWidget* pParent);
     virtual  ~BaseDockWidget();
 
+    void resizeEvent(QResizeEvent *event) override;
+
 public:
     virtual void initUI() = 0;
     virtual void updateUI() = 0;
 
     Editor* editor() const { return mEditor; }
     void setEditor( Editor* e ) { mEditor = e; }
+
+protected:
+    virtual int getMinHeightForWidth(int width);
 
 private:
     Editor* mEditor = nullptr;

--- a/core_lib/src/interface/flowlayout.cpp
+++ b/core_lib/src/interface/flowlayout.cpp
@@ -174,11 +174,13 @@ int FlowLayout::doLayout(const QRect &rect, bool testOnly) const
     int x = effectiveRect.x();
     int y = effectiveRect.y();
     int lineHeight = 0;
+    int rowCount = 0;
 //! [9]
 
 //! [10]
     QLayoutItem *item;
-    foreach (item, itemList) {
+    for(int i = 0; i < itemList.length(); i++) {
+        item = itemList.at(i);
         QWidget *wid = item->widget();
         int spaceX = horizontalSpacing();
         if (spaceX == -1)
@@ -192,11 +194,20 @@ int FlowLayout::doLayout(const QRect &rect, bool testOnly) const
 //! [11]
         int nextX = x + item->sizeHint().width() + spaceX;
         if (nextX - spaceX > effectiveRect.right() && lineHeight > 0) {
+            int offset = qFloor((effectiveRect.width() - x) / 2);
+            qDebug() << "Adding offset of" << offset;
+            for(int j = i-1; j > i-1-rowCount; j--) {
+                auto rowItem = itemList.at(j);
+                rowItem->setGeometry(rowItem->geometry().adjusted(offset, 0, offset, 0));
+            }
+
             x = effectiveRect.x();
             y = y + lineHeight + spaceY;
             nextX = x + item->sizeHint().width() + spaceX;
             lineHeight = 0;
+            rowCount = 0;
         }
+        rowCount++;
 
         if (!testOnly)
             item->setGeometry(QRect(QPoint(x, y), item->sizeHint()));
@@ -204,6 +215,14 @@ int FlowLayout::doLayout(const QRect &rect, bool testOnly) const
         x = nextX;
         lineHeight = qMax(lineHeight, item->sizeHint().height());
     }
+
+    int offset = qFloor((effectiveRect.width() - x) / 2);
+    qDebug() << "Adding offset of" << offset;
+    for(int j = itemList.length()-1; j > itemList.length()-1-rowCount; j--) {
+        auto rowItem = itemList.at(j);
+        rowItem->setGeometry(rowItem->geometry().adjusted(offset, 0, offset, 0));
+    }
+
     return y + lineHeight - rect.y() + bottom;
 }
 //! [11]

--- a/core_lib/src/interface/flowlayout.cpp
+++ b/core_lib/src/interface/flowlayout.cpp
@@ -179,10 +179,11 @@ int FlowLayout::doLayout(const QRect &rect, bool testOnly) const
 
 //! [10]
     QLayoutItem *item;
-    for(int i = 0; i < itemList.length(); i++) {
+    int spaceX = 0;
+    for (int i = 0; i < itemList.length(); i++) {
         item = itemList.at(i);
         QWidget *wid = item->widget();
-        int spaceX = horizontalSpacing();
+        spaceX = horizontalSpacing();
         if (spaceX == -1)
             spaceX = wid->style()->layoutSpacing(
                 QSizePolicy::PushButton, QSizePolicy::PushButton, Qt::Horizontal);
@@ -194,11 +195,12 @@ int FlowLayout::doLayout(const QRect &rect, bool testOnly) const
 //! [11]
         int nextX = x + item->sizeHint().width() + spaceX;
         if (nextX - spaceX > effectiveRect.right() && lineHeight > 0) {
-            int offset = qFloor((effectiveRect.width() - x) / 2);
-            qDebug() << "Adding offset of" << offset;
-            for(int j = i-1; j > i-1-rowCount; j--) {
-                auto rowItem = itemList.at(j);
-                rowItem->setGeometry(rowItem->geometry().adjusted(offset, 0, offset, 0));
+            if(!testOnly && alignment() & Qt::AlignHCenter) {
+                int offset = qFloor((effectiveRect.right() + spaceX - x) / 2);
+                for(int j = i-1; j > i-1-rowCount; j--) {
+                    auto rowItem = itemList.at(j);
+                    rowItem->setGeometry(rowItem->geometry().adjusted(offset, 0, offset, 0));
+                }
             }
 
             x = effectiveRect.x();
@@ -209,18 +211,20 @@ int FlowLayout::doLayout(const QRect &rect, bool testOnly) const
         }
         rowCount++;
 
-        if (!testOnly)
+        if (!testOnly) {
             item->setGeometry(QRect(QPoint(x, y), item->sizeHint()));
+        }
 
         x = nextX;
         lineHeight = qMax(lineHeight, item->sizeHint().height());
     }
 
-    int offset = qFloor((effectiveRect.width() - x) / 2);
-    qDebug() << "Adding offset of" << offset;
-    for(int j = itemList.length()-1; j > itemList.length()-1-rowCount; j--) {
-        auto rowItem = itemList.at(j);
-        rowItem->setGeometry(rowItem->geometry().adjusted(offset, 0, offset, 0));
+    if (!testOnly && alignment() & Qt::AlignHCenter) {
+        int offset = qFloor((effectiveRect.right() + spaceX - x) / 2);
+        for (int j = itemList.length()-1; j > itemList.length()-1-rowCount; j--) {
+            auto rowItem = itemList.at(j);
+            rowItem->setGeometry(rowItem->geometry().adjusted(offset, 0, offset, 0));
+        }
     }
 
     return y + lineHeight - rect.y() + bottom;


### PR DESCRIPTION
This PR tweaks a few parts of the display and tools dock widgets' appearance. These include:
- Updating the minimum height of the widgets which use FlowLayout on resize so that they cannot be resized in such a way that hides tools or other items.
- Use FlowLayout instead of GridLayout for the display options widget
- Add support for horizontal centering to FlowLayout. I currently only have this enabled for the display widget as it looks a little weird to me when the tools are not left-aligned like in all other programs.
- Added a spacer to the bottom of the onion skins dock widget just so it behaves like the tool options widget

And here are some visuals

FlowLayout Resizing:
![Toolbox Resizing 1](https://user-images.githubusercontent.com/3461051/77842971-be794980-7155-11ea-8721-4814ba2a9187.gif)
![Toolbox Resizing 2](https://user-images.githubusercontent.com/3461051/77842973-c0430d00-7155-11ea-867b-f1f5f11ff508.gif)

Horizontal centering:
![Display Centering](https://user-images.githubusercontent.com/3461051/77843035-5840f680-7156-11ea-8095-b5528f7aefb4.png)

Note that if you move a widget with FlowLayout from floating to a dock with a smaller width, it may overflow into the widget below. I have not found a fix for this, but I don't think it is very high priority since interacting with the widget in any way will trigger some update which fixes the issue.

Also note that this has only been tested on Linux. Given the slightly hackish nature of this solution, it is possible that it will not work on some other operating system. We should test Mac and Linux before applying these changes.
