### PR TITLE
Fix MinGW windows compiling issues

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -185,17 +185,26 @@ linux {
     INSTALLS += bashcompletion zshcompletion target mimepackage desktopentry icon
 }
 
-
-
 # --- core_lib ---
-win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../core_lib/release/ -lcore_lib
-else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../core_lib/debug/ -lcore_lib
-else:unix: LIBS += -L$$OUT_PWD/../core_lib/ -lcore_lib
 
 INCLUDEPATH += $$PWD/../core_lib/src
+DEPENDPATH += $$PWD/../core_lib/src
 
-win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core_lib/release/libcore_lib.a
-else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core_lib/debug/libcore_lib.a
-else:win32:!win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core_lib/release/core_lib.lib
-else:win32:!win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core_lib/debug/core_lib.lib
-else:unix: PRE_TARGETDEPS += $$OUT_PWD/../core_lib/libcore_lib.a
+CONFIG(debug,debug|release) BUILDTYPE = debug
+CONFIG(release,debug|release) BUILDTYPE = release
+
+win32-msvc*{
+  LIBS += -L$$OUT_PWD/../core_lib/$$BUILDTYPE/ -lcore_lib
+  PRE_TARGETDEPS += $$OUT_PWD/../core_lib/$$BUILDTYPE/core_lib.lib
+}
+
+win32-g++{
+  LIBS += -L$$OUT_PWD/../core_lib/ -lcore_lib
+  PRE_TARGETDEPS += $$OUT_PWD/../core_lib/libcore_lib.a
+}
+
+# --- mac os and linux
+unix {
+  LIBS += -L$$OUT_PWD/../core_lib/ -lcore_lib
+  PRE_TARGETDEPS += $$OUT_PWD/../core_lib/libcore_lib.a
+}

--- a/app/app.pro
+++ b/app/app.pro
@@ -198,9 +198,21 @@ win32-msvc*{
   PRE_TARGETDEPS += $$OUT_PWD/../core_lib/$$BUILDTYPE/core_lib.lib
 }
 
-win32-g++{
-  LIBS += -L$$OUT_PWD/../core_lib/ -lcore_lib
-  PRE_TARGETDEPS += $$OUT_PWD/../core_lib/libcore_lib.a
+
+# From 5.14, MinGW windows builds are not build with debug-release flag
+versionAtLeast(QT_VERSION, 5.14) {
+
+    win32-g++{
+      LIBS += -L$$OUT_PWD/../core_lib/ -lcore_lib
+      PRE_TARGETDEPS += $$OUT_PWD/../core_lib/libcore_lib.a
+    }
+
+} else {
+
+    win32-g++{
+      LIBS += -L$$OUT_PWD/../core_lib/$$BUILDTYPE/ -lcore_lib
+      PRE_TARGETDEPS += $$OUT_PWD/../core_lib/$$BUILDTYPE/libcore_lib.a
+    }
 }
 
 # --- mac os and linux

--- a/core_lib/src/miniz.cpp
+++ b/core_lib/src/miniz.cpp
@@ -2989,6 +2989,13 @@ void tinfl_decompressor_free(tinfl_decompressor *pDecomp)
 #if defined(_MSC_VER) || defined(__MINGW64__)
 #include <codecvt>
 #include <string>
+#endif
+
+#ifdef __MINGW64__
+#include <locale>
+#endif
+
+#if defined(_MSC_VER) || defined(__MINGW64__)
 static FILE *mz_fopen(const char *pFilename, const char *pMode)
 {
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -41,17 +41,37 @@ SOURCES += \
     src/test_bitmapimage.cpp \
     src/test_viewmanager.cpp
 
-# --- CoreLib ---
-win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../core_lib/release/ -lcore_lib
-else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../core_lib/debug/ -lcore_lib
-else:unix: LIBS += -L$$OUT_PWD/../core_lib/ -lcore_lib
+# --- core_lib ---
 
 INCLUDEPATH += $$PWD/../core_lib/src
 
-win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core_lib/release/libcore_lib.a
-else:win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core_lib/debug/libcore_lib.a
-else:win32:!win32-g++:CONFIG(release, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core_lib/release/core_lib.lib
-else:win32:!win32-g++:CONFIG(debug, debug|release): PRE_TARGETDEPS += $$OUT_PWD/../core_lib/debug/core_lib.lib
-else:unix: PRE_TARGETDEPS += $$OUT_PWD/../core_lib/libcore_lib.a
+CONFIG(debug,debug|release) BUILDTYPE = debug
+CONFIG(release,debug|release) BUILDTYPE = release
 
-macx: LIBS += -framework AppKit
+win32-msvc*{
+  LIBS += -L$$OUT_PWD/../core_lib/$$BUILDTYPE/ -lcore_lib
+  PRE_TARGETDEPS += $$OUT_PWD/../core_lib/$$BUILDTYPE/core_lib.lib
+}
+
+
+# From 5.14, MinGW windows builds are not build with debug-release flag
+versionAtLeast(QT_VERSION, 5.14) {
+
+    win32-g++{
+      LIBS += -L$$OUT_PWD/../core_lib/ -lcore_lib
+      PRE_TARGETDEPS += $$OUT_PWD/../core_lib/libcore_lib.a
+    }
+
+} else {
+
+    win32-g++{
+      LIBS += -L$$OUT_PWD/../core_lib/$$BUILDTYPE/ -lcore_lib
+      PRE_TARGETDEPS += $$OUT_PWD/../core_lib/$$BUILDTYPE/libcore_lib.a
+    }
+}
+
+# --- mac os and linux
+unix {
+  LIBS += -L$$OUT_PWD/../core_lib/ -lcore_lib
+  PRE_TARGETDEPS += $$OUT_PWD/../core_lib/libcore_lib.a
+}

--- a/util/after-build.ps1
+++ b/util/after-build.ps1
@@ -68,7 +68,7 @@ if ($upload -ne "yes") {
   exit 0
 }
 
-echo ">>> Uplaod to Google drive"
+echo ">>> Upload to Google drive"
 cd $PSScriptRoot
 
 $python3 = if (Test-Path env:PYTHON) { "$env:PYTHON\python.exe" } else { "python.exe" }


### PR DESCRIPTION
Now that I've got a windows dev environment up and running I was able to reproduce those obscure compiler errors that @Jose-Moreno has been mentioning for a while.

The first part of the problem is that mingw does not use release and debug destination folder by default, so I've restructured the project file to use only that when it's msvc and none when it's g++

The second problem came from an earlier change we've made to the miniz library to fix some encoding issues.. that's good and all but it didn't compile with mingw64... so I looked online and found out that for g++, the ```<locale>``` header is needed. Please verify that it comples on both linux and windows still. I've tested it on my windows machine with MinGW but not MSVC.