### PR TITLE
Fix playback audio sync issues

### DIFF
--- a/core_lib/src/soundplayer.cpp
+++ b/core_lib/src/soundplayer.cpp
@@ -16,6 +16,8 @@ GNU General Public License for more details.
 
 #include "soundplayer.h"
 #include <QMediaPlayer>
+#include <QBuffer>
+#include <QFile>
 #include "soundclip.h"
 
 SoundPlayer::SoundPlayer( )
@@ -33,7 +35,14 @@ void SoundPlayer::init( SoundClip* clip )
     mSoundClip = clip;
 
     mMediaPlayer = new QMediaPlayer( this );
-    mMediaPlayer->setMedia( QUrl::fromLocalFile( clip->fileName() ) );
+
+    QFile file(clip->fileName());
+    file.open(QIODevice::ReadOnly);
+    QBuffer *buffer = new QBuffer();
+    buffer->setData(file.readAll());
+    buffer->open(QBuffer::ReadOnly);
+
+    mMediaPlayer->setMedia( QUrl::fromLocalFile( clip->fileName() ), buffer );
     makeConnections();
 
     clip->attachPlayer( this );


### PR DESCRIPTION
This PR loads and keeps audio files in memory, and also fixes two small coding errors which were also causing audio delays. I am perhaps overly optimistic that this will completely fix #1179, #1227, #1298, and the many user complaints we've had everywhere else. This code still needs to be tested on Windows where the issue seems to be worst.

Assuming this works as I expect it to, the only remaining known issue with playback audio synchronization will occur when Pencil2D is not scrubbing at the target frame rate (either because it's set too high or the computer cannot process the frames fast enough).