### PR TITLE
LayerVisibility updated in settings. 

### DIFF
--- a/app/src/preferencesdialog.cpp
+++ b/app/src/preferencesdialog.cpp
@@ -427,6 +427,7 @@ void TimelinePage::updateValues()
 
     int visibilityType = mManager->getInt(SETTING::LAYER_VISIBILITY);
     ui->layerVisibilityComboBox->setCurrentIndex(visibilityType);
+    layerVisibilityChanged(visibilityType);
 }
 
 void TimelinePage::timelineLengthChanged(int value)
@@ -447,6 +448,8 @@ void TimelinePage::scrubChanged(int value)
 void TimelinePage::layerVisibilityChanged(int value)
 {
     mManager->set(SETTING::LAYER_VISIBILITY, value);
+    ui->visibilitySlider->setEnabled(value == 1);
+    ui->visibilitySpinbox->setEnabled(value == 1);
 }
 
 void TimelinePage::layerVisibilityThresholdChanged(int value)

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1478,34 +1478,17 @@ void ScribbleArea::setLayerVisibility(LayerVisibility visibility)
     updateAllFrames();
 }
 
-void ScribbleArea::updateLayerVisibility()
-{
-    switch (mLayerVisibility) {
-    case LayerVisibility::ALL:
-        mEditor->preference()->set(SETTING::LAYER_VISIBILITY, 0);
-        break;
-    case LayerVisibility::RELATED:
-        mEditor->preference()->set(SETTING::LAYER_VISIBILITY, 1);
-        break;
-    case LayerVisibility::CURRENTONLY:
-        mEditor->preference()->set(SETTING::LAYER_VISIBILITY, 2);
-        break;
-    default:
-        break;
-    }
-}
-
 void ScribbleArea::increaseLayerVisibilityIndex()
 {
     ++mLayerVisibility;
-    updateLayerVisibility();
+    mPrefs->set(SETTING::LAYER_VISIBILITY, static_cast<int>(mLayerVisibility));
     updateAllFrames();
 }
 
 void ScribbleArea::decreaseLayerVisibilityIndex()
 {
     --mLayerVisibility;
-    updateLayerVisibility();
+    mPrefs->set(SETTING::LAYER_VISIBILITY, static_cast<int>(mLayerVisibility));
     updateAllFrames();
 }
 

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1478,15 +1478,34 @@ void ScribbleArea::setLayerVisibility(LayerVisibility visibility)
     updateAllFrames();
 }
 
+void ScribbleArea::updateLayerVisibility()
+{
+    switch (mLayerVisibility) {
+    case LayerVisibility::ALL:
+        mEditor->preference()->set(SETTING::LAYER_VISIBILITY, 0);
+        break;
+    case LayerVisibility::RELATED:
+        mEditor->preference()->set(SETTING::LAYER_VISIBILITY, 1);
+        break;
+    case LayerVisibility::CURRENTONLY:
+        mEditor->preference()->set(SETTING::LAYER_VISIBILITY, 2);
+        break;
+    default:
+        break;
+    }
+}
+
 void ScribbleArea::increaseLayerVisibilityIndex()
 {
     ++mLayerVisibility;
+    updateLayerVisibility();
     updateAllFrames();
 }
 
 void ScribbleArea::decreaseLayerVisibilityIndex()
 {
     --mLayerVisibility;
+    updateLayerVisibility();
     updateAllFrames();
 }
 

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -130,6 +130,7 @@ public slots:
     void increaseLayerVisibilityIndex();
     void decreaseLayerVisibilityIndex();
     void setLayerVisibility(LayerVisibility visibility);
+    void updateLayerVisibility();
 
     void updateToolCursor();
     void paletteColorChanged(QColor);

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -130,7 +130,6 @@ public slots:
     void increaseLayerVisibilityIndex();
     void decreaseLayerVisibilityIndex();
     void setLayerVisibility(LayerVisibility visibility);
-    void updateLayerVisibility();
 
     void updateToolCursor();
     void paletteColorChanged(QColor);


### PR DESCRIPTION
This PR updates the layer visibility in settings at all times.
In the Preferences, the slider and spinbox are disabled, when not in RELATIVE mode.
closes #1319 