### PR TITLE
Fix OnionSkinWidget Prev/Next Button Behavior

### DIFF
--- a/app/src/onionskinwidget.cpp
+++ b/app/src/onionskinwidget.cpp
@@ -77,6 +77,9 @@ void OnionSkinWidget::makeConnections()
     connect(ui->onionSkinMode, &QCheckBox::stateChanged, this, &OnionSkinWidget::onionSkinModeChange);
     connect(ui->onionWhilePlayback, &QCheckBox::stateChanged, this, &OnionSkinWidget::playbackStateChanged);
 
+    PreferenceManager* prefs = editor()->preference();
+    connect(prefs, &PreferenceManager::optionChanged, this, &OnionSkinWidget::updateUI);
+
 }
 
 void OnionSkinWidget::updateUI()


### PR DESCRIPTION
- The onion skin widget buttons that were bound to a shortcut weren't being updated by these shortcuts upon activation.
- It seems the updateUI method was missing the connection to the preference manager so this was added.

Thanks to CandyFace for the advice.