### PR TITLE
Preferencemanager updated when fps changes

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1372,6 +1372,7 @@ void MainWindow2::makeConnections(Editor* pEditor, TimeLine* pTimeline)
 
     connect(pTimeline, &TimeLine::soundClick, pPlaybackManager, &PlaybackManager::enableSound);
     connect(pTimeline, &TimeLine::fpsChanged, pPlaybackManager, &PlaybackManager::setFps);
+    connect(pTimeline, &TimeLine::fpsChanged, pEditor, &Editor::setFps);
 
     connect(pTimeline, &TimeLine::addKeyClick, mCommands, &ActionCommands::addNewKey);
     connect(pTimeline, &TimeLine::removeKeyClick, mCommands, &ActionCommands::removeKey);

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -119,6 +119,11 @@ int Editor::fps()
     return mPlaybackManager->fps();
 }
 
+void Editor::setFps(int fps)
+{
+    mPreferenceManager->set(SETTING::FPS, fps);
+}
+
 void Editor::makeConnections()
 {
     connect(mPreferenceManager, &PreferenceManager::optionChanged, this, &Editor::settingUpdated);

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -89,6 +89,7 @@ public:
 
     int currentFrame();
     int fps();
+    void setFps(int fps);
 
     int  currentLayerIndex() { return mCurrentLayerIndex; }
     void setCurrentLayerIndex(int i);


### PR DESCRIPTION
While working on the sound scrub feature, I accidentally found out, that the preference manager is not updated when the fps changes. The playback manager is updated, but the preference manager get the fps from the file that loads with Pencil2D, and is not updated until next time it is opened.
It has had no impact on Pencil2D, but it prevented me from an enhancement I wanted, and thus it was discovered.