### PR TITLE
Fix #1033 Broken sound playback in AppImages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@
 #
 language: cpp
 compiler: g++
-sudo: required
 dist: trusty
 osx_image: xcode11.3
 
@@ -21,6 +20,7 @@ env:
     - DOXYFILE: $TRAVIS_BUILD_DIR/util/docs/Doxyfile-Travis
     - GH_REPO_REF: github.com/pencil2d/pencil-docs.git
     - DOXYGEN_OUTPUT_DIR: $TRAVIS_BUILD_DIR/docs
+    - MAKEFLAGS: -j2
 
 addons:
   apt:
@@ -38,23 +38,26 @@ addons:
       - qt59xmlpatterns
       - bsdtar
       - ffmpeg
+      - gstreamer1.0-plugins-base
+      - gstreamer1.0-plugins-good
+      - gstreamer1.0-plugins-bad
+      - gstreamer1.0-alsa
+      - gstreamer1.0-pulseaudio
       - doxygen
-      - doxygen-doc
-      - doxygen-latex
-      - doxygen-gui
       - graphviz
       - python3
       - python3-pip
 
 before_install:
   - echo "are changes related to source code?"
-  - bash $TRAVIS_BUILD_DIR/util/checkchanges.sh || travis_terminate 0;
+  - bash $TRAVIS_BUILD_DIR/util/checkchanges.sh || test "${FORCE_NIGHTLY_UPLOAD}" = "yes" || travis_terminate 0;
   - |
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
         brew update;
         brew install python3
-        brew install p7zip qt gpg;
+        brew install libarchive qt gpg;
         brew link qt --force;
+        export PATH="/usr/local/opt/libarchive/bin:$PATH"
     fi
 
 install:
@@ -85,80 +88,4 @@ script:
   - "$TRAVIS_BUILD_DIR/build/tests/tests"
 
 after_success:
-  - echo "look for build folder and zip file"
-  - ls
-  - 'if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      make INSTALL_ROOT="${PWD}/Pencil2D" install;
-      rm -rf Pencil2D/usr/lib;
-      echo "Creating AppImage...";
-      sed -i "/^Keywords\(\[[a-zA-Z_.@]\+\]\)\?=/d;/^Version=/cVersion=1.0" Pencil2D/usr/share/applications/pencil2d.desktop;
-      install -Dm755 /usr/bin/ffmpeg Pencil2D/usr/plugins/ffmpeg;
-      curl -fsSLO https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage;
-      chmod 755 linuxdeployqt-continuous-x86_64.AppImage;
-      LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu/pulseaudio" ./linuxdeployqt-continuous-x86_64.AppImage Pencil2D/usr/share/applications/pencil2d.desktop -executable=Pencil2D/usr/plugins/ffmpeg -extra-plugins=iconengines/libqsvgicon.so -appimage;
-      mv Pencil2D*.AppImage* "pencil2d-linux-$(date +"%Y-%m-%d").AppImage";
-     fi'
-  - 'if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      echo "cleaning...";
-      make clean;
-      mv bin Pencil2D;
-      cd Pencil2D;
-
-      echo "Copying ffmpeg plugin";
-      mkdir Pencil2D.app/Contents/MacOS/plugins;
-      wget -O ffmpeg.7z https://evermeet.cx/ffmpeg/getrelease/7z;
-      wget -O ffmpeg.7z.sig https://evermeet.cx/ffmpeg/getrelease/7z/sig;
-      echo "trusted-key 0x476C4B611A660874" > ~/.gnupg/gpg.conf;
-      curl https://evermeet.cx/ffmpeg/0x1A660874.asc | gpg --import;
-      gpg --verify ffmpeg.7z.sig ffmpeg.7z;
-      7z x ffmpeg.7z -o"Pencil2D.app/Contents/MacOS/plugins";
-      rm ffmpeg.7z ffmpeg.7z.sig;
-
-      echo "Copying necessary Qt frameworks";
-      macdeployqt Pencil2D.app;
-      echo "applying macdeployqt fix";
-      wget https://github.com/aurelien-rainone/macdeployqtfix/archive/master.zip; unzip -x master.zip; python $TRAVIS_BUILD_DIR/build/Pencil2D/macdeployqtfix-master/macdeployqtfix.py $TRAVIS_BUILD_DIR/build/Pencil2D/Pencil2D.app/Contents/MacOS/Pencil2D /usr/local/Cellar/qt/5.9.1/;
-      echo "Removing files";
-      rm -rf macdeployqtfix-master;
-      rm master.zip;
-      cd ..;
-      echo "Zipping...";
-      zip -r "pencil2d-mac-$(date +"%Y-%m-%d").zip" Pencil2D/;
-    fi'
-  - echo "zipping done"
-  - ls
-
-  # Upload to google drive
-  - 'if [ \( "$TRAVIS_BRANCH" == "master" -o "$TRAVIS_BRANCH" == "release" \) -o "$FORCE_NIGHTLY_UPLOAD" == "yes" ]; then
-    echo "Initiate deployment on Google Drive";
-    cd "$TRAVIS_BUILD_DIR/util";
-    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      python3 nightly-build-upload.py "$LINUX_NIGHTLY_PARENT" "$TRAVIS_BUILD_DIR/build/pencil2d-linux-$(date +"%Y-%m-%d").AppImage";
-    fi;
-    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      python3 nightly-build-upload.py "$OSX_NIGHTLY_PARENT" "$TRAVIS_BUILD_DIR/build/pencil2d-mac-$(date +"%Y-%m-%d").zip";
-    fi;
-    echo "Operation done";
-  fi'
-  # Upload internal pull request to google drive
-  - 'if [ "$TRAVIS_PULL_REQUEST_SLUG" == "pencil2d/pencil" ]; then
-    echo "Initiate deployment on Google Drive";
-    cd "$TRAVIS_BUILD_DIR/util";
-    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      mv "$TRAVIS_BUILD_DIR/build/pencil2d-linux-$(date +"%Y-%m-%d").AppImage" "$TRAVIS_BUILD_DIR/build/pencil2d-linux-pr-$TRAVIS_PULL_REQUEST.AppImage";
-      python3 pr-build-upload.py "$LINUX_PR_PARENT" "$TRAVIS_BUILD_DIR/build/pencil2d-linux-pr-$TRAVIS_PULL_REQUEST.AppImage";
-    fi;
-    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      mv "$TRAVIS_BUILD_DIR/build/pencil2d-mac-$(date +"%Y-%m-%d").zip" "$TRAVIS_BUILD_DIR/build/pencil2d-mac-pr-$TRAVIS_PULL_REQUEST.zip";
-      python3 pr-build-upload.py "$OSX_PR_PARENT" "$TRAVIS_BUILD_DIR/build/pencil2d-mac-pr-$TRAVIS_PULL_REQUEST.zip";
-    fi;
-  fi'
-
-  # Deploy doxygen documentation to github pages
-  - 'if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_OS_NAME" == "linux" ]; then
-      cd "$TRAVIS_BUILD_DIR/util/docs";
-      for i in core svg xmlpatterns; do
-        curl -fsSLO "https://doc.qt.io/qt-5/qt$i.tags";
-      done;
-      ./documentation-deploy.sh;
-    fi'
+  - '"${TRAVIS_BUILD_DIR}/util/after-build.sh"'

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -32,6 +32,29 @@ GNU General Public License for more details.
 #include "platformhandler.h"
 
 
+#ifdef Q_OS_LINUX
+/**
+ * If running as an AppImage, sets GStreamer environment variables to ensure
+ * the plugins contained in the AppImage are found
+ */
+static void setupAppImageGStreamer()
+{
+    QString appDir = QString::fromLocal8Bit(qgetenv("APPDIR"));
+    if (!appDir.isEmpty()) {
+        bool success = qputenv("GST_PLUGIN_SYSTEM_PATH_1_0",
+                               QString("%1/usr/lib/gstreamer-1.0:%2")
+                                   .arg(appDir, QString::fromLocal8Bit(qgetenv("GST_PLUGIN_SYSTEM_PATH_1_0")))
+                                   .toLocal8Bit());
+        success = qputenv("GST_PLUGIN_SCANNER_1_0",
+                          QString("%1/usr/lib/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner")
+                             .arg(appDir).toLocal8Bit()) && success;
+        if (!success) {
+            qWarning() << "Unable to set up GStreamer environment";
+        }
+    }
+}
+#endif
+
 void installTranslator(PencilApplication& app)
 {
     QSettings setting(PENCIL2D, PENCIL2D);
@@ -320,6 +343,9 @@ int main(int argc, char* argv[])
     // uses comma as separator.
     std::setlocale(LC_NUMERIC, "en_US.UTF-8");
     Q_INIT_RESOURCE(core_lib);
+#ifdef Q_OS_LINUX
+    setupAppImageGStreamer();
+#endif
 
     QSettings settings(PENCIL2D, PENCIL2D);
 #ifdef Q_OS_MACOS

--- a/util/after-build.sh
+++ b/util/after-build.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+trap 'echo -e "\033[1m\033[31m==> ERROR:\033[0m \033[1mCommand failed\033[0m" >&2' ERR
+set -eE
+
+msg() {
+  echo -e "\033[1m\033[32m==>\033[0m \033[1m$1\033[0m"
+}
+
+package_linux() {
+  make install INSTALL_ROOT="${PWD}/Pencil2D"
+
+  msg "Creating AppImage..."
+  # "Downgrade" the desktop entry to version 1.0
+  sed -i "/^Keywords\(\[[a-zA-Z_.@]\+\]\)\?=/d;/^Version=/cVersion=1.0" \
+    Pencil2D/usr/share/applications/pencil2d.desktop
+  install -Dm755 /usr/bin/ffmpeg Pencil2D/usr/plugins/ffmpeg
+  install -Dm755 "/usr/lib/x86_64-linux-gnu/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner" \
+    "Pencil2D/usr/lib/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner"
+  local gst_executables="-executable=Pencil2D/usr/lib/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner"
+  for plugin in adpcmdec alsa app audioconvert audioparsers audioresample \
+      autodetect coreelements gsm id3demux jack mpg123 mulaw playback \
+      pulse typefindfunctions wavparse; do
+    install -Dm755 "/usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgst${plugin}.so" \
+      "Pencil2D/usr/lib/gstreamer-1.0/libgst${plugin}.so"
+    gst_executables="${gst_executables} -executable=Pencil2D/usr/lib/gstreamer-1.0/libgst${plugin}.so"
+  done
+  curl -fsSLO https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
+  chmod 755 linuxdeployqt-continuous-x86_64.AppImage
+  LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/lib/x86_64-linux-gnu/pulseaudio" \
+    ./linuxdeployqt-continuous-x86_64.AppImage \
+    Pencil2D/usr/share/applications/pencil2d.desktop \
+    -executable=Pencil2D/usr/plugins/ffmpeg \
+    ${gst_executables} \
+    -appimage
+  mv Pencil2D*.AppImage* "pencil2d-linux-$(date +%F).AppImage"
+  msg "AppImage created"
+}
+
+package_osx() {
+  msg "Cleaning..."
+  make clean
+  mv bin Pencil2D
+  pushd Pencil2D >/dev/null
+
+  msg "Copying FFmpeg plugin..."
+  mkdir Pencil2D.app/Contents/MacOS/plugins
+  curl -fsSLo ffmpeg.7z https://evermeet.cx/ffmpeg/getrelease/7z
+  curl -fsSLo ffmpeg.7z.sig https://evermeet.cx/ffmpeg/getrelease/7z/sig
+  echo "trusted-key 0x476C4B611A660874" > ~/.gnupg/gpg.conf
+  curl -fsSL https://evermeet.cx/ffmpeg/0x1A660874.asc | gpg --import
+  gpg --verify ffmpeg.7z.sig ffmpeg.7z
+  bsdtar xfC ffmpeg.7z Pencil2D.app/Contents/MacOS/plugins
+  rm ffmpeg.7z ffmpeg.7z.sig
+
+  msg "Copying required Qt frameworks..."
+  macdeployqt Pencil2D.app
+  msg "Applying macdeployqt fix..."
+  curl -fsSLO https://github.com/aurelien-rainone/macdeployqtfix/archive/master.zip
+  bsdtar xf master.zip
+  python "${TRAVIS_BUILD_DIR}/build/Pencil2D/macdeployqtfix-master/macdeployqtfix.py" \
+    "${TRAVIS_BUILD_DIR}/build/Pencil2D/Pencil2D.app/Contents/MacOS/Pencil2D" \
+    /usr/local/Cellar/qt/5.9.1/
+  msg "Removing files..."
+  rm -rf macdeployqtfix-master master.zip
+  popd >/dev/null
+  msg "Zipping..."
+  bsdtar caf "pencil2d-mac-$(date +%F).zip" Pencil2D
+  msg "Zipping done"
+}
+
+upload_default() {
+  cd "${TRAVIS_BUILD_DIR}/util"
+
+  msg "Starting upload to Google Drive..."
+  case "${TRAVIS_OS_NAME}" in
+    linux)
+      python3 nightly-build-upload.py "${LINUX_NIGHTLY_PARENT}" \
+        "${TRAVIS_BUILD_DIR}/build/pencil2d-linux-$(date +%F).AppImage"
+      ;;
+    osx)
+      python3 nightly-build-upload.py "${OSX_NIGHTLY_PARENT}" \
+        "${TRAVIS_BUILD_DIR}/build/pencil2d-mac-$(date +%F).zip"
+      ;;
+  esac
+  msg "Upload complete"
+}
+
+upload_pr() {
+  cd "${TRAVIS_BUILD_DIR}/util"
+
+  msg "Starting upload to Google Drive..."
+  case "${TRAVIS_OS_NAME}" in
+    linux)
+      mv "${TRAVIS_BUILD_DIR}/build/pencil2d-linux-$(date +%F).AppImage" \
+        "${TRAVIS_BUILD_DIR}/build/pencil2d-linux-pr-${TRAVIS_PULL_REQUEST}.AppImage"
+      python3 pr-build-upload.py "${LINUX_PR_PARENT}" \
+        "${TRAVIS_BUILD_DIR}/build/pencil2d-linux-pr-${TRAVIS_PULL_REQUEST}.AppImage"
+      ;;
+    osx)
+      mv "${TRAVIS_BUILD_DIR}/build/pencil2d-mac-$(date +%F).zip" \
+        "${TRAVIS_BUILD_DIR}/build/pencil2d-mac-pr-${TRAVIS_PULL_REQUEST}.zip"
+      python3 pr-build-upload.py "${OSX_PR_PARENT}" \
+        "${TRAVIS_BUILD_DIR}/build/pencil2d-mac-pr-${TRAVIS_PULL_REQUEST}.zip"
+      ;;
+  esac
+  msg "Upload complete"
+}
+
+deploy_docs() {
+  cd "${TRAVIS_BUILD_DIR}/util/docs"
+
+  msg "Updating online documentation..."
+  for i in core svg xmlpatterns; do
+    curl -fsSLO "https://doc.qt.io/qt-5/qt${i}.tags"
+  done
+
+  ./documentation-deploy.sh
+  msg "Documentation updated"
+}
+
+"package_${TRAVIS_OS_NAME}"
+
+if [ "${TRAVIS_BRANCH}" = "master" ] || [ "${TRAVIS_BRANCH}" = "release" ] || [ "${FORCE_NIGHTLY_UPLOAD}" = "yes" ]; then
+  upload_default
+fi
+
+if [ "${TRAVIS_PULL_REQUEST_SLUG}" = "pencil2d/pencil" ]; then
+  upload_pr
+fi
+
+if [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+  deploy_docs
+fi


### PR DESCRIPTION
Took me long enough to figure out, but it’s finally here. To avoid insane amounts (~30MB) of bloat I had to pick the GStreamer plugins to distribute by hand, so there’s a chance I missed something, but I think most cases should be taken care of. Nonetheless, I think the most valuable “review” that can be done on this is trying it out on any nearby Linux systems. A build is available [here](https://drive.google.com/open?id=1h3JB80ZAv1ApcOQvzMqvu0E2UUkid1ng).

In addition to the sound stuff I also did some rework of the Travis setup, mostly by relocating the post-build instructions into a separate script (à la AppVeyor). The Doxygen packages I removed are required according to the deploy script, but personally I’m quite skeptical about that. The documentation certainly built fine without them for me locally.

One change that proved unexpectedly effective is the switch to bsdtar on macOS. I originally did this only because I disliked that the script used several different tools for handling archives. However, as it turns out, it resulted in noticeably smaller (~40%) files because the zip tool that was previously used apparently doesn’t support symlinks, so symlinked files had three identical copies included in the archive. Of course, since the zip tool doesn’t support symlinks, there is a chance that other tools don’t support them either, so it’d be great if one of you macOS guys could grab the build [here](https://drive.google.com/open?id=1pohQRL4VZkjyV3yTqfbaVloqNRtHDP3D) and check if whatever Apple’s default ZIP extraction tool is can handle them correctly.