### PR TITLE
1250 Updating ui correct during transformation

### DIFF
--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -230,8 +230,7 @@ void TimeLine::initUI()
 
 void TimeLine::updateUI()
 {
-    mTracks->update();
-    mLayerList->update();
+    updateContent();
 }
 
 int TimeLine::getLength()


### PR DESCRIPTION
If you were in the middle of moving a selection and wanted to add a keyframe, the timeline didn't update properly.
Closes #1250 