### PR TITLE
Add an action to open Pencil2D's temporary directory

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -911,6 +911,16 @@ void ActionCommands::checkForUpdates()
     dialog.exec();
 }
 
+// This action is a temporary measure until we have an automated recover mechanism in place
+void ActionCommands::openTemporaryDirectory()
+{
+    int ret = QMessageBox::warning(mParent, tr("Warning"), tr("The temporary directory is meant to be used only by Pencil2D. Do not modify it unless you know what you are doing."), QMessageBox::Cancel, QMessageBox::Ok);
+    if (ret == QMessageBox::Ok)
+    {
+        QDesktopServices::openUrl(QUrl::fromLocalFile(QDir::temp().filePath("Pencil2D")));
+    }
+}
+
 void ActionCommands::about()
 {
     AboutDialog* aboutBox = new AboutDialog(mParent);

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -90,6 +90,7 @@ public:
     void discord();
     void reportbug();
     void checkForUpdates();
+    void openTemporaryDirectory();
     void about();
 
 private:

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -395,6 +395,7 @@ void MainWindow2::createMenus()
     connect(ui->actionDiscord, &QAction::triggered, mCommands, &ActionCommands::discord);
     connect(ui->actionCheck_for_Updates, &QAction::triggered, mCommands, &ActionCommands::checkForUpdates);
     connect(ui->actionReport_Bug, &QAction::triggered, mCommands, &ActionCommands::reportbug);
+    connect(ui->actionOpen_Temporary_Directory, &QAction::triggered, mCommands, &ActionCommands::openTemporaryDirectory);
     connect(ui->actionAbout, &QAction::triggered, mCommands, &ActionCommands::about);
 
     //--- Menus ---

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
+    <width>831</width>
     <height>600</height>
    </rect>
   </property>
@@ -48,8 +48,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>800</width>
-     <height>19</height>
+     <width>831</width>
+     <height>41</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -254,6 +254,7 @@
     <addaction name="separator"/>
     <addaction name="actionCheck_for_Updates"/>
     <addaction name="actionReport_Bug"/>
+    <addaction name="actionOpen_Temporary_Directory"/>
     <addaction name="separator"/>
     <addaction name="actionAbout"/>
    </widget>
@@ -1022,7 +1023,7 @@
   <action name="actionImport_MovieAudio">
    <property name="text">
     <string>Movie Audio...</string>
-    </property>
+   </property>
   </action>
   <action name="actionImport_Append_Palette">
    <property name="text">
@@ -1078,6 +1079,11 @@
    </property>
    <property name="toolTip">
     <string>Onion Skins</string>
+   </property>
+  </action>
+  <action name="actionOpen_Temporary_Directory">
+   <property name="text">
+    <string>Open Temporary Directory</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Implemented as discussed. It is an action in the Help menu, and when clicked, it produces a warning message before opening the user directory. Works on Ubuntu, should be tested on other platforms.