### PR TITLE
Speed up compilation with precompiled headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Makefile*
 *-build-*
 .moc
 moc_predefs.h
+*-pch.h.cpp
 
 Makefile
 Makefile.Debug

--- a/app/app.pro
+++ b/app/app.pro
@@ -12,7 +12,7 @@ TEMPLATE = app
 TARGET = pencil2d
 QMAKE_APPLICATION_BUNDLE_NAME = Pencil2D
 
-CONFIG += qt
+CONFIG += qt precompile_header
 
 DESTDIR = ../bin
 
@@ -37,7 +37,10 @@ INCLUDEPATH += \
     ../core_lib/src/managers \
     ../core_lib/src/external
 
+PRECOMPILED_HEADER = src/app-pch.h
+
 HEADERS += \
+    src/app-pch.h \
     src/importlayersdialog.h \
     src/importpositiondialog.h \
     src/mainwindow2.h \

--- a/app/src/app-pch.h
+++ b/app/src/app-pch.h
@@ -1,0 +1,9 @@
+/* Add C includes here */
+
+#if defined __cplusplus
+/* Add C++ includes here */
+
+#include <QObject>
+#include <QString>
+#include <QWidget>
+#endif

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -29,6 +29,8 @@ GNU General Public License for more details.
 #include <QMessageBox>
 #include <QProgressDialog>
 #include <QTabletEvent>
+#include <QStandardPaths>
+#include <QDateTime>
 
 // core_lib headers
 #include "pencildef.h"

--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -9,7 +9,7 @@
 QT += core widgets gui xml xmlpatterns multimedia svg
 
 TEMPLATE = lib
-CONFIG += qt staticlib
+CONFIG += qt staticlib precompile_header
 
 RESOURCES += data/core_lib.qrc
 
@@ -28,8 +28,10 @@ INCLUDEPATH += src \
     src/managers \
     src/external
 
-# Input
+PRECOMPILED_HEADER = src/corelib-pch.h
+
 HEADERS +=  \
+    src/corelib-pch.h \
     src/graphics/bitmap/bitmapimage.h \
     src/graphics/vector/bezierarea.h \
     src/graphics/vector/beziercurve.h \

--- a/core_lib/src/canvaspainter.cpp
+++ b/core_lib/src/canvaspainter.cpp
@@ -16,6 +16,7 @@ GNU General Public License for more details.
 
 #include "canvaspainter.h"
 
+#include <QtMath>
 #include "object.h"
 #include "layerbitmap.h"
 #include "layervector.h"

--- a/core_lib/src/corelib-pch.h
+++ b/core_lib/src/corelib-pch.h
@@ -1,0 +1,10 @@
+
+/* Add C includes here */
+
+#if defined __cplusplus
+/* Add C++ includes here */
+
+#include <QObject>
+#include <QString>
+#include <QList>
+#endif

--- a/core_lib/src/graphics/vector/bezierarea.cpp
+++ b/core_lib/src/graphics/vector/bezierarea.cpp
@@ -17,8 +17,10 @@ GNU General Public License for more details.
 
 
 #include "bezierarea.h"
-
 #include "pencilerror.h"
+
+#include <QXmlStreamWriter>
+#include <QDomElement>
 
 BezierArea::BezierArea()
 {
@@ -85,7 +87,7 @@ Status BezierArea::createDomElement( QXmlStreamWriter& xmlStream )
     return Status::OK;
 }
 
-void BezierArea::loadDomElement(QDomElement element)
+void BezierArea::loadDomElement(const QDomElement& element)
 {
     mColourNumber = element.attribute("colourNumber").toInt();
 

--- a/core_lib/src/graphics/vector/bezierarea.h
+++ b/core_lib/src/graphics/vector/bezierarea.h
@@ -18,12 +18,14 @@ GNU General Public License for more details.
 #define BEZIERAREA_H
 
 
-#include <QtXml>
 #include <QPainterPath>
 
 #include "vertexref.h"
 
 class Status;
+class QXmlStreamWriter;
+class QDomElement;
+
 
 class BezierArea
 {
@@ -32,7 +34,7 @@ public:
     BezierArea(QList<VertexRef> vertexList, int colour);
 
     Status createDomElement(QXmlStreamWriter& xmlStream);
-    void loadDomElement(QDomElement element);
+    void loadDomElement(const QDomElement& element);
 
     VertexRef getVertexRef(int i);
     int getColourNumber() { return mColourNumber; }

--- a/core_lib/src/graphics/vector/beziercurve.cpp
+++ b/core_lib/src/graphics/vector/beziercurve.cpp
@@ -19,6 +19,9 @@ GNU General Public License for more details.
 
 #include <cmath>
 #include <QList>
+#include <QXmlStreamWriter>
+#include <QDomElement>
+#include <QDebug>
 #include "object.h"
 #include "pencilerror.h"
 
@@ -140,7 +143,7 @@ Status BezierCurve::createDomElement( QXmlStreamWriter& xmlStream )
     return Status::OK;
 }
 
-void BezierCurve::loadDomElement(QDomElement element)
+void BezierCurve::loadDomElement(const QDomElement& element)
 {
     width = element.attribute("width").toDouble();
     variableWidth = (element.attribute("variableWidth") == "1") || (element.attribute("variableWidth") == "true");

--- a/core_lib/src/graphics/vector/beziercurve.h
+++ b/core_lib/src/graphics/vector/beziercurve.h
@@ -16,11 +16,12 @@ GNU General Public License for more details.
 #ifndef BEZIERCURVE_H
 #define BEZIERCURVE_H
 
-#include <QtXml>
 #include <QPainter>
 
 class Object;
 class Status;
+class QXmlStreamWriter;
+class QDomElement;
 
 struct Intersection
 {
@@ -37,7 +38,7 @@ public:
     explicit BezierCurve(const QList<QPointF>& pointList, const QList<qreal>& pressureList, double tol, bool smooth=true);
 
     Status createDomElement(QXmlStreamWriter &xmlStream);
-    void loadDomElement(QDomElement element);
+    void loadDomElement(const QDomElement& element);
 
     qreal getWidth() const { return width; }
     qreal getFeather() const { return feather; }

--- a/core_lib/src/graphics/vector/vectorimage.cpp
+++ b/core_lib/src/graphics/vector/vectorimage.cpp
@@ -18,6 +18,10 @@ GNU General Public License for more details.
 
 #include <cmath>
 #include <QImage>
+#include <QFile>
+#include <QFileInfo>
+#include <QDebug>
+#include <QXmlStreamWriter>
 #include "object.h"
 
 

--- a/core_lib/src/graphics/vector/vectorimage.h
+++ b/core_lib/src/graphics/vector/vectorimage.h
@@ -18,7 +18,6 @@ GNU General Public License for more details.
 #define VECTORIMAGE_H
 
 #include <QTransform>
-#include <QStringList>
 
 #include "bezierarea.h"
 #include "beziercurve.h"

--- a/core_lib/src/interface/backupelement.h
+++ b/core_lib/src/interface/backupelement.h
@@ -32,12 +32,12 @@ public:
     enum types { UNDEFINED, BITMAP_MODIF, VECTOR_MODIF, SOUND_MODIF };
 
     QString undoText;
-    bool somethingSelected;
-    qreal rotationAngle;
+    bool somethingSelected = false;
+    qreal rotationAngle = 0.0;
     QRectF mySelection, myTransformedSelection, myTempTransformedSelection;
 
     virtual int type() { return UNDEFINED; }
-    virtual void restore(Editor*) { qDebug() << "Wrong"; }
+    virtual void restore(Editor*) { Q_ASSERT(false); }
 };
 
 class BackupBitmapElement : public BackupElement
@@ -46,7 +46,8 @@ class BackupBitmapElement : public BackupElement
 public:
     BackupBitmapElement(BitmapImage* bi) { bitmapImage = bi->copy(); }
 
-    int layer, frame;
+    int layer = 0;
+    int frame = 0;
     BitmapImage bitmapImage;
     int type() { return BackupElement::BITMAP_MODIF; }
     void restore(Editor*);
@@ -57,7 +58,8 @@ class BackupVectorElement : public BackupElement
     Q_OBJECT
 public:
     BackupVectorElement(VectorImage* vi) { vectorImage = *vi; }
-    int layer, frame;
+    int layer = 0;
+    int frame = 0;
     VectorImage vectorImage;
 
     int type() { return BackupElement::VECTOR_MODIF; }
@@ -69,7 +71,8 @@ class BackupSoundElement : public BackupElement
     Q_OBJECT
 public:
     BackupSoundElement(SoundClip* sound) { clip = *sound; }
-    int layer, frame;
+    int layer = 0;
+    int frame = 0;
     SoundClip clip;
     QString fileName;
 

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -25,6 +25,7 @@ GNU General Public License for more details.
 #include <QImageReader>
 #include <QDragEnterEvent>
 #include <QDropEvent>
+#include <QMimeData>
 
 #include "object.h"
 #include "objectdata.h"

--- a/core_lib/src/interface/flowlayout.cpp
+++ b/core_lib/src/interface/flowlayout.cpp
@@ -48,7 +48,9 @@
 **
 ****************************************************************************/
 
-#include <QtWidgets>
+#include <QWidget>
+#include <QLayout>
+#include <QtMath>
 
 #include "flowlayout.h"
 //! [1]

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -39,7 +39,6 @@ GNU General Public License for more details.
 #include "viewmanager.h"
 #include "selectionmanager.h"
 
-
 ScribbleArea::ScribbleArea(QWidget* parent) : QWidget(parent),
 mLog("ScribbleArea")
 {

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -25,7 +25,6 @@ GNU General Public License for more details.
 #include <memory>
 
 #include <QColor>
-#include <QTransform>
 #include <QPoint>
 #include <QWidget>
 #include <QPixmapCache>
@@ -34,8 +33,6 @@ GNU General Public License for more details.
 #include "log.h"
 #include "pencildef.h"
 #include "bitmapimage.h"
-#include "colourref.h"
-#include "vectorselection.h"
 #include "canvaspainter.h"
 #include "preferencemanager.h"
 #include "strokemanager.h"
@@ -47,6 +44,7 @@ class BaseTool;
 class PointerEvent;
 class BitmapImage;
 class VectorImage;
+
 
 class ScribbleArea : public QWidget
 {
@@ -225,10 +223,9 @@ private:
     int mDoubleClickMillis = 0;
     // Microsoft suggests that a double click action should be no more than 500 ms
     const int DOUBLE_CLICK_THRESHOLD = 500;
-    QTimer* mDoubleClickTimer;
+    QTimer* mDoubleClickTimer = nullptr;
 
     QPoint mCursorCenterPos;
-
     QPointF mTransformedCursorPos;
 
     //instant tool (temporal eg. eraser)

--- a/core_lib/src/interface/timecontrols.cpp
+++ b/core_lib/src/interface/timecontrols.cpp
@@ -17,8 +17,8 @@ GNU General Public License for more details.
 
 #include "timecontrols.h"
 
-#include <QtGui>
 #include <QLabel>
+#include <QSettings>
 
 #include "editor.h"
 #include "playbackmanager.h"

--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #include <QResizeEvent>
 #include <QMouseEvent>
 #include <QInputDialog>
+#include <QPainter>
 
 #include "object.h"
 #include "editor.h"

--- a/core_lib/src/movieexporter.cpp
+++ b/core_lib/src/movieexporter.cpp
@@ -26,6 +26,7 @@ GNU General Public License for more details.
 #include <QStandardPaths>
 #include <QThread>
 #include <QtMath>
+#include <QPainter>
 
 #include "object.h"
 #include "layercamera.h"

--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -18,6 +18,8 @@ GNU General Public License for more details.
 
 #include <QDebug>
 #include <QSettings>
+#include <QPainter>
+#include <QDomElement>
 #include "keyframe.h"
 #include "object.h"
 #include "timelinecells.h"
@@ -709,7 +711,7 @@ QDomElement Layer::createBaseDomElement(QDomDocument& doc)
     return layerTag;
 }
 
-void Layer::loadBaseDomElement(QDomElement& elem)
+void Layer::loadBaseDomElement(const QDomElement& elem)
 {
     if (!elem.attribute("id").isNull())
     {

--- a/core_lib/src/structure/layer.h
+++ b/core_lib/src/structure/layer.h
@@ -21,12 +21,13 @@ GNU General Public License for more details.
 #include <functional>
 #include <QObject>
 #include <QString>
-#include <QPainter>
 #include <QDomElement>
 #include "pencilerror.h"
 #include "pencildef.h"
 
 class QMouseEvent;
+class QPainter;
+
 class KeyFrame;
 class Object;
 class TimeLineCells;
@@ -67,10 +68,10 @@ public:
     void setVisible(bool b) { mVisible = b; }
 
     virtual Status saveKeyFrameFile(KeyFrame*, QString dataPath) = 0;
-    virtual void loadDomElement(QDomElement element, QString dataDirPath, ProgressCallback progressForward) = 0;
+    virtual void loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressForward) = 0;
     virtual QDomElement createDomElement(QDomDocument& doc) = 0;
     QDomElement createBaseDomElement(QDomDocument& doc);
-    void loadBaseDomElement(QDomElement& elem);
+    void loadBaseDomElement(const QDomElement& elem);
 
     // KeyFrame interface
     int getMaxKeyFramePosition() const;

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -180,7 +180,7 @@ QDomElement LayerBitmap::createDomElement(QDomDocument& doc)
     return layerElem;
 }
 
-void LayerBitmap::loadDomElement(QDomElement element, QString dataDirPath, ProgressCallback progressStep)
+void LayerBitmap::loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressStep)
 {
     this->loadBaseDomElement(element);
 

--- a/core_lib/src/structure/layerbitmap.h
+++ b/core_lib/src/structure/layerbitmap.h
@@ -31,7 +31,7 @@ public:
     ~LayerBitmap() override;
 
     QDomElement createDomElement(QDomDocument& doc) override;
-    void loadDomElement(QDomElement element, QString dataDirPath, ProgressCallback progressStep) override;
+    void loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressStep) override;
     Status presave(const QString& sDataFolder) override;
 
     BitmapImage* getBitmapImageAtFrame(int frameNumber);

--- a/core_lib/src/structure/layercamera.cpp
+++ b/core_lib/src/structure/layercamera.cpp
@@ -283,7 +283,7 @@ QDomElement LayerCamera::createDomElement( QDomDocument& doc )
     return layerElem;
 }
 
-void LayerCamera::loadDomElement(QDomElement element, QString dataDirPath, ProgressCallback progressStep)
+void LayerCamera::loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressStep)
 {
     Q_UNUSED(dataDirPath);
     Q_UNUSED(progressStep);

--- a/core_lib/src/structure/layercamera.h
+++ b/core_lib/src/structure/layercamera.h
@@ -57,7 +57,7 @@ public:
     
     void editProperties() override;
     QDomElement createDomElement(QDomDocument& doc) override;
-    void loadDomElement(QDomElement element, QString dataDirPath, ProgressCallback progressStep) override;
+    void loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressStep) override;
 
     Camera* getCameraAtFrame(int frameNumber);
     Camera* getLastCameraAtFrame(int frameNumber, int increment);

--- a/core_lib/src/structure/layersound.cpp
+++ b/core_lib/src/structure/layersound.cpp
@@ -86,7 +86,7 @@ QDomElement LayerSound::createDomElement(QDomDocument& doc)
     return layerElem;
 }
 
-void LayerSound::loadDomElement(QDomElement element, QString dataDirPath, ProgressCallback progressStep)
+void LayerSound::loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressStep)
 {
     this->loadBaseDomElement(element);
 

--- a/core_lib/src/structure/layersound.h
+++ b/core_lib/src/structure/layersound.h
@@ -30,7 +30,7 @@ public:
     LayerSound( Object* object );
     ~LayerSound();
     QDomElement createDomElement(QDomDocument& doc) override;
-    void loadDomElement(QDomElement element, QString dataDirPath, ProgressCallback progressStep) override;
+    void loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressStep) override;
 
     Status loadSoundClipAtFrame( const QString& sSoundClipName, const QString& filePathString, int frame );
     void updateFrameLengths(int fps);

--- a/core_lib/src/structure/layervector.cpp
+++ b/core_lib/src/structure/layervector.cpp
@@ -17,6 +17,9 @@ GNU General Public License for more details.
 #include "layervector.h"
 
 #include "vectorimage.h"
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
 
 
 LayerVector::LayerVector(Object* object) : Layer(object, Layer::VECTOR)
@@ -144,7 +147,7 @@ QDomElement LayerVector::createDomElement(QDomDocument& doc)
     return layerElem;
 }
 
-void LayerVector::loadDomElement(QDomElement element, QString dataDirPath, ProgressCallback progressStep)
+void LayerVector::loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressStep)
 {
     this->loadBaseDomElement(element);
 

--- a/core_lib/src/structure/layervector.h
+++ b/core_lib/src/structure/layervector.h
@@ -34,7 +34,7 @@ public:
     void loadImageAtFrame(QString strFileName, int);
 
     QDomElement createDomElement(QDomDocument& doc) override;
-    void loadDomElement(QDomElement element, QString dataDirPath, ProgressCallback progressStep) override;
+    void loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressStep) override;
 
     VectorImage* getVectorImageAtFrame(int frameNumber) const;
     VectorImage* getLastVectorImageAtFrame(int frameNumber, int increment) const;

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -21,6 +21,10 @@ GNU General Public License for more details.
 #include <QProgressDialog>
 #include <QApplication>
 #include <QFile>
+#include <QFileInfo>
+#include <QDir>
+#include <QDebug>
+#include <QDateTime>
 
 #include "layer.h"
 #include "layerbitmap.h"

--- a/core_lib/src/tool/basetool.cpp
+++ b/core_lib/src/tool/basetool.cpp
@@ -17,15 +17,15 @@ GNU General Public License for more details.
 
 #include "basetool.h"
 
-#include "pointerevent.h"
 #include <array>
 #include <QtMath>
+#include <QPixmap>
 #include "editor.h"
 #include "viewmanager.h"
 #include "toolmanager.h"
 #include "scribblearea.h"
 #include "strokemanager.h"
-
+#include "pointerevent.h"
 
 // ---- shared static variables ---- ( only one instance for all the tools )
 qreal BaseTool::msOriginalPropertyValue;  // start value (width, feather ..)

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -22,11 +22,11 @@ GNU General Public License for more details.
 #include <QString>
 #include <QCursor>
 #include <QPointF>
-#include <QPixmap>
 #include <QHash>
 #include "movemode.h"
 #include "pencildef.h"
 
+class QPixmap;
 class Editor;
 class ScribbleArea;
 class QKeyEvent;

--- a/core_lib/src/tool/brushtool.cpp
+++ b/core_lib/src/tool/brushtool.cpp
@@ -21,6 +21,7 @@ GNU General Public License for more details.
 #include <QSettings>
 #include <QPixmap>
 #include <QPainter>
+#include <QColor>
 
 #include "beziercurve.h"
 #include "vectorimage.h"

--- a/core_lib/src/tool/brushtool.h
+++ b/core_lib/src/tool/brushtool.h
@@ -19,6 +19,7 @@ GNU General Public License for more details.
 #define BRUSHTOOL_H
 
 #include "stroketool.h"
+#include <QColor>
 
 
 class BrushTool : public StrokeTool

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -18,6 +18,7 @@ GNU General Public License for more details.
 
 #include <QPixmap>
 #include <QPainter>
+#include <QtMath>
 #include "pointerevent.h"
 
 #include "layer.h"

--- a/core_lib/src/tool/strokemanager.cpp
+++ b/core_lib/src/tool/strokemanager.cpp
@@ -181,7 +181,7 @@ QPointF StrokeManager::interpolateStart(QPointF firstPoint)
         pressureQueue.clear();
     
         const int sampleSize = 5;
-        assert(sampleSize > 0);
+        Q_ASSERT(sampleSize > 0);
 
         // fill strokeQueue with firstPoint x times
         for (int i = sampleSize; i > 0; i--)
@@ -358,7 +358,7 @@ void StrokeManager::interpolateEnd()
             // TODO: Qt slider.
             int sampleSize = 5;
 
-            assert(sampleSize > 0);
+            Q_ASSERT(sampleSize > 0);
             for (int i = sampleSize; i > 0; i--)
             {
                 interpolatePoll();

--- a/core_lib/src/tool/strokemanager.h
+++ b/core_lib/src/tool/strokemanager.h
@@ -18,16 +18,14 @@ GNU General Public License for more details.
 #ifndef STROKEMANAGER_H
 #define STROKEMANAGER_H
 
+#include <ctime>
 #include <QQueue>
 #include <QPointF>
 #include <QList>
-#include <QPoint>
-#include <time.h>
-#include <QTabletEvent>
 #include <QTimer>
 #include <QElapsedTimer>
 #include "object.h"
-#include "assert.h"
+
 
 class PointerEvent;
 

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -17,6 +17,7 @@ GNU General Public License for more details.
 
 #include "stroketool.h"
 
+#include <QKeyEvent>
 #include "scribblearea.h"
 #include "strokemanager.h"
 #include "viewmanager.h"


### PR DESCRIPTION
Precompiled headers can reduce build time significantly. 

In this PR, I tried:
1. Add precompiled headers to app & core_lib
2. Minimise the header includes in .h files
3. Use forward declaration as much as possible

On my laptop, the build time of a Release full rebuild goes down from 167 sec to 75 sec.

It also helps our CI:
- Travis CI Linux: 5 min 38 sec -> 4 min 43 sec
- Travis CI Mac: 7 min 33 sec -> 5 min 15 sec
- AppVeyor Win32: 12 min 23 sec ->  8 min 13 sec
- AppVeyor Win64: 13 min 16 sec -> 9 min 49 sec




