### PR TITLE
Change: Colour -> Color (Filenames and file content)

### DIFF
--- a/app/src/colorpalettewidget.cpp
+++ b/app/src/colorpalettewidget.cpp
@@ -36,7 +36,7 @@ GNU General Public License for more details.
 #include <QAbstractItemModel>
 
 // Project
-#include "colourref.h"
+#include "colorref.h"
 #include "object.h"
 #include "editor.h"
 #include "colorbox.h"
@@ -92,7 +92,7 @@ void ColorPaletteWidget::initUI()
     connect(ui->colorListWidget, &QListWidget::itemClicked, this, &ColorPaletteWidget::clickColorListItem);
     connect(ui->colorListWidget->model(), &QAbstractItemModel::rowsMoved, this, &ColorPaletteWidget::onRowsMoved);
 
-    connect(ui->colorListWidget, &QListWidget::itemDoubleClicked, this, &ColorPaletteWidget::changeColourName);
+    connect(ui->colorListWidget, &QListWidget::itemDoubleClicked, this, &ColorPaletteWidget::changeColorName);
     connect(ui->colorListWidget, &QListWidget::itemChanged, this, &ColorPaletteWidget::onItemChanged);
 
     connect(ui->addColorButton, &QPushButton::clicked, this, &ColorPaletteWidget::clickAddColorButton);
@@ -131,14 +131,14 @@ void ColorPaletteWidget::showContextMenu(const QPoint& pos)
 void ColorPaletteWidget::addItem()
 {
     QSignalBlocker b(ui->colorListWidget);
-    QColor newColour = mEditor->color()->frontColor();
+    QColor newColor = mEditor->color()->frontColor();
 
     // add in front of selected color
     int colorIndex = ui->colorListWidget->currentRow()+1;
 
-    ColourRef ref(newColour);
+    ColorRef ref(newColor);
 
-    mObject->addColourAtIndex(colorIndex, ref);
+    mObject->addColorAtIndex(colorIndex, ref);
     refreshColorList();
     if (mFitSwatches)
     {
@@ -151,12 +151,12 @@ void ColorPaletteWidget::replaceItem()
     QSignalBlocker b(ui->colorListWidget);
     int index = ui->colorListWidget->currentRow();
 
-    QColor newColour = mEditor->color()->frontColor();
+    QColor newColor = mEditor->color()->frontColor();
 
     if (index >= 0)
     {
-        updateItemColor(index, newColour);
-        emit colorChanged(newColour);
+        updateItemColor(index, newColor);
+        emit colorChanged(newColor);
         ui->colorListWidget->setCurrentRow(index);
     }
 }
@@ -183,7 +183,7 @@ void ColorPaletteWidget::selectColorNumber(int colorNumber)
     ui->colorListWidget->setCurrentRow(colorNumber);
 }
 
-int ColorPaletteWidget::currentColourNumber()
+int ColorPaletteWidget::currentColorNumber()
 {
     if (ui->colorListWidget->currentRow() < 0)
     {
@@ -200,11 +200,11 @@ void ColorPaletteWidget::refreshColorList()
         ui->colorListWidget->clear();
     }
 
-    QPixmap originalColourSwatch(mIconSize);
-    QPainter swatchPainter(&originalColourSwatch);
+    QPixmap originalColorSwatch(mIconSize);
+    QPainter swatchPainter(&originalColorSwatch);
     swatchPainter.drawTiledPixmap(0, 0, mIconSize.width(), mIconSize.height(), QPixmap(":/background/checkerboard.png"));
     swatchPainter.end();
-    QPixmap colourSwatch;
+    QPixmap colorSwatch;
     QPen borderShadow(QColor(0, 0, 0, 200), 1, Qt::DotLine, Qt::FlatCap, Qt::MiterJoin);
     QVector<qreal> dashPattern;
     dashPattern << 4 << 4;
@@ -213,27 +213,27 @@ void ColorPaletteWidget::refreshColorList()
     borderHighlight.setColor(QColor(255, 255, 255, 200));
     borderHighlight.setDashOffset(4);
 
-    int colourCount = mObject->getColourCount();
+    int colorCount = mObject->getColorCount();
 
-    for (int i = 0; i < colourCount; i++)
+    for (int i = 0; i < colorCount; i++)
     {
-        const ColourRef colourRef = mObject->getColour(i);
-        QListWidgetItem* colourItem = new QListWidgetItem(ui->colorListWidget);
+        const ColorRef colorRef = mObject->getColor(i);
+        QListWidgetItem* colorItem = new QListWidgetItem(ui->colorListWidget);
 
         if (ui->colorListWidget->viewMode() != QListView::IconMode)
         {
-            colourItem->setText(colourRef.name);
+            colorItem->setText(colorRef.name);
         }
         else
         {
-            colourItem->setToolTip(colourRef.name);
+            colorItem->setToolTip(colorRef.name);
         }
-        colourSwatch = originalColourSwatch;
-        swatchPainter.begin(&colourSwatch);
-        swatchPainter.fillRect(0, 0, mIconSize.width(), mIconSize.height(), colourRef.colour);
+        colorSwatch = originalColorSwatch;
+        swatchPainter.begin(&colorSwatch);
+        swatchPainter.fillRect(0, 0, mIconSize.width(), mIconSize.height(), colorRef.color);
 
         QIcon swatchIcon;
-        swatchIcon.addPixmap(colourSwatch, QIcon::Normal);
+        swatchIcon.addPixmap(colorSwatch, QIcon::Normal);
 
         // Draw selection border
         if(ui->colorListWidget->viewMode() == QListView::IconMode) {
@@ -242,19 +242,19 @@ void ColorPaletteWidget::refreshColorList()
             swatchPainter.setPen(borderShadow);
             swatchPainter.drawRect(0, 0, mIconSize.width() - 1, mIconSize.height() - 1);
         }
-        swatchIcon.addPixmap(colourSwatch, QIcon::Selected);
+        swatchIcon.addPixmap(colorSwatch, QIcon::Selected);
 
-        colourItem->setIcon(swatchIcon);
+        colorItem->setIcon(swatchIcon);
         swatchPainter.end();
-        colourItem->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsEditable | Qt::ItemIsDragEnabled);
+        colorItem->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsEditable | Qt::ItemIsDragEnabled);
 
-        ui->colorListWidget->addItem(colourItem);
+        ui->colorListWidget->addItem(colorItem);
     }
     updateGridUI();
     update();
 }
 
-void ColorPaletteWidget::changeColourName(QListWidgetItem* item)
+void ColorPaletteWidget::changeColorName(QListWidgetItem* item)
 {
     Q_ASSERT(item != NULL);
 
@@ -265,14 +265,14 @@ void ColorPaletteWidget::changeColourName(QListWidgetItem* item)
         {
             bool ok;
             QString text = QInputDialog::getText(this,
-                                                 tr("Colour name"),
-                                                 tr("Colour name"),
+                                                 tr("Color name"),
+                                                 tr("Color name"),
                                                  QLineEdit::Normal,
-                                                 mObject->getColour(colorNumber).name,
+                                                 mObject->getColor(colorNumber).name,
                                                  &ok);
             if (ok && !text.isEmpty())
             {
-                mObject->renameColour(colorNumber, text);
+                mObject->renameColor(colorNumber, text);
                 refreshColorList();
             }
         }
@@ -283,7 +283,7 @@ void ColorPaletteWidget::onItemChanged(QListWidgetItem* item)
 {
     int index = ui->colorListWidget->row(item);
     QString newColorName = item->text();
-    mObject->renameColour(index, newColorName);
+    mObject->renameColor(index, newColorName);
 }
 
 void ColorPaletteWidget::onRowsMoved(const QModelIndex &parent, int start, int end, const QModelIndex &destination, int row)
@@ -303,13 +303,13 @@ void ColorPaletteWidget::onRowsMoved(const QModelIndex &parent, int start, int e
 
         mObject->movePaletteColor(startIndex, endIndex);
 
-        mObject->addColour(mObject->getColour(startIndex));
-        mObject->moveVectorColor(startIndex, mObject->getColourCount() - 1);
+        mObject->addColor(mObject->getColor(startIndex));
+        mObject->moveVectorColor(startIndex, mObject->getColorCount() - 1);
         for (int i = startIndex; i < endIndex; i++)
         {
             mObject->moveVectorColor(i + 1, i);
         }
-        mObject->moveVectorColor(mObject->getColourCount() - 1, endIndex);
+        mObject->moveVectorColor(mObject->getColorCount() - 1, endIndex);
     }
     else
     {
@@ -320,16 +320,16 @@ void ColorPaletteWidget::onRowsMoved(const QModelIndex &parent, int start, int e
 
         mObject->movePaletteColor(startIndex, endIndex);
 
-        mObject->addColour(mObject->getColour(startIndex));
-        mObject->moveVectorColor(startIndex, mObject->getColourCount() - 1);
+        mObject->addColor(mObject->getColor(startIndex));
+        mObject->moveVectorColor(startIndex, mObject->getColorCount() - 1);
         for (int i = startIndex; i > endIndex; i--)
         {
             mObject->moveVectorColor(i - 1, i);
         }
-        mObject->moveVectorColor(mObject->getColourCount() - 1, endIndex);
+        mObject->moveVectorColor(mObject->getColorCount() - 1, endIndex);
     }
 
-    mObject->removeColour(mObject->getColourCount() - 1);
+    mObject->removeColor(mObject->getColorCount() - 1);
 
     refreshColorList();
 }
@@ -478,7 +478,7 @@ void ColorPaletteWidget::fitSwatchSize()
     int width = ui->colorListWidget->width();
     int hScrollBar = ui->colorListWidget->horizontalScrollBar()->geometry().height() + 6;
     int vScrollBar = ui->colorListWidget->verticalScrollBar()->geometry().width() * 2;
-    int colorCount = editor()->object()->getColourCount();
+    int colorCount = editor()->object()->getColorCount();
     int size;
 
     if (ui->colorListWidget->viewMode() == QListView::ListMode)
@@ -565,26 +565,26 @@ void ColorPaletteWidget::clickAddColorButton()
 {
     QColor prevColor = Qt::white;
 
-    QColor newColour;
+    QColor newColor;
 
     if (mIsColorDialog)
-        newColour = QColorDialog::getColor(prevColor.rgba(), this, QString(), QColorDialog::ShowAlphaChannel);
+        newColor = QColorDialog::getColor(prevColor.rgba(), this, QString(), QColorDialog::ShowAlphaChannel);
     else 
-        newColour = mEditor->color()->frontColor();
+        newColor = mEditor->color()->frontColor();
 
-    if (!newColour.isValid())
+    if (!newColor.isValid())
     {
         return; // User canceled operation
     }
 
-    int colorIndex = mObject->getColourCount();
-    ColourRef ref(newColour);
+    int colorIndex = mObject->getColorCount();
+    ColorRef ref(newColor);
 
-    mObject->addColour(ref);
+    mObject->addColor(ref);
     refreshColorList();
 
     editor()->color()->setColorNumber(colorIndex);
-    editor()->color()->setColor(ref.colour);
+    editor()->color()->setColor(ref.color);
     if (mFitSwatches)
     {
         fitSwatchSize();
@@ -600,24 +600,24 @@ void ColorPaletteWidget::clickRemoveColorButton()
         // items are not deleted by qt, it has to be done manually
         // delete should happen before removing the color from from palette
         // as the palette will be one ahead and crash otherwise
-        if (mObject->isColourInUse(index))
+        if (mObject->isColorInUse(index))
         {
             bool accepted = false;
             if (!mMultipleSelected)
                 accepted = showPaletteWarning();
 
-            if ((accepted || mMultipleSelected) && mObject->getColourCount() > 1)
+            if ((accepted || mMultipleSelected) && mObject->getColorCount() > 1)
             {
                 delete item;
-                mObject->removeColour(index);
+                mObject->removeColor(index);
             }
         }
-        else if (mObject->getColourCount() > 1)
+        else if (mObject->getColorCount() > 1)
         {
             delete item;
-            mObject->removeColour(index);
+            mObject->removeColor(index);
         }
-        else if (mObject->getColourCount() == 1)
+        else if (mObject->getColorCount() == 1)
         {
             showPaletteReminder();
         }
@@ -657,8 +657,8 @@ void ColorPaletteWidget::showPaletteReminder()
 
 void ColorPaletteWidget::updateItemColor(int itemIndex, QColor newColor)
 {
-    QPixmap colourSwatch(mIconSize);
-    QPainter swatchPainter(&colourSwatch);
+    QPixmap colorSwatch(mIconSize);
+    QPainter swatchPainter(&colorSwatch);
     swatchPainter.drawTiledPixmap(0, 0, mIconSize.width(), mIconSize.height(), QPixmap(":/background/checkerboard.png"));
     swatchPainter.fillRect(0, 0, mIconSize.width(), mIconSize.height(), newColor);
 
@@ -671,7 +671,7 @@ void ColorPaletteWidget::updateItemColor(int itemIndex, QColor newColor)
     borderHighlight.setDashOffset(4);
 
     QIcon swatchIcon;
-    swatchIcon.addPixmap(colourSwatch, QIcon::Normal);
+    swatchIcon.addPixmap(colorSwatch, QIcon::Normal);
 
     if(ui->colorListWidget->viewMode() == QListView::IconMode)
     {
@@ -681,7 +681,7 @@ void ColorPaletteWidget::updateItemColor(int itemIndex, QColor newColor)
         swatchPainter.setPen(borderShadow);
         swatchPainter.drawRect(0, 0, mIconSize.width() - 1, mIconSize.height() - 1);
     }
-    swatchIcon.addPixmap(colourSwatch, QIcon::Selected);
+    swatchIcon.addPixmap(colorSwatch, QIcon::Selected);
 
     ui->colorListWidget->item(itemIndex)->setIcon(swatchIcon);
 

--- a/app/src/colorpalettewidget.h
+++ b/app/src/colorpalettewidget.h
@@ -48,7 +48,7 @@ public:
     void updateUI() override;
     void setCore(Editor* editor);
 
-    int currentColourNumber();
+    int currentColorNumber();
 
     void selectColorNumber(int);
     void setColor(QColor, int);
@@ -67,7 +67,7 @@ protected:
 
 private slots:
     void clickColorListItem(QListWidgetItem*);
-    void changeColourName(QListWidgetItem*);
+    void changeColorName(QListWidgetItem*);
     void onItemChanged(QListWidgetItem* item);
     void onRowsMoved(const QModelIndex &parent, int start, int end, const QModelIndex &destination, int row);
     void clickAddColorButton();

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1310,11 +1310,11 @@ void MainWindow2::importPalette()
 void MainWindow2::openPalette()
 {
     int count = 0;
-    int maxNumber = mEditor->object()->getColourCount();
+    int maxNumber = mEditor->object()->getColorCount();
     bool openPalette = true;
     while (count < maxNumber)
     {
-        if (mEditor->object()->isColourInUse(count))
+        if (mEditor->object()->isColorInUse(count))
         {
             QMessageBox msgBox;
             msgBox.setText(tr("Opening palette, will replace the old palette.\n"

--- a/app/ui/colorpalette.ui
+++ b/app/ui/colorpalette.ui
@@ -342,7 +342,7 @@
  <slots>
   <slot>colorListCurrentItemChanged(QListWidgetItem*,QListWidgetItem*)</slot>
   <slot>clickColorListItem(QListWidgetItem*)</slot>
-  <slot>changeColourName(QListWidgetItem*)</slot>
+  <slot>changeColorName(QListWidgetItem*)</slot>
   <slot>onActiveColorNameChange(QString)</slot>
   <slot>clickAddColorButton()</slot>
   <slot>clickRemoveColorButton()</slot>

--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -35,7 +35,7 @@ HEADERS +=  \
     src/graphics/bitmap/bitmapimage.h \
     src/graphics/vector/bezierarea.h \
     src/graphics/vector/beziercurve.h \
-    src/graphics/vector/colourref.h \
+    src/graphics/vector/colorref.h \
     src/graphics/vector/vectorimage.h \
     src/graphics/vector/vectorselection.h \
     src/graphics/vector/vertexref.h \
@@ -110,7 +110,7 @@ HEADERS +=  \
 SOURCES +=  src/graphics/bitmap/bitmapimage.cpp \
     src/graphics/vector/bezierarea.cpp \
     src/graphics/vector/beziercurve.cpp \
-    src/graphics/vector/colourref.cpp \
+    src/graphics/vector/colorref.cpp \
     src/graphics/vector/vectorimage.cpp \
     src/graphics/vector/vectorselection.cpp \
     src/graphics/vector/vertexref.cpp \

--- a/core_lib/src/canvaspainter.cpp
+++ b/core_lib/src/canvaspainter.cpp
@@ -423,7 +423,7 @@ void CanvasPainter::paintVectorFrame(QPainter& painter,
     vectorImage->outputImage(pImage, mViewTransform, mOptions.bOutlines, mOptions.bThinLines, mOptions.bAntiAlias);
 
     //painter.drawImage( QPoint( 0, 0 ), *pImage );
-    // Go through a Bitmap image to paint the onion skin colour
+    // Go through a Bitmap image to paint the onion skin color
     BitmapImage tempBitmapImage;
     tempBitmapImage.setImage(pImage);
 

--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -36,11 +36,11 @@ BitmapImage::BitmapImage(const BitmapImage& a) : KeyFrame(a)
     mImage = std::make_shared<QImage>(*a.mImage);
 }
 
-BitmapImage::BitmapImage(const QRect& rectangle, const QColor& colour)
+BitmapImage::BitmapImage(const QRect& rectangle, const QColor& color)
 {
     mBounds = rectangle;
     mImage = std::make_shared<QImage>(mBounds.size(), QImage::Format_ARGB32_Premultiplied);
-    mImage->fill(colour.rgba());
+    mImage->fill(color.rgba());
     mMinBound = false;
 }
 
@@ -526,17 +526,17 @@ QRgb BitmapImage::pixel(QPoint p)
     return result;
 }
 
-void BitmapImage::setPixel(int x, int y, QRgb colour)
+void BitmapImage::setPixel(int x, int y, QRgb color)
 {
-    setPixel(QPoint(x, y), colour);
+    setPixel(QPoint(x, y), color);
 }
 
-void BitmapImage::setPixel(QPoint p, QRgb colour)
+void BitmapImage::setPixel(QPoint p, QRgb color)
 {
     setCompositionModeBounds(QRect(p, QSize(1,1)), true, QPainter::CompositionMode_SourceOver);
     if (mBounds.contains(p))
     {
-        image()->setPixel(p - mBounds.topLeft(), colour);
+        image()->setPixel(p - mBounds.topLeft(), color);
     }
     modification();
 }
@@ -746,7 +746,7 @@ QRgb BitmapImage::constScanLine(int x, int y) const
     return result;
 }
 
-void BitmapImage::scanLine(int x, int y, QRgb colour)
+void BitmapImage::scanLine(int x, int y, QRgb color)
 {
     extend(QPoint(x, y));
     if (mBounds.contains(QPoint(x, y)))
@@ -754,10 +754,10 @@ void BitmapImage::scanLine(int x, int y, QRgb colour)
         // Make sure color is premultiplied before calling
         *(reinterpret_cast<QRgb*>(image()->scanLine(y - mBounds.top())) + x - mBounds.left()) =
             qRgba(
-                qRed(colour),
-                qGreen(colour),
-                qBlue(colour),
-                qAlpha(colour));
+                qRed(color),
+                qGreen(color),
+                qBlue(color),
+                qAlpha(color));
     }
 }
 

--- a/core_lib/src/graphics/bitmap/bitmapimage.h
+++ b/core_lib/src/graphics/bitmap/bitmapimage.h
@@ -27,7 +27,7 @@ class BitmapImage : public KeyFrame
 public:
     BitmapImage();
     BitmapImage(const BitmapImage&);
-    BitmapImage(const QRect &rectangle, const QColor& colour);
+    BitmapImage(const QRect &rectangle, const QColor& color);
     BitmapImage(const QPoint& topLeft, const QImage& image);
     BitmapImage(const QPoint& topLeft, const QString& path);
 
@@ -63,12 +63,12 @@ public:
 
     QRgb pixel(int x, int y);
     QRgb pixel(QPoint p);
-    void setPixel(int x, int y, QRgb colour);
-    void setPixel(QPoint p, QRgb colour);
+    void setPixel(int x, int y, QRgb color);
+    void setPixel(QPoint p, QRgb color);
     void fillNonAlphaPixels(const QRgb color);
 
     inline QRgb constScanLine(int x, int y) const;
-    inline void scanLine(int x, int y, QRgb colour);
+    inline void scanLine(int x, int y, QRgb color);
     void clear();
     void clear(QRect rectangle);
     void clear(QRectF rectangle) { clear(rectangle.toRect()); }

--- a/core_lib/src/graphics/vector/bezierarea.cpp
+++ b/core_lib/src/graphics/vector/bezierarea.cpp
@@ -54,7 +54,7 @@ void BezierArea::setSelected(bool YesOrNo)
 Status BezierArea::createDomElement( QXmlStreamWriter& xmlStream )
 {
     xmlStream.writeStartElement( "area" );
-    xmlStream.writeAttribute( "colorNumber", QString::number( mColorNumber ) );
+    xmlStream.writeAttribute( "colourNumber", QString::number( mColorNumber ) );
     xmlStream.writeAttribute("filled", QString::number( mIsFilled ) );
 
     int errorLocation = -1;
@@ -89,7 +89,7 @@ Status BezierArea::createDomElement( QXmlStreamWriter& xmlStream )
 
 void BezierArea::loadDomElement(const QDomElement& element)
 {
-    mColorNumber = element.attribute("colorNumber").toInt();
+    mColorNumber = element.attribute("colourNumber").toInt();
 
     QDomNode vertexTag = element.firstChild();
     while (!vertexTag.isNull())

--- a/core_lib/src/graphics/vector/bezierarea.cpp
+++ b/core_lib/src/graphics/vector/bezierarea.cpp
@@ -26,10 +26,10 @@ BezierArea::BezierArea()
 {
 }
 
-BezierArea::BezierArea(QList<VertexRef> vertexList, int colour)
+BezierArea::BezierArea(QList<VertexRef> vertexList, int color)
 {
     mVertex = vertexList;
-    mColourNumber = colour;
+    mColorNumber = color;
     mSelected = false;
 }
 
@@ -54,7 +54,7 @@ void BezierArea::setSelected(bool YesOrNo)
 Status BezierArea::createDomElement( QXmlStreamWriter& xmlStream )
 {
     xmlStream.writeStartElement( "area" );
-    xmlStream.writeAttribute( "colourNumber", QString::number( mColourNumber ) );
+    xmlStream.writeAttribute( "colorNumber", QString::number( mColorNumber ) );
     xmlStream.writeAttribute("filled", QString::number( mIsFilled ) );
 
     int errorLocation = -1;
@@ -76,7 +76,7 @@ Status BezierArea::createDomElement( QXmlStreamWriter& xmlStream )
     {
         DebugDetails debugInfo;
         debugInfo << "BezierArea::createDomElement";
-        debugInfo << QString("colourNumber = %1").arg(mColourNumber);
+        debugInfo << QString("colorNumber = %1").arg(mColorNumber);
         debugInfo << QString("- mVertex[%1] has failed to write").arg(errorLocation);
         debugInfo << QString("&nbsp;&nbsp;curve = %1").arg(mVertex.at(errorLocation).curveNumber);
         debugInfo << QString("&nbsp;&nbsp;vertex = %1 ").arg(mVertex.at(errorLocation).vertexNumber);
@@ -89,7 +89,7 @@ Status BezierArea::createDomElement( QXmlStreamWriter& xmlStream )
 
 void BezierArea::loadDomElement(const QDomElement& element)
 {
-    mColourNumber = element.attribute("colourNumber").toInt();
+    mColorNumber = element.attribute("colorNumber").toInt();
 
     QDomNode vertexTag = element.firstChild();
     while (!vertexTag.isNull())

--- a/core_lib/src/graphics/vector/bezierarea.h
+++ b/core_lib/src/graphics/vector/bezierarea.h
@@ -31,21 +31,21 @@ class BezierArea
 {
 public:
     BezierArea();
-    BezierArea(QList<VertexRef> vertexList, int colour);
+    BezierArea(QList<VertexRef> vertexList, int color);
 
     Status createDomElement(QXmlStreamWriter& xmlStream);
     void loadDomElement(const QDomElement& element);
 
     VertexRef getVertexRef(int i);
-    int getColourNumber() { return mColourNumber; }
-    void decreaseColourNumber() { mColourNumber--; }
+    int getColorNumber() { return mColorNumber; }
+    void decreaseColorNumber() { mColorNumber--; }
     void setSelected(bool YesOrNo);
     bool isSelected() const { return mSelected; }
-    void setColourNumber(int cn) { mColourNumber = cn; }
+    void setColorNumber(int cn) { mColorNumber = cn; }
 
     QList<VertexRef> mVertex;
     QPainterPath mPath;
-    int mColourNumber = 0;
+    int mColorNumber = 0;
 
 private:
     bool mSelected = false;

--- a/core_lib/src/graphics/vector/beziercurve.cpp
+++ b/core_lib/src/graphics/vector/beziercurve.cpp
@@ -91,7 +91,7 @@ Status BezierCurve::createDomElement( QXmlStreamWriter& xmlStream )
     if (feather>0) xmlStream.writeAttribute( "feather", QString::number( feather ) );
     xmlStream.writeAttribute( "invisible", invisible ? "true" : "false" );
     xmlStream.writeAttribute( "filled", mFilled ? "true" : "false" );
-    xmlStream.writeAttribute( "colourNumber", QString::number( colourNumber ) );
+    xmlStream.writeAttribute( "colorNumber", QString::number( colorNumber ) );
     xmlStream.writeAttribute( "originX", QString::number( origin.x() ) );
     xmlStream.writeAttribute( "originY", QString::number( origin.y() ) );
     xmlStream.writeAttribute( "originPressure", QString::number( pressure.at(0) ) );
@@ -124,7 +124,7 @@ Status BezierCurve::createDomElement( QXmlStreamWriter& xmlStream )
         debugInfo << QString("feather = %1").arg(feather);
         debugInfo << QString("invisible = %1").arg(invisible);
         debugInfo << QString("filled = %1").arg(mFilled);
-        debugInfo << QString("colourNumber = %1").arg(colourNumber);
+        debugInfo << QString("colorNumber = %1").arg(colorNumber);
         debugInfo << QString("originX = %1").arg(origin.x());
         debugInfo << QString("originY = %1").arg(origin.y());
         debugInfo << QString("originPressure = %1").arg(pressure.at(0));
@@ -152,7 +152,7 @@ void BezierCurve::loadDomElement(const QDomElement& element)
     mFilled = (element.attribute("filled") == "1") || (element.attribute("filled") == "true");
     if (width == 0) invisible = true;
 
-    colourNumber = element.attribute("colourNumber").toInt();
+    colorNumber = element.attribute("colorNumber").toInt();
     origin = QPointF( element.attribute("originX").toFloat(), element.attribute("originY").toFloat() );
     pressure.append( element.attribute("originPressure").toFloat() );
     selected.append(false);
@@ -430,7 +430,7 @@ void BezierCurve::removeVertex(int i)
 
 void BezierCurve::drawPath(QPainter& painter, Object* object, QTransform transformation, bool simplified, bool showThinLines )
 {
-    QColor colour = object->getColour(colourNumber).colour;
+    QColor color = object->getColor(colorNumber).color;
 
     BezierCurve myCurve;
     if (isPartlySelected()) { myCurve = (transformed(transformation)); }
@@ -438,8 +438,8 @@ void BezierCurve::drawPath(QPainter& painter, Object* object, QTransform transfo
 
     if ( variableWidth && !simplified && !invisible)
     {
-        painter.setPen(QPen(QBrush(colour), 1, Qt::NoPen, Qt::RoundCap,Qt::RoundJoin));
-        painter.setBrush(colour);
+        painter.setPen(QPen(QBrush(color), 1, Qt::NoPen, Qt::RoundCap,Qt::RoundJoin));
+        painter.setBrush(color);
         painter.drawPath(myCurve.getStrokedPath());
     }
     else
@@ -464,7 +464,7 @@ void BezierCurve::drawPath(QPainter& painter, Object* object, QTransform transfo
                 }
                 else
                 {
-                    painter.setPen(QPen(QBrush(colour), 0, Qt::DotLine, Qt::RoundCap,Qt::RoundJoin));
+                    painter.setPen(QPen(QBrush(color), 0, Qt::DotLine, Qt::RoundCap,Qt::RoundJoin));
                 }
             }
             else
@@ -474,7 +474,7 @@ void BezierCurve::drawPath(QPainter& painter, Object* object, QTransform transfo
         }
         else
         {
-            painter.setPen( QPen( QBrush( colour ), renderedWidth, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin ) );
+            painter.setPen( QPen( QBrush( color ), renderedWidth, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin ) );
             //painter.setPen( QPen( Qt::darkYellow , 5, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin ) );
         }
         QPainterPath path = myCurve.getSimplePath();
@@ -484,11 +484,11 @@ void BezierCurve::drawPath(QPainter& painter, Object* object, QTransform transfo
     if (!simplified)
     {
         // highlight the selected elements
-        colour = QColor(100,150,255);  // highlight colour
+        color = QColor(100,150,255);  // highlight color
         painter.setBrush(Qt::NoBrush);
         qreal lineWidth = 1.5/painter.worldTransform().m11();
         lineWidth = fabs(lineWidth); // make sure line width is positive, otherwise nothing is drawn
-        painter.setPen(QPen(QBrush(colour), lineWidth, Qt::SolidLine, Qt::RoundCap,Qt::RoundJoin));
+        painter.setPen(QPen(QBrush(color), lineWidth, Qt::SolidLine, Qt::RoundCap,Qt::RoundJoin));
         if (isSelected()) painter.drawPath(myCurve.getSimplePath());
 
 
@@ -496,9 +496,9 @@ void BezierCurve::drawPath(QPainter& painter, Object* object, QTransform transfo
         {
             if (isSelected(i))
             {
-//                painter.fillRect(myCurve.getVertex(i).x()-0.5*squareWidth, myCurve.getVertex(i).y()-0.5*squareWidth, squareWidth, squareWidth, colour);
+//                painter.fillRect(myCurve.getVertex(i).x()-0.5*squareWidth, myCurve.getVertex(i).y()-0.5*squareWidth, squareWidth, squareWidth, color);
 
-                //painter.fillRect(QRectF(myCurve.getVertex(i).x()-0.5*squareWidth, myCurve.getVertex(i).y()-0.5*squareWidth, squareWidth, squareWidth), colour);
+                //painter.fillRect(QRectF(myCurve.getVertex(i).x()-0.5*squareWidth, myCurve.getVertex(i).y()-0.5*squareWidth, squareWidth, squareWidth), color);
 
                 /*painter.drawText(myCurve.getVertex(i)+QPointF(4.0,0.0), QString::number(i)+"-"+QString::number(myCurve.getVertex(i).x())+","+QString::number(myCurve.getVertex(i).y()));
                 QPointF normale = QPointF(4.0, 0.0);
@@ -652,7 +652,7 @@ void BezierCurve::createCurve(const QList<QPointF>& pointList, const QList<qreal
     {
         smoothCurve();
     }
-    //colourNumber = 0;
+    //colorNumber = 0;
     feather = 0;
 }
 

--- a/core_lib/src/graphics/vector/beziercurve.cpp
+++ b/core_lib/src/graphics/vector/beziercurve.cpp
@@ -91,7 +91,7 @@ Status BezierCurve::createDomElement( QXmlStreamWriter& xmlStream )
     if (feather>0) xmlStream.writeAttribute( "feather", QString::number( feather ) );
     xmlStream.writeAttribute( "invisible", invisible ? "true" : "false" );
     xmlStream.writeAttribute( "filled", mFilled ? "true" : "false" );
-    xmlStream.writeAttribute( "colorNumber", QString::number( colorNumber ) );
+    xmlStream.writeAttribute( "colourNumber", QString::number( colorNumber ) );
     xmlStream.writeAttribute( "originX", QString::number( origin.x() ) );
     xmlStream.writeAttribute( "originY", QString::number( origin.y() ) );
     xmlStream.writeAttribute( "originPressure", QString::number( pressure.at(0) ) );
@@ -152,7 +152,7 @@ void BezierCurve::loadDomElement(const QDomElement& element)
     mFilled = (element.attribute("filled") == "1") || (element.attribute("filled") == "true");
     if (width == 0) invisible = true;
 
-    colorNumber = element.attribute("colorNumber").toInt();
+    colorNumber = element.attribute("colourNumber").toInt();
     origin = QPointF( element.attribute("originX").toFloat(), element.attribute("originY").toFloat() );
     pressure.append( element.attribute("originPressure").toFloat() );
     selected.append(false);

--- a/core_lib/src/graphics/vector/beziercurve.h
+++ b/core_lib/src/graphics/vector/beziercurve.h
@@ -43,8 +43,8 @@ public:
     qreal getWidth() const { return width; }
     qreal getFeather() const { return feather; }
     bool getVariableWidth() const { return variableWidth; }
-    int getColourNumber() const { return colourNumber; }
-    void decreaseColourNumber() { colourNumber--; }
+    int getColorNumber() const { return colorNumber; }
+    void decreaseColorNumber() { colorNumber--; }
     int getVertexSize() const { return vertex.size(); }
     QPointF getOrigin() const {	return origin; }
     QPointF getVertex(int i) const { if (i==-1) { return origin; } else { return vertex.at(i);} }
@@ -69,7 +69,7 @@ public:
     void setFeather(qreal desiredFeather);
     void setVariableWidth(bool YesOrNo);
     void setInvisibility(bool YesOrNo);
-    void setColourNumber(int colourNumber) { this->colourNumber = colourNumber; }
+    void setColorNumber(int colorNumber) { this->colorNumber = colorNumber; }
     void setSelected(bool YesOrNo) { for(int i=0; i<selected.size(); i++) { selected[i] = YesOrNo; } }
     void setSelected(int i, bool YesOrNo);
     void setFilled(bool yesOrNo);
@@ -108,7 +108,7 @@ private:
     QList<QPointF> c2;
     QList<QPointF> vertex;
     QList<float> pressure; // this list has one more element than the other list (the first element is for the origin)
-    int colourNumber = 0;
+    int colorNumber = 0;
     float width = 0.f;
     float feather = 0.f;
     bool variableWidth = 0.f;

--- a/core_lib/src/graphics/vector/colorref.cpp
+++ b/core_lib/src/graphics/vector/colorref.cpp
@@ -14,7 +14,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 */
-#include "colourref.h"
+#include "colorref.h"
 
 #include <cmath>
 #include <QtMath>
@@ -22,21 +22,21 @@ GNU General Public License for more details.
 
 #include "util/colordictionary.h"
 
-ColourRef::ColourRef()
+ColorRef::ColorRef()
 {
-    colour = Qt::green;
+    color = Qt::green;
     name = QObject::tr("Green");
 }
 
-ColourRef::ColourRef(QColor theColour, QString theName)
+ColorRef::ColorRef(QColor theColor, QString theName)
 {
-    colour = theColour;
-    name = theName.isNull() ? ColourRef::getDefaultColorName(theColour) : theName;
+    color = theColor;
+    name = theName.isNull() ? ColorRef::getDefaultColorName(theColor) : theName;
 }
 
-bool ColourRef::operator==(ColourRef colourRef1)
+bool ColorRef::operator==(ColorRef colorRef1)
 {
-    if ( (colour == colourRef1.colour) && (name == colourRef1.name) )
+    if ( (color == colorRef1.color) && (name == colorRef1.name) )
     {
         return true;
     }
@@ -46,9 +46,9 @@ bool ColourRef::operator==(ColourRef colourRef1)
     }
 }
 
-bool ColourRef::operator!=(ColourRef colourRef1)
+bool ColorRef::operator!=(ColorRef colorRef1)
 {
-    if ( (colour != colourRef1.colour) || (name != colourRef1.name) )
+    if ( (color != colorRef1.color) || (name != colorRef1.name) )
     {
         return true;
     }
@@ -58,13 +58,13 @@ bool ColourRef::operator!=(ColourRef colourRef1)
     }
 }
 
-QDebug& operator<<(QDebug debug, const ColourRef& colourRef)
+QDebug& operator<<(QDebug debug, const ColorRef& colorRef)
 {
-    debug.nospace() << "ColourRef(" << colourRef.colour << " " << colourRef.name <<")";
+    debug.nospace() << "ColorRef(" << colorRef.color << " " << colorRef.name <<")";
     return debug.maybeSpace();
 }
 
-QString ColourRef::getDefaultColorName(const QColor c)
+QString ColorRef::getDefaultColorName(const QColor c)
 {
     // Separate rgb values for convenience
     const int r = c.red();

--- a/core_lib/src/graphics/vector/colorref.h
+++ b/core_lib/src/graphics/vector/colorref.h
@@ -15,26 +15,26 @@ GNU General Public License for more details.
 
 */
 
-#ifndef COLOURREF_H
-#define COLOURREF_H
+#ifndef COLORREF_H
+#define COLORREF_H
 
 #include <QColor>
 #include <QString>
 
-class ColourRef
+class ColorRef
 {
 public:
-    ColourRef();
-    ColourRef(QColor theColour, QString theName = QString());
-    bool operator==(ColourRef colourRef1);
-    bool operator!=(ColourRef colourRef1);
+    ColorRef();
+    ColorRef(QColor theColor, QString theName = QString());
+    bool operator==(ColorRef colorRef1);
+    bool operator!=(ColorRef colorRef1);
 
-    QColor colour;
+    QColor color;
     QString name;
 
     static QString getDefaultColorName(const QColor c);
 };
 
-QDebug& operator<<(QDebug debug, const ColourRef &colourRef);
+QDebug& operator<<(QDebug debug, const ColorRef &colorRef);
 
 #endif

--- a/core_lib/src/graphics/vector/vectorimage.cpp
+++ b/core_lib/src/graphics/vector/vectorimage.cpp
@@ -1056,62 +1056,62 @@ void VectorImage::paste(VectorImage& vectorImage)
 }
 
 /**
- * @brief VectorImage::getColour
- * @param colourNumber: the color number which is referred to in the palette
+ * @brief VectorImage::getColor
+ * @param colorNumber: the color number which is referred to in the palette
  * @return QColor
  */
-QColor VectorImage::getColour(int colourNumber)
+QColor VectorImage::getColor(int colorNumber)
 {
-    return mObject->getColour(colourNumber).colour;
+    return mObject->getColor(colorNumber).color;
 }
 
 /**
- * @brief VectorImage::getColourNumber
+ * @brief VectorImage::getColorNumber
  * @param point: The QPoint of the BezierArea
  * @return The color number in the palette based on the BezierArea
  */
-int VectorImage::getColourNumber(QPointF point)
+int VectorImage::getColorNumber(QPointF point)
 {
     int result = -1;
     int areaNumber = getLastAreaNumber(point);
     if (areaNumber != -1)
     {
-        result = mArea[areaNumber].mColourNumber;
+        result = mArea[areaNumber].mColorNumber;
     }
     return result;
 }
 
 /**
- * @brief VectorImage::usesColour
+ * @brief VectorImage::usesColor
  * @param index
  * @return
  */
-bool VectorImage::usesColour(int index)
+bool VectorImage::usesColor(int index)
 {
     for (int i = 0; i < mArea.size(); i++)
     {
-        if (mArea[i].mColourNumber == index) return true;
+        if (mArea[i].mColorNumber == index) return true;
     }
     for (int i = 0; i < mCurves.size(); i++)
     {
-        if (mCurves[i].getColourNumber() == index) return true;
+        if (mCurves[i].getColorNumber() == index) return true;
     }
     return false;
 }
 
 /**
- * @brief VectorImage::removeColour
+ * @brief VectorImage::removeColor
  * @param index: int
  */
-void VectorImage::removeColour(int index)
+void VectorImage::removeColor(int index)
 {
     for (int i = 0; i < mArea.size(); i++)
     {
-        if (mArea[i].getColourNumber() > index) mArea[i].decreaseColourNumber();
+        if (mArea[i].getColorNumber() > index) mArea[i].decreaseColorNumber();
     }
     for (int i = 0; i < mCurves.size(); i++)
     {
-        if (mCurves[i].getColourNumber() > index) mCurves[i].decreaseColourNumber();
+        if (mCurves[i].getColorNumber() > index) mCurves[i].decreaseColorNumber();
     }
 }
 
@@ -1119,11 +1119,11 @@ void VectorImage::moveColor(int start, int end)
 {
     for(int i=0; i< mArea.size(); i++)
      {
-         if (mArea[i].getColourNumber() == start) mArea[i].setColourNumber(end);
+         if (mArea[i].getColorNumber() == start) mArea[i].setColorNumber(end);
      }
      for(int i=0; i< mCurves.size(); i++)
      {
-         if (mCurves[i].getColourNumber() == start) mCurves[i].setColourNumber(end);
+         if (mCurves[i].getColorNumber() == start) mCurves[i].setColorNumber(end);
      }
 }
 
@@ -1156,19 +1156,19 @@ void VectorImage::paintImage(QPainter& painter,
             updateArea(mArea[i]); // to do: if selected
 
             // --- fill areas ---- //
-            QColor colour = getColour(mArea[i].mColourNumber);
+            QColor color = getColor(mArea[i].mColorNumber);
 
             painter.save();
             painter.setWorldMatrixEnabled(false);
 
             if (mArea[i].isSelected())
             {
-                painter.setBrush(QBrush(qPremultiply(colour.rgba()), Qt::Dense2Pattern));
+                painter.setBrush(QBrush(qPremultiply(color.rgba()), Qt::Dense2Pattern));
             }
             else
             {
-                painter.setPen(QPen(QBrush(colour), 1, Qt::NoPen, Qt::RoundCap, Qt::RoundJoin));
-                painter.setBrush(QBrush(colour, Qt::SolidPattern));
+                painter.setPen(QPen(QBrush(color), 1, Qt::NoPen, Qt::RoundCap, Qt::RoundJoin));
+                painter.setBrush(QBrush(color, Qt::SolidPattern));
             }
 
             painter.drawPath(painter.transform().map(mArea[i].mPath));
@@ -1259,28 +1259,28 @@ void VectorImage::applySelectionTransformation(QTransform transf)
 }
 
 /**
- * @brief VectorImage::applyColourToSelectedCurve
- * @param colourNumber: int
+ * @brief VectorImage::applyColorToSelectedCurve
+ * @param colorNumber: int
  * Changes the color of the curve
  */
-void VectorImage::applyColourToSelectedCurve(int colourNumber)
+void VectorImage::applyColorToSelectedCurve(int colorNumber)
 {
     for (int i = 0; i < mCurves.size(); i++)
     {
-        if (mCurves.at(i).isSelected()) mCurves[i].setColourNumber(colourNumber);
+        if (mCurves.at(i).isSelected()) mCurves[i].setColorNumber(colorNumber);
     }
     modification();
 }
 
 /**
- * @brief VectorImage::applyColourToSelectedArea
- * @param colourNumber: int
+ * @brief VectorImage::applyColorToSelectedArea
+ * @param colorNumber: int
  */
-void VectorImage::applyColourToSelectedArea(int colourNumber)
+void VectorImage::applyColorToSelectedArea(int colorNumber)
 {
     for (int i = 0; i < mArea.size(); i++)
     {
-        if (mArea.at(i).isSelected()) mArea[i].setColourNumber(colourNumber);
+        if (mArea.at(i).isSelected()) mArea[i].setColorNumber(colorNumber);
     }
     modification();
 }
@@ -1748,10 +1748,10 @@ BezierArea VectorImage::getSelectedArea(QPointF currentPoint)
 /**
  * @brief VectorImage::fillSelectedPath
  * @param QPointF currentPoint
- * @param int colour
+ * @param int color
  * fills the selected path with a given color
  */
-void VectorImage::fillSelectedPath(int colour)
+void VectorImage::fillSelectedPath(int color)
 {
     QList<VertexRef> vertexPath;
     QList<int> curveNumbers = getSelectedCurveNumbers();
@@ -1772,7 +1772,7 @@ void VectorImage::fillSelectedPath(int colour)
             }
         }
 
-        BezierArea bezierArea(vertexPath, colour);
+        BezierArea bezierArea(vertexPath, color);
         addArea(bezierArea);
 
         // set selected curves as filled
@@ -1788,10 +1788,10 @@ void VectorImage::fillSelectedPath(int colour)
 /**
  * @brief VectorImage::fillContour
  * @param QList<QPointF> contourPath
- * @param int colour
+ * @param int color
  * fills the contour with a given color
  */
-void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
+void VectorImage::fillContour(QList<QPointF> contourPath, int color)
 {
     QList<VertexRef> vertexPath;
     VertexRef vertex;
@@ -1807,7 +1807,7 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
         }
     }
 
-    BezierArea bezierArea(vertexPath, colour);
+    BezierArea bezierArea(vertexPath, color);
 
     addArea(bezierArea);
     modification();
@@ -1840,9 +1840,9 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 //    QPointF startPoint((maxWidth / 2) + point.x(), (maxHeight / 2) + point.y());
 //    queue.append( startPoint.toPoint() );
 
-//    // Check the colour of the clicked point
-//    QRgb colourFrom = image->pixel(startPoint.x(), startPoint.y());
-//    QRgb colourTo = Qt::green;
+//    // Check the color of the clicked point
+//    QRgb colorFrom = image->pixel(startPoint.x(), startPoint.y());
+//    QRgb colorTo = Qt::green;
 
 //    QPoint currentPoint;
 
@@ -1859,7 +1859,7 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 //        queue.removeAt(0);
 
 //        // Inspect a line from edge to edge
-//        if (image->pixel(currentPoint.x(), currentPoint.y()) == colourFrom) {
+//        if (image->pixel(currentPoint.x(), currentPoint.y()) == colorFrom) {
 //            leftX = currentPoint.x();
 //            rightX = currentPoint.x();
 
@@ -1879,8 +1879,8 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 //                QPoint leftPoint = QPoint(leftX, currentPoint.y());
 
 //                // Are we getting to a curve ?
-//                if ( image->pixel(leftPoint.x(), leftPoint.y()) != colourFrom &&
-//                     image->pixel(leftPoint.x(), leftPoint.y()) != colourTo ) {
+//                if ( image->pixel(leftPoint.x(), leftPoint.y()) != colorFrom &&
+//                     image->pixel(leftPoint.x(), leftPoint.y()) != colorTo ) {
 
 //                    foundLeftBound = true;
 
@@ -1894,7 +1894,7 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 //                    while (leftPoint.x() - increment > 0 && increment < 3 && !foundFillAfter) {
 //                        QPoint pointAfter = QPoint(leftPoint.x() - increment, leftPoint.y());
 
-//                        if (image->pixel(pointAfter.x(), pointAfter.y()) == colourTo) {
+//                        if (image->pixel(pointAfter.x(), pointAfter.y()) == colorTo) {
 //                            foundFillAfter = true;
 //                        }
 
@@ -1925,8 +1925,8 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 //                QPoint rightPoint = QPoint(rightX, currentPoint.y());
 
 //                // Are we getting to a curve ?
-//                if ( image->pixel(rightPoint.x(), rightPoint.y()) != colourFrom &&
-//                     image->pixel(rightPoint.x(), rightPoint.y()) != colourTo) {
+//                if ( image->pixel(rightPoint.x(), rightPoint.y()) != colorFrom &&
+//                     image->pixel(rightPoint.x(), rightPoint.y()) != colorTo) {
 
 //                    foundRightBound = true;
 
@@ -1940,7 +1940,7 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 //                    while (rightPoint.x() + increment < maxWidth && increment < 3 && !foundFillAfter) {
 //                        QPoint pointAfter = QPoint(rightPoint.x() + increment, rightPoint.y());
 
-//                        if (image->pixel(pointAfter.x(), pointAfter.y()) == colourTo) {
+//                        if (image->pixel(pointAfter.x(), pointAfter.y()) == colorTo) {
 //                            foundFillAfter = true;
 //                        }
 
@@ -1969,14 +1969,14 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 
 //            for (int x = leftX + 1; x < rightX; x++) {
 
-//                // The current line point is checked (Coloured)
+//                // The current line point is checked (Colored)
 //                QPoint linePoint = QPoint(x, lineY);
-//                image->setPixel(linePoint.x(), linePoint.y(), colourTo);
+//                image->setPixel(linePoint.x(), linePoint.y(), colorTo);
 
 //                QPoint topPoint = QPoint(x, topY);
 
-//                if ( image->pixel(topPoint.x(), topPoint.y()) != colourFrom &&
-//                     image->pixel(topPoint.x(), topPoint.y()) != colourTo) {
+//                if ( image->pixel(topPoint.x(), topPoint.y()) != colorFrom &&
+//                     image->pixel(topPoint.x(), topPoint.y()) != colorTo) {
 
 //                    // Convert point to view coordinates
 //                    QPointF contourPoint( topPoint.x() - (maxWidth / 2), topPoint.y() - (maxHeight / 2));
@@ -1988,7 +1988,7 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 //                    while (topPoint.y() - increment > 0 && increment < 3 && !foundFillAfter) {
 //                        QPoint pointAfter = QPoint(topPoint.x(), topPoint.y() - increment);
 
-//                        if (image->pixel(pointAfter.x(), pointAfter.y()) == colourTo) {
+//                        if (image->pixel(pointAfter.x(), pointAfter.y()) == colorTo) {
 //                            foundFillAfter = true;
 //                        }
 //                        increment ++;
@@ -2008,8 +2008,8 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 
 //                QPoint bottomPoint = QPoint(x, bottomY);
 
-//                if ( image->pixel(bottomPoint.x(), bottomPoint.y()) != colourFrom &&
-//                     image->pixel(bottomPoint.x(), bottomPoint.y()) != colourTo ) {
+//                if ( image->pixel(bottomPoint.x(), bottomPoint.y()) != colorFrom &&
+//                     image->pixel(bottomPoint.x(), bottomPoint.y()) != colorTo ) {
 
 //                    QPointF contourPoint( bottomPoint.x() - (maxWidth / 2), bottomPoint.y() - (maxHeight / 2));
 
@@ -2020,7 +2020,7 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 //                    while (bottomPoint.y() + increment < maxHeight && increment < 3 && !foundFillAfter) {
 //                        QPoint pointAfter = QPoint(bottomPoint.x(), bottomPoint.y() + increment);
 
-//                        if (image->pixel(pointAfter.x(), pointAfter.y()) == colourTo) {
+//                        if (image->pixel(pointAfter.x(), pointAfter.y()) == colorTo) {
 //                            foundFillAfter = true;
 //                        }
 
@@ -2055,7 +2055,7 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 //    return contourPoints;
 //}
 
-//void VectorImage::fill(QPointF point, int colour, float tolerance)
+//void VectorImage::fill(QPointF point, int color, float tolerance)
 //{
 //    // Check if we clicked on a curve. In that case, we change its color.
 //    QList<int> closestCurves = getCurvesCloseTo( point, tolerance );
@@ -2065,7 +2065,7 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 //        // For each clicked curves, we change the color if requiered
 //        for (int i = 0; i < closestCurves.size(); i++) {
 //            int curveNumber = closestCurves[i];
-//            m_curves[curveNumber].setColourNumber(colour);
+//            m_curves[curveNumber].setColorNumber(color);
 //        }
 
 //        return;
@@ -2074,7 +2074,7 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 //    // Check if we clicked on an area of the same color.
 //    // We don't want to create another area.
 //    int areaNum = getLastAreaNumber(point);
-//    if (areaNum > -1 && area[areaNum].mColourNumber == colour) {
+//    if (areaNum > -1 && area[areaNum].mColorNumber == color) {
 //        return;
 //    }
 
@@ -2164,7 +2164,7 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 
 //    // Fill the path if we have one.
 //    if (completedPath) {
-//        fillSelectedPath(mainContourPath, colour);
+//        fillSelectedPath(mainContourPath, color);
 //    }
 //    else {
 //        // Check if we clicked on an area in this position and as we couldn't create one,
@@ -2172,10 +2172,10 @@ void VectorImage::fillContour(QList<QPointF> contourPath, int colour)
 //        int areaNum = getLastAreaNumber(point);
 //        if (areaNum > -1) {
 
-//            int clickedColorNum = area[areaNum].getColourNumber();
+//            int clickedColorNum = area[areaNum].getColorNumber();
 
-//            if (clickedColorNum != colour) {
-//                area[areaNum].setColourNumber(colour);
+//            if (clickedColorNum != color) {
+//                area[areaNum].setColorNumber(color);
 //            }
 //        }
 //    }

--- a/core_lib/src/graphics/vector/vectorimage.h
+++ b/core_lib/src/graphics/vector/vectorimage.h
@@ -81,10 +81,10 @@ public:
 
     void paste(VectorImage&);
 
-    QColor getColour(int i);
-    int  getColourNumber(QPointF point);
-    bool usesColour(int index);
-    void removeColour(int index);
+    QColor getColor(int i);
+    int  getColorNumber(QPointF point);
+    bool usesColor(int index);
+    void removeColor(int index);
     void moveColor(int start, int end);
 
     void paintImage(QPainter& painter, bool simplified, bool showThinCurves, bool antialiasing);
@@ -95,16 +95,16 @@ public:
     void setSelectionTransformation(QTransform transform);
     void applySelectionTransformation();
     void applySelectionTransformation(QTransform transform);
-    void applyColourToSelectedCurve(int colourNumber);
-    void applyColourToSelectedArea(int colourNumber);
+    void applyColorToSelectedCurve(int colorNumber);
+    void applyColorToSelectedArea(int colorNumber);
     void applyWidthToSelection(qreal width);
     void applyFeatherToSelection(qreal feather);
     void applyOpacityToSelection(qreal opacity);
     void applyInvisibilityToSelection(bool YesOrNo);
     void applyVariableWidthToSelection(bool YesOrNo);
-    void fillContour(QList<QPointF> contourPath, int colour);
-    void fillSelectedPath(int colour);
-    //    void fill(QPointF point, int colour, float tolerance);
+    void fillContour(QList<QPointF> contourPath, int color);
+    void fillSelectedPath(int color);
+    //    void fill(QPointF point, int color, float tolerance);
     void addArea(BezierArea bezierArea);
     int  getFirstAreaNumber(QPointF point);
     int  getLastAreaNumber(QPointF point);

--- a/core_lib/src/interface/backgroundwidget.cpp
+++ b/core_lib/src/interface/backgroundwidget.cpp
@@ -117,15 +117,15 @@ void BackgroundWidget::drawShadow( QPainter& painter )
     int radius1 = 12;
     int radius2 = 8;
 
-    QColor colour = Qt::black;
+    QColor color = Qt::black;
     qreal opacity = 0.15;
 
     QLinearGradient shadow = QLinearGradient( 0, 0, 0, radius1 );
 
-    int r = colour.red();
-    int g = colour.green();
-    int b = colour.blue();
-    qreal a = colour.alphaF();
+    int r = color.red();
+    int g = color.green();
+    int b = color.blue();
+    qreal a = color.alphaF();
     shadow.setColorAt( 0.0, QColor( r, g, b, qRound( a * 255 * opacity ) ) );
     shadow.setColorAt( 1.0, QColor( r, g, b, 0 ) );
 

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -999,10 +999,10 @@ void ScribbleArea::paintEvent(QPaintEvent* event)
                 // ----- paints the edited elements
                 QPen pen2(Qt::black, 0.5, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
                 painter.setPen(pen2);
-                QColor colour;
+                QColor color;
                 // ------------ vertices of the edited curves
-                colour = QColor(200, 200, 200);
-                painter.setBrush(colour);
+                color = QColor(200, 200, 200);
+                painter.setBrush(color);
                 VectorSelection vectorSelection = selectMan->vectorSelection;
                 for (int k = 0; k < vectorSelection.curve.size(); k++)
                 {
@@ -1019,8 +1019,8 @@ void ScribbleArea::paintEvent(QPaintEvent* event)
                     }
                 }
                 // ------------ selected vertices of the edited curves
-                colour = QColor(100, 100, 255);
-                painter.setBrush(colour);
+                color = QColor(100, 100, 255);
+                painter.setBrush(color);
                 for (int k = 0; k < vectorSelection.vertex.size(); k++)
                 {
                     VertexRef vertexRef = vectorSelection.vertex.at(k);
@@ -1029,8 +1029,8 @@ void ScribbleArea::paintEvent(QPaintEvent* event)
                     painter.drawRect(rectangle0);
                 }
                 // ----- paints the closest vertices
-                colour = QColor(255, 0, 0);
-                painter.setBrush(colour);
+                color = QColor(255, 0, 0);
+                painter.setBrush(color);
                 QList<VertexRef> closestVertices = selectMan->closestVertices();
                 if (vectorSelection.curve.size() > 0)
                 {
@@ -1162,15 +1162,15 @@ void ScribbleArea::drawCanvas(int frame, QRect rect)
     mCanvasPainter.paint();
 }
 
-void ScribbleArea::setGaussianGradient(QGradient &gradient, QColor colour, qreal opacity, qreal offset)
+void ScribbleArea::setGaussianGradient(QGradient &gradient, QColor color, qreal opacity, qreal offset)
 {
     if (offset < 0) { offset = 0; }
     if (offset > 100) { offset = 100; }
 
-    int r = colour.red();
-    int g = colour.green();
-    int b = colour.blue();
-    qreal a = colour.alphaF();
+    int r = color.red();
+    int g = color.green();
+    int b = color.blue();
+    qreal a = color.alphaF();
 
     int mainColorAlpha = qRound(a * 255 * opacity);
 
@@ -1182,34 +1182,34 @@ void ScribbleArea::setGaussianGradient(QGradient &gradient, QColor colour, qreal
     gradient.setColorAt(1.0 - (offset / 100.0), QColor(r, g, b, mainColorAlpha - alphaAdded));
 }
 
-void ScribbleArea::drawPen(QPointF thePoint, qreal brushWidth, QColor fillColour, bool useAA)
+void ScribbleArea::drawPen(QPointF thePoint, qreal brushWidth, QColor fillColor, bool useAA)
 {
     QRectF rectangle(thePoint.x() - 0.5 * brushWidth, thePoint.y() - 0.5 * brushWidth, brushWidth, brushWidth);
 
-    mBufferImg->drawEllipse(rectangle, Qt::NoPen, QBrush(fillColour, Qt::SolidPattern),
+    mBufferImg->drawEllipse(rectangle, Qt::NoPen, QBrush(fillColor, Qt::SolidPattern),
                             QPainter::CompositionMode_Source, useAA);
 }
 
-void ScribbleArea::drawPencil(QPointF thePoint, qreal brushWidth, qreal fixedBrushFeather, QColor fillColour, qreal opacity)
+void ScribbleArea::drawPencil(QPointF thePoint, qreal brushWidth, qreal fixedBrushFeather, QColor fillColor, qreal opacity)
 {
-    drawBrush(thePoint, brushWidth, fixedBrushFeather, fillColour, opacity, true);
+    drawBrush(thePoint, brushWidth, fixedBrushFeather, fillColor, opacity, true);
 }
 
-void ScribbleArea::drawBrush(QPointF thePoint, qreal brushWidth, qreal mOffset, QColor fillColour, qreal opacity, bool usingFeather, bool useAA)
+void ScribbleArea::drawBrush(QPointF thePoint, qreal brushWidth, qreal mOffset, QColor fillColor, qreal opacity, bool usingFeather, bool useAA)
 {
     QRectF rectangle(thePoint.x() - 0.5 * brushWidth, thePoint.y() - 0.5 * brushWidth, brushWidth, brushWidth);
 
     if (usingFeather)
     {
         QRadialGradient radialGrad(thePoint, 0.5 * brushWidth);
-        setGaussianGradient(radialGrad, fillColour, opacity, mOffset);
+        setGaussianGradient(radialGrad, fillColor, opacity, mOffset);
 
         mBufferImg->drawEllipse(rectangle, Qt::NoPen, radialGrad,
                                 QPainter::CompositionMode_SourceOver, false);
     }
     else
     {
-        mBufferImg->drawEllipse(rectangle, Qt::NoPen, QBrush(fillColour, Qt::SolidPattern),
+        mBufferImg->drawEllipse(rectangle, Qt::NoPen, QBrush(fillColor, Qt::SolidPattern),
                                 QPainter::CompositionMode_SourceOver, useAA);
     }
 }
@@ -1443,13 +1443,13 @@ void ScribbleArea::displaySelectionProperties()
                 mEditor->tools()->setFeather(vectorImage->curve(selectedCurve).getFeather());
                 mEditor->tools()->setInvisibility(vectorImage->curve(selectedCurve).isInvisible());
                 mEditor->tools()->setPressure(vectorImage->curve(selectedCurve).getVariableWidth());
-                mEditor->color()->setColorNumber(vectorImage->curve(selectedCurve).getColourNumber());
+                mEditor->color()->setColorNumber(vectorImage->curve(selectedCurve).getColorNumber());
             }
 
             int selectedArea = vectorImage->getFirstSelectedArea();
             if (selectedArea != -1)
             {
-                mEditor->color()->setColorNumber(vectorImage->mArea[selectedArea].mColourNumber);
+                mEditor->color()->setColorNumber(vectorImage->mArea[selectedArea].mColorNumber);
             }
         }
     }

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -152,9 +152,9 @@ public:
     void drawPolyline(QPainterPath path, QPen pen, bool useAA);
     void drawLine(QPointF P1, QPointF P2, QPen pen, QPainter::CompositionMode cm);
     void drawPath(QPainterPath path, QPen pen, QBrush brush, QPainter::CompositionMode cm);
-    void drawPen(QPointF thePoint, qreal brushWidth, QColor fillColour, bool useAA = true);
-    void drawPencil(QPointF thePoint, qreal brushWidth, qreal fixedBrushFeather, QColor fillColour, qreal opacity);
-    void drawBrush(QPointF thePoint, qreal brushWidth, qreal offset, QColor fillColour, qreal opacity, bool usingFeather = true, bool useAA = false);
+    void drawPen(QPointF thePoint, qreal brushWidth, QColor fillColor, bool useAA = true);
+    void drawPencil(QPointF thePoint, qreal brushWidth, qreal fixedBrushFeather, QColor fillColor, qreal opacity);
+    void drawBrush(QPointF thePoint, qreal brushWidth, qreal offset, QColor fillColor, qreal opacity, bool usingFeather = true, bool useAA = false);
     void blurBrush(BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal offset_, qreal opacity_);
     void liquifyBrush(BitmapImage *bmiSource_, QPointF srcPoint_, QPointF thePoint_, qreal brushWidth_, qreal offset_, qreal opacity_);
 
@@ -164,7 +164,7 @@ public:
     void clearBitmapBuffer();
     void refreshBitmap(const QRectF& rect, int rad);
     void refreshVector(const QRectF& rect, int rad);
-    void setGaussianGradient(QGradient &gradient, QColor colour, qreal opacity, qreal offset);
+    void setGaussianGradient(QGradient &gradient, QColor color, qreal opacity, qreal offset);
 
     void pointerPressEvent(PointerEvent*);
     void pointerMoveEvent(PointerEvent*);

--- a/core_lib/src/managers/colormanager.cpp
+++ b/core_lib/src/managers/colormanager.cpp
@@ -53,7 +53,7 @@ void ColorManager::workingLayerChanged(Layer* layer)
     mIsWorkingOnVectorLayer = (layer->type() == Layer::VECTOR);
     if (mIsWorkingOnVectorLayer)
     {
-        mCurrentFrontColor = object()->getColour(mCurrentColorIndex).colour;
+        mCurrentFrontColor = object()->getColor(mCurrentColorIndex).color;
         emit colorChanged(mCurrentFrontColor, mCurrentColorIndex);
     }
 }
@@ -62,7 +62,7 @@ QColor ColorManager::frontColor()
 {
 
     if (mIsWorkingOnVectorLayer)
-        return object()->getColour(mCurrentColorIndex).colour;
+        return object()->getColor(mCurrentColorIndex).color;
     else
         return mCurrentFrontColor;
 }
@@ -73,7 +73,7 @@ void ColorManager::setColorNumber(int n)
 
     mCurrentColorIndex = n;
 
-    QColor currentColor = object()->getColour(mCurrentColorIndex).colour;
+    QColor currentColor = object()->getColor(mCurrentColorIndex).color;
 
     emit colorNumberChanged(mCurrentColorIndex);
     emit colorChanged(currentColor, mCurrentColorIndex);
@@ -89,7 +89,7 @@ void ColorManager::setColor(const QColor& newColor)
 
         if (mIsWorkingOnVectorLayer)
         {
-            object()->setColour(mCurrentColorIndex, newColor);
+            object()->setColor(mCurrentColorIndex, newColor);
         }
     }
 }

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -435,7 +435,7 @@ QDomElement FileManager::saveProjectData(ObjectData* data, QDomDocument& xmlDoc)
     currentFrameTag.setAttribute("value", data->getCurrentFrame());
     rootTag.appendChild(currentFrameTag);
 
-    // Current Colour
+    // Current Color
     QDomElement currentColorTag = xmlDoc.createElement("currentColor");
     QColor color = data->getCurrentColor();
     currentColorTag.setAttribute("r", color.red());
@@ -602,16 +602,16 @@ void FileManager::unzip(const QString& strZipFile, const QString& strUnzipTarget
     mstrLastTempFolder = strUnzipTarget;
 }
 
-QList<ColourRef> FileManager::loadPaletteFile(QString strFilename)
+QList<ColorRef> FileManager::loadPaletteFile(QString strFilename)
 {
     QFileInfo fileInfo(strFilename);
     if (!fileInfo.exists())
     {
-        return QList<ColourRef>();
+        return QList<ColorRef>();
     }
 
     // TODO: Load Palette.
-    return QList<ColourRef>();
+    return QList<ColorRef>();
 }
 
 Status FileManager::verifyObject(Object* obj)

--- a/core_lib/src/structure/filemanager.h
+++ b/core_lib/src/structure/filemanager.h
@@ -25,7 +25,7 @@ GNU General Public License for more details.
 #include "log.h"
 #include "pencildef.h"
 #include "pencilerror.h"
-#include "colourref.h"
+#include "colorref.h"
 
 class Object;
 class ObjectData;
@@ -41,7 +41,7 @@ public:
     Object* load(QString sFilenNme);
     Status  save(Object*, QString sFileName);
 
-    QList<ColourRef> loadPaletteFile(QString strFilename);
+    QList<ColorRef> loadPaletteFile(QString strFilename);
     Status error() const { return mError; }
     Status verifyObject(Object* obj);
 

--- a/core_lib/src/structure/layervector.cpp
+++ b/core_lib/src/structure/layervector.cpp
@@ -31,25 +31,25 @@ LayerVector::~LayerVector()
 {
 }
 
-bool LayerVector::usesColour(int colorIndex)
+bool LayerVector::usesColor(int colorIndex)
 {
     bool bUseColor = false;
     foreachKeyFrame([&](KeyFrame* pKeyFrame)
     {
         auto pVecImage = static_cast<VectorImage*>(pKeyFrame);
 
-        bUseColor = bUseColor || pVecImage->usesColour(colorIndex);
+        bUseColor = bUseColor || pVecImage->usesColor(colorIndex);
     });
 
     return bUseColor;
 }
 
-void LayerVector::removeColour(int colorIndex)
+void LayerVector::removeColor(int colorIndex)
 {
     foreachKeyFrame([=](KeyFrame* pKeyFrame)
     {
         auto pVecImage = static_cast<VectorImage*>(pKeyFrame);
-        pVecImage->removeColour(colorIndex);
+        pVecImage->removeColor(colorIndex);
     });
 }
 

--- a/core_lib/src/structure/layervector.h
+++ b/core_lib/src/structure/layervector.h
@@ -39,8 +39,8 @@ public:
     VectorImage* getVectorImageAtFrame(int frameNumber) const;
     VectorImage* getLastVectorImageAtFrame(int frameNumber, int increment) const;
 
-    bool usesColour(int index);
-    void removeColour(int index);
+    bool usesColor(int index);
+    void removeColor(int index);
     void moveColor(int start, int end);
 
 protected:

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -293,9 +293,9 @@ void Object::addLayer(Layer *layer)
     }
 }
 
-ColourRef Object::getColour(int index) const
+ColorRef Object::getColor(int index) const
 {
-    ColourRef result(Qt::white, tr("error"));
+    ColorRef result(Qt::white, tr("error"));
     if (index > -1 && index < mPalette.size())
     {
         result = mPalette.at(index);
@@ -303,21 +303,21 @@ ColourRef Object::getColour(int index) const
     return result;
 }
 
-void Object::setColour(int index, QColor newColour)
+void Object::setColor(int index, QColor newColor)
 {
     Q_ASSERT(index >= 0);
 
-    mPalette[index].colour = newColour;
+    mPalette[index].color = newColor;
 }
 
-void Object::setColourRef(int index, ColourRef newColourRef)
+void Object::setColorRef(int index, ColorRef newColorRef)
 {
-    mPalette[index] = newColourRef;
+    mPalette[index] = newColorRef;
 }
 
-void Object::addColour(QColor colour)
+void Object::addColor(QColor color)
 {
-    addColour(ColourRef(colour, tr("Colour %1").arg(QString::number(mPalette.size()))));
+    addColor(ColorRef(color, tr("Color %1").arg(QString::number(mPalette.size()))));
 }
 
 void Object::movePaletteColor(int start, int end)
@@ -337,12 +337,12 @@ void Object::moveVectorColor(int start, int end)
     }
 }
 
-void Object::addColourAtIndex(int index, ColourRef newColour)
+void Object::addColorAtIndex(int index, ColorRef newColor)
 {
-    mPalette.insert(index, newColour);
+    mPalette.insert(index, newColor);
 }
 
-bool Object::isColourInUse(int index)
+bool Object::isColorInUse(int index)
 {
     for (int i = 0; i < getLayerCount(); i++)
     {
@@ -351,7 +351,7 @@ bool Object::isColourInUse(int index)
         {
             LayerVector* layerVector = static_cast<LayerVector*>(layer);
 
-            if (layerVector->usesColour(index))
+            if (layerVector->usesColor(index))
             {
                 return true;
             }
@@ -361,7 +361,7 @@ bool Object::isColourInUse(int index)
 
 }
 
-void Object::removeColour(int index)
+void Object::removeColor(int index)
 {
     for (int i = 0; i < getLayerCount(); i++)
     {
@@ -369,16 +369,16 @@ void Object::removeColour(int index)
         if (layer->type() == Layer::VECTOR)
         {
             LayerVector* layerVector = static_cast<LayerVector*>(layer);
-            layerVector->removeColour(index);
+            layerVector->removeColor(index);
         }
     }
 
     mPalette.removeAt(index);
 
-    // update the vector pictures using that colour !
+    // update the vector pictures using that color !
 }
 
-void Object::renameColour(int i, QString text)
+void Object::renameColor(int i, QString text)
 {
     mPalette[i].name = text;
 }
@@ -402,9 +402,9 @@ void Object::exportPaletteGPL(QFile& file)
     out << "Name: " << fileName << "\n";
     out << "#" << "\n";
 
-    for (ColourRef ref : mPalette)
+    for (ColorRef ref : mPalette)
     {
-        QColor toRgb = ref.colour.toRgb();
+        QColor toRgb = ref.color.toRgb();
         out << QString("%1 %2 %3").arg(toRgb.red()).arg(toRgb.green()).arg(toRgb.blue());
         out << " " << ref.name << "\n";
     }
@@ -419,13 +419,13 @@ void Object::exportPalettePencil(QFile& file)
     doc.appendChild(root);
     for (int i = 0; i < mPalette.size(); i++)
     {
-        ColourRef ref = mPalette.at(i);
-        QDomElement tag = doc.createElement("Colour");
+        ColorRef ref = mPalette.at(i);
+        QDomElement tag = doc.createElement("Color");
         tag.setAttribute("name", ref.name);
-        tag.setAttribute("red", ref.colour.red());
-        tag.setAttribute("green", ref.colour.green());
-        tag.setAttribute("blue", ref.colour.blue());
-        tag.setAttribute("alpha", ref.colour.alpha());
+        tag.setAttribute("red", ref.color.red());
+        tag.setAttribute("green", ref.color.green());
+        tag.setAttribute("blue", ref.color.blue());
+        tag.setAttribute("alpha", ref.color.alpha());
         root.appendChild(tag);
     }
     int IndentSize = 2;
@@ -458,7 +458,7 @@ bool Object::exportPalette(QString filePath)
  * This should load colors the same as GIMP, with the following intentional exceptions:
  * - Whitespace before and after a name does not appear in the name
  * - The last line is processed, even if there is not a trailing newline
- * - Colours without a name will use our automatic naming system rather than "Untitled"
+ * - Colors without a name will use our automatic naming system rather than "Untitled"
  */
 void Object::importPaletteGPL(QFile& file)
 {
@@ -484,9 +484,9 @@ void Object::importPaletteGPL(QFile& file)
         }
     }
 
-    // Colours inherit the value from the previous colour for missing channels
+    // Colors inherit the value from the previous color for missing channels
     // Some palettes may rely on this behavior so we should try to replicate it
-    QColor prevColour(Qt::black);
+    QColor prevColor(Qt::black);
 
     do
     {
@@ -522,20 +522,20 @@ void Object::importPaletteGPL(QFile& file)
         // trim additional spaces
         name = name.trimmed();
 
-        // Get values from previous colour if necessary
-        if (countInLine < 2) green = prevColour.green();
-        if (countInLine < 3) blue = prevColour.blue();
+        // Get values from previous color if necessary
+        if (countInLine < 2) green = prevColor.green();
+        if (countInLine < 3) blue = prevColor.blue();
 
-        // GIMP assigns colours the name "Untitled" by default now
+        // GIMP assigns colors the name "Untitled" by default now
         // so in addition to missing names, we also use automatic
         // naming for this
         if (name.isEmpty() || name == "Untitled") name = QString();
 
-        QColor colour(red, green, blue);
-        if (colour.isValid())
+        QColor color(red, green, blue);
+        if (color.isValid())
         {
-            mPalette.append(ColourRef(colour, name));
-            prevColour = colour;
+            mPalette.append(ColorRef(color, name));
+            prevColor = color;
         }
     } while (in.readLineInto(&line));
 }
@@ -557,7 +557,7 @@ void Object::importPalettePencil(QFile& file)
             int g = e.attribute("green").toInt();
             int b = e.attribute("blue").toInt();
             int a = e.attribute("alpha", "255").toInt();
-            mPalette.append(ColourRef(QColor(r, g, b, a), name));
+            mPalette.append(ColorRef(QColor(r, g, b, a), name));
         }
         tag = tag.nextSibling();
     }
@@ -600,30 +600,30 @@ bool Object::importPalette(QString filePath)
 void Object::loadDefaultPalette()
 {
     mPalette.clear();
-    addColour(ColourRef(QColor(Qt::black), QString(tr("Black"))));
-    addColour(ColourRef(QColor(Qt::red), QString(tr("Red"))));
-    addColour(ColourRef(QColor(Qt::darkRed), QString(tr("Dark Red"))));
-    addColour(ColourRef(QColor(255, 128, 0), QString(tr("Orange"))));
-    addColour(ColourRef(QColor(128, 64, 0), QString(tr("Dark Orange"))));
-    addColour(ColourRef(QColor(Qt::yellow), QString(tr("Yellow"))));
-    addColour(ColourRef(QColor(Qt::darkYellow), QString(tr("Dark Yellow"))));
-    addColour(ColourRef(QColor(Qt::green), QString(tr("Green"))));
-    addColour(ColourRef(QColor(Qt::darkGreen), QString(tr("Dark Green"))));
-    addColour(ColourRef(QColor(Qt::cyan), QString(tr("Cyan"))));
-    addColour(ColourRef(QColor(Qt::darkCyan), QString(tr("Dark Cyan"))));
-    addColour(ColourRef(QColor(Qt::blue), QString(tr("Blue"))));
-    addColour(ColourRef(QColor(Qt::darkBlue), QString(tr("Dark Blue"))));
-    addColour(ColourRef(QColor(255, 255, 255), QString(tr("White"))));
-    addColour(ColourRef(QColor(220, 220, 229), QString(tr("Very Light Grey"))));
-    addColour(ColourRef(QColor(Qt::lightGray), QString(tr("Light Grey"))));
-    addColour(ColourRef(QColor(Qt::gray), QString(tr("Grey"))));
-    addColour(ColourRef(QColor(Qt::darkGray), QString(tr("Dark Grey"))));
-    addColour(ColourRef(QColor(255, 227, 187), QString(tr("Light Skin"))));
-    addColour(ColourRef(QColor(221, 196, 161), QString(tr("Light Skin \u2013 shade"))));
-    addColour(ColourRef(QColor(255, 214, 156), QString(tr("Skin"))));
-    addColour(ColourRef(QColor(207, 174, 127), QString(tr("Skin \u2013 shade"))));
-    addColour(ColourRef(QColor(255, 198, 116), QString(tr("Dark Skin"))));
-    addColour(ColourRef(QColor(227, 177, 105), QString(tr("Dark Skin \u2013 shade")) ));
+    addColor(ColorRef(QColor(Qt::black), QString(tr("Black"))));
+    addColor(ColorRef(QColor(Qt::red), QString(tr("Red"))));
+    addColor(ColorRef(QColor(Qt::darkRed), QString(tr("Dark Red"))));
+    addColor(ColorRef(QColor(255, 128, 0), QString(tr("Orange"))));
+    addColor(ColorRef(QColor(128, 64, 0), QString(tr("Dark Orange"))));
+    addColor(ColorRef(QColor(Qt::yellow), QString(tr("Yellow"))));
+    addColor(ColorRef(QColor(Qt::darkYellow), QString(tr("Dark Yellow"))));
+    addColor(ColorRef(QColor(Qt::green), QString(tr("Green"))));
+    addColor(ColorRef(QColor(Qt::darkGreen), QString(tr("Dark Green"))));
+    addColor(ColorRef(QColor(Qt::cyan), QString(tr("Cyan"))));
+    addColor(ColorRef(QColor(Qt::darkCyan), QString(tr("Dark Cyan"))));
+    addColor(ColorRef(QColor(Qt::blue), QString(tr("Blue"))));
+    addColor(ColorRef(QColor(Qt::darkBlue), QString(tr("Dark Blue"))));
+    addColor(ColorRef(QColor(255, 255, 255), QString(tr("White"))));
+    addColor(ColorRef(QColor(220, 220, 229), QString(tr("Very Light Grey"))));
+    addColor(ColorRef(QColor(Qt::lightGray), QString(tr("Light Grey"))));
+    addColor(ColorRef(QColor(Qt::gray), QString(tr("Grey"))));
+    addColor(ColorRef(QColor(Qt::darkGray), QString(tr("Dark Grey"))));
+    addColor(ColorRef(QColor(255, 227, 187), QString(tr("Light Skin"))));
+    addColor(ColorRef(QColor(221, 196, 161), QString(tr("Light Skin \u2013 shade"))));
+    addColor(ColorRef(QColor(255, 214, 156), QString(tr("Skin"))));
+    addColor(ColorRef(QColor(207, 174, 127), QString(tr("Skin \u2013 shade"))));
+    addColor(ColorRef(QColor(255, 198, 116), QString(tr("Dark Skin"))));
+    addColor(ColorRef(QColor(227, 177, 105), QString(tr("Dark Skin \u2013 shade")) ));
 }
 
 void Object::paintImage(QPainter& painter,int frameNumber,

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -22,7 +22,7 @@ GNU General Public License for more details.
 #include <QList>
 #include <QColor>
 #include "layer.h"
-#include "colourref.h"
+#include "colorref.h"
 #include "pencilerror.h"
 #include "pencildef.h"
 #include "objectdata.h"
@@ -83,19 +83,19 @@ public:
     QString copyFileToDataFolder(QString strFilePath);
 
     // Color palette
-    ColourRef getColour(int index) const;
-    void setColour(int index, QColor newColour);
-    void setColourRef(int index, ColourRef newColourRef);
-    void addColour(QColor);
+    ColorRef getColor(int index) const;
+    void setColor(int index, QColor newColor);
+    void setColorRef(int index, ColorRef newColorRef);
+    void addColor(QColor);
     void movePaletteColor(int start, int end);
     void moveVectorColor(int start, int end);
 
-    void addColour(ColourRef newColour) { mPalette.append(newColour); }
-    void addColourAtIndex(int index, ColourRef newColour);
-    void removeColour(int index);
-    bool isColourInUse(int index);
-    void renameColour(int i, QString text);
-    int getColourCount() { return mPalette.size(); }
+    void addColor(ColorRef newColor) { mPalette.append(newColor); }
+    void addColorAtIndex(int index, ColorRef newColor);
+    void removeColor(int index);
+    bool isColorInUse(int index);
+    void renameColor(int i, QString text);
+    int getColorCount() { return mPalette.size(); }
     bool importPalette(QString filePath);
     void importPaletteGPL(QFile& file);
     void importPalettePencil(QFile& file);
@@ -169,7 +169,7 @@ private:
     QList<Layer*> mLayers;
     bool modified = false;
 
-    QList<ColourRef> mPalette;
+    QList<ColorRef> mPalette;
 
     std::unique_ptr<ObjectData> mData;
     mutable std::unique_ptr<ActiveFramePool> mActiveFramePool;

--- a/core_lib/src/tool/brushtool.cpp
+++ b/core_lib/src/tool/brushtool.cpp
@@ -324,7 +324,7 @@ void BrushTool::paintVectorStroke()
         curve.setFilled(false);
         curve.setInvisibility(properties.invisibility);
         curve.setVariableWidth(properties.pressure);
-        curve.setColourNumber(mEditor->color()->frontColorNumber());
+        curve.setColorNumber(mEditor->color()->frontColorNumber());
 
         VectorImage* vectorImage = static_cast<VectorImage*>(layer->getLastKeyFrameAtPosition(mEditor->currentFrame()));
         vectorImage->addCurve(curve, mEditor->view()->scaling(), false);

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -178,8 +178,8 @@ void BucketTool::paintVector(Layer* layer)
     }
 
     vectorImage->applyWidthToSelection(properties.width);
-    vectorImage->applyColourToSelectedCurve(mEditor->color()->frontColorNumber());
-    vectorImage->applyColourToSelectedArea(mEditor->color()->frontColorNumber());
+    vectorImage->applyColorToSelectedCurve(mEditor->color()->frontColorNumber());
+    vectorImage->applyColorToSelectedArea(mEditor->color()->frontColorNumber());
 
     applyChanges();
 

--- a/core_lib/src/tool/eyedroppertool.cpp
+++ b/core_lib/src/tool/eyedroppertool.cpp
@@ -56,7 +56,7 @@ QCursor EyedropperTool::cursor()
     }
 }
 
-QCursor EyedropperTool::cursor(const QColor colour)
+QCursor EyedropperTool::cursor(const QColor color)
 {
     QPixmap icon(":icons/eyedropper.png");
 
@@ -66,7 +66,7 @@ QCursor EyedropperTool::cursor(const QColor colour)
     QPainter painter(&pixmap);
     painter.drawPixmap(0, 0, icon);
     painter.setPen(QPen(Qt::black, 1, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-    painter.setBrush(colour);
+    painter.setBrush(color);
     painter.drawRect(16, 16, 15, 15);
     painter.end();
 
@@ -86,17 +86,17 @@ void EyedropperTool::pointerMoveEvent(PointerEvent*)
         BitmapImage* targetImage = ((LayerBitmap *)layer)->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0);
         if (targetImage->contains(getCurrentPoint()))
         {
-            QColor pickedColour;
-            //pickedColour.setRgba(targetImage->pixel(getCurrentPoint().x(), getCurrentPoint().y()));
-            pickedColour.setRgba(targetImage->pixel(getCurrentPoint().x(), getCurrentPoint().y()));
-            int transp = 255 - pickedColour.alpha();
-            pickedColour.setRed(pickedColour.red() + transp);
-            pickedColour.setGreen(pickedColour.green() + transp);
-            pickedColour.setBlue(pickedColour.blue() + transp);
+            QColor pickedColor;
+            //pickedColor.setRgba(targetImage->pixel(getCurrentPoint().x(), getCurrentPoint().y()));
+            pickedColor.setRgba(targetImage->pixel(getCurrentPoint().x(), getCurrentPoint().y()));
+            int transp = 255 - pickedColor.alpha();
+            pickedColor.setRed(pickedColor.red() + transp);
+            pickedColor.setGreen(pickedColor.green() + transp);
+            pickedColor.setBlue(pickedColor.blue() + transp);
 
-            if (pickedColour.alpha() != 0)
+            if (pickedColor.alpha() != 0)
             {
-                mScribbleArea->setCursor(cursor(pickedColour));
+                mScribbleArea->setCursor(cursor(pickedColor));
             }
             else
             {
@@ -111,10 +111,10 @@ void EyedropperTool::pointerMoveEvent(PointerEvent*)
     if (layer->type() == Layer::VECTOR)
     {
         VectorImage* vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
-        int colourNumber = vectorImage->getColourNumber(getCurrentPoint());
-        if (colourNumber != -1)
+        int colorNumber = vectorImage->getColorNumber(getCurrentPoint());
+        if (colorNumber != -1)
         {
-            mScribbleArea->setCursor(cursor(mEditor->object()->getColour(colourNumber).colour));
+            mScribbleArea->setCursor(cursor(mEditor->object()->getColor(colorNumber).color));
         }
         else
         {
@@ -142,24 +142,24 @@ void EyedropperTool::updateFrontColor()
     if (layer->type() == Layer::BITMAP)
     {
         BitmapImage* targetImage = ((LayerBitmap*)layer)->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0);
-        QColor pickedColour;
-        pickedColour.setRgba(targetImage->pixel(getLastPoint().x(), getLastPoint().y()));
-        int transp = 255 - pickedColour.alpha();
-        pickedColour.setRed(pickedColour.red() + transp);
-        pickedColour.setGreen(pickedColour.green() + transp);
-        pickedColour.setBlue(pickedColour.blue() + transp);
-        if (pickedColour.alpha() != 0)
+        QColor pickedColor;
+        pickedColor.setRgba(targetImage->pixel(getLastPoint().x(), getLastPoint().y()));
+        int transp = 255 - pickedColor.alpha();
+        pickedColor.setRed(pickedColor.red() + transp);
+        pickedColor.setGreen(pickedColor.green() + transp);
+        pickedColor.setBlue(pickedColor.blue() + transp);
+        if (pickedColor.alpha() != 0)
         {
-            mEditor->color()->setColor(pickedColour);
+            mEditor->color()->setColor(pickedColor);
         }
     }
     else if (layer->type() == Layer::VECTOR)
     {
         VectorImage* vectorImage = ((LayerVector*)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
-        int colourNumber = vectorImage->getColourNumber(getLastPoint());
-        if (colourNumber != -1)
+        int colorNumber = vectorImage->getColorNumber(getLastPoint());
+        if (colorNumber != -1)
         {
-            mEditor->color()->setColorNumber(colourNumber);
+            mEditor->color()->setColorNumber(colorNumber);
         }
     }
 }

--- a/core_lib/src/tool/eyedroppertool.h
+++ b/core_lib/src/tool/eyedroppertool.h
@@ -29,7 +29,7 @@ public:
     ToolType type() override { return EYEDROPPER; }
     void loadSettings() override;
     QCursor cursor() override;
-    QCursor cursor( const QColor colour );
+    QCursor cursor( const QColor color );
 
     void pointerPressEvent( PointerEvent* ) override;
     void pointerReleaseEvent( PointerEvent* event ) override;

--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -312,7 +312,7 @@ void PencilTool::paintVectorStroke(Layer* layer)
     curve.setFilled(false);
     curve.setInvisibility(true);
     curve.setVariableWidth(false);
-    curve.setColourNumber(mEditor->color()->frontColorNumber());
+    curve.setColorNumber(mEditor->color()->frontColorNumber());
     VectorImage* vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
 
     vectorImage->addCurve(curve, qAbs(mEditor->view()->scaling()), properties.vectorMergeEnabled);

--- a/core_lib/src/tool/pentool.cpp
+++ b/core_lib/src/tool/pentool.cpp
@@ -277,7 +277,7 @@ void PenTool::paintVectorStroke(Layer* layer)
     curve.setFilled(false);
     curve.setInvisibility(properties.invisibility);
     curve.setVariableWidth(properties.pressure);
-    curve.setColourNumber(mEditor->color()->frontColorNumber());
+    curve.setColorNumber(mEditor->color()->frontColorNumber());
 
     auto pLayerVector = static_cast<LayerVector*>(layer);
     VectorImage* vectorImage = pLayerVector->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -251,7 +251,7 @@ void PolylineTool::endPolyline(QList<QPointF> points)
         {
             curve.setWidth(properties.width);
         }
-        curve.setColourNumber(mEditor->color()->frontColorNumber());
+        curve.setColorNumber(mEditor->color()->frontColorNumber());
         curve.setVariableWidth(false);
         curve.setInvisibility(mScribbleArea->makeInvisible());
 

--- a/tests/src/catch.hpp
+++ b/tests/src/catch.hpp
@@ -219,7 +219,7 @@ namespace Catch {
 #  endif
 
 // Universal Windows platform does not support SEH
-// Or console colors (or console at all...)
+// Or console colours (or console at all...)
 #  if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
 #    define CATCH_CONFIG_COLOUR_NONE
 #  else

--- a/tests/src/catch.hpp
+++ b/tests/src/catch.hpp
@@ -219,7 +219,7 @@ namespace Catch {
 #  endif
 
 // Universal Windows platform does not support SEH
-// Or console colours (or console at all...)
+// Or console colors (or console at all...)
 #  if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
 #    define CATCH_CONFIG_COLOUR_NONE
 #  else
@@ -3980,7 +3980,7 @@ namespace Catch {
         InLexicographicalOrder,
         InRandomOrder
     }; };
-    struct UseColour { enum YesOrNo {
+    struct UseColor { enum YesOrNo {
         Auto,
         Yes,
         No
@@ -4013,7 +4013,7 @@ namespace Catch {
         virtual RunTests::InWhatOrder runOrder() const = 0;
         virtual unsigned int rngSeed() const = 0;
         virtual int benchmarkResolutionMultiple() const = 0;
-        virtual UseColour::YesOrNo useColour() const = 0;
+        virtual UseColor::YesOrNo useColor() const = 0;
         virtual std::vector<std::string> const& getSectionsToRun() const = 0;
         virtual Verbosity verbosity() const = 0;
     };
@@ -4058,7 +4058,7 @@ namespace Catch {
         WarnAbout::What warnings = WarnAbout::Nothing;
         ShowDurations::OrNot showDurations = ShowDurations::DefaultForReporter;
         RunTests::InWhatOrder runOrder = RunTests::InDeclarationOrder;
-        UseColour::YesOrNo useColour = UseColour::Auto;
+        UseColor::YesOrNo useColor = UseColor::Auto;
         WaitForKeypress::When waitForKeypress = WaitForKeypress::Never;
 
         std::string outputFilename;
@@ -4110,7 +4110,7 @@ namespace Catch {
         RunTests::InWhatOrder runOrder() const override;
         unsigned int rngSeed() const override;
         int benchmarkResolutionMultiple() const override;
-        UseColour::YesOrNo useColour() const override;
+        UseColor::YesOrNo useColor() const override;
         bool shouldDebugBreak() const override;
         int abortAfter() const override;
         bool showInvisibles() const override;
@@ -4713,11 +4713,11 @@ namespace Catch {
 } // end namespace Catch
 
 // end catch_reporter_bases.hpp
-// start catch_console_colour.h
+// start catch_console_color.h
 
 namespace Catch {
 
-    struct Colour {
+    struct Color {
         enum Code {
             None = 0,
 
@@ -4755,23 +4755,23 @@ namespace Catch {
         };
 
         // Use constructed object for RAII guard
-        Colour( Code _colourCode );
-        Colour( Colour&& other ) noexcept;
-        Colour& operator=( Colour&& other ) noexcept;
-        ~Colour();
+        Color( Code _colorCode );
+        Color( Color&& other ) noexcept;
+        Color& operator=( Color&& other ) noexcept;
+        ~Color();
 
         // Use static method for one-shot changes
-        static void use( Code _colourCode );
+        static void use( Code _colorCode );
 
     private:
         bool m_moved = false;
     };
 
-    std::ostream& operator << ( std::ostream& os, Colour const& );
+    std::ostream& operator << ( std::ostream& os, Color const& );
 
 } // end namespace Catch
 
-// end catch_console_colour.h
+// end catch_console_color.h
 // start catch_reporter_registrars.hpp
 
 
@@ -7287,17 +7287,17 @@ namespace Catch {
                 config.rngSeed = static_cast<unsigned int>( std::time(nullptr) );
                 return ParserResult::ok( ParseResultType::Matched );
             };
-        auto const setColourUsage = [&]( std::string const& useColour ) {
-                    auto mode = toLower( useColour );
+        auto const setColorUsage = [&]( std::string const& useColor ) {
+                    auto mode = toLower( useColor );
 
                     if( mode == "yes" )
-                        config.useColour = UseColour::Yes;
+                        config.useColor = UseColor::Yes;
                     else if( mode == "no" )
-                        config.useColour = UseColour::No;
+                        config.useColor = UseColor::No;
                     else if( mode == "auto" )
-                        config.useColour = UseColour::Auto;
+                        config.useColor = UseColor::Auto;
                     else
-                        return ParserResult::runtimeError( "colour mode must be one of: auto, yes or no. '" + useColour + "' not recognised" );
+                        return ParserResult::runtimeError( "color mode must be one of: auto, yes or no. '" + useColor + "' not recognised" );
                 return ParserResult::ok( ParseResultType::Matched );
             };
         auto const setWaitForKeypress = [&]( std::string const& keypress ) {
@@ -7403,9 +7403,9 @@ namespace Catch {
             | Opt( setRngSeed, "'time'|number" )
                 ["--rng-seed"]
                 ( "set a specific seed for random numbers" )
-            | Opt( setColourUsage, "yes|no" )
-                ["--use-colour"]
-                ( "should output be colourised" )
+            | Opt( setColorUsage, "yes|no" )
+                ["--use-color"]
+                ( "should output be colorised" )
             | Opt( config.libIdentify )
                 ["--libidentify"]
                 ( "report name and version according to libidentify standard" )
@@ -7512,7 +7512,7 @@ namespace Catch {
     RunTests::InWhatOrder Config::runOrder() const     { return m_data.runOrder; }
     unsigned int Config::rngSeed() const               { return m_data.rngSeed; }
     int Config::benchmarkResolutionMultiple() const    { return m_data.benchmarkResolutionMultiple; }
-    UseColour::YesOrNo Config::useColour() const       { return m_data.useColour; }
+    UseColor::YesOrNo Config::useColor() const       { return m_data.useColor; }
     bool Config::shouldDebugBreak() const              { return m_data.shouldDebugBreak; }
     int Config::abortAfter() const                     { return m_data.abortAfter; }
     bool Config::showInvisibles() const                { return m_data.showInvisibles; }
@@ -7524,7 +7524,7 @@ namespace Catch {
 
 } // end namespace Catch
 // end catch_config.cpp
-// start catch_console_colour.cpp
+// start catch_console_color.cpp
 
 #if defined(__clang__)
 #    pragma clang diagnostic push
@@ -7551,16 +7551,16 @@ namespace Catch {
 namespace Catch {
     namespace {
 
-        struct IColourImpl {
-            virtual ~IColourImpl() = default;
-            virtual void use( Colour::Code _colourCode ) = 0;
+        struct IColorImpl {
+            virtual ~IColorImpl() = default;
+            virtual void use( Color::Code _colorCode ) = 0;
         };
 
-        struct NoColourImpl : IColourImpl {
-            void use( Colour::Code ) {}
+        struct NoColorImpl : IColorImpl {
+            void use( Color::Code ) {}
 
-            static IColourImpl* instance() {
-                static NoColourImpl s_instance;
+            static IColorImpl* instance() {
+                static NoColorImpl s_instance;
                 return &s_instance;
             }
         };
@@ -7581,9 +7581,9 @@ namespace Catch {
 namespace Catch {
 namespace {
 
-    class Win32ColourImpl : public IColourImpl {
+    class Win32ColorImpl : public IColorImpl {
     public:
-        Win32ColourImpl() : stdoutHandle( GetStdHandle(STD_OUTPUT_HANDLE) )
+        Win32ColorImpl() : stdoutHandle( GetStdHandle(STD_OUTPUT_HANDLE) )
         {
             CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
             GetConsoleScreenBufferInfo( stdoutHandle, &csbiInfo );
@@ -7591,27 +7591,27 @@ namespace {
             originalBackgroundAttributes = csbiInfo.wAttributes & ~( FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY );
         }
 
-        virtual void use( Colour::Code _colourCode ) override {
-            switch( _colourCode ) {
-                case Colour::None:      return setTextAttribute( originalForegroundAttributes );
-                case Colour::White:     return setTextAttribute( FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE );
-                case Colour::Red:       return setTextAttribute( FOREGROUND_RED );
-                case Colour::Green:     return setTextAttribute( FOREGROUND_GREEN );
-                case Colour::Blue:      return setTextAttribute( FOREGROUND_BLUE );
-                case Colour::Cyan:      return setTextAttribute( FOREGROUND_BLUE | FOREGROUND_GREEN );
-                case Colour::Yellow:    return setTextAttribute( FOREGROUND_RED | FOREGROUND_GREEN );
-                case Colour::Grey:      return setTextAttribute( 0 );
+        virtual void use( Color::Code _colorCode ) override {
+            switch( _colorCode ) {
+                case Color::None:      return setTextAttribute( originalForegroundAttributes );
+                case Color::White:     return setTextAttribute( FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE );
+                case Color::Red:       return setTextAttribute( FOREGROUND_RED );
+                case Color::Green:     return setTextAttribute( FOREGROUND_GREEN );
+                case Color::Blue:      return setTextAttribute( FOREGROUND_BLUE );
+                case Color::Cyan:      return setTextAttribute( FOREGROUND_BLUE | FOREGROUND_GREEN );
+                case Color::Yellow:    return setTextAttribute( FOREGROUND_RED | FOREGROUND_GREEN );
+                case Color::Grey:      return setTextAttribute( 0 );
 
-                case Colour::LightGrey:     return setTextAttribute( FOREGROUND_INTENSITY );
-                case Colour::BrightRed:     return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_RED );
-                case Colour::BrightGreen:   return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_GREEN );
-                case Colour::BrightWhite:   return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE );
-                case Colour::BrightYellow:  return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_RED | FOREGROUND_GREEN );
+                case Color::LightGrey:     return setTextAttribute( FOREGROUND_INTENSITY );
+                case Color::BrightRed:     return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_RED );
+                case Color::BrightGreen:   return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_GREEN );
+                case Color::BrightWhite:   return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE );
+                case Color::BrightYellow:  return setTextAttribute( FOREGROUND_INTENSITY | FOREGROUND_RED | FOREGROUND_GREEN );
 
-                case Colour::Bright: CATCH_INTERNAL_ERROR( "not a colour" );
+                case Color::Bright: CATCH_INTERNAL_ERROR( "not a color" );
 
                 default:
-                    CATCH_ERROR( "Unknown colour requested" );
+                    CATCH_ERROR( "Unknown color requested" );
             }
         }
 
@@ -7624,18 +7624,18 @@ namespace {
         WORD originalBackgroundAttributes;
     };
 
-    IColourImpl* platformColourInstance() {
-        static Win32ColourImpl s_instance;
+    IColorImpl* platformColorInstance() {
+        static Win32ColorImpl s_instance;
 
         IConfigPtr config = getCurrentContext().getConfig();
-        UseColour::YesOrNo colourMode = config
-            ? config->useColour()
-            : UseColour::Auto;
-        if( colourMode == UseColour::Auto )
-            colourMode = UseColour::Yes;
-        return colourMode == UseColour::Yes
+        UseColor::YesOrNo colorMode = config
+            ? config->useColor()
+            : UseColor::Auto;
+        if( colorMode == UseColor::Auto )
+            colorMode = UseColor::Yes;
+        return colorMode == UseColor::Yes
             ? &s_instance
-            : NoColourImpl::instance();
+            : NoColorImpl::instance();
     }
 
 } // end anon namespace
@@ -7652,41 +7652,41 @@ namespace {
     // Thanks to Adam Strzelecki for original contribution
     // (http://github.com/nanoant)
     // https://github.com/philsquared/Catch/pull/131
-    class PosixColourImpl : public IColourImpl {
+    class PosixColorImpl : public IColorImpl {
     public:
-        virtual void use( Colour::Code _colourCode ) override {
-            switch( _colourCode ) {
-                case Colour::None:
-                case Colour::White:     return setColour( "[0m" );
-                case Colour::Red:       return setColour( "[0;31m" );
-                case Colour::Green:     return setColour( "[0;32m" );
-                case Colour::Blue:      return setColour( "[0;34m" );
-                case Colour::Cyan:      return setColour( "[0;36m" );
-                case Colour::Yellow:    return setColour( "[0;33m" );
-                case Colour::Grey:      return setColour( "[1;30m" );
+        virtual void use( Color::Code _colorCode ) override {
+            switch( _colorCode ) {
+                case Color::None:
+                case Color::White:     return setColor( "[0m" );
+                case Color::Red:       return setColor( "[0;31m" );
+                case Color::Green:     return setColor( "[0;32m" );
+                case Color::Blue:      return setColor( "[0;34m" );
+                case Color::Cyan:      return setColor( "[0;36m" );
+                case Color::Yellow:    return setColor( "[0;33m" );
+                case Color::Grey:      return setColor( "[1;30m" );
 
-                case Colour::LightGrey:     return setColour( "[0;37m" );
-                case Colour::BrightRed:     return setColour( "[1;31m" );
-                case Colour::BrightGreen:   return setColour( "[1;32m" );
-                case Colour::BrightWhite:   return setColour( "[1;37m" );
-                case Colour::BrightYellow:  return setColour( "[1;33m" );
+                case Color::LightGrey:     return setColor( "[0;37m" );
+                case Color::BrightRed:     return setColor( "[1;31m" );
+                case Color::BrightGreen:   return setColor( "[1;32m" );
+                case Color::BrightWhite:   return setColor( "[1;37m" );
+                case Color::BrightYellow:  return setColor( "[1;33m" );
 
-                case Colour::Bright: CATCH_INTERNAL_ERROR( "not a colour" );
-                default: CATCH_INTERNAL_ERROR( "Unknown colour requested" );
+                case Color::Bright: CATCH_INTERNAL_ERROR( "not a color" );
+                default: CATCH_INTERNAL_ERROR( "Unknown color requested" );
             }
         }
-        static IColourImpl* instance() {
-            static PosixColourImpl s_instance;
+        static IColorImpl* instance() {
+            static PosixColorImpl s_instance;
             return &s_instance;
         }
 
     private:
-        void setColour( const char* _escapeCode ) {
+        void setColor( const char* _escapeCode ) {
             Catch::cout() << '\033' << _escapeCode;
         }
     };
 
-    bool useColourOnPlatform() {
+    bool useColorOnPlatform() {
         return
 #ifdef CATCH_PLATFORM_MAC
             !isDebuggerActive() &&
@@ -7698,19 +7698,19 @@ namespace {
 #endif
             ;
     }
-    IColourImpl* platformColourInstance() {
+    IColorImpl* platformColorInstance() {
         ErrnoGuard guard;
         IConfigPtr config = getCurrentContext().getConfig();
-        UseColour::YesOrNo colourMode = config
-            ? config->useColour()
-            : UseColour::Auto;
-        if( colourMode == UseColour::Auto )
-            colourMode = useColourOnPlatform()
-                ? UseColour::Yes
-                : UseColour::No;
-        return colourMode == UseColour::Yes
-            ? PosixColourImpl::instance()
-            : NoColourImpl::instance();
+        UseColor::YesOrNo colorMode = config
+            ? config->useColor()
+            : UseColor::Auto;
+        if( colorMode == UseColor::Auto )
+            colorMode = useColorOnPlatform()
+                ? UseColor::Yes
+                : UseColor::No;
+        return colorMode == UseColor::Yes
+            ? PosixColorImpl::instance()
+            : NoColorImpl::instance();
     }
 
 } // end anon namespace
@@ -7720,7 +7720,7 @@ namespace {
 
 namespace Catch {
 
-    static IColourImpl* platformColourInstance() { return NoColourImpl::instance(); }
+    static IColorImpl* platformColorInstance() { return NoColorImpl::instance(); }
 
 } // end namespace Catch
 
@@ -7728,25 +7728,25 @@ namespace Catch {
 
 namespace Catch {
 
-    Colour::Colour( Code _colourCode ) { use( _colourCode ); }
-    Colour::Colour( Colour&& rhs ) noexcept {
+    Color::Color( Code _colorCode ) { use( _colorCode ); }
+    Color::Color( Color&& rhs ) noexcept {
         m_moved = rhs.m_moved;
         rhs.m_moved = true;
     }
-    Colour& Colour::operator=( Colour&& rhs ) noexcept {
+    Color& Color::operator=( Color&& rhs ) noexcept {
         m_moved = rhs.m_moved;
         rhs.m_moved  = true;
         return *this;
     }
 
-    Colour::~Colour(){ if( !m_moved ) use( None ); }
+    Color::~Color(){ if( !m_moved ) use( None ); }
 
-    void Colour::use( Code _colourCode ) {
-        static IColourImpl* impl = platformColourInstance();
-        impl->use( _colourCode );
+    void Color::use( Code _colorCode ) {
+        static IColorImpl* impl = platformColorInstance();
+        impl->use( _colorCode );
     }
 
-    std::ostream& operator << ( std::ostream& os, Colour const& ) {
+    std::ostream& operator << ( std::ostream& os, Color const& ) {
         return os;
     }
 
@@ -7756,7 +7756,7 @@ namespace Catch {
 #    pragma clang diagnostic pop
 #endif
 
-// end catch_console_colour.cpp
+// end catch_console_color.cpp
 // start catch_context.cpp
 
 namespace Catch {
@@ -8566,10 +8566,10 @@ namespace Catch {
 
         auto matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
         for( auto const& testCaseInfo : matchedTestCases ) {
-            Colour::Code colour = testCaseInfo.isHidden()
-                ? Colour::SecondaryText
-                : Colour::None;
-            Colour colourGuard( colour );
+            Color::Code color = testCaseInfo.isHidden()
+                ? Color::SecondaryText
+                : Color::None;
+            Color colorGuard( color );
 
             Catch::cout() << Column( testCaseInfo.name ).initialIndent( 2 ).indent( 4 ) << "\n";
             if( config.verbosity() >= Verbosity::High ) {
@@ -10382,7 +10382,7 @@ namespace Catch {
         const auto& exceptions = getRegistryHub().getStartupExceptionRegistry().getExceptions();
         if ( !exceptions.empty() ) {
             m_startupExceptions = true;
-            Colour colourGuard( Colour::Red );
+            Color colorGuard( Color::Red );
             Catch::cerr() << "Errors occurred during startup!" << '\n';
             // iterate over all exceptions and notify user
             for ( const auto& ex_ptr : exceptions ) {
@@ -10423,7 +10423,7 @@ namespace Catch {
         auto result = m_cli.parse( clara::Args( argc, argv ) );
         if( !result ) {
             Catch::cerr()
-                << Colour( Colour::Red )
+                << Color( Color::Red )
                 << "\nError(s) in input:\n"
                 << Column( result.errorMessage() ).indent( 2 )
                 << "\n\n";
@@ -12501,8 +12501,8 @@ namespace {
     const char* passedString() { return "passed"; }
 #endif
 
-    // Colour::LightGrey
-    Catch::Colour::Code dimColour() { return Catch::Colour::FileName; }
+    // Color::LightGrey
+    Catch::Color::Code dimColor() { return Catch::Color::FileName; }
 
     std::string bothOrAll( std::size_t count ) {
         return count == 1 ? std::string() :
@@ -12513,7 +12513,7 @@ namespace {
 
 namespace Catch {
 namespace {
-// Colour, message variants:
+// Color, message variants:
 // - white: No tests ran.
 // -   red: Failed [both/all] N test cases, failed [both/all] M assertions.
 // - white: Passed [both/all] N test cases (no assertions).
@@ -12523,7 +12523,7 @@ void printTotals(std::ostream& out, const Totals& totals) {
     if (totals.testCases.total() == 0) {
         out << "No tests ran.";
     } else if (totals.testCases.failed == totals.testCases.total()) {
-        Colour colour(Colour::ResultError);
+        Color color(Color::ResultError);
         const std::string qualify_assertions_failed =
             totals.assertions.failed == totals.assertions.total() ?
             bothOrAll(totals.assertions.failed) : std::string();
@@ -12538,12 +12538,12 @@ void printTotals(std::ostream& out, const Totals& totals) {
             << pluralise(totals.testCases.total(), "test case")
             << " (no assertions).";
     } else if (totals.assertions.failed) {
-        Colour colour(Colour::ResultError);
+        Color color(Color::ResultError);
         out <<
             "Failed " << pluralise(totals.testCases.failed, "test case") << ", "
             "failed " << pluralise(totals.assertions.failed, "assertion") << '.';
     } else {
-        Colour colour(Colour::ResultSuccess);
+        Color color(Color::ResultSuccess);
         out <<
             "Passed " << bothOrAll(totals.testCases.passed)
             << pluralise(totals.testCases.passed, "test case") <<
@@ -12570,77 +12570,77 @@ public:
 
         switch (result.getResultType()) {
         case ResultWas::Ok:
-            printResultType(Colour::ResultSuccess, passedString());
+            printResultType(Color::ResultSuccess, passedString());
             printOriginalExpression();
             printReconstructedExpression();
             if (!result.hasExpression())
-                printRemainingMessages(Colour::None);
+                printRemainingMessages(Color::None);
             else
                 printRemainingMessages();
             break;
         case ResultWas::ExpressionFailed:
             if (result.isOk())
-                printResultType(Colour::ResultSuccess, failedString() + std::string(" - but was ok"));
+                printResultType(Color::ResultSuccess, failedString() + std::string(" - but was ok"));
             else
-                printResultType(Colour::Error, failedString());
+                printResultType(Color::Error, failedString());
             printOriginalExpression();
             printReconstructedExpression();
             printRemainingMessages();
             break;
         case ResultWas::ThrewException:
-            printResultType(Colour::Error, failedString());
+            printResultType(Color::Error, failedString());
             printIssue("unexpected exception with message:");
             printMessage();
             printExpressionWas();
             printRemainingMessages();
             break;
         case ResultWas::FatalErrorCondition:
-            printResultType(Colour::Error, failedString());
+            printResultType(Color::Error, failedString());
             printIssue("fatal error condition with message:");
             printMessage();
             printExpressionWas();
             printRemainingMessages();
             break;
         case ResultWas::DidntThrowException:
-            printResultType(Colour::Error, failedString());
+            printResultType(Color::Error, failedString());
             printIssue("expected exception, got none");
             printExpressionWas();
             printRemainingMessages();
             break;
         case ResultWas::Info:
-            printResultType(Colour::None, "info");
+            printResultType(Color::None, "info");
             printMessage();
             printRemainingMessages();
             break;
         case ResultWas::Warning:
-            printResultType(Colour::None, "warning");
+            printResultType(Color::None, "warning");
             printMessage();
             printRemainingMessages();
             break;
         case ResultWas::ExplicitFailure:
-            printResultType(Colour::Error, failedString());
+            printResultType(Color::Error, failedString());
             printIssue("explicitly");
-            printRemainingMessages(Colour::None);
+            printRemainingMessages(Color::None);
             break;
             // These cases are here to prevent compiler warnings
         case ResultWas::Unknown:
         case ResultWas::FailureBit:
         case ResultWas::Exception:
-            printResultType(Colour::Error, "** internal error **");
+            printResultType(Color::Error, "** internal error **");
             break;
         }
     }
 
 private:
     void printSourceInfo() const {
-        Colour colourGuard(Colour::FileName);
+        Color colorGuard(Color::FileName);
         stream << result.getSourceInfo() << ':';
     }
 
-    void printResultType(Colour::Code colour, std::string const& passOrFail) const {
+    void printResultType(Color::Code color, std::string const& passOrFail) const {
         if (!passOrFail.empty()) {
             {
-                Colour colourGuard(colour);
+                Color colorGuard(color);
                 stream << ' ' << passOrFail;
             }
             stream << ':';
@@ -12655,7 +12655,7 @@ private:
         if (result.hasExpression()) {
             stream << ';';
             {
-                Colour colour(dimColour());
+                Color color(dimColor());
                 stream << " expression was:";
             }
             printOriginalExpression();
@@ -12671,7 +12671,7 @@ private:
     void printReconstructedExpression() const {
         if (result.hasExpandedExpression()) {
             {
-                Colour colour(dimColour());
+                Color color(dimColor());
                 stream << " for: ";
             }
             stream << result.getExpandedExpression();
@@ -12685,7 +12685,7 @@ private:
         }
     }
 
-    void printRemainingMessages(Colour::Code colour = dimColour()) {
+    void printRemainingMessages(Color::Code color = dimColor()) {
         if (itMessage == messages.end())
             return;
 
@@ -12694,7 +12694,7 @@ private:
         const std::size_t N = static_cast<std::size_t>(std::distance(itMessage, itEnd));
 
         {
-            Colour colourGuard(colour);
+            Color colorGuard(color);
             stream << " with " << pluralise(N, "message") << ':';
         }
 
@@ -12703,7 +12703,7 @@ private:
             if (printInfoMessages || itMessage->type != ResultWas::Info) {
                 stream << " '" << itMessage->message << '\'';
                 if (++itMessage != itEnd) {
-                    Colour colourGuard(dimColour());
+                    Color colorGuard(dimColor());
                     stream << " and";
                 }
             }
@@ -12796,13 +12796,13 @@ public:
         : stream(_stream),
         stats(_stats),
         result(_stats.assertionResult),
-        colour(Colour::None),
+        color(Color::None),
         message(result.getMessage()),
         messages(_stats.infoMessages),
         printInfoMessages(_printInfoMessages) {
         switch (result.getResultType()) {
         case ResultWas::Ok:
-            colour = Colour::Success;
+            color = Color::Success;
             passOrFail = "PASSED";
             //if( result.hasMessage() )
             if (_stats.infoMessages.size() == 1)
@@ -12812,10 +12812,10 @@ public:
             break;
         case ResultWas::ExpressionFailed:
             if (result.isOk()) {
-                colour = Colour::Success;
+                color = Color::Success;
                 passOrFail = "FAILED - but was ok";
             } else {
-                colour = Colour::Error;
+                color = Color::Error;
                 passOrFail = "FAILED";
             }
             if (_stats.infoMessages.size() == 1)
@@ -12824,7 +12824,7 @@ public:
                 messageLabel = "with messages";
             break;
         case ResultWas::ThrewException:
-            colour = Colour::Error;
+            color = Color::Error;
             passOrFail = "FAILED";
             messageLabel = "due to unexpected exception with ";
             if (_stats.infoMessages.size() == 1)
@@ -12833,12 +12833,12 @@ public:
                 messageLabel += "messages";
             break;
         case ResultWas::FatalErrorCondition:
-            colour = Colour::Error;
+            color = Color::Error;
             passOrFail = "FAILED";
             messageLabel = "due to a fatal error condition";
             break;
         case ResultWas::DidntThrowException:
-            colour = Colour::Error;
+            color = Color::Error;
             passOrFail = "FAILED";
             messageLabel = "because no exception was thrown where one was expected";
             break;
@@ -12850,7 +12850,7 @@ public:
             break;
         case ResultWas::ExplicitFailure:
             passOrFail = "FAILED";
-            colour = Colour::Error;
+            color = Color::Error;
             if (_stats.infoMessages.size() == 1)
                 messageLabel = "explicitly with message";
             if (_stats.infoMessages.size() > 1)
@@ -12861,7 +12861,7 @@ public:
         case ResultWas::FailureBit:
         case ResultWas::Exception:
             passOrFail = "** internal error **";
-            colour = Colour::Error;
+            color = Color::Error;
             break;
         }
     }
@@ -12881,13 +12881,13 @@ public:
 private:
     void printResultType() const {
         if (!passOrFail.empty()) {
-            Colour colourGuard(colour);
+            Color colorGuard(color);
             stream << passOrFail << ":\n";
         }
     }
     void printOriginalExpression() const {
         if (result.hasExpression()) {
-            Colour colourGuard(Colour::OriginalExpression);
+            Color colorGuard(Color::OriginalExpression);
             stream << "  ";
             stream << result.getExpressionInMacro();
             stream << '\n';
@@ -12896,7 +12896,7 @@ private:
     void printReconstructedExpression() const {
         if (result.hasExpandedExpression()) {
             stream << "with expansion:\n";
-            Colour colourGuard(Colour::ReconstructedExpression);
+            Color colorGuard(Color::ReconstructedExpression);
             stream << Column(result.getExpandedExpression()).indent(2) << '\n';
         }
     }
@@ -12910,14 +12910,14 @@ private:
         }
     }
     void printSourceInfo() const {
-        Colour colourGuard(Colour::FileName);
+        Color colorGuard(Color::FileName);
         stream << result.getSourceInfo() << ": ";
     }
 
     std::ostream& stream;
     AssertionStats const& stats;
     AssertionResult const& result;
-    Colour::Code colour;
+    Color::Code color;
     std::string passOrFail;
     std::string messageLabel;
     std::string message;
@@ -13139,7 +13139,7 @@ void ConsoleReporter::sectionEnded(SectionStats const& _sectionStats) {
     m_tablePrinter->close();
     if (_sectionStats.missingAssertions) {
         lazyPrint();
-        Colour colour(Colour::ResultError);
+        Color color(Color::ResultError);
         if (m_sectionStack.size() > 1)
             stream << "\nNo assertions in section";
         else
@@ -13219,7 +13219,7 @@ void ConsoleReporter::lazyPrintWithoutClosingBenchmarkTable() {
 }
 void ConsoleReporter::lazyPrintRunInfo() {
     stream << '\n' << getLineOfChars<'~'>() << '\n';
-    Colour colour(Colour::SecondaryText);
+    Color color(Color::SecondaryText);
     stream << currentTestRunInfo->name
         << " is a Catch v" << libraryVersion() << " host application.\n"
         << "Run with -? for options\n\n";
@@ -13240,7 +13240,7 @@ void ConsoleReporter::printTestCaseAndSectionHeader() {
     printOpenHeader(currentTestCaseInfo->name);
 
     if (m_sectionStack.size() > 1) {
-        Colour colourGuard(Colour::Headers);
+        Color colorGuard(Color::Headers);
 
         auto
             it = m_sectionStack.begin() + 1, // Skip first section (test case)
@@ -13253,7 +13253,7 @@ void ConsoleReporter::printTestCaseAndSectionHeader() {
 
     if (!lineInfo.empty()) {
         stream << getLineOfChars<'-'>() << '\n';
-        Colour colourGuard(Colour::FileName);
+        Color colorGuard(Color::FileName);
         stream << lineInfo << '\n';
     }
     stream << getLineOfChars<'.'>() << '\n' << std::endl;
@@ -13266,7 +13266,7 @@ void ConsoleReporter::printClosedHeader(std::string const& _name) {
 void ConsoleReporter::printOpenHeader(std::string const& _name) {
     stream << getLineOfChars<'-'>() << '\n';
     {
-        Colour colourGuard(Colour::Headers);
+        Color colorGuard(Color::Headers);
         printHeaderString(_name);
     }
 }
@@ -13284,9 +13284,9 @@ void ConsoleReporter::printHeaderString(std::string const& _string, std::size_t 
 
 struct SummaryColumn {
 
-    SummaryColumn( std::string _label, Colour::Code _colour )
+    SummaryColumn( std::string _label, Color::Code _color )
     :   label( std::move( _label ) ),
-        colour( _colour ) {}
+        color( _color ) {}
     SummaryColumn addRow( std::size_t count ) {
         ReusableStringStream rss;
         rss << count;
@@ -13302,16 +13302,16 @@ struct SummaryColumn {
     }
 
     std::string label;
-    Colour::Code colour;
+    Color::Code color;
     std::vector<std::string> rows;
 
 };
 
 void ConsoleReporter::printTotals( Totals const& totals ) {
     if (totals.testCases.total() == 0) {
-        stream << Colour(Colour::Warning) << "No tests ran\n";
+        stream << Color(Color::Warning) << "No tests ran\n";
     } else if (totals.assertions.total() > 0 && totals.testCases.allPassed()) {
-        stream << Colour(Colour::ResultSuccess) << "All tests passed";
+        stream << Color(Color::ResultSuccess) << "All tests passed";
         stream << " ("
             << pluralise(totals.assertions.passed, "assertion") << " in "
             << pluralise(totals.testCases.passed, "test case") << ')'
@@ -13319,16 +13319,16 @@ void ConsoleReporter::printTotals( Totals const& totals ) {
     } else {
 
         std::vector<SummaryColumn> columns;
-        columns.push_back(SummaryColumn("", Colour::None)
+        columns.push_back(SummaryColumn("", Color::None)
                           .addRow(totals.testCases.total())
                           .addRow(totals.assertions.total()));
-        columns.push_back(SummaryColumn("passed", Colour::Success)
+        columns.push_back(SummaryColumn("passed", Color::Success)
                           .addRow(totals.testCases.passed)
                           .addRow(totals.assertions.passed));
-        columns.push_back(SummaryColumn("failed", Colour::ResultError)
+        columns.push_back(SummaryColumn("failed", Color::ResultError)
                           .addRow(totals.testCases.failed)
                           .addRow(totals.assertions.failed));
-        columns.push_back(SummaryColumn("failed as expected", Colour::ResultExpectedFailure)
+        columns.push_back(SummaryColumn("failed as expected", Color::ResultExpectedFailure)
                           .addRow(totals.testCases.failedButOk)
                           .addRow(totals.assertions.failedButOk));
 
@@ -13344,10 +13344,10 @@ void ConsoleReporter::printSummaryRow(std::string const& label, std::vector<Summ
             if (value != "0")
                 stream << value;
             else
-                stream << Colour(Colour::Warning) << "- none -";
+                stream << Color(Color::Warning) << "- none -";
         } else if (value != "0") {
-            stream << Colour(Colour::LightGrey) << " | ";
-            stream << Colour(col.colour)
+            stream << Color(Color::LightGrey) << " | ";
+            stream << Color(col.color)
                 << value << ' ' << col.label;
         }
     }
@@ -13364,14 +13364,14 @@ void ConsoleReporter::printTotalsDivider(Totals const& totals) {
         while (failedRatio + failedButOkRatio + passedRatio > CATCH_CONFIG_CONSOLE_WIDTH - 1)
             findMax(failedRatio, failedButOkRatio, passedRatio)--;
 
-        stream << Colour(Colour::Error) << std::string(failedRatio, '=');
-        stream << Colour(Colour::ResultExpectedFailure) << std::string(failedButOkRatio, '=');
+        stream << Color(Color::Error) << std::string(failedRatio, '=');
+        stream << Color(Color::ResultExpectedFailure) << std::string(failedButOkRatio, '=');
         if (totals.testCases.allPassed())
-            stream << Colour(Colour::ResultSuccess) << std::string(passedRatio, '=');
+            stream << Color(Color::ResultSuccess) << std::string(passedRatio, '=');
         else
-            stream << Colour(Colour::Success) << std::string(passedRatio, '=');
+            stream << Color(Color::Success) << std::string(passedRatio, '=');
     } else {
-        stream << Colour(Colour::Warning) << std::string(CATCH_CONFIG_CONSOLE_WIDTH - 1, '=');
+        stream << Color(Color::Warning) << std::string(CATCH_CONFIG_CONSOLE_WIDTH - 1, '=');
     }
     stream << '\n';
 }

--- a/tests/src/test_object.cpp
+++ b/tests/src/test_object.cpp
@@ -33,7 +33,7 @@ TEST_CASE("Object::addXXXLayer()")
     {
         obj->init();
         REQUIRE(obj->getLayerCount() == 0);
-        REQUIRE(obj->getColourCount() > 0);
+        REQUIRE(obj->getColorCount() > 0);
     }
 
     SECTION("Add a bitmap layer")
@@ -158,7 +158,7 @@ void TestObject::testExportColorPalette()
 {
     std::shared_ptr< Object > obj = std::make_shared<Object>();
 
-    obj->addColour(ColourRef(QColor(255, 254, 253, 100), "TestColor1"));
+    obj->addColor(ColorRef(QColor(255, 254, 253, 100), "TestColor1"));
 
     QTemporaryDir dir;
     if (dir.isValid())
@@ -167,13 +167,13 @@ void TestObject::testExportColorPalette()
         QVERIFY(obj->exportPalette(sOutPath));
         QVERIFY(obj->importPalette(sOutPath));
 
-        ColourRef c = obj->getColour(0);
+        ColorRef c = obj->getColor(0);
 
         QVERIFY(c.name == "TestColor1");
-        QCOMPARE(c.colour.red(), 255);
-        QCOMPARE(c.colour.green(), 254);
-        QCOMPARE(c.colour.blue(), 253);
-        QCOMPARE(c.colour.alpha(), 100);
+        QCOMPARE(c.color.red(), 255);
+        QCOMPARE(c.color.green(), 254);
+        QCOMPARE(c.color.blue(), 253);
+        QCOMPARE(c.color.alpha(), 100);
     }
 
 }

--- a/translations/pencil.ts
+++ b/translations/pencil.ts
@@ -493,7 +493,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="268"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="269"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2455,7 +2455,7 @@ Color(s) in strokes will be altered by this action!
     </message>
     <message>
         <location filename="../core_lib/src/structure/object.cpp" line="320"/>
-        <source>Colour %1</source>
+        <source>Color %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4402,7 +4402,7 @@ Check selection, and please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../core_lib/src/graphics/vector/colourref.cpp" line="28"/>
+        <location filename="../core_lib/src/graphics/vector/colorref.cpp" line="28"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/pencil.ts
+++ b/translations/pencil.ts
@@ -493,7 +493,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="268"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="269"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2455,7 +2455,7 @@ Color(s) in strokes will be altered by this action!
     </message>
     <message>
         <location filename="../core_lib/src/structure/object.cpp" line="320"/>
-        <source>Color %1</source>
+        <source>Colour %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4402,7 +4402,7 @@ Check selection, and please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../core_lib/src/graphics/vector/colorref.cpp" line="28"/>
+        <location filename="../core_lib/src/graphics/vector/colourref.cpp" line="28"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/pencil_ar.ts
+++ b/translations/pencil_ar.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>اسم اللون</translation>
     </message>
     <message>

--- a/translations/pencil_ar.ts
+++ b/translations/pencil_ar.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>اسم اللون</translation>
     </message>
     <message>

--- a/translations/pencil_ca.ts
+++ b/translations/pencil_ca.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Nom del color</translation>
     </message>
     <message>

--- a/translations/pencil_ca.ts
+++ b/translations/pencil_ca.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Nom del color</translation>
     </message>
     <message>

--- a/translations/pencil_cs.ts
+++ b/translations/pencil_cs.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Název barvy</translation>
     </message>
     <message>

--- a/translations/pencil_cs.ts
+++ b/translations/pencil_cs.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Název barvy</translation>
     </message>
     <message>

--- a/translations/pencil_da.ts
+++ b/translations/pencil_da.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Farve navn</translation>
     </message>
     <message>

--- a/translations/pencil_da.ts
+++ b/translations/pencil_da.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Farve navn</translation>
     </message>
     <message>

--- a/translations/pencil_de.ts
+++ b/translations/pencil_de.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Name der Farbe</translation>
     </message>
     <message>

--- a/translations/pencil_de.ts
+++ b/translations/pencil_de.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Name der Farbe</translation>
     </message>
     <message>

--- a/translations/pencil_el.ts
+++ b/translations/pencil_el.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Όνομα χρώματος</translation>
     </message>
     <message>

--- a/translations/pencil_el.ts
+++ b/translations/pencil_el.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Όνομα χρώματος</translation>
     </message>
     <message>

--- a/translations/pencil_es.ts
+++ b/translations/pencil_es.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Nombre del color</translation>
     </message>
     <message>

--- a/translations/pencil_es.ts
+++ b/translations/pencil_es.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Nombre del color</translation>
     </message>
     <message>
@@ -1532,7 +1532,7 @@
     <message>
         <location filename="../app/ui/mainwindow2.ui" line="532"/>
         <source>Show next onion skin</source>
-        <translation>Mostrar papel cebolla posterior </translation>
+        <translation>Mostrar papel cebolla posterior </translation>
     </message>
     <message>
         <location filename="../app/ui/mainwindow2.ui" line="541"/>

--- a/translations/pencil_et.ts
+++ b/translations/pencil_et.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Värvi nimi</translation>
     </message>
     <message>

--- a/translations/pencil_et.ts
+++ b/translations/pencil_et.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Värvi nimi</translation>
     </message>
     <message>

--- a/translations/pencil_fr.ts
+++ b/translations/pencil_fr.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Nom de la couleur</translation>
     </message>
     <message>

--- a/translations/pencil_fr.ts
+++ b/translations/pencil_fr.ts
@@ -10,7 +10,7 @@
     <message>
         <location filename="../app/ui/aboutdialog.ui" line="52"/>
         <source>Official site: &lt;a href=&quot;https://www.pencil2d.org&quot;&gt;pencil2d.org&lt;/a&gt;&lt;br&gt;Developed by: &lt;b&gt;Pascal Naidon, Patrick Corrieri, Matt Chang&lt;/b&gt;&lt;br&gt;Thanks to Qt Framework &lt;a href=&quot;https://www.qt.io/download&quot;&gt;https://www.qt.io/&lt;/a&gt;&lt;br&gt;miniz: &lt;a href=&quot;https://github.com/richgel999/miniz&quot;&gt;https://github.com/richgel999/miniz&lt;/a&gt;&lt;br&gt;Distributed under the &lt;a href=&quot;http://www.gnu.org/licenses/gpl-2.0.html&quot;&gt;GNU General Public License, version 2&lt;/a&gt;</source>
-        <translation>Site officiel : &lt;a href=&quot;https://www.pencil2d.org&quot;&gt;pencil2d.org&lt;/a&gt;&lt;br&gt; Développé par: &lt;b&gt;Pascal Naidon, Patrick Corrieri, Matt Chang&lt;/b&gt;&lt;br&gt; Remerciements à Qt Framework &lt;a href=&quot;https://www.qt.io/download&quot;&gt;https://www.qt.io/&lt;/a&gt;&lt;br&gt;miniz: &lt;a href=&quot;https://github.com/richgel999/miniz&quot;&gt;https://github.com/richgel999/miniz&lt;/a&gt; &lt;br&gt;Distribué sous la &lt;a href=&quot;http://www.gnu.org/licenses/gpl-2.0.html&quot;&gt;GNU General Public License, version 2&lt;/a&gt;</translation>
+        <translation>Site officiel : &lt;a href=&quot;https://www.pencil2d.org&quot;&gt;pencil2d.org&lt;/a&gt;&lt;br&gt; Développé par: &lt;b&gt;Pascal Naidon, Patrick Corrieri, Matt Chang&lt;/b&gt;&lt;br&gt; Remerciements à Qt Framework &lt;a href=&quot;https://www.qt.io/download&quot;&gt;https://www.qt.io/&lt;/a&gt;&lt;br&gt;miniz: &lt;a href=&quot;https://github.com/richgel999/miniz&quot;&gt;https://github.com/richgel999/miniz&lt;/a&gt; &lt;br&gt;Distribué sous la &lt;a href=&quot;http://www.gnu.org/licenses/gpl-2.0.html&quot;&gt;GNU General Public License, version 2&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../app/src/aboutdialog.cpp" line="43"/>
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Nom de la couleur</translation>
     </message>
     <message>

--- a/translations/pencil_he.ts
+++ b/translations/pencil_he.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>שם צבע</translation>
     </message>
     <message>

--- a/translations/pencil_he.ts
+++ b/translations/pencil_he.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>שם צבע</translation>
     </message>
     <message>

--- a/translations/pencil_hu_HU.ts
+++ b/translations/pencil_hu_HU.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Szín neve</translation>
     </message>
     <message>

--- a/translations/pencil_hu_HU.ts
+++ b/translations/pencil_hu_HU.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Szín neve</translation>
     </message>
     <message>

--- a/translations/pencil_id.ts
+++ b/translations/pencil_id.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Nama warna</translation>
     </message>
     <message>

--- a/translations/pencil_id.ts
+++ b/translations/pencil_id.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Nama warna</translation>
     </message>
     <message>

--- a/translations/pencil_it.ts
+++ b/translations/pencil_it.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Nome colore</translation>
     </message>
     <message>

--- a/translations/pencil_it.ts
+++ b/translations/pencil_it.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Nome colore</translation>
     </message>
     <message>

--- a/translations/pencil_ja.ts
+++ b/translations/pencil_ja.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>色名</translation>
     </message>
     <message>

--- a/translations/pencil_ja.ts
+++ b/translations/pencil_ja.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>色名</translation>
     </message>
     <message>

--- a/translations/pencil_kab.ts
+++ b/translations/pencil_kab.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Isem n yini</translation>
     </message>
     <message>

--- a/translations/pencil_kab.ts
+++ b/translations/pencil_kab.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Isem n yini</translation>
     </message>
     <message>

--- a/translations/pencil_pl.ts
+++ b/translations/pencil_pl.ts
@@ -430,7 +430,7 @@ Polskie tłumaczenie: Reptile (&lt;a href=mailto:&quot;reptile@o2.pl&quot;&gt;re
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Nazwa koloru</translation>
     </message>
     <message>

--- a/translations/pencil_pl.ts
+++ b/translations/pencil_pl.ts
@@ -430,7 +430,7 @@ Polskie tłumaczenie: Reptile (&lt;a href=mailto:&quot;reptile@o2.pl&quot;&gt;re
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Nazwa koloru</translation>
     </message>
     <message>

--- a/translations/pencil_pt.ts
+++ b/translations/pencil_pt.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Nome da cor</translation>
     </message>
     <message>

--- a/translations/pencil_pt.ts
+++ b/translations/pencil_pt.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Nome da cor</translation>
     </message>
     <message>

--- a/translations/pencil_pt_BR.ts
+++ b/translations/pencil_pt_BR.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Nome da cor</translation>
     </message>
     <message>

--- a/translations/pencil_pt_BR.ts
+++ b/translations/pencil_pt_BR.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Nome da cor</translation>
     </message>
     <message>

--- a/translations/pencil_ru.ts
+++ b/translations/pencil_ru.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Параметры образца</translation>
     </message>
     <message>

--- a/translations/pencil_ru.ts
+++ b/translations/pencil_ru.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Параметры образца</translation>
     </message>
     <message>

--- a/translations/pencil_sl.ts
+++ b/translations/pencil_sl.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Ime barve</translation>
     </message>
     <message>
@@ -4188,7 +4188,7 @@ Uspešno ste izbpraznili seznam</translation>
     <message>
         <location filename="../app/src/toolbox.cpp" line="100"/>
         <source>Smudge Tool (%1):&lt;br&gt;Edit polyline/curves&lt;br&gt;Liquify bitmap pixels&lt;br&gt; (%1)+[Alt]: Smooth</source>
-        <translation>Orodje zamazanje (%1): &lt;br&gt;Uredi večsegmentne črte/krivulje&lt;br&gt;Razmaži bitne točke&lt;br&gt; (%1)+[Alt]: Zgladi</translation>
+        <translation>Orodje zamazanje (%1): &lt;br&gt;Uredi večsegmentne črte/krivulje&lt;br&gt;Razmaži bitne točke&lt;br&gt; (%1)+[Alt]: Zgladi</translation>
     </message>
     <message>
         <location filename="../app/src/toolbox.cpp" line="104"/>

--- a/translations/pencil_sl.ts
+++ b/translations/pencil_sl.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Ime barve</translation>
     </message>
     <message>

--- a/translations/pencil_sv.ts
+++ b/translations/pencil_sv.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Färgnamn</translation>
     </message>
     <message>

--- a/translations/pencil_sv.ts
+++ b/translations/pencil_sv.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Färgnamn</translation>
     </message>
     <message>

--- a/translations/pencil_tr.ts
+++ b/translations/pencil_tr.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Renk adı</translation>
     </message>
     <message>

--- a/translations/pencil_tr.ts
+++ b/translations/pencil_tr.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Renk adı</translation>
     </message>
     <message>

--- a/translations/pencil_vi.ts
+++ b/translations/pencil_vi.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>Tên màu</translation>
     </message>
     <message>

--- a/translations/pencil_vi.ts
+++ b/translations/pencil_vi.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>Tên màu</translation>
     </message>
     <message>

--- a/translations/pencil_zh_CN.ts
+++ b/translations/pencil_zh_CN.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>颜色名</translation>
     </message>
     <message>

--- a/translations/pencil_zh_CN.ts
+++ b/translations/pencil_zh_CN.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>颜色名</translation>
     </message>
     <message>

--- a/translations/pencil_zh_TW.ts
+++ b/translations/pencil_zh_TW.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Color name</source>
+        <source>Colour name</source>
         <translation>顏色名稱</translation>
     </message>
     <message>

--- a/translations/pencil_zh_TW.ts
+++ b/translations/pencil_zh_TW.ts
@@ -429,7 +429,7 @@
     <message>
         <location filename="../app/src/colorpalettewidget.cpp" line="244"/>
         <location filename="../app/src/colorpalettewidget.cpp" line="245"/>
-        <source>Colour name</source>
+        <source>Color name</source>
         <translation>顏色名稱</translation>
     </message>
     <message>


### PR DESCRIPTION
This PR affects only the development side.
I've changed 'colour' to 'color' in all files, and renamed the class 'ColourRef' to 'ColorRef'. There seemed to consensus on 'color' last time we discussed it, and it is consistent with Qt, who has QColor, QColorDialog etc.
I've used Qt Creators Search and Replace. When I search now, there are still 22 strings that contain 'olour', and all of them are *.qm files in 'translations'. Is this a problem?