### PR TITLE
eyedroppertool improvements

### DIFF
--- a/core_lib/src/graphics/vector/vectorimage.cpp
+++ b/core_lib/src/graphics/vector/vectorimage.cpp
@@ -1097,7 +1097,7 @@ int VectorImage::getCurvesColor(int curve)
 /**
  * @brief VectorImage::isCurveInvisible
  * @param curve: Int of the curve from a QList of curves
- * @return bool, true = invisible, false = not invisible
+ * @return bool: true = invisible, false = visible
  */
 bool VectorImage::isCurveInvisible(int curve)
 {

--- a/core_lib/src/graphics/vector/vectorimage.cpp
+++ b/core_lib/src/graphics/vector/vectorimage.cpp
@@ -1089,8 +1089,22 @@ int VectorImage::getCurvesColor(int curve)
 {
     int result = -1;
     if (curve > -1)
-    {
+    {        
         result = mCurves[curve].getColourNumber();
+    }
+    return result;
+}
+/**
+ * @brief VectorImage::isCurveInvisible
+ * @param curve: Int of the curve from a QList of curves
+ * @return bool, true = invisible, false = not invisible
+ */
+bool VectorImage::isCurveInvisible(int curve)
+{
+    int result = false;
+    if (curve > -1)
+    {
+        result = mCurves[curve].isInvisible();
     }
     return result;
 }

--- a/core_lib/src/graphics/vector/vectorimage.h
+++ b/core_lib/src/graphics/vector/vectorimage.h
@@ -84,6 +84,7 @@ public:
     QColor getColour(int i);
     int  getColourNumber(QPointF point);
     int getCurvesColor(int curve);
+    bool isCurveInvisible(int curve);
     bool usesColour(int index);
     void removeColour(int index);
     void moveColor(int start, int end);

--- a/core_lib/src/tool/eyedroppertool.cpp
+++ b/core_lib/src/tool/eyedroppertool.cpp
@@ -114,14 +114,21 @@ void EyedropperTool::pointerMoveEvent(PointerEvent*)
         int colourNumber = vectorImage->getColourNumber(getCurrentPoint());
         qreal myqreal = 10.0;
         QList<int> closestCurve = vectorImage->getCurvesCloseTo(getCurrentPoint(), myqreal);
-        if (colourNumber != -1)
+        for (int i = closestCurve.length()-1; i >= 0; i--)
+        {
+            if(vectorImage->isCurveInvisible(closestCurve[i]))
+            {
+                closestCurve.removeAt(i);
+            }
+        }
+        if(!closestCurve.isEmpty())
+        {
+            int curveColor = vectorImage->getCurvesColor(closestCurve.last());
+            mScribbleArea->setCursor(cursor(mEditor->object()->getColour(curveColor).colour));
+        }
+        else if (colourNumber != -1)
         {
             mScribbleArea->setCursor(cursor(mEditor->object()->getColour(colourNumber).colour));
-        }
-        else if(!closestCurve.isEmpty())
-        {
-            int curveColor = vectorImage->getCurvesColor(closestCurve.first());
-            mScribbleArea->setCursor(cursor(mEditor->object()->getColour(curveColor).colour));
         }
         else
         {
@@ -166,14 +173,21 @@ void EyedropperTool::updateFrontColor()
         int colourNumber = vectorImage->getColourNumber(getLastPoint());
         qreal myqreal = 10.0;
         QList<int> closestCurve = vectorImage->getCurvesCloseTo(getCurrentPoint(), myqreal);
-        if (colourNumber != -1)
+        for (int i = closestCurve.length()-1; i >= 0; i--)
+        {
+            if(vectorImage->isCurveInvisible(closestCurve[i]))
+            {
+                closestCurve.removeAt(i);
+            }
+        }
+        if(!closestCurve.isEmpty())
+        {
+            int curveColor = vectorImage->getCurvesColor(closestCurve.last());
+            mEditor->color()->setColorNumber(curveColor);
+        }
+        else if (colourNumber != -1)
         {
             mEditor->color()->setColorNumber(colourNumber);
-        }
-        else if(!closestCurve.isEmpty())
-        {
-            int curveColor = vectorImage->getCurvesColor(closestCurve.first());
-            mEditor->color()->setColorNumber(curveColor);
         }
     }
 }


### PR DESCRIPTION
eyedroppertool will now ignore invisible mCurves.  
It will display the color of vectors (mCurves) over mAreas.
It will show the top (or last drawn vector) over bottom vectors.