### PR TITLE
Fix errors, warnings and deprecations from Qt 5.15

### DIFF
--- a/app/src/displayoptionwidget.cpp
+++ b/app/src/displayoptionwidget.cpp
@@ -102,22 +102,22 @@ void DisplayOptionWidget::updateUI()
 {
     PreferenceManager* prefs = editor()->preference();
 
-    SignalBlocker b1(ui->thinLinesButton);
+    QSignalBlocker b1(ui->thinLinesButton);
     ui->thinLinesButton->setChecked(prefs->isOn(SETTING::INVISIBLE_LINES));
 
-    SignalBlocker b2(ui->outLinesButton);
+    QSignalBlocker b2(ui->outLinesButton);
     ui->outLinesButton->setChecked(prefs->isOn(SETTING::OUTLINES));
 
-    SignalBlocker b9(ui->overlayCenterButton);
+    QSignalBlocker b9(ui->overlayCenterButton);
     ui->overlayCenterButton->setChecked(prefs->isOn(SETTING::OVERLAY_CENTER));
 
-    SignalBlocker b10(ui->overlayThirdsButton);
+    QSignalBlocker b10(ui->overlayThirdsButton);
     ui->overlayThirdsButton->setChecked(prefs->isOn(SETTING::OVERLAY_THIRDS));
 
-    SignalBlocker b11(ui->overlayGoldenRatioButton);
+    QSignalBlocker b11(ui->overlayGoldenRatioButton);
     ui->overlayGoldenRatioButton->setChecked(prefs->isOn(SETTING::OVERLAY_GOLDEN));
 
-    SignalBlocker b12(ui->overlaySafeAreaButton);
+    QSignalBlocker b12(ui->overlaySafeAreaButton);
     ui->overlaySafeAreaButton->setChecked(prefs->isOn(SETTING::OVERLAY_SAFE));
 
     if (prefs->isOn(SETTING::ACTION_SAFE_ON) || prefs->isOn(SETTING::TITLE_SAFE_ON))
@@ -129,10 +129,10 @@ void DisplayOptionWidget::updateUI()
 
     ViewManager* view = editor()->view();
 
-    SignalBlocker b3(ui->mirrorButton);
+    QSignalBlocker b3(ui->mirrorButton);
     ui->mirrorButton->setChecked(view->isFlipHorizontal());
 
-    SignalBlocker b4(ui->mirrorVButton);
+    QSignalBlocker b4(ui->mirrorVButton);
     ui->mirrorVButton->setChecked(view->isFlipVertical());
 }
 

--- a/app/src/exportimagedialog.cpp
+++ b/app/src/exportimagedialog.cpp
@@ -64,8 +64,8 @@ void ExportImageDialog::setDefaultRange(int startFrame, int endFrame, int endFra
     mEndFrame = endFrame;
     mEndFrameWithSounds = endFrameWithSounds;
 
-    SignalBlocker b1( ui->startSpinBox );
-    SignalBlocker b2( ui->endSpinBox );
+    QSignalBlocker b1( ui->startSpinBox );
+    QSignalBlocker b2( ui->endSpinBox );
 
     ui->startSpinBox->setValue( startFrame );
     ui->endSpinBox->setValue( endFrame );

--- a/app/src/exportmoviedialog.cpp
+++ b/app/src/exportmoviedialog.cpp
@@ -61,8 +61,8 @@ void ExportMovieDialog::updateResolutionCombo( int index )
 {
     QSize camSize = ui->cameraCombo->itemData( index ).toSize();
 
-    SignalBlocker b1( ui->widthSpinBox );
-    SignalBlocker b2( ui->heightSpinBox );
+    QSignalBlocker b1( ui->widthSpinBox );
+    QSignalBlocker b2( ui->heightSpinBox );
 
     ui->widthSpinBox->setValue( camSize.width() );
     ui->heightSpinBox->setValue( camSize.height() );
@@ -73,8 +73,8 @@ void ExportMovieDialog::setDefaultRange(int startFrame, int endFrame, int endFra
     mEndFrame = endFrame;
     mEndFrameWithSounds = endFrameWithSounds;
 
-    SignalBlocker b1( ui->startSpinBox );
-    SignalBlocker b2( ui->endSpinBox );
+    QSignalBlocker b1( ui->startSpinBox );
+    QSignalBlocker b2( ui->endSpinBox );
 
     ui->startSpinBox->setValue( startFrame );
     ui->endSpinBox->setValue( endFrame );

--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -155,7 +155,7 @@ FileType ImportImageSeqDialog::getFileType()
 
 void ImportImageSeqDialog::setSpace(int number)
 {
-    SignalBlocker b1(uiOptionsBox->spaceSpinBox);
+    QSignalBlocker b1(uiOptionsBox->spaceSpinBox);
     uiOptionsBox->spaceSpinBox->setValue(number);
 }
 

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -413,7 +413,7 @@ void MainWindow2::createMenus()
 
 void MainWindow2::setMenuActionChecked(QAction* action, bool bChecked)
 {
-    SignalBlocker b(action);
+    QSignalBlocker b(action);
     action->setChecked(bChecked);
 }
 

--- a/app/src/onionskinwidget.cpp
+++ b/app/src/onionskinwidget.cpp
@@ -86,16 +86,16 @@ void OnionSkinWidget::updateUI()
 {
     PreferenceManager* prefs = editor()->preference();
 
-    SignalBlocker b1(ui->onionPrevButton);
+    QSignalBlocker b1(ui->onionPrevButton);
     ui->onionPrevButton->setChecked(prefs->isOn(SETTING::PREV_ONION));
 
-    SignalBlocker b2(ui->onionNextButton);
+    QSignalBlocker b2(ui->onionNextButton);
     ui->onionNextButton->setChecked(prefs->isOn(SETTING::NEXT_ONION));
 
-    SignalBlocker b3(ui->onionBlueButton);
+    QSignalBlocker b3(ui->onionBlueButton);
     ui->onionBlueButton->setChecked(prefs->isOn(SETTING::ONION_BLUE));
 
-    SignalBlocker b4(ui->onionRedButton);
+    QSignalBlocker b4(ui->onionRedButton);
     ui->onionRedButton->setChecked(prefs->isOn(SETTING::ONION_RED));
 
     ui->onionMaxOpacityBox->setValue(prefs->getInt(SETTING::ONION_MAX_OPACITY));
@@ -103,10 +103,10 @@ void OnionSkinWidget::updateUI()
     ui->onionPrevFramesNumBox->setValue(prefs->getInt(SETTING::ONION_PREV_FRAMES_NUM));
     ui->onionNextFramesNumBox->setValue(prefs->getInt(SETTING::ONION_NEXT_FRAMES_NUM));
 
-    SignalBlocker b5(ui->onionSkinMode);
+    QSignalBlocker b5(ui->onionSkinMode);
     ui->onionSkinMode->setChecked(prefs->getString(SETTING::ONION_TYPE) == "absolute");
 
-    SignalBlocker b6(ui->onionWhilePlayback);
+    QSignalBlocker b6(ui->onionWhilePlayback);
     ui->onionWhilePlayback->setChecked(prefs->getInt(SETTING::ONION_WHILE_PLAYBACK));
 
 }

--- a/app/src/preferencesdialog.cpp
+++ b/app/src/preferencesdialog.cpp
@@ -185,50 +185,50 @@ void GeneralPage::updateValues()
 
     if (index >= 0)
     {
-        SignalBlocker b(ui->languageCombo);
+        QSignalBlocker b(ui->languageCombo);
         ui->languageCombo->setCurrentIndex(index);
     }
 
-    SignalBlocker b1(ui->curveSmoothingLevel);
+    QSignalBlocker b1(ui->curveSmoothingLevel);
     ui->curveSmoothingLevel->setValue(mManager->getInt(SETTING::CURVE_SMOOTHING));
-    SignalBlocker b2(ui->windowOpacityLevel);
+    QSignalBlocker b2(ui->windowOpacityLevel);
     ui->windowOpacityLevel->setValue(100 - mManager->getInt(SETTING::WINDOW_OPACITY));
-    SignalBlocker b3(ui->shadowsBox);
+    QSignalBlocker b3(ui->shadowsBox);
     ui->shadowsBox->setChecked(mManager->isOn(SETTING::SHADOW));
-    SignalBlocker b4(ui->toolCursorsBox);
+    QSignalBlocker b4(ui->toolCursorsBox);
     ui->toolCursorsBox->setChecked(mManager->isOn(SETTING::TOOL_CURSOR));
-    SignalBlocker b5(ui->antialiasingBox);
+    QSignalBlocker b5(ui->antialiasingBox);
     ui->antialiasingBox->setChecked(mManager->isOn(SETTING::ANTIALIAS));
-    SignalBlocker b6(ui->dottedCursorBox);
+    QSignalBlocker b6(ui->dottedCursorBox);
     ui->dottedCursorBox->setChecked(mManager->isOn(SETTING::DOTTED_CURSOR));
-    SignalBlocker b7(ui->gridSizeInputW);
+    QSignalBlocker b7(ui->gridSizeInputW);
     ui->gridSizeInputW->setValue(mManager->getInt(SETTING::GRID_SIZE_W));
-    SignalBlocker b11(ui->gridSizeInputH);
+    QSignalBlocker b11(ui->gridSizeInputH);
     ui->gridSizeInputH->setValue(mManager->getInt(SETTING::GRID_SIZE_H));
-    SignalBlocker b8(ui->gridCheckBox);
+    QSignalBlocker b8(ui->gridCheckBox);
     ui->gridCheckBox->setChecked(mManager->isOn(SETTING::GRID));
-    SignalBlocker b16(ui->actionSafeCheckBox);
+    QSignalBlocker b16(ui->actionSafeCheckBox);
 
     bool actionSafeOn = mManager->isOn(SETTING::ACTION_SAFE_ON);
     ui->actionSafeCheckBox->setChecked(actionSafeOn);
-    SignalBlocker b14(ui->actionSafeInput);
+    QSignalBlocker b14(ui->actionSafeInput);
     ui->actionSafeInput->setValue(mManager->getInt(SETTING::ACTION_SAFE));
-    SignalBlocker b17(ui->titleSafeCheckBox);
+    QSignalBlocker b17(ui->titleSafeCheckBox);
     bool titleSafeOn = mManager->isOn(SETTING::TITLE_SAFE_ON);
     ui->titleSafeCheckBox->setChecked(titleSafeOn);
-    SignalBlocker b15(ui->titleSafeInput);
+    QSignalBlocker b15(ui->titleSafeInput);
     ui->titleSafeInput->setValue(mManager->getInt(SETTING::TITLE_SAFE));
 
-    SignalBlocker b18(ui->safeHelperTextCheckbox);
+    QSignalBlocker b18(ui->safeHelperTextCheckbox);
     ui->safeHelperTextCheckbox->setChecked(mManager->isOn(SETTING::OVERLAY_SAFE_HELPER_TEXT_ON));
 
-    SignalBlocker b9(ui->highResBox);
+    QSignalBlocker b9(ui->highResBox);
     ui->highResBox->setChecked(mManager->isOn(SETTING::HIGH_RESOLUTION));
 
-    SignalBlocker b10(ui->backgroundButtons);
+    QSignalBlocker b10(ui->backgroundButtons);
     QString bgName = mManager->getString(SETTING::BACKGROUND_STYLE);
 
-    SignalBlocker b12(ui->framePoolSizeSpin);
+    QSignalBlocker b12(ui->framePoolSizeSpin);
     ui->framePoolSizeSpin->setValue(mManager->getInt(SETTING::FRAME_POOL_SIZE));
 
     int buttonIdx = 1;
@@ -392,17 +392,17 @@ TimelinePage::~TimelinePage()
 
 void TimelinePage::updateValues()
 {
-    SignalBlocker b1(ui->scrubBox);
+    QSignalBlocker b1(ui->scrubBox);
     ui->scrubBox->setChecked(mManager->isOn(SETTING::SHORT_SCRUB));
 
-    SignalBlocker b3(ui->timelineLength);
+    QSignalBlocker b3(ui->timelineLength);
     ui->timelineLength->setValue(mManager->getInt(SETTING::TIMELINE_SIZE));
     if (mManager->getString(SETTING::TIMELINE_SIZE).toInt() <= 0)
         ui->timelineLength->setValue(240);
 
-    SignalBlocker b4(ui->radioButtonAddNewKey);
-    SignalBlocker b5(ui->radioButtonDuplicate);
-    SignalBlocker b6(ui->radioButtonDrawOnPrev);
+    QSignalBlocker b4(ui->radioButtonAddNewKey);
+    QSignalBlocker b5(ui->radioButtonDuplicate);
+    QSignalBlocker b6(ui->radioButtonDrawOnPrev);
     int action = mManager->getInt(SETTING::DRAW_ON_EMPTY_FRAME_ACTION);
     switch (action)
     {
@@ -472,10 +472,10 @@ void TimelinePage::layerVisibilityThresholdChanged(int value)
     float percentage = static_cast<float>(value/100.0f);
     mManager->set(SETTING::LAYER_VISIBILITY_THRESHOLD, percentage);
 
-    SignalBlocker b8(ui->visibilitySlider);
+    QSignalBlocker b8(ui->visibilitySlider);
     ui->visibilitySlider->setValue(value);
 
-    SignalBlocker b9(ui->visibilitySpinbox);
+    QSignalBlocker b9(ui->visibilitySpinbox);
     ui->visibilitySpinbox->setValue(value);
 }
 

--- a/app/src/presetdialog.cpp
+++ b/app/src/presetdialog.cpp
@@ -79,7 +79,7 @@ void PresetDialog::initPresets()
     QSettings presets(dataDir.filePath("presets.ini"), QSettings::IniFormat, this);
     
     bool ok = true;
-    for (const QString key : presets.allKeys())
+    for (const QString& key : presets.allKeys())
     {
         int index = key.toInt(&ok);
         if (!ok || index == 0 || !dataDir.exists(QString("%1.pclx").arg(index))) continue;

--- a/app/src/tooloptionwidget.cpp
+++ b/app/src/tooloptionwidget.cpp
@@ -221,64 +221,64 @@ void ToolOptionWidget::onToolChanged(ToolType)
 
 void ToolOptionWidget::setPenWidth(qreal width)
 {
-    SignalBlocker b(ui->sizeSlider);
+    QSignalBlocker b(ui->sizeSlider);
     ui->sizeSlider->setEnabled(true);
     ui->sizeSlider->setValue(width);
 
-    SignalBlocker b2(ui->brushSpinBox);
+    QSignalBlocker b2(ui->brushSpinBox);
     ui->brushSpinBox->setEnabled(true);
     ui->brushSpinBox->setValue(width);
 }
 
 void ToolOptionWidget::setPenFeather(qreal featherValue)
 {
-    SignalBlocker b(ui->featherSlider);
+    QSignalBlocker b(ui->featherSlider);
     ui->featherSlider->setEnabled(true);
     ui->featherSlider->setValue(featherValue);
 
-    SignalBlocker b2(ui->featherSpinBox);
+    QSignalBlocker b2(ui->featherSpinBox);
     ui->featherSpinBox->setEnabled(true);
     ui->featherSpinBox->setValue(featherValue);
 }
 
 void ToolOptionWidget::setUseFeather(bool useFeather)
 {
-    SignalBlocker b(ui->useFeatherBox);
+    QSignalBlocker b(ui->useFeatherBox);
     ui->useFeatherBox->setEnabled(true);
     ui->useFeatherBox->setChecked(useFeather);
 }
 
 void ToolOptionWidget::setPenInvisibility(int x)
 {
-    SignalBlocker b(ui->makeInvisibleBox);
+    QSignalBlocker b(ui->makeInvisibleBox);
     ui->makeInvisibleBox->setEnabled(true);
     ui->makeInvisibleBox->setChecked(x > 0);
 }
 
 void ToolOptionWidget::setPressure(int x)
 {
-    SignalBlocker b(ui->usePressureBox);
+    QSignalBlocker b(ui->usePressureBox);
     ui->usePressureBox->setEnabled(true);
     ui->usePressureBox->setChecked(x > 0);
 }
 
 void ToolOptionWidget::setPreserveAlpha(int x)
 {
-    SignalBlocker b(ui->preserveAlphaBox);
+    QSignalBlocker b(ui->preserveAlphaBox);
     ui->preserveAlphaBox->setEnabled(true);
     ui->preserveAlphaBox->setChecked(x > 0);
 }
 
 void ToolOptionWidget::setVectorMergeEnabled(int x)
 {
-    SignalBlocker b(ui->vectorMergeBox);
+    QSignalBlocker b(ui->vectorMergeBox);
     ui->vectorMergeBox->setEnabled(true);
     ui->vectorMergeBox->setChecked(x > 0);
 }
 
 void ToolOptionWidget::setAA(int x)
 {
-    SignalBlocker b(ui->useAABox);
+    QSignalBlocker b(ui->useAABox);
     ui->useAABox->setEnabled(true);
     ui->useAABox->setVisible(false);
 
@@ -306,25 +306,25 @@ void ToolOptionWidget::setStabilizerLevel(int x)
 
 void ToolOptionWidget::setTolerance(int tolerance)
 {
-    SignalBlocker b(ui->toleranceSlider);
+    QSignalBlocker b(ui->toleranceSlider);
     ui->toleranceSlider->setEnabled(true);
     ui->toleranceSlider->setValue(tolerance);
 
-    SignalBlocker b2(ui->toleranceSpinBox);
+    QSignalBlocker b2(ui->toleranceSpinBox);
     ui->toleranceSpinBox->setEnabled(true);
     ui->toleranceSpinBox->setValue(tolerance);
 }
 
 void ToolOptionWidget::setFillContour(int useFill)
 {
-    SignalBlocker b(ui->fillContourBox);
+    QSignalBlocker b(ui->fillContourBox);
     ui->fillContourBox->setEnabled(true);
     ui->fillContourBox->setChecked(useFill > 0);
 }
 
 void ToolOptionWidget::setBezier(bool useBezier)
 {
-    SignalBlocker b(ui->useBezierBox);
+    QSignalBlocker b(ui->useBezierBox);
     ui->useBezierBox->setChecked(useBezier);
 }
 

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -1015,11 +1015,6 @@
     <string>Peg bar Alignment</string>
    </property>
   </action>
-  <action name="actionImport_MovieVideo">
-   <property name="text">
-    <string>Movie Video...</string>
-   </property>
-  </action>
   <action name="actionImport_MovieAudio">
    <property name="text">
     <string>Movie Audio...</string>

--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #include <QDebug>
 #include <QtMath>
 #include <QFile>
+#include <QPainterPath>
 #include "util.h"
 
 BitmapImage::BitmapImage()

--- a/core_lib/src/graphics/vector/beziercurve.cpp
+++ b/core_lib/src/graphics/vector/beziercurve.cpp
@@ -22,6 +22,7 @@ GNU General Public License for more details.
 #include <QXmlStreamWriter>
 #include <QDomElement>
 #include <QDebug>
+#include <QPainterPath>
 #include "object.h"
 #include "pencilerror.h"
 

--- a/core_lib/src/graphics/vector/vectorimage.cpp
+++ b/core_lib/src/graphics/vector/vectorimage.cpp
@@ -42,6 +42,17 @@ VectorImage::~VectorImage()
 {
 }
 
+VectorImage& VectorImage::operator=(const VectorImage& a) {
+    if (this != &a) {
+        deselectAll();
+        mObject = a.mObject;
+        mCurves = a.mCurves;
+        mArea = a.mArea;
+        modification();
+    }
+    return *this;
+}
+
 VectorImage* VectorImage::clone()
 {
     return new VectorImage(*this);
@@ -96,7 +107,7 @@ Status VectorImage::write(QString filePath, QString format)
     debugInfo << "VectorImage::write";
     debugInfo << QString("filePath = ").append(filePath);
     debugInfo << QString("format = ").append(format);
-    
+
     QFile file(filePath);
     bool result = file.open(QIODevice::WriteOnly);
     if (!result)
@@ -599,8 +610,8 @@ void VectorImage::setSelected(int curveNumber, bool YesOrNo)
     if (mCurves.isEmpty()) return;
 
     mCurves[curveNumber].setSelected(YesOrNo);
-    
-    if (YesOrNo) 
+
+    if (YesOrNo)
         mSelectionRect |= mCurves[curveNumber].getBoundingRect();
     modification();
 }

--- a/core_lib/src/graphics/vector/vectorimage.h
+++ b/core_lib/src/graphics/vector/vectorimage.h
@@ -35,6 +35,7 @@ public:
     VectorImage();
     VectorImage(const VectorImage&);
     virtual ~VectorImage();
+    VectorImage& operator=(const VectorImage& a);
 
     VectorImage* clone() override;
 

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -925,9 +925,10 @@ void ScribbleArea::handleDrawingOnEmptyFrame()
                 mEditor->scrubTo(frameNumber);
                 break;
             }
-            // if the previous keyframe doesn't exist,
-            // fallthrough and create empty keyframe
         }
+        // if the previous keyframe doesn't exist,
+        // an empty keyframe needs to be created, so
+        // fallthrough
         case CREATE_NEW_KEY:
             mEditor->addNewKey();
 

--- a/core_lib/src/interface/timecontrols.cpp
+++ b/core_lib/src/interface/timecontrols.cpp
@@ -127,16 +127,16 @@ void TimeControls::updateUI()
 
     mPlaybackRangeCheckBox->setChecked(playback->isRangedPlaybackOn()); // don't block this signal since it enables start/end range spinboxes.
 
-    SignalBlocker b1(mLoopStartSpinBox);
+    QSignalBlocker b1(mLoopStartSpinBox);
     mLoopStartSpinBox->setValue(playback->markInFrame());
 
-    SignalBlocker b2(mLoopEndSpinBox);
+    QSignalBlocker b2(mLoopEndSpinBox);
     mLoopEndSpinBox->setValue(playback->markOutFrame());
 
-    SignalBlocker b3(mFpsBox);
+    QSignalBlocker b3(mFpsBox);
     mFpsBox->setValue(playback->fps());
 
-    SignalBlocker b4(mLoopButton);
+    QSignalBlocker b4(mLoopButton);
     mLoopButton->setChecked(playback->isLooping());
 }
 
@@ -148,7 +148,7 @@ void TimeControls::setEditor(Editor* editor)
 
 void TimeControls::setFps(int value)
 {
-    SignalBlocker blocker(mFpsBox);
+    QSignalBlocker blocker(mFpsBox);
     mFpsBox->setValue(value);
 }
 

--- a/core_lib/src/managers/playbackmanager.cpp
+++ b/core_lib/src/managers/playbackmanager.cpp
@@ -111,20 +111,6 @@ void PlaybackManager::play()
         frame = editor()->currentFrame();
     }
 
-    // get keyframe from layer
-    KeyFrame* key = nullptr;
-    if (!mListOfActiveSoundFrames.isEmpty())
-    {
-        for (int i = 0; i < object()->getLayerCount(); ++i)
-        {
-            Layer* layer = object()->getLayer(i);
-            if (layer->type() == Layer::SOUND)
-            {
-                key = layer->getKeyFrameWhichCovers(frame);
-            }
-        }
-    }
-
     mListOfActiveSoundFrames.clear();
     // Check for any sounds we should start playing part-way through.
     mCheckForSoundsHalfway = true;
@@ -359,14 +345,14 @@ bool PlaybackManager::skipFrame()
     //float expectedTime = (mPlayingFrameCounter) * (1000.f / mFps);
     //qDebug("Expected:  %.2f ms", expectedTime);
     //qDebug("Actual:    %d   ms", mElapsedTimer->elapsed());
-    
+
     int t = qRound((mPlayingFrameCounter - 1) * (1000.f / mFps));
     if (mElapsedTimer->elapsed() < t)
     {
         qDebug() << "skip";
         return true;
     }
-    
+
     ++mPlayingFrameCounter;
     return false;
 }
@@ -425,7 +411,7 @@ void PlaybackManager::timerTick()
     if (skipFrame())
         return;
 
-    // keep going 
+    // keep going
     editor()->scrubForward();
 
     int newFrame = editor()->currentFrame();

--- a/core_lib/src/managers/selectionmanager.cpp
+++ b/core_lib/src/managers/selectionmanager.cpp
@@ -236,7 +236,7 @@ void SelectionManager::adjustSelection(const QPointF& currentPoint, qreal offset
     {
         mTempTransformedSelection = transformedSelection;
         QPointF anchorPoint = transformedSelection.center();
-        qreal rotatedAngle = MathUtils::radToDeg(MathUtils::getDifferenceAngle(anchorPoint, currentPoint)) - rotationOffset;
+        qreal rotatedAngle = qRadiansToDegrees(MathUtils::getDifferenceAngle(anchorPoint, currentPoint)) - rotationOffset;
         if (rotationIncrement > 0) {
             mRotatedAngle = constrainRotationToAngle(rotatedAngle, rotationIncrement);
         } else {

--- a/core_lib/src/managers/viewmanager.cpp
+++ b/core_lib/src/managers/viewmanager.cpp
@@ -15,6 +15,7 @@ GNU General Public License for more details.
 
 */
 
+#include <QPainterPath>
 #include "viewmanager.h"
 #include "editor.h"
 #include "object.h"

--- a/core_lib/src/movieexporter.cpp
+++ b/core_lib/src/movieexporter.cpp
@@ -185,8 +185,8 @@ Status MovieExporter::assembleAudio(const Object* obj,
 
     int clipCount = 0;
 
-    QString strCmd, filterComplex, amergeInput, panChannelLayout;
-    strCmd += QString("\"%1\"").arg(ffmpegPath);
+    QString filterComplex, amergeInput, panChannelLayout;
+    QStringList args;
 
     int wholeLen = qCeil((endFrame - startFrame) * 44100.0 / fps);
     for (auto clip : allSoundClips)
@@ -197,7 +197,7 @@ Status MovieExporter::assembleAudio(const Object* obj,
         }
 
         // Add sound file as input
-        strCmd += QString(" -i \"%1\"").arg(clip->fileName());
+        args << "-i" << clip->fileName();
 
         // Offset the sound to its correct position
         // See https://superuser.com/questions/716320/ffmpeg-placing-audio-at-specific-location
@@ -212,18 +212,18 @@ Status MovieExporter::assembleAudio(const Object* obj,
     panChannelLayout.chop(1);
     // Output arguments
     // Mix audio
-    strCmd += QString(" -filter_complex \"%1%2 amerge=inputs=%3, pan=mono|c0=%4 [out]\"")
+    args << "-filter_complex" << QString("%1%2 amerge=inputs=%3, pan=mono|c0=%4 [out]")
             .arg(filterComplex).arg(amergeInput).arg(clipCount).arg(panChannelLayout);
     // Convert audio file: 44100Hz sampling rate, stereo, signed 16 bit little endian
     // Supported audio file types: wav, mp3, ogg... ( all file types supported by ffmpeg )
-    strCmd += " -ar 44100 -acodec pcm_s16le -ac 2 -map \"[out]\" -y";
+    args << "-ar" << "44100" << "-acodec" << "pcm_s16le" << "-ac" << "2" << "-map" << "[out]" << "-y";
     // Trim audio
-    strCmd += QString(" -ss %1").arg((startFrame - 1) / static_cast<double>(fps));
-    strCmd += QString(" -to %1").arg(endFrame / static_cast<double>(fps));
+    args << "-ss" << QString::number((startFrame - 1) / static_cast<double>(fps));
+    args << "-to" << QString::number(endFrame / static_cast<double>(fps));
     // Output path
-    strCmd += QString(" \"%1\"").arg(tempAudioPath);
+    args << tempAudioPath;
 
-    STATUS_CHECK(MovieExporter::executeFFmpeg(strCmd, [&progress, this] (int frame) { progress(frame / static_cast<float>(mDesc.endFrame - mDesc.startFrame)); return !mCanceled; }))
+    STATUS_CHECK(MovieExporter::executeFFmpeg(ffmpegPath, args, [&progress, this] (int frame) { progress(frame / static_cast<float>(mDesc.endFrame - mDesc.startFrame)); return !mCanceled; }))
     qDebug() << "audio file: " + tempAudioPath;
 
     return Status::OK;
@@ -304,41 +304,40 @@ Status MovieExporter::generateMovie(
     //int exportFps = mDesc.videoFps;
     const QString tempAudioPath = QDir(mTempWorkDir).filePath("tmpaudio.wav");
 
-    QString strCmd = QString("\"%1\"").arg(ffmpegPath);
-    strCmd += QString(" -f rawvideo -pixel_format bgra");
-    strCmd += QString(" -video_size %1x%2").arg(exportSize.width()).arg(exportSize.height());
-    strCmd += QString(" -framerate %1").arg(mDesc.fps);
+    QStringList args = {"-f", "rawvideo", "-pixel_format", "bgra"};
+    args << "-video_size" << QString("%1x%2").arg(exportSize.width()).arg(exportSize.height());
+    args << "-framerate" << QString::number(mDesc.fps);
 
-    //strCmd += QString( " -r %1").arg( exportFps );
-    strCmd += QString(" -i -");
-    strCmd += QString(" -threads %1").arg(QThread::idealThreadCount() == 1 ? 0 : QThread::idealThreadCount());
+    //args << "-r" << QString::number(exportFps);
+    args << "-i" << "-";
+    args << "-threads" << (QThread::idealThreadCount() == 1 ? "0" : QString::number(QThread::idealThreadCount()));
 
     if (QFile::exists(tempAudioPath))
     {
-        strCmd += QString(" -i \"%1\" ").arg(tempAudioPath);
+        args << "-i" << tempAudioPath;
     }
 
     if (strOutputFile.endsWith(".apng", Qt::CaseInsensitive))
     {
-        strCmd += QString(" -plays %1").arg(loop ? "0" : "1");
+        args << "-plays" << (loop ? "0" : "1");
     }
 
     if (strOutputFile.endsWith("mp4", Qt::CaseInsensitive))
     {
-        strCmd += QString(" -pix_fmt yuv420p");
+        args << "-pix_fmt" << "yuv420p";
     }
 
     if (strOutputFile.endsWith(".avi", Qt::CaseInsensitive))
     {
-        strCmd += " -q:v 5";
+        args << "-q:v" << "5";
     }
 
-    strCmd += " -y";
-    strCmd += QString(" \"%1\"").arg(strOutputFile);
+    args << "-y";
+    args << strOutputFile;
 
     // Run FFmpeg command
 
-    STATUS_CHECK(executeFFMpegPipe(strCmd, progress, [&](QProcess& ffmpeg, int framesProcessed)
+    STATUS_CHECK(executeFFMpegPipe(ffmpegPath, args, progress, [&](QProcess& ffmpeg, int framesProcessed)
     {
         if(framesProcessed < 0)
         {
@@ -439,23 +438,22 @@ Status MovieExporter::generateGif(
 
     // Build FFmpeg command
 
-    QString strCmd = QString("\"%1\"").arg(ffmpegPath);
-    strCmd += QString(" -f rawvideo -pixel_format bgra");
-    strCmd += QString(" -video_size %1x%2").arg(exportSize.width()).arg(exportSize.height());
-    strCmd += QString(" -framerate %1").arg(mDesc.fps);
+    QStringList args = {"-f", "rawvideo", "-pixel_format", "bgra"};
+    args << "-video_size" << QString("%1x%2").arg(exportSize.width()).arg(exportSize.height());
+    args << "-framerate" << QString::number(mDesc.fps);
 
-    strCmd += " -i -";
+    args << "-i" << "-";
 
-    strCmd += " -y";
+    args << "-y";
 
-    strCmd += " -filter_complex \"[0:v]palettegen [p]; [0:v][p] paletteuse\"";
+    args << "-filter_complex" << "[0:v]palettegen [p]; [0:v][p] paletteuse";
 
-    strCmd += QString(" -loop %1").arg(loop ? "0" : "-1");
-    strCmd += QString(" \"%1\"").arg(strOut);
+    args << "-loop" << (loop ? "0" : "-1");
+    args << strOut;
 
     // Run FFmpeg command
 
-    STATUS_CHECK(executeFFMpegPipe(strCmd, progress, [&](QProcess& ffmpeg, int framesProcessed)
+    STATUS_CHECK(executeFFMpegPipe(ffmpegPath, args, progress, [&](QProcess& ffmpeg, int framesProcessed)
     {
         /* The GIF FFmpeg command requires the entires stream to be
          * written before FFmpeg can encode the GIF. This is because
@@ -494,8 +492,9 @@ Status MovieExporter::generateGif(
 
 /** Runs the specified command (should be ffmpeg) and allows for progress feedback.
  *
- *  @param[in]  strCmd A string containing the command to execute and
- *              all of its arguments
+ *  @param[in]  cmd A string containing the command to execute
+ *  @param[in]  args A string list containing the arguments to
+ *              pass to the command
  *  @param[out] progress A function that takes one float argument
  *              (the percentage of the ffmpeg operation complete) and
  *              may display the output to the user in any way it
@@ -507,15 +506,15 @@ Status MovieExporter::generateGif(
  *  @return Returns Status::OK if everything went well, and Status::FAIL
  *  and error is detected (usually a non-zero exit code for ffmpeg).
  */
-Status MovieExporter::executeFFmpeg(QString strCmd, std::function<bool(int)> progress)
+Status MovieExporter::executeFFmpeg(const QString& cmd, const QStringList& args, std::function<bool(int)> progress)
 {
-    qDebug() << strCmd;
+    qDebug() << cmd;
 
     QProcess ffmpeg;
     ffmpeg.setReadChannel(QProcess::StandardOutput);
     // FFmpeg writes to stderr only for some reason, so we just read both channels together
     ffmpeg.setProcessChannelMode(QProcess::MergedChannels);
-    ffmpeg.start(strCmd);
+    ffmpeg.start(cmd, args);
 
     Status status = Status::OK;
     DebugDetails dd;
@@ -582,8 +581,9 @@ Status MovieExporter::executeFFmpeg(QString strCmd, std::function<bool(int)> pro
 /** Runs the specified command (should be ffmpeg), and lets
  *  writeFrame pipe data into it 1 frame at a time.
  *
- *  @param[in]  strCmd A string containing the command to execute and
- *              all of its arguments
+ *  @param[in]  cmd A string containing the command to execute
+ *  @param[in]  args A string list containing the arguments to
+ *              pass to the command
  *  @param[out] progress A function that takes one float argument
  *              (the percentage of the ffmpeg operation complete) and
  *              may display the output to the user in any way it
@@ -596,7 +596,7 @@ Status MovieExporter::executeFFmpeg(QString strCmd, std::function<bool(int)> pro
  *              actually wrote a frame.
  *
  *  This function operates generally as follows:
- *  1. Spawn process with the command from strCmd
+ *  1. Spawn process with the command from cmd
  *  2. Check ffmpeg's output for a progress update.
  *  3. Add frames with writeFrame until it returns false.
  *  4. Repeat from step 2 until all frames have been written.
@@ -621,15 +621,15 @@ Status MovieExporter::executeFFmpeg(QString strCmd, std::function<bool(int)> pro
  *  @return Returns Status::OK if everything went well, and Status::FAIL
  *  and error is detected (usually a non-zero exit code for ffmpeg).
  */
-Status MovieExporter::executeFFMpegPipe(QString strCmd, std::function<void(float)> progress, std::function<bool(QProcess&, int)> writeFrame)
+Status MovieExporter::executeFFMpegPipe(const QString& cmd, const QStringList& args, std::function<void(float)> progress, std::function<bool(QProcess&, int)> writeFrame)
 {
-    qDebug() << strCmd;
+    qDebug() << cmd;
 
     QProcess ffmpeg;
     ffmpeg.setReadChannel(QProcess::StandardOutput);
     // FFmpeg writes to stderr only for some reason, so we just read both channels together
     ffmpeg.setProcessChannelMode(QProcess::MergedChannels);
-    ffmpeg.start(strCmd);
+    ffmpeg.start(cmd, args);
     if (ffmpeg.waitForStarted())
     {
         int framesGenerated = 0;

--- a/core_lib/src/movieexporter.h
+++ b/core_lib/src/movieexporter.h
@@ -54,13 +54,13 @@ public:
 
     void cancel() { mCanceled = true; }
 
-    static Status executeFFmpeg(QString strCmd, std::function<bool(int)> progress);
+    static Status executeFFmpeg(const QString& cmd, const QStringList& args, std::function<bool(int)> progress);
 private:
     Status assembleAudio(const Object* obj, QString ffmpegPath, std::function<void(float)> progress);
     Status generateMovie(const Object *obj, QString ffmpegPath, QString strOutputFile, std::function<void(float)> progress);
     Status generateGif(const Object *obj, QString ffmpeg, QString strOut, std::function<void(float)>  progress);
 
-    Status executeFFMpegPipe(QString strCmd, std::function<void(float)> progress, std::function<bool(QProcess&,int)> writeFrame);
+    Status executeFFMpegPipe(const QString& cmd, const QStringList& args, std::function<void(float)> progress, std::function<bool(QProcess&,int)> writeFrame);
     Status checkInputParameters(const ExportMovieDesc&);
 
 private:

--- a/core_lib/src/structure/soundclip.cpp
+++ b/core_lib/src/structure/soundclip.cpp
@@ -36,6 +36,13 @@ SoundClip::~SoundClip()
     //QFile::remove( fileName() );
 }
 
+SoundClip& SoundClip::operator=(const SoundClip& a) {
+    if (this != &a) {
+        mOriginalSoundClipName = a.mOriginalSoundClipName;
+    }
+    return *this;
+}
+
 SoundClip* SoundClip::clone()
 {
     return new SoundClip(*this);

--- a/core_lib/src/structure/soundclip.h
+++ b/core_lib/src/structure/soundclip.h
@@ -29,6 +29,7 @@ public:
     explicit SoundClip();
     explicit SoundClip(const SoundClip&);
     ~SoundClip() override;
+    SoundClip& operator=(const SoundClip& a);
 
     SoundClip* clone() override;
 

--- a/core_lib/src/tool/handtool.cpp
+++ b/core_lib/src/tool/handtool.cpp
@@ -28,7 +28,6 @@ GNU General Public License for more details.
 #include "strokemanager.h"
 #include "viewmanager.h"
 #include "scribblearea.h"
-#include "mathutils.h"
 
 
 HandTool::HandTool(QObject* parent) : BaseTool(parent)
@@ -109,7 +108,7 @@ void HandTool::transformView(Qt::KeyboardModifiers keyMod, Qt::MouseButtons butt
         QVector2D curV(getCurrentPixel() - centralPixel);
 
         qreal angleOffset = static_cast<qreal>(atan2(curV.y(), curV.x()) - atan2(startV.y(), startV.x()));
-        angleOffset = MathUtils::radToDeg(angleOffset);
+        angleOffset = qRadiansToDegrees(angleOffset);
         float newAngle = viewMgr->rotation() + static_cast<float>(angleOffset);
         viewMgr->rotate(newAngle);
     }

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -214,7 +214,7 @@ void MoveTool::beginInteraction(Qt::KeyboardModifiers keyMod, Layer* layer)
     if(selectMan->getMoveMode() == MoveMode::ROTATION) {
         QPointF curPoint = getCurrentPoint();
         QPointF anchorPoint = selectionRect.center();
-        mRotatedAngle = MathUtils::radToDeg(MathUtils::getDifferenceAngle(anchorPoint, curPoint)) - selectMan->myRotation();
+        mRotatedAngle = qRadiansToDegrees(MathUtils::getDifferenceAngle(anchorPoint, curPoint)) - selectMan->myRotation();
     }
 }
 

--- a/core_lib/src/util/mathutils.h
+++ b/core_lib/src/util/mathutils.h
@@ -6,26 +6,6 @@
 
 namespace MathUtils
 {
-    /** Convert angles from radians to degrees.
-     *
-     * \param radians Angle in radians.
-     * \return Angle in degrees.
-     */
-    inline qreal radToDeg(const qreal radians)
-    {
-        return radians * 180.0 / M_PI;
-    }
-
-    /** Convert angles from degrees to radians.
-     *
-     * \param degrees Angle in degrees.
-     * \return Angle in radians.
-     */
-    inline qreal degToRad(const qreal degrees)
-    {
-        return degrees * M_PI / 180.0;
-    }
-
     /** Get the angle from the difference vector a->b to the x-axis.
      *
      * \param a Start point of vector

--- a/core_lib/src/util/util.cpp
+++ b/core_lib/src/util/util.cpp
@@ -47,17 +47,6 @@ QTransform RectMapTransform( QRectF source, QRectF target )
     return matrix;
 }
 
-SignalBlocker::SignalBlocker( QObject* o )
-    : mObject( o ),
-    mBlocked( o && o->blockSignals( true ) )
-{}
-
-SignalBlocker::~SignalBlocker()
-{
-    if ( mObject )
-        mObject->blockSignals( mBlocked );
-}
-
 void clearFocusOnFinished(QAbstractSpinBox *spinBox)
 {
     QObject::connect(spinBox, &QAbstractSpinBox::editingFinished, spinBox, &QAbstractSpinBox::clearFocus);

--- a/core_lib/src/util/util.h
+++ b/core_lib/src/util/util.h
@@ -27,6 +27,7 @@ QTransform RectMapTransform( QRectF source, QRectF target );
 
 void clearFocusOnFinished(QAbstractSpinBox *spinBox);
 
+// NOTE: Replace this implementation with QScopeGuard once we drop support for Qt < 5.12
 class ScopeGuard
 {
 public:
@@ -46,16 +47,6 @@ private:
 #define NULLReturn( p, ret ) if ( p == nullptr ) { return ret; }
 #define NULLReturnAssert( p ) if ( p == nullptr ) { Q_ASSERT(false); return; }
 
-
-class SignalBlocker
-{
-public:
-    explicit SignalBlocker(QObject* o);
-    ~SignalBlocker();
-private:
-    QObject* mObject = nullptr;
-    bool mBlocked = false;
-};
 
 QString ffprobeLocation();
 QString ffmpegLocation();


### PR DESCRIPTION
With the recent release of Qt 5.15, I once again had a closer look at my compiler output. Most of the changes are rather boring, but it’d be nice if someone could have a look at the copy assignment operators. I based them on existing, related code, but since I’m not exactly familiar with that part of the codebase I’m not really sure if that is sufficient.

Fixes #1370.