### PR TITLE
Check for vector layer, before toggle showInvisibleLines

### DIFF
--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -156,7 +156,7 @@ void PencilTool::pointerPressEvent(PointerEvent*)
     startStroke();
 
     // note: why are we doing this on device press event?
-    if ( !mEditor->preference()->isOn(SETTING::INVISIBLE_LINES) )
+    if (mEditor->layers()->currentLayer()->type() == Layer::VECTOR && !mEditor->preference()->isOn(SETTING::INVISIBLE_LINES) )
     {
         mScribbleArea->toggleThinLines();
     }

--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -156,7 +156,7 @@ void PencilTool::pointerPressEvent(PointerEvent*)
     startStroke();
 
     // note: why are we doing this on device press event?
-    if (mEditor->layers()->currentLayer()->type() == Layer::VECTOR && !mEditor->preference()->isOn(SETTING::INVISIBLE_LINES) )
+    if (mEditor->layers()->currentLayer()->type() == Layer::VECTOR && !mEditor->preference()->isOn(SETTING::INVISIBLE_LINES))
     {
         mScribbleArea->toggleThinLines();
     }
@@ -185,7 +185,7 @@ void PencilTool::pointerReleaseEvent(PointerEvent*)
     {
         drawStroke();
     }
-    
+
     Layer* layer = mEditor->layers()->currentLayer();
     if (layer->type() == Layer::BITMAP)
         paintBitmapStroke();


### PR DESCRIPTION
When drawing, the setting INVISIBLE_LINES was set, no matter what type layer was drawn onto.
Now it checks for Layer::VECTOR