### PR TITLE
Disabling OK until files are selected and verified

### DIFF
--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -47,6 +47,8 @@ ImportImageSeqDialog::ImportImageSeqDialog(QWidget* parent, Mode mode, FileType 
     } else {
         setupLayout();
     }
+
+    getDialogButtonBox()->button(QDialogButtonBox::StandardButton::Ok)->setEnabled(false);
 }
 
 void ImportImageSeqDialog::setupLayout()
@@ -61,6 +63,7 @@ void ImportImageSeqDialog::setupLayout()
     }
 
     connect(uiOptionsBox->spaceSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &ImportImageSeqDialog::setSpace);
+    connect(this, &ImportImageSeqDialog::filePathsChanged, this, &ImportImageSeqDialog::validateFiles);
 }
 
 void ImportImageSeqDialog::setupPredefinedLayout()
@@ -363,5 +366,34 @@ Status ImportImageSeqDialog::validateKeySet(const PredefinedKeySet& keySet, cons
         status.setDescription(QString(tr("The following file did not meet the criteria: \n%1 \n\nRead the instructions and try again")).arg(failedPathsString));
     }
 
+    return status;
+}
+
+Status ImportImageSeqDialog::validateFiles(const QStringList &filepaths)
+{
+    QString failedPathsString = "";
+
+    Status status = Status::OK;
+
+    if (filepaths.isEmpty()) { status = Status::FAIL; }
+
+    for (int i = 0; i < filepaths.count(); i++)
+    {
+        QFileInfo file = filepaths.at(i);
+        if (!file.exists())
+            failedPathsString += filepaths.at(i) + "\n";
+    }
+
+    if (!failedPathsString.isEmpty())
+    {
+        status = Status::FAIL;
+        status.setTitle(tr("Invalid path"));
+        status.setDescription(QString(tr("The following file(-s) did not meet the criteria: \n%1")).arg(failedPathsString));
+    }
+
+    if (status == Status::OK)
+    {
+        getDialogButtonBox()->button(QDialogButtonBox::StandardButton::Ok)->setEnabled(true);
+    }
     return status;
 }

--- a/app/src/importimageseqdialog.h
+++ b/app/src/importimageseqdialog.h
@@ -81,6 +81,7 @@ private:
     void setupLayout();
     void setupPredefinedLayout();
     Status validateKeySet(const PredefinedKeySet& keySet, const QStringList& filepaths);
+    Status validateFiles(const QStringList& filepaths);
 
     Ui::ImportImageSeqOptions *uiOptionsBox;
     Ui::ImportImageSeqPreviewGroupBox *uiGroupBoxPreview;


### PR DESCRIPTION
When importing files (arbitrary set, predefined set or gif animation), you could press OK without selecting any. This PR prevents that.