### PR TITLE
Position new palette colors at bottom, and renaming immediately

### DIFF
--- a/app/src/colorpalettewidget.cpp
+++ b/app/src/colorpalettewidget.cpp
@@ -139,13 +139,6 @@ void ColorPaletteWidget::addItem()
     ColorRef ref(newColor);
 
     mObject->addColorAtIndex(colorIndex, ref);
-    refreshColorList();
-
-    if (mFitSwatches)
-    {
-        fitSwatchSize();
-    }
-
     bool ok;
     QString text = QInputDialog::getText(this,
                                          tr("Color name"),
@@ -156,7 +149,13 @@ void ColorPaletteWidget::addItem()
     if (ok && !text.isEmpty())
     {
         mObject->renameColor(colorIndex, text);
-        refreshColorList();
+    }
+
+    refreshColorList();
+
+    if (mFitSwatches)
+    {
+        fitSwatchSize();
     }
 }
 

--- a/app/src/colorpalettewidget.cpp
+++ b/app/src/colorpalettewidget.cpp
@@ -133,16 +133,30 @@ void ColorPaletteWidget::addItem()
     QSignalBlocker b(ui->colorListWidget);
     QColor newColor = mEditor->color()->frontColor();
 
-    // add in front of selected color
-    int colorIndex = ui->colorListWidget->currentRow()+1;
+    // add at bottom
+    int colorIndex = ui->colorListWidget->count();
 
     ColorRef ref(newColor);
 
     mObject->addColorAtIndex(colorIndex, ref);
     refreshColorList();
+
     if (mFitSwatches)
     {
         fitSwatchSize();
+    }
+
+    bool ok;
+    QString text = QInputDialog::getText(this,
+                                         tr("Color name"),
+                                         tr("Color name"),
+                                         QLineEdit::Normal,
+                                         mObject->getColor(colorIndex).name,
+                                         &ok);
+    if (ok && !text.isEmpty())
+    {
+        mObject->renameColor(colorIndex, text);
+        refreshColorList();
     }
 }
 


### PR DESCRIPTION
This fixes a 'bug' that has often bothered me.
1) New colors were placed in front of the selected color, and that made sense before the colors could be dragged and dropped. I always expect to find the new colors at the bottom of the palette, because they logically should be appended to the palette. This PR places new colors at the bottom of the list.
2) The reason for having names for the colors is to use them. If we don't use the names, we might as well just have them numbered. My colors get names like 'Lisa skin', 'Lisa eyes', 'Lisa Hair' etc, and not 'Magenta', 'Vivid Reddish Purple', or some of the other suggested names. For that reason, I've put the rename color dialog up front, so you're naming your color when you add it. This is more logical, and if you indeed want the name to be 'Vivid Reddish Purple', then just press enter.