### PR TITLE
Draw the timeline using palette colours (AKA dark theme support for the timeline)

### DIFF
--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -737,7 +737,7 @@ void TimeLineCells::mouseDoubleClickEvent(QMouseEvent* event)
     int layerNumber = getLayerNumber(event->pos().y());
 
     // -- short scrub --
-    if (event->pos().y() < 20)
+    if (event->pos().y() < 20 && (mType != TIMELINE_CELL_TYPE::Layers || event->pos().x() >= 15))
     {
         mPrefs->set(SETTING::SHORT_SCRUB, !mbShortScrub);
     }
@@ -750,7 +750,7 @@ void TimeLineCells::mouseDoubleClickEvent(QMouseEvent* event)
         {
             mEditor->object()->getLayer(layerNumber)->mouseDoubleClick(event, frameNumber);
         }
-        else if (mType == TIMELINE_CELL_TYPE::Layers)
+        else if (mType == TIMELINE_CELL_TYPE::Layers && event->pos().x() >= 15)
         {
             if (layer->type() == Layer::CAMERA)
             {

--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -282,20 +282,20 @@ void TimeLineCells::drawContent()
     if (mType == TIMELINE_CELL_TYPE::Layers)
     {
         // --- draw circle
-        painter.setPen(palette.color(QPalette::Mid));
+        painter.setPen(palette.color(QPalette::Text));
         if (mEditor->layerVisibility() == LayerVisibility::CURRENTONLY)
         {
             painter.setBrush(palette.color(QPalette::Base));
         }
         else if (mEditor->layerVisibility() == LayerVisibility::RELATED)
         {
-            QColor color = palette.color(QPalette::Highlight);
+            QColor color = palette.color(QPalette::Text);
             color.setAlpha(128);
             painter.setBrush(color);
         }
         else if (mEditor->layerVisibility() == LayerVisibility::ALL)
         {
-            painter.setBrush(palette.brush(QPalette::Highlight));
+            painter.setBrush(palette.brush(QPalette::Text));
         }
         painter.setRenderHint(QPainter::Antialiasing, true);
         painter.drawEllipse(6, 4, 9, 9);

--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -16,6 +16,7 @@ GNU General Public License for more details.
 */
 #include "layer.h"
 
+#include <QApplication>
 #include <QDebug>
 #include <QSettings>
 #include <QPainter>
@@ -322,6 +323,7 @@ void Layer::paintTrack(QPainter& painter, TimeLineCells* cells,
                        int x, int y, int width, int height,
                        bool selected, int frameSize)
 {
+    const QPalette palette = QApplication::palette();
     if (mVisible)
     {
         QColor col;
@@ -332,10 +334,10 @@ void Layer::paintTrack(QPainter& painter, TimeLineCells* cells,
 
         painter.save();
         painter.setBrush(col);
-        painter.setPen(QPen(QBrush(QColor(100, 100, 100)), 1, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+        painter.setPen(QPen(QBrush(palette.color(QPalette::Mid)), 1, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
         painter.drawRect(x, y - 1, width, height);
 
-        // changes the apparence if selected
+        // changes the appearance if selected
         if (selected)
         {
             paintSelection(painter, x, y, width, height);
@@ -358,8 +360,8 @@ void Layer::paintTrack(QPainter& painter, TimeLineCells* cells,
     }
     else
     {
-        painter.setBrush(Qt::gray);
-        painter.setPen(QPen(QBrush(QColor(100, 100, 100)), 1, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+        painter.setBrush(palette.color(QPalette::Base));
+        painter.setPen(QPen(QBrush(palette.color(QPalette::Mid)), 1, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
         painter.drawRect(x, y - 1, width, height); // empty rectangle  by default
     }
 }
@@ -409,36 +411,41 @@ void Layer::paintLabel(QPainter& painter, TimeLineCells* cells,
                        bool selected, LayerVisibility layerVisibility)
 {
     Q_UNUSED(cells)
-    painter.setBrush(Qt::lightGray);
-    painter.setPen(QPen(QBrush(QColor(100, 100, 100)), 1, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-    painter.drawRect(x, y - 1, width, height); // empty rectangle  by default
-
+    const QPalette palette = QApplication::palette();
 
     if (selected)
     {
-        paintSelection(painter, x, y, width, height);
-    } else {
-        painter.save();
-        QLinearGradient linearGrad(QPointF(0, y), QPointF(0, y + height));
-        linearGrad.setColorAt(0, QColor(255,255,255,150));
-        linearGrad.setColorAt(1, QColor(0,0,0,0));
-        painter.setCompositionMode(QPainter::CompositionMode_Overlay);
-        painter.setBrush(linearGrad);
-        painter.drawRect(x, y - 1, width, height);
-        painter.restore();
-    }
-
-    if (mVisible)
-    {
-        if ((layerVisibility == LayerVisibility::ALL) || selected) painter.setBrush(Qt::black);
-        else if (layerVisibility == LayerVisibility::CURRENTONLY) painter.setBrush(Qt::NoBrush);
-        else if (layerVisibility == LayerVisibility::RELATED) painter.setBrush(Qt::darkGray);
+        painter.setBrush(palette.color(QPalette::Highlight));
     }
     else
     {
-        painter.setBrush(Qt::NoBrush);
+        painter.setBrush(palette.color(QPalette::Base));
     }
-    painter.setPen(Qt::black);
+    painter.setPen(Qt::NoPen);
+    painter.drawRect(x, y - 1, width, height); // empty rectangle  by default
+
+    if (!mVisible)
+    {
+        painter.setBrush(palette.color(QPalette::Base));
+    }
+    else
+    {
+        if ((layerVisibility == LayerVisibility::ALL) || selected)
+        {
+            painter.setBrush(palette.color(QPalette::Highlight));
+        }
+        else if (layerVisibility == LayerVisibility::CURRENTONLY)
+        {
+            painter.setBrush(palette.color(QPalette::Base));
+        }
+        else if (layerVisibility == LayerVisibility::RELATED)
+        {
+            QColor color = palette.color(QPalette::Highlight);
+            color.setAlpha(128);
+            painter.setBrush(color);
+        }
+    }
+    painter.setPen(palette.color(QPalette::Mid));
     painter.setRenderHint(QPainter::Antialiasing, true);
     painter.drawEllipse(x + 6, y + 4, 9, 9);
     painter.setRenderHint(QPainter::Antialiasing, false);
@@ -448,7 +455,14 @@ void Layer::paintLabel(QPainter& painter, TimeLineCells* cells,
     if (type() == SOUND) painter.drawPixmap(QPoint(21, y + 2), QPixmap(":/icons/layer-sound.png"));
     if (type() == CAMERA) painter.drawPixmap(QPoint(21, y + 2), QPixmap(":/icons/layer-camera.png"));
 
-    painter.setPen(Qt::black);
+    if (selected)
+    {
+        painter.setPen(palette.color(QPalette::HighlightedText));
+    }
+    else
+    {
+        painter.setPen(palette.color(QPalette::Text));
+    }
     painter.drawText(QPoint(45, y + (2 * height) / 3), mName);
 }
 

--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -324,46 +324,40 @@ void Layer::paintTrack(QPainter& painter, TimeLineCells* cells,
                        bool selected, int frameSize)
 {
     const QPalette palette = QApplication::palette();
-    if (mVisible)
+    QColor col;
+    if (type() == BITMAP) col = QColor(51, 155, 252);
+    if (type() == VECTOR) col = QColor(70, 205, 123);
+    if (type() == SOUND) col = QColor(255, 141, 112);
+    if (type() == CAMERA) col = QColor(253, 202, 92);
+    if (!mVisible) col.setAlpha(64);
+
+    painter.save();
+    painter.setBrush(col);
+    painter.setPen(QPen(QBrush(palette.color(QPalette::Mid)), 1, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+    painter.drawRect(x, y - 1, width, height);
+
+    if (!mVisible) return;
+
+    // changes the appearance if selected
+    if (selected)
     {
-        QColor col;
-        if (type() == BITMAP) col = QColor(51, 155, 252);
-        if (type() == VECTOR) col = QColor(70, 205, 123);
-        if (type() == SOUND) col = QColor(255, 141, 112);
-        if (type() == CAMERA) col = QColor(253, 202, 92);
-
-        painter.save();
-        painter.setBrush(col);
-        painter.setPen(QPen(QBrush(palette.color(QPalette::Mid)), 1, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-        painter.drawRect(x, y - 1, width, height);
-
-        // changes the appearance if selected
-        if (selected)
-        {
-            paintSelection(painter, x, y, width, height);
-        }
-        else
-        {
-            painter.save();
-            QLinearGradient linearGrad(QPointF(0, y), QPointF(0, y + height));
-            linearGrad.setColorAt(0, QColor(255,255,255,150));
-            linearGrad.setColorAt(1, QColor(0,0,0,0));
-            painter.setCompositionMode(QPainter::CompositionMode_Overlay);
-            painter.setBrush(linearGrad);
-            painter.drawRect(x, y - 1, width, height);
-            painter.restore();
-        }
-
-        paintFrames(painter, col, cells, y, height, selected, frameSize);
-
-        painter.restore();
+        paintSelection(painter, x, y, width, height);
     }
     else
     {
-        painter.setBrush(palette.color(QPalette::Base));
-        painter.setPen(QPen(QBrush(palette.color(QPalette::Mid)), 1, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-        painter.drawRect(x, y - 1, width, height); // empty rectangle  by default
+        painter.save();
+        QLinearGradient linearGrad(QPointF(0, y), QPointF(0, y + height));
+        linearGrad.setColorAt(0, QColor(255,255,255,150));
+        linearGrad.setColorAt(1, QColor(0,0,0,0));
+        painter.setCompositionMode(QPainter::CompositionMode_Overlay);
+        painter.setBrush(linearGrad);
+        painter.drawRect(x, y - 1, width, height);
+        painter.restore();
     }
+
+    paintFrames(painter, col, cells, y, height, selected, frameSize);
+
+    painter.restore();
 }
 
 void Layer::paintFrames(QPainter& painter, QColor trackCol, TimeLineCells* cells, int y, int height, bool selected, int frameSize)
@@ -432,7 +426,7 @@ void Layer::paintLabel(QPainter& painter, TimeLineCells* cells,
     {
         if ((layerVisibility == LayerVisibility::ALL) || selected)
         {
-            painter.setBrush(palette.color(QPalette::Highlight));
+            painter.setBrush(palette.color(QPalette::Text));
         }
         else if (layerVisibility == LayerVisibility::CURRENTONLY)
         {
@@ -440,12 +434,19 @@ void Layer::paintLabel(QPainter& painter, TimeLineCells* cells,
         }
         else if (layerVisibility == LayerVisibility::RELATED)
         {
-            QColor color = palette.color(QPalette::Highlight);
+            QColor color = palette.color(QPalette::Text);
             color.setAlpha(128);
             painter.setBrush(color);
         }
     }
-    painter.setPen(palette.color(QPalette::Mid));
+    if (selected)
+    {
+        painter.setPen(palette.color(QPalette::HighlightedText));
+    }
+    else
+    {
+        painter.setPen(palette.color(QPalette::Text));
+    }
     painter.setRenderHint(QPainter::Antialiasing, true);
     painter.drawEllipse(x + 6, y + 4, 9, 9);
     painter.setRenderHint(QPainter::Antialiasing, false);


### PR DESCRIPTION
In order to make some progress on #550, I modified the timeline rendering to use colours from the application palette instead of hardcoded values. With this change, the only remaining dark theme issues are those related to the icons.

Here is a before/after comparison using a random dark theme:

![Before](https://user-images.githubusercontent.com/2063777/88030877-13453380-cb3c-11ea-88ca-2e46bd139d52.png)

![After](https://user-images.githubusercontent.com/2063777/88030899-1c360500-cb3c-11ea-89d6-18d00a30c0bd.png)

In addition to the colour changes, I also simplified the design a little in order to accommodate the somewhat limited selection of colours available from QPalette and to make sure the timeline continues to look good regardless of which theme is used. I tested this with a wide range of different themes, both light and dark, and I’m happy with the results, but if you find a theme that “breaks” the timeline, let me know.

Grab a build here: [Linux](https://drive.google.com/file/d/1ykvkfqN0ikptV6fgY3hgK2BFLMpcANwp/view?usp=sharing) [macOS](https://drive.google.com/file/d/1LBQAJw5ff1aghMTgeMyKWd9rD3qMjJoQ/view?usp=sharing) [Windows x86_64](https://drive.google.com/file/d/15ZIy5YvM281UNQgtowb9WBVeuv5ATamQ/view?usp=sharing) [Windows x86](https://drive.google.com/file/d/1oooXl-P3NiAZyhC8qhy2VwarYsEHx1Bh/view?usp=sharing)