### PR TITLE
Handle angle-based high resolution scrolling properly

### DIFF
--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -398,11 +398,14 @@ void ScribbleArea::wheelEvent(QWheelEvent* event)
 
     const QPoint pixels = event->pixelDelta();
     const QPoint angle = event->angleDelta();
-    const QPointF offset = mEditor->view()->mapScreenToCanvas(event->position());
+    const QPointF offset = mEditor->view()->mapScreenToCanvas(event->posF());
 
     const qreal currentScale = mEditor->view()->scaling();
     if (!pixels.isNull())
     {
+        // XXX: This pixel-based zooming algorithm currently has some shortcomings compared to the angle-based one:
+        //      Zooming in is faster than zooming out and scrolling twice with delta x yields different zoom than
+        //      scrolling once with delta 2x. Someone with the ability to test this code might want to "upgrade" it.
         const int delta = pixels.y();
         const qreal newScale = currentScale * (1 + (delta * 0.01));
         mEditor->view()->scale(newScale, offset);

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -398,20 +398,21 @@ void ScribbleArea::wheelEvent(QWheelEvent* event)
 
     const QPoint pixels = event->pixelDelta();
     const QPoint angle = event->angleDelta();
+    const QPointF offset = mEditor->view()->mapScreenToCanvas(event->position());
 
     const float currentScale = mEditor->view()->scaling();
     if (!pixels.isNull())
     {
         const auto delta = static_cast<float>(pixels.y());
         const float newScale = currentScale * (1.f + (delta * 0.01f));
-        mEditor->view()->scale(newScale);
+        mEditor->view()->scale(newScale, offset);
     }
     else if (!angle.isNull())
     {
         const auto delta = static_cast<float>(angle.y());
         // 12 rotation steps at "standard" wheel resolution (120/step) result in 100x zoom
         const float newScale = currentScale * std::pow(100.f, delta / (12 * 120));
-        mEditor->view()->scale(newScale);
+        mEditor->view()->scale(newScale, offset);
     }
     updateCanvasCursor();
     event->accept();
@@ -510,6 +511,7 @@ void ScribbleArea::pointerPressEvent(PointerEvent* event)
     if (event->buttons() & (Qt::MidButton | Qt::RightButton))
     {
         setTemporaryTool(HAND);
+        getTool(HAND)->pointerPressEvent(event);
     }
 
     const bool isPressed = event->buttons() & Qt::LeftButton;

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -398,26 +398,20 @@ void ScribbleArea::wheelEvent(QWheelEvent* event)
 
     const QPoint pixels = event->pixelDelta();
     const QPoint angle = event->angleDelta();
-    //qDebug() <<"angle"<<angle<<"pixels"<<pixels;
 
+    const float currentScale = mEditor->view()->scaling();
     if (!pixels.isNull())
     {
-        float delta = pixels.y();
-        float currentScale = mEditor->view()->scaling();
-        float newScale = currentScale * (1.f + (delta * 0.01f));
+        const auto delta = static_cast<float>(pixels.y());
+        const float newScale = currentScale * (1.f + (delta * 0.01f));
         mEditor->view()->scale(newScale);
     }
     else if (!angle.isNull())
     {
-        float delta = angle.y();
-        if (delta < 0)
-        {
-            mEditor->view()->scaleDown();
-        }
-        else
-        {
-            mEditor->view()->scaleUp();
-        }
+        const auto delta = static_cast<float>(angle.y());
+        // 12 rotation steps at "standard" wheel resolution (120/step) result in 100x zoom
+        const float newScale = currentScale * std::pow(100.f, delta / (12 * 120));
+        mEditor->view()->scale(newScale);
     }
     updateCanvasCursor();
     event->accept();

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -400,18 +400,18 @@ void ScribbleArea::wheelEvent(QWheelEvent* event)
     const QPoint angle = event->angleDelta();
     const QPointF offset = mEditor->view()->mapScreenToCanvas(event->position());
 
-    const float currentScale = mEditor->view()->scaling();
+    const qreal currentScale = mEditor->view()->scaling();
     if (!pixels.isNull())
     {
-        const auto delta = static_cast<float>(pixels.y());
-        const float newScale = currentScale * (1.f + (delta * 0.01f));
+        const int delta = pixels.y();
+        const qreal newScale = currentScale * (1 + (delta * 0.01));
         mEditor->view()->scale(newScale, offset);
     }
     else if (!angle.isNull())
     {
-        const auto delta = static_cast<float>(angle.y());
+        const int delta = angle.y();
         // 12 rotation steps at "standard" wheel resolution (120/step) result in 100x zoom
-        const float newScale = currentScale * std::pow(100.f, delta / (12 * 120));
+        const qreal newScale = currentScale * std::pow(100, delta / (12.0 * 120));
         mEditor->view()->scale(newScale, offset);
     }
     updateCanvasCursor();

--- a/core_lib/src/managers/viewmanager.cpp
+++ b/core_lib/src/managers/viewmanager.cpp
@@ -22,15 +22,15 @@ GNU General Public License for more details.
 #include "camera.h"
 #include "layercamera.h"
 
-const static float mMinScale = 0.01f;
-const static float mMaxScale = 100.0f;
+const static qreal mMinScale = 0.01;
+const static qreal mMaxScale = 100.0;
 
-const std::vector<float> gZoomLevels
+const std::vector<qreal> gZoomLevels
 {
-    0.01f, 0.02f, 0.04f, 0.06f, 0.08f, 0.12f,
-    0.16f, 0.25f, 0.33f, 0.5f, 0.75f, 1.0f,
-    1.5f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f,
-    8.0f, 16.0f, 32.f, 48.f, 64.f, 96.0f
+    0.01, 0.02, 0.04, 0.06, 0.08, 0.12,
+    0.16, 0.25, 0.33, 0.5, 0.75, 1.0,
+    1.5, 2.0, 3.0, 4.0, 5.0, 6.0,
+    8.0, 16.0, 32.0, 48.0, 64.0, 96.0
 };
 
 
@@ -203,13 +203,13 @@ void ViewManager::rotate(float degree)
     }
 }
 
-float ViewManager::scaling()
+qreal ViewManager::scaling()
 {
     if (mCurrentCamera)
     {
-        return static_cast<float>(mCurrentCamera->scaling());
+        return mCurrentCamera->scaling();
     }
-    return 0.0f;
+    return 0.0;
 }
 
 void ViewManager::scaleUp()
@@ -224,7 +224,7 @@ void ViewManager::scaleUp()
     }
 
     // out of pre-defined zoom levels
-    scale(scaling() * 1.18f);
+    scale(scaling() * 1.18);
 }
 
 void ViewManager::scaleDown()
@@ -237,45 +237,45 @@ void ViewManager::scaleDown()
             return;
         }
     }
-    scale(scaling() * 0.8333f);
+    scale(scaling() * 0.8333);
 }
 
 void ViewManager::scale100()
 {
-    scale(1.0f);
+    scale(1.0);
 }
 
 void ViewManager::scale400()
 {
-    scale(4.0f);
+    scale(4.0);
 }
 
 void ViewManager::scale300()
 {
-    scale(3.0f);
+    scale(3.0);
 }
 
 void ViewManager::scale200()
 {
-    scale(2.0f);
+    scale(2.0);
 }
 
 void ViewManager::scale50()
 {
-    scale(0.5f);
+    scale(0.5);
 }
 
 void ViewManager::scale33()
 {
-    scale(0.33f);
+    scale(0.33);
 }
 
 void ViewManager::scale25()
 {
-    scale(0.25f);
+    scale(0.25);
 }
 
-void ViewManager::scale(float scaleValue, QPointF offset)
+void ViewManager::scale(qreal scaleValue, QPointF offset)
 {
     if (scaleValue < mMinScale)
     {
@@ -288,7 +288,7 @@ void ViewManager::scale(float scaleValue, QPointF offset)
 
     if (mCurrentCamera)
     {
-        mCurrentCamera->scale(static_cast<qreal>(scaleValue), offset);
+        mCurrentCamera->scale(scaleValue, offset);
         updateViewTransforms();
 
         Q_EMIT viewChanged();

--- a/core_lib/src/managers/viewmanager.cpp
+++ b/core_lib/src/managers/viewmanager.cpp
@@ -275,7 +275,7 @@ void ViewManager::scale25()
     scale(0.25f);
 }
 
-void ViewManager::scale(float scaleValue)
+void ViewManager::scale(float scaleValue, QPointF offset)
 {
     if (scaleValue < mMinScale)
     {
@@ -288,7 +288,7 @@ void ViewManager::scale(float scaleValue)
 
     if (mCurrentCamera)
     {
-        mCurrentCamera->scale(static_cast<qreal>(scaleValue));
+        mCurrentCamera->scale(static_cast<qreal>(scaleValue), offset);
         updateViewTransforms();
 
         Q_EMIT viewChanged();

--- a/core_lib/src/managers/viewmanager.h
+++ b/core_lib/src/managers/viewmanager.h
@@ -62,8 +62,8 @@ public:
     float rotation();
     void rotate(float degree);
 
-    float scaling();
-    void scale(float scaleValue, QPointF offset = {0, 0});
+    qreal scaling();
+    void scale(qreal scaleValue, QPointF offset = {0, 0});
     void scaleUp();
     void scaleDown();
     void scale400();

--- a/core_lib/src/managers/viewmanager.h
+++ b/core_lib/src/managers/viewmanager.h
@@ -63,7 +63,7 @@ public:
     void rotate(float degree);
 
     float scaling();
-    void scale(float scaleValue);
+    void scale(float scaleValue, QPointF offset = {0, 0});
     void scaleUp();
     void scaleDown();
     void scale400();

--- a/core_lib/src/structure/camera.cpp
+++ b/core_lib/src/structure/camera.cpp
@@ -120,8 +120,11 @@ void Camera::rotate(qreal degree)
     modification();
 }
 
-void Camera::scale(qreal scaleValue)
+void Camera::scale(qreal scaleValue, QPointF offset)
 {
+    if (!offset.isNull()) {
+        mTranslate = (mTranslate + offset) * mScale / scaleValue - offset;
+    }
     mScale = scaleValue;
 
     mNeedUpdateView = true;

--- a/core_lib/src/structure/camera.h
+++ b/core_lib/src/structure/camera.h
@@ -43,7 +43,7 @@ public:
     void rotate(qreal degree);
     qreal rotation() { return mRotate; }
 
-    void scale(qreal scaleValue);
+    void scale(qreal scaleValue, QPointF offset = {0, 0});
     qreal scaling() { return mScale; }
 
     QTransform view;

--- a/core_lib/src/tool/handtool.cpp
+++ b/core_lib/src/tool/handtool.cpp
@@ -51,6 +51,7 @@ QCursor HandTool::cursor()
 void HandTool::pointerPressEvent(PointerEvent*)
 {
     mLastPixel = getCurrentPixel();
+    mStartPoint = mEditor->view()->mapScreenToCanvas(mLastPixel);
     mIsHeld = true;
 
     mScribbleArea->updateToolCursor();
@@ -116,6 +117,6 @@ void HandTool::transformView(Qt::KeyboardModifiers keyMod, Qt::MouseButtons butt
     {
         float delta = (static_cast<float>(getCurrentPixel().y() - mLastPixel.y())) / 100.f;
         float scaleValue = viewMgr->scaling() * (1.f + delta);
-        viewMgr->scale(scaleValue);
+        viewMgr->scale(scaleValue, mStartPoint);
     }
 }

--- a/core_lib/src/tool/handtool.cpp
+++ b/core_lib/src/tool/handtool.cpp
@@ -108,7 +108,7 @@ void HandTool::transformView(Qt::KeyboardModifiers keyMod, Qt::MouseButtons butt
         QVector2D startV(getLastPixel() - centralPixel);
         QVector2D curV(getCurrentPixel() - centralPixel);
 
-        qreal angleOffset = static_cast<qreal>(atan2(curV.y(), curV.x()) - atan2(startV.y(), startV.x()));
+        qreal angleOffset = static_cast<qreal>(std::atan2(curV.y(), curV.x()) - std::atan2(startV.y(), startV.x()));
         angleOffset = qRadiansToDegrees(angleOffset);
         float newAngle = viewMgr->rotation() + static_cast<float>(angleOffset);
         viewMgr->rotate(newAngle);
@@ -116,7 +116,7 @@ void HandTool::transformView(Qt::KeyboardModifiers keyMod, Qt::MouseButtons butt
     else if (isScale)
     {
         float delta = (static_cast<float>(getCurrentPixel().y() - mLastPixel.y())) / 100.f;
-        float scaleValue = viewMgr->scaling() * (1.f + delta);
+        qreal scaleValue = viewMgr->scaling() * (1 + delta);
         viewMgr->scale(scaleValue, mStartPoint);
     }
 }

--- a/core_lib/src/tool/handtool.h
+++ b/core_lib/src/tool/handtool.h
@@ -41,6 +41,7 @@ private:
     void transformView(Qt::KeyboardModifiers keyMod, Qt::MouseButtons buttons);
 
     QPointF mLastPixel;
+    QPointF mStartPoint;
     bool mIsHeld = false;
 };
 

--- a/translations/pencil_cs.ts
+++ b/translations/pencil_cs.ts
@@ -2849,7 +2849,7 @@ Prověřte výběr a zkuste to, prosím, znovu.</translation>
     <message>
         <location filename="../core_lib/src/util/colordictionary.h" line="290"/>
         <source>Pale Pink</source>
-        <translation>Světlá růžová</translation>
+        <translation>Bledá růžová</translation>
     </message>
     <message>
         <location filename="../core_lib/src/util/colordictionary.h" line="291"/>


### PR DESCRIPTION
For zooming, Pencil2D currently handles all wheel events that are not pixel-based as if they had the same resolution. This leads to sub-par zooming for devices which report high resolution wheel data. With this PR, I fixed that by taking the same approach already used for pixel-based scrolling and tweaking it so that the algorithm satisfies a few additional properties:

- After first scrolling forward by X degrees, scrolling backward by the same X degrees returns the zoom to its original state
- Scrolling forward by X degrees, then scrolling forward by another Y degrees is the same as scrolling forward by (X + Y) degrees
- Using a mouse with "standard" 15 degree resolution, it’s possible to go back to exactly 100% from min/max zoom without having to use "Reset zoom/rotate"
- Using a mouse with "standard" 15 degree resolution, the zoom sensitivity feels roughly the same as before (100x zoom per 180 degree rotation to be precise; though since it wasn’t linear before there’s no direct comparison)

It would probably be a good idea to modify the pixel-based code like that as well (at least when it comes to the first two bullet points), but unfortunately I don’t have the hardware and/or software to test that code, hence why I didn’t do that myself. If anyone has the means to test that (most likely MacBook users) and wants to give it a shot, feel free to commit directly to this PR.

The drawback of this change is that scrolling now works differently for mouse wheel and keyboard, but since this was already true for pixel-based scrolling anyway I don’t think it’s a problem.

[Here](https://streamable.com/rncav5) is an example of how high-resolution scrolling looks without this change. It’s choppy, and even though I’m only making very small movements it goes almost all the way from min zoom to max zoom and back. [Here](https://streamable.com/luklzm) is how it looks with this PR. The zoom doesn’t go crazy fast anymore and is also much smoother (though the video recording/encoding seems to have messed it up a little).

Builds: [Linux](https://drive.google.com/file/d/14NP6fnDh1Y615xQyeaRtvB5yrK3fErXh/view?usp=sharing) [macOS](https://drive.google.com/file/d/1F3YZJ9MV7FpWaRgLKcIX2UnMwqWRYUej/view?usp=sharing) [Windows x86_64](https://drive.google.com/file/d/1zuSirdjUJVZqg2aEKVSrrc7SFYHkqwjH/view?usp=sharing) [Windows x86](https://drive.google.com/file/d/1dSfxScxOPGSQ4_WQCV32nOXQFcCRaxuU/view?usp=sharing)

