### PR TITLE
qmake CONFIG+=NO_TESTS to skip building unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,6 @@ addons:
     - gpg
 
 before_install:
-  - echo "Any source code changed?"
-  - test "${FORCE_NIGHTLY_UPLOAD}" = "yes" || test "$TRAVIS_BRANCH" = "release" || bash $TRAVIS_BUILD_DIR/util/checkchanges.sh || travis_terminate 0;
   - |
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
         brew link qt --force;

--- a/pencil2d.pro
+++ b/pencil2d.pro
@@ -4,22 +4,23 @@
 
 TEMPLATE = subdirs
 
-SUBDIRS = \ # sub-project names
-    core_lib \
-    app \
-    tests
-
 # build the project sequentially as listed in SUBDIRS !
 CONFIG += ordered
 
-# where to find the sub projects - give the folders
+SUBDIRS += core_lib
 core_lib.subdir = core_lib
-app.subdir      = app
-tests.subdir    = tests
 
-# what subproject depends on others
-app.depends      = core_lib
-tests.depends    = core_lib
+SUBDIRS += app
+app.subdir = app
+app.depends = core_lib
+
+SUBDIRS += tests
+tests.subdir = tests
+tests.depends = core_lib
+
+NO_TESTS {
+  SUBDIRS -= tests
+}
 
 TRANSLATIONS += translations/pencil.ts \
                 translations/pencil_ar.ts \
@@ -48,4 +49,3 @@ TRANSLATIONS += translations/pencil.ts \
                 translations/pencil_zh_CN.ts \
                 translations/pencil_zh_TW.ts
 
-macx: LIBS += -framework AppKit


### PR DESCRIPTION
Address #1410 FreeBSD Qt resource tool doesn't work well with Unicode filenames

Add a qmake config flag `NO_TESTS` for package maintainers who don't want to run unit tests

Usage:
```
qmake pencil2d.pro CONFIG+=NO_TESTS
```