### PR TITLE
Fix #1195 check for updates failure

### DIFF
--- a/app/src/checkupdatesdialog.cpp
+++ b/app/src/checkupdatesdialog.cpp
@@ -78,7 +78,7 @@ void CheckUpdatesDialog::startChecking()
 void CheckUpdatesDialog::regularBuildCheck()
 {
     mNetworkManager = new QNetworkAccessManager(this);
-    QUrl url("http://github.com/pencil2d/pencil/releases.atom");
+    QUrl url("https://github.com/pencil2d/pencil/releases.atom");
 
     QNetworkRequest req;
     req.setUrl(url);

--- a/app/src/checkupdatesdialog.h
+++ b/app/src/checkupdatesdialog.h
@@ -1,4 +1,4 @@
-#ifndef CHECKUPDATESDIALOG_H
+﻿#ifndef CHECKUPDATESDIALOG_H
 #define CHECKUPDATESDIALOG_H
 
 #include <QDialog>
@@ -24,6 +24,8 @@ private:
     void regularBuildCheck();
     void nightlyBuildCheck();
     void networkErrorHappened();
+    void networkResponseIsEmpty();
+    void invalidReleaseXml();
 
     void networkRequestFinished(QNetworkReply* reply);
     bool compareVersion(QString currentVersion, QString latestVersion);

--- a/util/after-build.ps1
+++ b/util/after-build.ps1
@@ -14,6 +14,18 @@ $arch = switch ($platform) {
   default {"Unknown"; break}
 }
 
+$libcrypto = switch ($platform) {
+  "x86"   {"C:\OpenSSL-v111-Win32\bin\libcrypto-1_1.dll"; break}
+  "amd64" {"C:\OpenSSL-v111-Win64\bin\libcrypto-1_1-x64.dll"; break}
+  default {""; break}
+}
+
+$libssl = switch ($platform) {
+  "x86"   {"C:\OpenSSL-v111-Win32\bin\libssl-1_1.dll"; break}
+  "amd64" {"C:\OpenSSL-v111-Win64\bin\libssl-1_1-x64.dll"; break}
+  default {""; break}
+}
+
 [string]$ffmpegFileName = "ffmpeg-4.1.1-$arch-static"
 [string]$ffmpegUrl = "https://ffmpeg.zeranoe.com/builds/$arch/static/$ffmpegFileName.zip"
 
@@ -43,15 +55,19 @@ Remove-Item -Path "./$ffmpegFileName" -Recurse
 
 Remove-Item -Path "./Pencil2D" -Recurse -ErrorAction SilentlyContinue
 Copy-Item -Path "./bin" -Destination "./Pencil2D" -Recurse
+Remove-Item -Path "./Pencil2D/*.pdb"
+Remove-Item -Path "./Pencil2D/*.ilk"
 
 echo ">>> Deploying Qt libraries"
 
 & "windeployqt" @("Pencil2D/pencil2d.exe")
 
+echo ">>> Copy OpenSSL DLLs"
+Copy-Item $libcrypto -Destination "./Pencil2D"
+Copy-Item $libssl -Destination "./Pencil2D"
+
 echo ">>> Zipping bin folder"
 
-Remove-Item -Path "./Pencil2D/*.pdb"
-Remove-Item -Path "./Pencil2D/*.ilk"
 Compress-Archive -Path "./Pencil2D" -DestinationPath "./Pencil2D.zip"
 
 $today = Get-Date -Format "yyyy-MM-dd"


### PR DESCRIPTION
Addressing #1195

1. Now the version info request link is HTTPS (HTTP doesn't work anymore)
2. Deploy OpenSSL DLLs in our Windows CI process.

Note: 
The current Qt version (5.12) uses OpenSSL 1.1.1d
AppVeyor has OpenSSL pre-installed 
https://www.appveyor.com/docs/windows-images-software/