### PR TITLE
New layer naming #1414

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -186,7 +186,7 @@ Status ActionCommands::importSound()
         bool ok = false;
         QString strLayerName = QInputDialog::getText(mParent, tr("Layer Properties", "Dialog title on creating a sound layer"),
                                                      tr("Layer name:"), QLineEdit::Normal,
-                                                     tr("Sound Layer", "Default name on creating a sound layer"), &ok);
+                                                     mEditor->layers()->nameSuggestLayer(tr("Sound Layer", "Default name on creating a sound layer")), &ok);
         if (ok && !strLayerName.isEmpty())
         {
             Layer* newLayer = mEditor->layers()->createSoundLayer(strLayerName);

--- a/core_lib/src/managers/layermanager.cpp
+++ b/core_lib/src/managers/layermanager.cpp
@@ -177,9 +177,7 @@ QString LayerManager::nameSuggestLayer(const QString& name)
 LayerBitmap* LayerManager::createBitmapLayer(const QString& strLayerName)
 {
     LayerBitmap* layer = object()->addNewBitmapLayer();
-
-    const QString& name = nameSuggestLayer(strLayerName);
-    layer->setName(name);
+    layer->setName(strLayerName);
 
     Q_EMIT layerCountChanged(count());
     setCurrentLayer(getLastLayerIndex());
@@ -190,8 +188,7 @@ LayerBitmap* LayerManager::createBitmapLayer(const QString& strLayerName)
 LayerVector* LayerManager::createVectorLayer(const QString& strLayerName)
 {
     LayerVector* layer = object()->addNewVectorLayer();
-    const QString& name = nameSuggestLayer(strLayerName);
-    layer->setName(name);
+    layer->setName(strLayerName);
 
     Q_EMIT layerCountChanged(count());
     setCurrentLayer(getLastLayerIndex());
@@ -202,8 +199,7 @@ LayerVector* LayerManager::createVectorLayer(const QString& strLayerName)
 LayerCamera* LayerManager::createCameraLayer(const QString& strLayerName)
 {
     LayerCamera* layer = object()->addNewCameraLayer();
-    const QString& name = nameSuggestLayer(strLayerName);
-    layer->setName(name);
+    layer->setName(strLayerName);
 
     Q_EMIT layerCountChanged(count());
     setCurrentLayer(getLastLayerIndex());
@@ -214,8 +210,7 @@ LayerCamera* LayerManager::createCameraLayer(const QString& strLayerName)
 LayerSound* LayerManager::createSoundLayer(const QString& strLayerName)
 {
     LayerSound* layer = object()->addNewSoundLayer();
-    const QString& name = nameSuggestLayer(strLayerName);
-    layer->setName(name);
+    layer->setName(strLayerName);
 
     Q_EMIT layerCountChanged(count());
     setCurrentLayer(getLastLayerIndex());


### PR DESCRIPTION
A new sound layer was named 'Sound layer 2', even if one selected 'Sound layer'. The reason was that the nameSuggestLayer() function was called twice.
Fixes #1414