### PR TITLE
Only creating keyframes that exists in *.pclx

### DIFF
--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -184,6 +184,7 @@ void LayerBitmap::loadDomElement(const QDomElement& element, QString dataDirPath
 {
     this->loadBaseDomElement(element);
 
+    QList<int> frameList;
     QDomNode imageTag = element.firstChild();
     while (!imageTag.isNull())
     {
@@ -199,10 +200,13 @@ void LayerBitmap::loadDomElement(const QDomElement& element, QString dataDirPath
                 int x = imageElement.attribute("topLeftX").toInt();
                 int y = imageElement.attribute("topLeftY").toInt();
                 loadImageAtFrame(path, QPoint(x, y), position);
+                frameList.append(position);
 
                 progressStep();
             }
         }
         imageTag = imageTag.nextSibling();
     }
+    if (!frameList.contains(1))
+        removeKeyFrame(1);
 }

--- a/core_lib/src/structure/layercamera.cpp
+++ b/core_lib/src/structure/layercamera.cpp
@@ -289,6 +289,7 @@ void LayerCamera::loadDomElement(const QDomElement& element, QString dataDirPath
 
     this->loadBaseDomElement(element);
 
+    QList<int> frameList;
     int width = element.attribute("width").toInt();
     int height = element.attribute("height").toInt();
     viewRect = QRect(-width / 2, -height / 2, width, height);
@@ -309,8 +310,11 @@ void LayerCamera::loadDomElement(const QDomElement& element, QString dataDirPath
                 qreal dy = imageElement.attribute("dy", "0").toDouble();
 
                 loadImageAtFrame(frame, dx, dy, rotate, scale);
+                frameList.append(frame);
             }
         }
         imageTag = imageTag.nextSibling();
     }
+    if (!frameList.contains(1))
+        removeKeyFrame(1);
 }

--- a/core_lib/src/structure/layersound.cpp
+++ b/core_lib/src/structure/layersound.cpp
@@ -90,6 +90,7 @@ void LayerSound::loadDomElement(const QDomElement& element, QString dataDirPath,
 {
     this->loadBaseDomElement(element);
 
+    QList<int> frameList;
     QDomNode soundTag = element.firstChild();
     while (!soundTag.isNull())
     {
@@ -112,12 +113,15 @@ void LayerSound::loadDomElement(const QDomElement& element, QString dataDirPath,
                 int position = soundElement.attribute("frame").toInt();
                 Status st = loadSoundClipAtFrame(sSoundClipName, sFullPath, position);
                 Q_ASSERT(st.ok());
+                frameList.append(position);
             }
             progressStep();
         }
 
         soundTag = soundTag.nextSibling();
     }
+    if (!frameList.contains(1))
+        removeKeyFrame(1);
 }
 
 Status LayerSound::saveKeyFrameFile(KeyFrame* key, QString path)

--- a/core_lib/src/structure/layervector.cpp
+++ b/core_lib/src/structure/layervector.cpp
@@ -151,6 +151,7 @@ void LayerVector::loadDomElement(const QDomElement& element, QString dataDirPath
 {
     this->loadBaseDomElement(element);
 
+    QList<int> frameList;
     QDomNode imageTag = element.firstChild();
     while (!imageTag.isNull())
     {
@@ -166,18 +167,22 @@ void LayerVector::loadDomElement(const QDomElement& element, QString dataDirPath
                     if (!fi.exists()) path = imageElement.attribute("src");
                     int position = imageElement.attribute("frame").toInt();
                     loadImageAtFrame(path, position);
+                    frameList.append(position);
                 }
                 else
                 {
                     int frame = imageElement.attribute("frame").toInt();
                     addNewKeyFrameAt(frame);
                     getVectorImageAtFrame(frame)->loadDomElement(imageElement);
+                    frameList.append(frame);
                 }
                 progressStep();
             }
         }
         imageTag = imageTag.nextSibling();
     }
+    if (!frameList.contains(1))
+        removeKeyFrame(1);
 }
 
 VectorImage* LayerVector::getVectorImageAtFrame(int frameNumber) const


### PR DESCRIPTION
If you, for some reason, delete frame 1 on some layer, it doesn't appear in the *.pclx file. Nonetheless, Pencil2D uses to reinstate frame 1, when reloading the file.
This PR removes these non-existing frames.
If you can think of a smarter way to implement it, please come forward.
fixes #1372 