### PR TITLE
Fix temporary tools getting stuck if changing applications

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -220,6 +220,7 @@ int handleArguments(PencilApplication& app)
 
     // Now that (almost) all possible user errors are handled, the actual program can be initialized
     MainWindow2 mainWindow;
+    QObject::connect(&app, &PencilApplication::lostFocus, &mainWindow, &MainWindow2::appLostFocus);
     QObject::connect(&app, &PencilApplication::openFileRequested, &mainWindow, &MainWindow2::openFile);
     app.emitOpenFileRequest();
 

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1366,6 +1366,7 @@ void MainWindow2::openPalette()
 
 void MainWindow2::makeConnections(Editor* editor)
 {
+    connect(this, &MainWindow2::appLostFocus, editor->getScribbleArea(), &ScribbleArea::setPrevTool);
     connect(editor, &Editor::updateBackup, this, &MainWindow2::updateSaveState);
     connect(editor, &Editor::needDisplayInfo, this, &MainWindow2::displayMessageBox);
     connect(editor, &Editor::needDisplayInfoNoTitle, this, &MainWindow2::displayMessageBoxNoTitle);

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -105,6 +105,7 @@ public:
 
 Q_SIGNALS:
     void updateRecentFilesList(bool b);
+    void appLostFocus();
 
 protected:
     void tabletEvent(QTabletEvent*) override;

--- a/app/src/pencilapplication.cpp
+++ b/app/src/pencilapplication.cpp
@@ -38,6 +38,11 @@ PencilApplication::PencilApplication(int& argc, char** argv) :
 
 bool PencilApplication::event(QEvent* event)
 {
+    if(event->type() == QEvent::ApplicationStateChange && static_cast<QApplicationStateChangeEvent*>(event)->applicationState() == Qt::ApplicationInactive) {
+        emit lostFocus();
+        return true;
+    }
+
     if (event->type() == QEvent::FileOpen)
     {
         mStartPath = static_cast<QFileOpenEvent*>(event)->file();

--- a/app/src/pencilapplication.h
+++ b/app/src/pencilapplication.h
@@ -32,6 +32,7 @@ public:
 
 signals:
     void openFileRequested(QString filename);
+    void lostFocus();
 
 private:
     QString mStartPath;

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1625,8 +1625,11 @@ void ScribbleArea::clearImage()
 
 void ScribbleArea::setPrevTool()
 {
-    editor()->tools()->setCurrentTool(mPrevTemporalToolType);
-    mInstantTool = false;
+    if (mInstantTool)
+    {
+        editor()->tools()->setCurrentTool(mPrevTemporalToolType);
+        mInstantTool = false;
+    }
 }
 
 void ScribbleArea::paletteColorChanged(QColor color)


### PR DESCRIPTION
This applies in particular to the eyedropper temporary tool, which is activated while switching to other applications with the alt+tab shortcut. The solution I have come up with for this problem is to catch the event that is generated when leaving an application and then reverting any temporary tool when that occurs.

This has only been tested on Linux, it should be tested on Windows as well to make sure that it generates the same event and fixes the issue.