### PR TITLE
1428 fix crash under peculiar circumstances

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -464,6 +464,7 @@ void MainWindow2::openPegAlignDialog()
     }
 
     mPegAlign = new PegBarAlignmentDialog(mEditor, this);
+    mPegAlign->setAttribute(Qt::WA_DeleteOnClose);
     connect(mPegAlign, &PegBarAlignmentDialog::closedialog, this, &MainWindow2::closePegAlignDialog);
     mPegAlign->updatePegRegLayers();
     mPegAlign->setRefLayer(mEditor->layers()->currentLayer()->name());


### PR DESCRIPTION
After setting an additional attribute to the pegbar alignment dialog, the dialog closes properly, and with this change, I can't reproduce the crashes described by @Jose-Moreno .
This should fix #1428 