### PR TITLE
Project recovery after Pencil2D crashes

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1568,12 +1568,15 @@ void MainWindow2::tryRecoverUnsavedProject()
 
 void MainWindow2::startProjectRecovery(int result)
 {
-    if (result != QMessageBox::Open)
-    {
-        return;
-    }
     QMessageBox* msgBox = dynamic_cast<QMessageBox*>(QObject::sender());
     const QString recoverPath = msgBox->property("RecoverPath").toString();
+
+    if (result != QMessageBox::Open)
+    {
+        // The user presses discard
+        QDir(recoverPath).removeRecursively();
+        return;
+    }
 
     FileManager fm;
     Object* o = fm.recoverUnsavedProject(recoverPath);

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1580,11 +1580,15 @@ void MainWindow2::startProjectRecovery(int result)
     if (!fm.error().ok())
     {
         Q_ASSERT(o == nullptr);
-        QMessageBox::information(this, tr("Recovery Failed."), tr("Sorry! Pencil2D is unable to restore your project"));
+        const QString title = tr("Recovery Failed.");
+        const QString text = tr("Sorry! Pencil2D is unable to restore your project");
+        QMessageBox::information(this, title, QString("<h4>%1</h4>%2").arg(title).arg(text));
     }
 
     mEditor->setObject(o);
     updateSaveState();
 
-    QMessageBox::information(this, tr("Recovery Succeeded!"), tr("Please save your work immediately to prevent loss of data"));
+    const QString title = tr("Recovery Succeeded!");
+    const QString text = tr("Please save your work immediately to prevent loss of data");
+    QMessageBox::information(this, title, QString("<h4>%1</h4>%2").arg(title).arg(text));
 }

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1559,6 +1559,7 @@ void MainWindow2::tryRecoverUnsavedProject()
     msgBox->setText(QString("<h4>%1</h4>%2").arg(caption).arg(text));
     msgBox->setInformativeText(QString("<b>%1</b>").arg(retrieveProjectNameFromTempPath(recoverPath)));
     msgBox->setStandardButtons(QMessageBox::Open | QMessageBox::Discard);
+
     hideQuestionMark(*msgBox);
 
     connect(msgBox, &QMessageBox::finished, [recoverPath, this](int result)
@@ -1567,8 +1568,11 @@ void MainWindow2::tryRecoverUnsavedProject()
         {
             FileManager fm;
             Object* o = fm.recoverUnsavedProject(recoverPath);
-            mEditor->setObject(o);
-            updateSaveState();
+            if (fm.error().ok())
+            {
+                mEditor->setObject(o);
+                updateSaveState();
+            }
         }
     });
     msgBox->open();

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1579,6 +1579,7 @@ void MainWindow2::startProjectRecovery(int result)
     Object* o = fm.recoverUnsavedProject(recoverPath);
     if (!fm.error().ok())
     {
+        Q_ASSERT(o == nullptr);
         QMessageBox::information(this, tr("Recovery Failed."), tr("Sorry! Pencil2D is unable to restore your project"));
     }
 

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -152,6 +152,7 @@ private:
     void bindActionWithSetting(QAction*, const SETTING&);
 
     void tryRecoverUnsavedProject();
+    void startProjectRecovery(int result);
 
     // UI: Dock widgets
     ColorBox*             mColorBox = nullptr;

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -96,7 +96,7 @@ public:
     void setSoundScrubMsec(int msec);
     void setOpacity(int opacity);
     void preferences();
- 
+
     void openFile(QString filename);
 
     PreferencesDialog* getPrefDialog() { return mPrefDialog; }
@@ -111,6 +111,7 @@ Q_SIGNALS:
 protected:
     void tabletEvent(QTabletEvent*) override;
     void closeEvent(QCloseEvent*) override;
+    void showEvent(QShowEvent*) override;
 
 private slots:
     void resetAndDockAllSubWidgets();
@@ -150,6 +151,8 @@ private:
 
     void bindActionWithSetting(QAction*, const SETTING&);
 
+    void tryRecoverUnsavedProject();
+
     // UI: Dock widgets
     ColorBox*             mColorBox = nullptr;
     ColorPaletteWidget*   mColorPalette = nullptr;
@@ -181,7 +184,7 @@ private:
 
     // whether we are currently importing an image sequence.
     bool mIsImportingImageSequence = false;
-    
+
     Ui::MainWindow2* ui = nullptr;
 };
 

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -151,7 +151,7 @@ private:
 
     void bindActionWithSetting(QAction*, const SETTING&);
 
-    void tryRecoverUnsavedProject();
+    bool tryRecoverUnsavedProject();
     void startProjectRecovery(int result);
 
     // UI: Dock widgets

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -716,7 +716,7 @@ Status FileManager::recoverObject(Object* object)
     mainXmlOK &= (!root.isNull());
 
     QDomElement objectTag = root.firstChildElement("object");
-    mainXmlOK &= (objectTag.isNull());
+    mainXmlOK &= (objectTag.isNull() == false);
 
     if (mainXmlOK == false)
     {

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -699,26 +699,38 @@ Object* FileManager::recoverUnsavedProject(QString intermeidatePath)
 
 Status FileManager::recoverObject(Object* object)
 {
-    QFile file(object->mainXMLFile());
-    if (!file.exists()) { return Status::FAIL; }
+    // Check whether the main.xml is fine, if not we should make a valid one.
+    bool mainXmlOK = true;
 
-    bool openOK = file.open(QFile::ReadOnly);
-    if (!openOK) { return Status::FAIL; }
+    QFile file(object->mainXMLFile());
+    mainXmlOK &= file.exists();
+    mainXmlOK &= file.open(QFile::ReadOnly);
 
     QDomDocument xmlDoc;
-    if (!xmlDoc.setContent(&file)) { return Status::FAIL; }
+    mainXmlOK &= xmlDoc.setContent(&file);
 
     QDomDocumentType type = xmlDoc.doctype();
-    if (!(type.name() == "PencilDocument" || type.name() == "MyObject"))
-    {
-        return Status::FAIL;;
-    }
+    mainXmlOK &= (type.name() == "PencilDocument" || type.name() == "MyObject");
 
     QDomElement root = xmlDoc.documentElement();
-    if (root.isNull()) { return Status::FAIL; }
+    mainXmlOK &= (!root.isNull());
 
-    QDomElement e = root.firstChildElement("object");
-    if (e.isNull()) { return Status::FAIL; }
+    QDomElement objectTag = root.firstChildElement("object");
+    mainXmlOK &= (objectTag.isNull());
+
+    if (mainXmlOK == false)
+    {
+        // the main.xml is broken, try to rebuild one
+        rebuildMainXML(object);
+
+        // Load the newly built main.xml
+        QFile file(object->mainXMLFile());
+        file.open(QFile::ReadOnly);
+        xmlDoc.setContent(&file);
+        root = xmlDoc.documentElement();
+        objectTag = root.firstChildElement("object");
+    }
+    loadPalette(object);
 
     bool ok = loadObject(object, root);
     verifyObject(object);
@@ -726,3 +738,137 @@ Status FileManager::recoverObject(Object* object)
     return ok ? Status::OK : Status::FAIL;
 }
 
+/** Create a new main.xml based on the png/vec filenames left in the data folder */
+Status FileManager::rebuildMainXML(Object* object)
+{
+    QDir dataDir(object->dataDir());
+
+    QStringList nameFiler;
+    nameFiler << "*.png" << "*.vec";
+    const QStringList entries = dataDir.entryList(nameFiler, QDir::Files | QDir::Readable, QDir::Name);
+
+    QMap<int, QStringList> keyFrameGroups;
+
+    // grouping keyframe files by layers
+    for (const QString& s : entries)
+    {
+        int layerIndex = layerIndexFromFilename(s);
+        if (layerIndex > 0)
+        {
+            keyFrameGroups[layerIndex].append(s);
+        }
+    }
+
+    // build the new main XML file
+    const QString mainXMLPath = object->mainXMLFile();
+    QFile file(mainXMLPath);
+    if (!file.open(QFile::WriteOnly | QFile::Text))
+    {
+        return Status::ERROR_FILE_CANNOT_OPEN;
+    }
+
+    QDomDocument xmlDoc("PencilDocument");
+    QDomElement root = xmlDoc.createElement("document");
+    QDomProcessingInstruction encoding = xmlDoc.createProcessingInstruction("xml", "version=\"1.0\" encoding=\"UTF-8\"");
+    xmlDoc.appendChild(encoding);
+    xmlDoc.appendChild(root);
+
+    // save editor information
+    QDomElement projDataXml = saveProjectData(object->data(), xmlDoc);
+    root.appendChild(projDataXml);
+
+    // save object
+    QDomElement elemObject = xmlDoc.createElement("object");
+    root.appendChild(elemObject);
+
+    for (const int layerIndex : keyFrameGroups.keys())
+    {
+        const QStringList& frames = keyFrameGroups.value(layerIndex);
+        Status st = rebuildLayerXmlTag(xmlDoc, elemObject, layerIndex, frames);
+    }
+
+    QTextStream fout(&file);
+    xmlDoc.save(fout, 2);
+    fout.flush();
+    file.close();
+
+    return Status::OK;
+}
+/**
+ *  Rebuild a layer xml tag. example:
+ *    <layer id="2" type="2" visibility="1" name="Vector Layer">
+ *      <image src="002.001.vec" frame="1"/>
+ *    </layer>
+ */
+Status FileManager::rebuildLayerXmlTag(QDomDocument& doc,
+                                       QDomElement& elemObject,
+                                       const int layerIndex,
+                                       const QStringList& frames)
+{
+    Q_ASSERT(frames.length() > 0);
+
+    Layer::LAYER_TYPE type = frames[0].endsWith(".png") ? Layer::BITMAP : Layer::VECTOR;
+
+    QDomElement elemLayer = doc.createElement("layer");
+    elemLayer.setAttribute("id", layerIndex + 1); // starts from 1, not 0.
+    elemLayer.setAttribute("name", recoverLayerName(type, layerIndex));
+    elemLayer.setAttribute("visibility", true);
+    elemLayer.setAttribute("type", type);
+    elemObject.appendChild(elemLayer);
+
+    for (const QString& s : frames)
+    {
+        const int framePos = framePosFromFilename(s);
+        if (framePos < 0) { continue; }
+
+        QDomElement elemFrame = doc.createElement("image");
+        elemFrame.setAttribute("frame", framePos);
+        elemFrame.setAttribute("src", s);
+
+        if (type == Layer::BITMAP)
+        {
+            // Since we have no way to know the original img position
+            // Put it at the top left corner of the default camera
+            elemFrame.setAttribute("topLeftX", -800);
+            elemFrame.setAttribute("topLeftY", -600);
+        }
+        elemLayer.appendChild(elemFrame);
+    }
+    return Status::OK;
+}
+
+QString FileManager::recoverLayerName(Layer::LAYER_TYPE type, int index)
+{
+    switch (type)
+    {
+    case Layer::BITMAP:
+        return QString("%1 %2").arg(tr("Bitmap Layer")).arg(index);
+    case Layer::VECTOR:
+        return QString("%1 %2").arg(tr("Vector Layer")).arg(index);
+    case Layer::SOUND:
+        return QString("%1 %2").arg(tr("Sound Layer")).arg(index);
+    default:
+        Q_ASSERT(false);
+    }
+    return "";
+}
+
+int FileManager::layerIndexFromFilename(const QString& filename)
+{
+    const QStringList tokens = filename.split("."); // e.g., 001.019.png or 012.132.vec
+    if (tokens.length() >= 3) // a correct file name must have 3 tokens
+    {
+        return tokens[0].toInt();
+    }
+    return -1;
+}
+
+int FileManager::framePosFromFilename(const QString& filename)
+{
+    const QStringList tokens = filename.split("."); // e.g., 001.019.png or 012.132.vec
+    if (tokens.length() >= 3) // a correct file name must have 3 tokens
+    {
+        return tokens[1].toInt();
+    }
+    return -1;
+}

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -687,8 +687,12 @@ Object* FileManager::recoverUnsavedProject(QString intermeidatePath)
     object->setMainXMLFile(mainXMLPath);
     object->setDataDir(dataFolder);
 
-    recoverObject(object.get());
-
+    Status st = recoverObject(object.get());
+    if (!st.ok())
+    {
+        mError = st;
+        return nullptr;
+    }
     // Transfer ownership to the caller
     return object.release();
 }

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -682,7 +682,7 @@ Object* FileManager::recoverUnsavedProject(QString intermeidatePath)
     const QString mainXMLPath = projectDir.filePath(PFF_XML_FILE_NAME);
     const QString dataFolder = projectDir.filePath(PFF_DATA_DIR);
 
-    std::unique_ptr<Object> object = std::make_unique<Object>();
+    std::unique_ptr<Object> object(new Object);
     object->setWorkingDir(intermeidatePath);
     object->setMainXMLFile(mainXMLPath);
     object->setDataDir(dataFolder);

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -705,6 +705,7 @@ Status FileManager::recoverObject(Object* object)
     QFile file(object->mainXMLFile());
     mainXmlOK &= file.exists();
     mainXmlOK &= file.open(QFile::ReadOnly);
+    file.close();
 
     QDomDocument xmlDoc;
     mainXmlOK &= xmlDoc.setContent(&file);

--- a/core_lib/src/structure/filemanager.h
+++ b/core_lib/src/structure/filemanager.h
@@ -26,6 +26,7 @@ GNU General Public License for more details.
 #include "pencildef.h"
 #include "pencilerror.h"
 #include "colorref.h"
+#include "layer.h"
 
 class Object;
 class ObjectData;
@@ -71,9 +72,16 @@ private:
 
     void progressForward();
 
+
 private: // Project recovery
-    Status recoverObject(Object* object);
     bool isProjectRecoverable(const QString& projectFolder);
+    Status recoverObject(Object* object);
+    Status rebuildMainXML(Object* object);
+    Status rebuildLayerXmlTag(QDomDocument& doc, QDomElement& elemObject,
+                              const int layerIndex, const QStringList& frames);
+    QString recoverLayerName(Layer::LAYER_TYPE, int index);
+    int layerIndexFromFilename(const QString& filename);
+    int framePosFromFilename(const QString& filename);
 
 private:
     Status mError = Status::OK;

--- a/core_lib/src/structure/filemanager.h
+++ b/core_lib/src/structure/filemanager.h
@@ -45,6 +45,9 @@ public:
     Status error() const { return mError; }
     Status verifyObject(Object* obj);
 
+    QStringList searchForUnsavedProjects();
+    Object* recoverUnsavedProject(QString projectIntermediatePath);
+
 Q_SIGNALS:
     void progressChanged(int progress);
     void progressRangeChanged(int maxValue);
@@ -67,6 +70,10 @@ private:
     void deleteBackupFile(const QString& fileName);
 
     void progressForward();
+
+private: // Project recovery
+    Status recoverObject(Object* object);
+    bool isProjectRecoverable(const QString& projectFolder);
 
 private:
     Status mError = Status::OK;

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -149,7 +149,7 @@ QString LayerBitmap::fileName(KeyFrame* key) const
 }
 
 bool LayerBitmap::needSaveFrame(KeyFrame* key, const QString& savePath)
-{    
+{
     if (key->isModified()) // keyframe was modified
         return true;
     if (QFile::exists(savePath) == false) // hasn't been saved before

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -163,15 +163,15 @@ LayerCamera* Object::addNewCameraLayer()
 
 void Object::createWorkingDir()
 {
-    QString strFolderName;
+    QString projectName;
     if (mFilePath.isEmpty())
     {
-        strFolderName = "Default";
+        projectName = "Default";
     }
     else
     {
         QFileInfo fileInfo(mFilePath);
-        strFolderName = fileInfo.completeBaseName();
+        projectName = fileInfo.completeBaseName();
     }
     QDir dir(QDir::tempPath());
 
@@ -180,7 +180,7 @@ void Object::createWorkingDir()
     {
         strWorkingDir = QString("%1/Pencil2D/%2_%3_%4/")
             .arg(QDir::tempPath())
-            .arg(strFolderName)
+            .arg(projectName)
             .arg(PFF_TMP_DECOMPRESS_EXT)
             .arg(uniqueString(8));
     }
@@ -200,8 +200,16 @@ void Object::deleteWorkingDir() const
     if (!mWorkingDirPath.isEmpty())
     {
         QDir dir(mWorkingDirPath);
-        dir.removeRecursively();
+        bool ok = dir.removeRecursively();
+        Q_ASSERT(ok);
     }
+}
+
+void Object::setWorkingDir(const QString& path)
+{
+    QDir dir(path);
+    Q_ASSERT(dir.exists());
+    mWorkingDirPath = path;
 }
 
 void Object::createDefaultLayers()

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -62,6 +62,7 @@ public:
     void init();
     void createWorkingDir();
     void deleteWorkingDir() const;
+    void setWorkingDir(const QString& path); // used by crash recovery
     void createDefaultLayers();
 
     QString filePath() const { return mFilePath; }

--- a/core_lib/src/util/fileformat.cpp
+++ b/core_lib/src/util/fileformat.cpp
@@ -17,25 +17,25 @@ GNU General Public License for more details.
 
 #include "fileformat.h"
 #include <QDir>
+#include <QFileInfo>
 
-bool removePFFTmpDirectory (const QString& dirName)
+bool removePFFTmpDirectory(const QString& dirName)
 {
-    if ( dirName.isEmpty() )
+    if (dirName.isEmpty())
     {
         return false;
     }
 
-    QDir dir( dirName );
-	
-    if ( !dir.exists() )
+    QDir dir(dirName);
+
+    if (!dir.exists())
     {
-        Q_ASSERT( false );
+        Q_ASSERT(false);
         return false;
     }
 
     bool result = dir.removeRecursively();
-	
-	return result;
+    return result;
 }
 
 QString uniqueString(int len)
@@ -52,4 +52,14 @@ QString uniqueString(int len)
     }
     s[len] = 0;
     return QString::fromUtf8(s);
+}
+
+QString retrieveProjectNameFromTempPath(const QString& path)
+{
+    QFileInfo info(path);
+    QString fileName = info.completeBaseName();
+
+    QStringList tokens = fileName.split("_");
+    //qDebug() << tokens;
+    return tokens[0];
 }

--- a/core_lib/src/util/fileformat.h
+++ b/core_lib/src/util/fileformat.h
@@ -71,8 +71,9 @@ GNU General Public License for more details.
 #define PFF_TMP_DECOMPRESS_EXT 	"Y2xD"
 #define PFF_PALETTE_FILE        "palette.xml"
 
-bool removePFFTmpDirectory (const QString& dirName);
+bool removePFFTmpDirectory(const QString& dirName);
 QString uniqueString(int len);
+QString retrieveProjectNameFromTempPath(const QString& path);
 
 
 #endif

--- a/tests/src/test_filemanager.cpp
+++ b/tests/src/test_filemanager.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 
 Pencil - Traditional Animation Software
 Copyright (C) 2012-2020 Matthew Chiawen Chang
@@ -430,7 +430,7 @@ TEST_CASE("Empty Sound Frames")
             REQUIRE(newObj->getLayer(0)->type() == 4);
             REQUIRE(newObj->getLayer(0)->id() == 5);
             REQUIRE(newObj->getLayer(0)->name() == "GoodLayer");
-            REQUIRE(newObj->getLayer(0)->getVisibility() == 1);
+            REQUIRE(newObj->getLayer(0)->getVisibility() == true);
             REQUIRE(newObj->getLayer(0)->getKeyFrameAt(1) == nullptr);
 
             delete newObj;


### PR DESCRIPTION
![Annotation 2020-08-20 153254](https://user-images.githubusercontent.com/163800/90720708-73c1bf00-e2fa-11ea-871b-7675785659e0.png)

Try to restore the last unsaved project, usually because of Pencil2D crashes.
A recovery popup will show if the app finds any project files left in the temp folder. 

There are two recovery modes:
1. Both `main.xml` and images (.png and .vec) are fine. In this case, just load the project up from the temp folder.
2. `main.xml` is broken. Then try to rebuild the main.xml based on the images left in `data` folder, and then call mode 1. In this mode, the images are no way to be on the correct position anymore.

Things need to do next but not included in this PR:
1. Preset pop-up. Both Recovery & Preset popup are showing when the app starts.
2. Inconsistency between images and main.xml. Maybe there are images in the data folder but images are not added to main.xml yet due to uncompleted save procedure. Not sure if we need this. 
3. Multiple projects recovery. Currently it only recocvers one project at a time.

How to test:
1. Create/Load a project.
2. Force close the app
3. Maybe go to the temp folder and mess up `main.xml` 
4. Restart Pencil2D. See if the restore pop-up shows
