### PR TITLE
[Refactor] Break down FileManager::save() and introduce FileManager::flush()

### DIFF
--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -320,8 +320,9 @@ Status FileManager::save(const Object* object, QString sFileName)
                           tr("An internal error occurred. Your file may not be saved successfully."));
         }
         dd << "Zip file saved successfully";
+        Q_ASSERT(stMiniz.ok());
 
-        if (stMiniz.ok() && saveOk)
+        if (saveOk)
             deleteBackupFile(sBackupFile);
     }
 

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -292,7 +292,7 @@ Status FileManager::save(const Object* object, QString sFileName)
     }
 
     QStringList filesToZip; // A files list in the working folder needs to be zipped
-    Status stKeyFrames = flushKeyFrameFiles(object, sDataFolder, filesToZip);
+    Status stKeyFrames = writeKeyFrameFiles(object, sDataFolder, filesToZip);
     dd.collect(stKeyFrames.details());
 
     Status stMainXml = writeMainXml(object, sMainXMLFile, filesToZip);
@@ -337,7 +337,7 @@ Status FileManager::save(const Object* object, QString sFileName)
     return Status::OK;
 }
 
-Status FileManager::flush(const Object* object)
+Status FileManager::writeToWorkingFolder(const Object* object)
 {
     DebugDetails dd;
 
@@ -346,7 +346,7 @@ Status FileManager::flush(const Object* object)
     const QString dataFolder = object->dataDir();
     const QString mainXml = object->mainXMLFile();
 
-    Status stKeyFrames = flushKeyFrameFiles(object, dataFolder, filesWritten);
+    Status stKeyFrames = writeKeyFrameFiles(object, dataFolder, filesWritten);
     dd.collect(stKeyFrames.details());
 
     Status stMainXml = writeMainXml(object, mainXml, filesWritten);
@@ -549,7 +549,7 @@ bool FileManager::loadPalette(Object* obj)
     return true;
 }
 
-Status FileManager::flushKeyFrameFiles(const Object* object, const QString& dataFolder, QStringList& filesFlushed)
+Status FileManager::writeKeyFrameFiles(const Object* object, const QString& dataFolder, QStringList& filesFlushed)
 {
     DebugDetails dd;
 

--- a/core_lib/src/structure/filemanager.h
+++ b/core_lib/src/structure/filemanager.h
@@ -61,6 +61,9 @@ private:
     bool loadObjectOldWay(Object*, const QDomElement& root);
     bool isOldForamt(const QString& fileName) const;
     bool loadPalette(Object*);
+    Status flushKeyFrameFiles(const Object* obj, const QString& dataFolder, QStringList& files);
+    Status writeMainXml(const Object* obj, const QString& mainXml, QStringList& files);
+    Status writePalette(const Object* obj, const QString& dataFolder, QStringList& files);
 
     ObjectData* loadProjectData(const QDomElement& element);
     QDomElement saveProjectData(ObjectData*, QDomDocument& xmlDoc);

--- a/core_lib/src/structure/filemanager.h
+++ b/core_lib/src/structure/filemanager.h
@@ -41,7 +41,7 @@ public:
 
     Object* load(QString sFilenNme);
     Status  save(const Object*, QString sFileName);
-    Status  flush(const Object*);
+    Status  writeToWorkingFolder(const Object*);
 
     QList<ColorRef> loadPaletteFile(QString strFilename);
     Status error() const { return mError; }
@@ -61,7 +61,7 @@ private:
     bool loadObjectOldWay(Object*, const QDomElement& root);
     bool isOldForamt(const QString& fileName) const;
     bool loadPalette(Object*);
-    Status flushKeyFrameFiles(const Object* obj, const QString& dataFolder, QStringList& filesWritten);
+    Status writeKeyFrameFiles(const Object* obj, const QString& dataFolder, QStringList& filesWritten);
     Status writeMainXml(const Object* obj, const QString& mainXml, QStringList& filesWritten);
     Status writePalette(const Object* obj, const QString& dataFolder, QStringList& filesWritten);
 

--- a/core_lib/src/structure/filemanager.h
+++ b/core_lib/src/structure/filemanager.h
@@ -41,7 +41,7 @@ public:
 
     Object* load(QString sFilenNme);
     Status  save(const Object*, QString sFileName);
-    //Status  flush(Object*);
+    Status  flush(const Object*);
 
     QList<ColorRef> loadPaletteFile(QString strFilename);
     Status error() const { return mError; }

--- a/core_lib/src/structure/filemanager.h
+++ b/core_lib/src/structure/filemanager.h
@@ -61,9 +61,9 @@ private:
     bool loadObjectOldWay(Object*, const QDomElement& root);
     bool isOldForamt(const QString& fileName) const;
     bool loadPalette(Object*);
-    Status flushKeyFrameFiles(const Object* obj, const QString& dataFolder, QStringList& files);
-    Status writeMainXml(const Object* obj, const QString& mainXml, QStringList& files);
-    Status writePalette(const Object* obj, const QString& dataFolder, QStringList& files);
+    Status flushKeyFrameFiles(const Object* obj, const QString& dataFolder, QStringList& filesWritten);
+    Status writeMainXml(const Object* obj, const QString& mainXml, QStringList& filesWritten);
+    Status writePalette(const Object* obj, const QString& dataFolder, QStringList& filesWritten);
 
     ObjectData* loadProjectData(const QDomElement& element);
     QDomElement saveProjectData(ObjectData*, QDomDocument& xmlDoc);


### PR DESCRIPTION
This is a PR of code refactoring. It's a preparation step for further file saving improvements.

There are 2 parts in this PR:

1. Breaking down `FileManager::save()` into 3 smaller functions 
  - `flushKeyFrameFiles()`: write all bitmap/vector keyframes to the temp working folder.
  - `writeMainXml()`: write the main xml to disk
  - `writePalette`: write the palette xml to disk

This change makes the file save process more clear & descriptive, also make the second part possible.

2. Introducing `FileManager::flush()`

This function flushes all changes to the temp working folder without touching `.pclx`. Calling `flush()` at the right time will improve the recoverability of projects. For example, recovering a newly created project which has nothing in the temp working folder. More PRs will come soon.
