### PR TITLE
Manage ActiveFramePool using image size rather than number of frames

### DIFF
--- a/app/ui/generalpage.ui
+++ b/app/ui/generalpage.ui
@@ -38,9 +38,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-335</y>
-        <width>303</width>
-        <height>866</height>
+        <y>-302</y>
+        <width>292</width>
+        <height>845</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="lay">
@@ -428,7 +428,7 @@
           <item>
            <widget class="QLabel" name="cacheLabel">
             <property name="text">
-             <string>Cached Frame Number:</string>
+             <string>Memory Cache Budget</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -458,14 +458,17 @@
               <height>16777215</height>
              </size>
             </property>
+            <property name="suffix">
+             <string>MB</string>
+            </property>
             <property name="minimum">
-             <number>11</number>
+             <number>100</number>
             </property>
             <property name="maximum">
-             <number>1500</number>
+             <number>16000</number>
             </property>
             <property name="value">
-             <number>200</number>
+             <number>1024</number>
             </property>
            </widget>
           </item>

--- a/core_lib/src/activeframepool.cpp
+++ b/core_lib/src/activeframepool.cpp
@@ -58,11 +58,6 @@ void ActiveFramePool::put(KeyFrame* key)
     discardLeastUsedFrames();
 }
 
-size_t ActiveFramePool::size() const
-{
-    return mCacheFramesMap.size();
-}
-
 void ActiveFramePool::clear()
 {
     for (KeyFrame* key : mCacheFramesList)

--- a/core_lib/src/activeframepool.cpp
+++ b/core_lib/src/activeframepool.cpp
@@ -18,7 +18,6 @@ GNU General Public License for more details.
 #include "activeframepool.h"
 #include "keyframe.h"
 #include "pencildef.h"
-#include <QDebug>
 
 
 ActiveFramePool::ActiveFramePool()
@@ -52,7 +51,6 @@ void ActiveFramePool::put(KeyFrame* key)
     if (!keyExistsInPool)
     {
         mTotalUsedMemory += key->memoryUsage();
-        //qDebug() << "Total Memory:" << mTotalUsedMemory;
     }
 
     discardLeastUsedFrames();
@@ -115,10 +113,8 @@ void ActiveFramePool::discardLeastUsedFrames()
 
 void ActiveFramePool::unloadFrame(KeyFrame* key)
 {
-    //qDebug() << "Unload frame:" << key->pos();
     mTotalUsedMemory -= key->memoryUsage();
     key->unloadFile();
-    //qDebug() << "Total Memory:" << mTotalUsedMemory;
 }
 
 void ActiveFramePool::recalcuateTotalUsedMemory()
@@ -128,5 +124,4 @@ void ActiveFramePool::recalcuateTotalUsedMemory()
     {
         mTotalUsedMemory += key->memoryUsage();
     }
-    //qDebug() << "Total Memory:" << mTotalUsedMemory;
 }

--- a/core_lib/src/activeframepool.h
+++ b/core_lib/src/activeframepool.h
@@ -28,7 +28,7 @@ GNU General Public License for more details.
  * A key frame will be unloaded if it's not accessed for a while (at the end of cache list)
  * The ActiveFramePool will be updated whenever Editor::scrubTo() gets called.
  *
- * Note: ActiveFramePool doesn't not handle file saving. It loads frames, but never write frames to disks.
+ * Note: ActiveFramePool does not handle file saving. It loads frames, but never writes frames to disks.
  */
 class ActiveFramePool : public KeyFrameEventListener
 {
@@ -37,9 +37,8 @@ public:
     virtual ~ActiveFramePool();
 
     void put(KeyFrame* key);
-    size_t size() const;
     void clear();
-    void resize(quint64 n);
+    void resize(quint64 memoryBudget);
     bool isFrameInPool(KeyFrame*);
 
     void onKeyFrameDestroy(KeyFrame*) override;

--- a/core_lib/src/activeframepool.h
+++ b/core_lib/src/activeframepool.h
@@ -23,7 +23,7 @@ GNU General Public License for more details.
 #include "keyframe.h"
 
 
-/** 
+/**
  * ActiveFramePool implemented a LRU cache to keep tracking the most recent accessed key frames
  * A key frame will be unloaded if it's not accessed for a while (at the end of cache list)
  * The ActiveFramePool will be updated whenever Editor::scrubTo() gets called.
@@ -33,13 +33,13 @@ GNU General Public License for more details.
 class ActiveFramePool : public KeyFrameEventListener
 {
 public:
-    explicit ActiveFramePool(unsigned long n);
+    explicit ActiveFramePool();
     virtual ~ActiveFramePool();
 
     void put(KeyFrame* key);
     size_t size() const;
     void clear();
-    void resize(int n);
+    void resize(quint64 n);
     bool isFrameInPool(KeyFrame*);
 
     void onKeyFrameDestroy(KeyFrame*) override;
@@ -47,12 +47,14 @@ public:
 private:
     void discardLeastUsedFrames();
     void unloadFrame(KeyFrame* key);
+    void recalcuateTotalUsedMemory();
 
     using list_iterator_t = std::list<KeyFrame*>::iterator;
 
     std::list<KeyFrame*> mCacheFramesList;
     std::unordered_map<KeyFrame*, list_iterator_t> mCacheFramesMap;
-    size_t mMaxSize = 200;
+    quint64 mMemoryBudgetInBytes = 1024 * 1024 * 1024; // 1GB
+    quint64 mTotalUsedMemory = 0;
 };
 
 #endif // ACTIVEFRAMEPOOL_H

--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -112,6 +112,15 @@ bool BitmapImage::isLoaded()
     return (mImage != nullptr);
 }
 
+quint64 BitmapImage::memoryUsage()
+{
+    if (mImage)
+    {
+        return imageSize(*mImage);
+    }
+    return 0;
+}
+
 void BitmapImage::paintImage(QPainter& painter)
 {
     painter.drawImage(mBounds.topLeft(), *image());

--- a/core_lib/src/graphics/bitmap/bitmapimage.h
+++ b/core_lib/src/graphics/bitmap/bitmapimage.h
@@ -38,6 +38,7 @@ public:
     void loadFile() override;
     void unloadFile() override;
     bool isLoaded() override;
+    quint64 memoryUsage() override;
 
     void paintImage(QPainter& painter);
     void paintImage(QPainter &painter, QImage &image, QRect sourceRect, QRect destRect);

--- a/core_lib/src/managers/preferencemanager.cpp
+++ b/core_lib/src/managers/preferencemanager.cpp
@@ -82,7 +82,7 @@ void PreferenceManager::loadPrefs()
     set(SETTING::BACKGROUND_STYLE,         settings.value(SETTING_BACKGROUND_STYLE,       "white").toString());
 
     set(SETTING::LAYOUT_LOCK,              settings.value(SETTING_LAYOUT_LOCK,            false).toBool());
-    set(SETTING::FRAME_POOL_SIZE,          settings.value(SETTING_FRAME_POOL_SIZE,        200).toInt());
+    set(SETTING::FRAME_POOL_SIZE,          settings.value(SETTING_FRAME_POOL_SIZE,        1024).toInt());
 
     set(SETTING::FPS,                      settings.value(SETTING_FPS,                    12).toInt());
     set(SETTING::FIELD_W,                  settings.value(SETTING_FIELD_W,                800).toInt());

--- a/core_lib/src/structure/keyframe.h
+++ b/core_lib/src/structure/keyframe.h
@@ -57,6 +57,8 @@ public:
     virtual void unloadFile() {}
     virtual bool isLoaded() { return true; }
 
+    virtual quint64 memoryUsage() { return 0; }
+
 private:
     int mFrame = -1;
     int mLength = 1;

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -44,7 +44,7 @@ GNU General Public License for more details.
 Object::Object(QObject* parent) : QObject(parent)
 {
     setData(new ObjectData());
-    mActiveFramePool.reset(new ActiveFramePool(400));
+    mActiveFramePool.reset(new ActiveFramePool);
 }
 
 Object::~Object()
@@ -919,7 +919,8 @@ void Object::updateActiveFrames(int frame) const
     }
 }
 
-void Object::setActiveFramePoolSize(int n)
+void Object::setActiveFramePoolSize(int sizeInMB)
 {
-    mActiveFramePool->resize(n);
+    // convert MB to Byte
+    mActiveFramePool->resize(qint64(sizeInMB) * 1024 * 1024);
 }

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -153,7 +153,7 @@ public:
 
     int totalKeyFrameCount() const;
     void updateActiveFrames(int frame) const;
-    void setActiveFramePoolSize(int n);
+    void setActiveFramePoolSize(int sizeInMB);
 
 signals:
     void layerViewChanged();

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -233,7 +233,7 @@ const static int MaxFramesBound = 9999;
 #define SETTING_ONION_BLUE       "OnionBlue"
 #define SETTING_ONION_RED        "OnionRed"
 
-#define SETTING_FRAME_POOL_SIZE "FramePoolSize"
+#define SETTING_FRAME_POOL_SIZE  "FramePoolSizeInMB"
 #define SETTING_GRID_SIZE_W      "GridSizeW"
 #define SETTING_GRID_SIZE_H      "GridSizeH"
 #define SETTING_OVERLAY_CENTER   "OverlayCenter"

--- a/core_lib/src/util/util.cpp
+++ b/core_lib/src/util/util.cpp
@@ -93,3 +93,12 @@ QString ffmpegLocation()
     return QStandardPaths::findExecutable("ffmpeg"); // ffmpeg is a standalone project.
 #endif
 }
+
+quint64 imageSize(const QImage& img)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+    return img.sizeInBytes();
+#else
+    return img.byteCount();
+#endif
+}

--- a/core_lib/src/util/util.h
+++ b/core_lib/src/util/util.h
@@ -51,4 +51,6 @@ Container filter(const Container& container, Pred predicate) {
 QString ffprobeLocation();
 QString ffmpegLocation();
 
+quint64 imageSize(const QImage&);
+
 #endif // UTIL_H


### PR DESCRIPTION
`ActiveFramePool` can now manage the pool with a memory budget (for example 1GB) and calculate the actual total used memory by adding up the memory usage of each frame. This is a more accurate way to prevent the app crashing from out of memory.

Previously `ActiveFramePool` keeps a certain number of keyframes, for instance, 400 frames in the memory, which is not good due to the variation of the image size as well as memory usage.

![image](https://user-images.githubusercontent.com/163800/91782989-0d199b00-ec42-11ea-897a-aebdf9a50c4d.png)

The default pool size is 1GB.