### PR TITLE
Miniz improvements

### DIFF
--- a/core_lib/src/qminiz.cpp
+++ b/core_lib/src/qminiz.cpp
@@ -57,7 +57,7 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
     if (!ok)
     {
         mz_zip_error err = mz_zip_get_last_error(mz);
-        dd << QString("Miniz writer init failed: %1").arg((int)err);
+        dd << QString("Miniz writer init failed: error %1, %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));;
     }
 
     //qDebug() << "SrcFolder=" << srcFolderPath;
@@ -75,17 +75,25 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
         if (!ok)
         {
             mz_zip_error err = mz_zip_get_last_error(mz);
-            dd << QString("  Cannot add %1: error %2, %3").arg(sRelativePath).arg((int)err).arg(mz_zip_get_error_string(err));
+            dd << QString("Cannot add %1: error %2, %3").arg(sRelativePath).arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
         }
     }
     ok &= mz_zip_writer_finalize_archive(mz);
-    mz_zip_writer_end(mz);
-
     if (!ok)
     {
-        dd << "Miniz finalize archive failed";
+        mz_zip_error err = mz_zip_get_last_error(mz);
+        dd << QString("Miniz finalize archive failed: error %1, %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
         return Status(Status::FAIL, dd);
     }
+
+    ok &= mz_zip_writer_end(mz);
+    if (!ok)
+    {
+        mz_zip_error err = mz_zip_get_last_error(mz);
+        dd << QString("Miniz writer end failed: error %1, %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
+        return Status(Status::FAIL, dd);
+    }
+
     return Status::OK;
 }
 

--- a/core_lib/src/util/util.h
+++ b/core_lib/src/util/util.h
@@ -31,9 +31,13 @@ class ScopeGuard
 {
 public:
     explicit ScopeGuard(std::function< void() > onScopeExit) { m_onScopeExit = onScopeExit; }
-    ~ScopeGuard() { m_onScopeExit(); }
+    ScopeGuard(const ScopeGuard&) = delete;
+    ~ScopeGuard() { if(m_invoke) { m_onScopeExit(); } }
+
+    void dismiss() { m_invoke = false; };
 private:
     std::function<void()> m_onScopeExit;
+    bool m_invoke = true;
 };
 
 #define SCOPEGUARD_LINENAME_CAT(name, line) name##line


### PR DESCRIPTION
The main changes here is that `mz_zip_reader_end` and `mz_zip_reader_end` are always called now, even if an error is encountered. When compressing always put `mz_zip_get_last_error` in the debug details if the compression fails. The remainder of the changes are cosmetic.