### PR TITLE
Add Retiming feature

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -73,7 +73,8 @@ HEADERS += \
     src/doubleprogressdialog.h \
     src/colorslider.h \
     src/checkupdatesdialog.h \
-    src/presetdialog.h    
+    src/presetdialog.h \
+    src/retimedialog.h
 
 SOURCES += \
     src/importlayersdialog.cpp \
@@ -109,7 +110,8 @@ SOURCES += \
     src/colorslider.cpp \
     src/checkupdatesdialog.cpp \
     src/presetdialog.cpp \
-    src/app_util.cpp
+    src/app_util.cpp \
+    src/retimedialog.cpp
 
 FORMS += \
     ui/importimageseqpreview.ui \
@@ -137,7 +139,8 @@ FORMS += \
     ui/filespage.ui \
     ui/toolspage.ui \
     ui/toolboxwidget.ui \
-    ui/presetdialog.ui
+    ui/presetdialog.ui \
+    ui/retimedialog.ui
 
 
 

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -56,6 +56,7 @@ GNU General Public License for more details.
 #include "doubleprogressdialog.h"
 #include "checkupdatesdialog.h"
 #include "errordialog.h"
+#include "retimedialog.h"
 
 
 ActionCommands::ActionCommands(QWidget* parent) : QObject(parent)
@@ -576,6 +577,18 @@ void ActionCommands::selectAll()
 void ActionCommands::deselectAll()
 {
     mEditor->deselectAll();
+}
+
+void ActionCommands::retime()
+{
+    auto dialog = new RetimeDialog(mParent);
+    dialog->setOrigFps(mEditor->fps());
+    dialog->exec();
+
+    if (dialog->result() == QDialog::Accepted)
+    {
+        mEditor->retime(dialog->getNewFps());
+    }
 }
 
 void ActionCommands::ZoomIn()

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -769,7 +769,7 @@ void ActionCommands::retime()
 
     if (dialog->result() == QDialog::Accepted)
     {
-        mEditor->retime(dialog->getNewFps());
+        mEditor->retime(dialog->getNewFps(), dialog->getNewSpeed());
     }
 }
 

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -579,18 +579,6 @@ void ActionCommands::deselectAll()
     mEditor->deselectAll();
 }
 
-void ActionCommands::retime()
-{
-    auto dialog = new RetimeDialog(mParent);
-    dialog->setOrigFps(mEditor->fps());
-    dialog->exec();
-
-    if (dialog->result() == QDialog::Accepted)
-    {
-        mEditor->retime(dialog->getNewFps());
-    }
-}
-
 void ActionCommands::ZoomIn()
 {
     mEditor->view()->scaleUp();
@@ -770,6 +758,18 @@ void ActionCommands::moveFrameBackward()
         {
             mEditor->scrubBackward();
         }
+    }
+}
+
+void ActionCommands::retime()
+{
+    auto dialog = new RetimeDialog(mParent);
+    dialog->setOrigFps(mEditor->fps());
+    dialog->exec();
+
+    if (dialog->result() == QDialog::Accepted)
+    {
+        mEditor->retime(dialog->getNewFps());
     }
 }
 

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -49,7 +49,6 @@ public:
     void flipSelectionY();
     void selectAll();
     void deselectAll();
-    void retime();
 
     // view
     void ZoomIn();
@@ -71,6 +70,7 @@ public:
     void duplicateKey();
     void moveFrameForward();
     void moveFrameBackward();
+    void retime();
 
     // Layer
     Status addNewBitmapLayer();

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -49,6 +49,7 @@ public:
     void flipSelectionY();
     void selectAll();
     void deselectAll();
+    void retime();
 
     // view
     void ZoomIn();

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -352,6 +352,7 @@ void MainWindow2::createMenus()
     connect(ui->actionDuplicate_Frame, &QAction::triggered, mCommands, &ActionCommands::duplicateKey);
     connect(ui->actionMove_Frame_Forward, &QAction::triggered, mCommands, &ActionCommands::moveFrameForward);
     connect(ui->actionMove_Frame_Backward, &QAction::triggered, mCommands, &ActionCommands::moveFrameBackward);
+    connect(ui->actionRetime, &QAction::triggered, mCommands, &ActionCommands::retime);
 
     //--- Tool Menu ---
     connect(ui->actionMove, &QAction::triggered, mToolBox, &ToolBoxWidget::moveOn);
@@ -1243,6 +1244,7 @@ void MainWindow2::setupKeyboardShortcuts()
     ui->actionRemove_Frame->setShortcut(cmdKeySeq(CMD_REMOVE_FRAME));
     ui->actionMove_Frame_Backward->setShortcut(cmdKeySeq(CMD_MOVE_FRAME_BACKWARD));
     ui->actionMove_Frame_Forward->setShortcut(cmdKeySeq(CMD_MOVE_FRAME_FORWARD));
+    ui->actionRetime->setShortcut(cmdKeySeq(CMD_RETIME));
     ui->actionFlip_inbetween->setShortcut(cmdKeySeq(CMD_FLIP_INBETWEEN));
     ui->actionFlip_rolling->setShortcut(cmdKeySeq(CMD_FLIP_ROLLING));
 

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1452,6 +1452,7 @@ void MainWindow2::makeConnections(Editor* pEditor, TimeLine* pTimeline)
     connect(pTimeline, &TimeLine::newCameraLayer, mCommands, &ActionCommands::addNewCameraLayer);
 
     connect(mTimeLine, &TimeLine::playButtonTriggered, mCommands, &ActionCommands::PlayStop);
+    connect(mTimeLine, &TimeLine::retimeTriggered, mCommands, &ActionCommands::retime);
 
     connect(pEditor->layers(), &LayerManager::currentLayerChanged, pTimeline, &TimeLine::updateUI);
     connect(pEditor->layers(), &LayerManager::layerCountChanged, pTimeline, &TimeLine::updateUI);
@@ -1460,6 +1461,8 @@ void MainWindow2::makeConnections(Editor* pEditor, TimeLine* pTimeline)
 
     connect(pEditor, &Editor::objectLoaded, pTimeline, &TimeLine::onObjectLoaded);
     connect(pEditor, &Editor::updateTimeLine, pTimeline, &TimeLine::updateUI);
+
+    connect(pEditor, &Editor::retimed, pTimeline, &TimeLine::updateFps);
 
     connect(pEditor->layers(), &LayerManager::currentLayerChanged, mToolOptions, &ToolOptionWidget::updateUI);
 }

--- a/app/src/retimedialog.cpp
+++ b/app/src/retimedialog.cpp
@@ -1,0 +1,25 @@
+#include "retimedialog.h"
+#include "ui_retimedialog.h"
+
+RetimeDialog::RetimeDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::RetimeDialog)
+{
+    ui->setupUi(this);
+}
+
+RetimeDialog::~RetimeDialog()
+{
+    delete ui;
+}
+
+void RetimeDialog::setOrigFps(int origFps)
+{
+    ui->origFps->setText(QString("<span style=' font-weight:600;'>%1 %2</span>").arg(origFps).arg(tr("fps")));
+    ui->newFpsBox->setValue(origFps);
+}
+
+int RetimeDialog::getNewFps()
+{
+    return ui->newFpsBox->value();
+}

--- a/app/src/retimedialog.cpp
+++ b/app/src/retimedialog.cpp
@@ -23,3 +23,8 @@ int RetimeDialog::getNewFps()
 {
     return ui->newFpsBox->value();
 }
+
+qreal RetimeDialog::getNewSpeed()
+{
+    return ui->newSpeedBox->value();
+}

--- a/app/src/retimedialog.h
+++ b/app/src/retimedialog.h
@@ -1,0 +1,25 @@
+#ifndef RETIMEDIALOG_H
+#define RETIMEDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class RetimeDialog;
+}
+
+class RetimeDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit RetimeDialog(QWidget *parent = nullptr);
+    ~RetimeDialog();
+
+    void setOrigFps(int origFps);
+    int getNewFps();
+
+private:
+    Ui::RetimeDialog *ui;
+};
+
+#endif // RETIMEDIALOG_H

--- a/app/src/retimedialog.h
+++ b/app/src/retimedialog.h
@@ -18,6 +18,8 @@ public:
     void setOrigFps(int origFps);
     int getNewFps();
 
+    qreal getNewSpeed();
+
 private:
     Ui::RetimeDialog *ui;
 };

--- a/app/src/shortcutspage.cpp
+++ b/app/src/shortcutspage.cpp
@@ -330,6 +330,7 @@ static QString getHumanReadableShortcutName(const QString& cmdName)
         {CMD_LOOP, QObject::tr("Toggle Loop", "Shortcut")},
         {CMD_MOVE_FRAME_BACKWARD, QObject::tr("Move Frame Backward", "Shortcut")},
         {CMD_MOVE_FRAME_FORWARD, QObject::tr("Move Frame Forward", "Shortcut")},
+        {CMD_RETIME, QObject::tr("Retime Animation", "Shortcut")},
         {CMD_NEW_BITMAP_LAYER, QObject::tr("New Bitmap Layer", "Shortcut")},
         {CMD_NEW_CAMERA_LAYER, QObject::tr("New Camera Layer", "Shortcut")},
         {CMD_NEW_FILE, QObject::tr("New File", "Shortcut")},

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -49,7 +49,7 @@
      <x>0</x>
      <y>0</y>
      <width>831</width>
-     <height>30</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -197,6 +197,7 @@
     <addaction name="separator"/>
     <addaction name="actionMove_Frame_Forward"/>
     <addaction name="actionMove_Frame_Backward"/>
+    <addaction name="actionRetime"/>
     <addaction name="separator"/>
     <addaction name="actionFlip_inbetween"/>
     <addaction name="actionFlip_rolling"/>
@@ -1087,6 +1088,11 @@
   <action name="actionOpen_Temporary_Directory">
    <property name="text">
     <string>Open Temporary Directory</string>
+   </property>
+  </action>
+  <action name="actionRetime">
+   <property name="text">
+    <string>Retime Animation</string>
    </property>
   </action>
  </widget>

--- a/app/ui/retimedialog.ui
+++ b/app/ui/retimedialog.ui
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>RetimeDialog</class>
+ <widget class="QDialog" name="RetimeDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>261</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="text">
+      <string>&lt;h1&gt;Retime Project&lt;/h1&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="descLabel">
+     <property name="text">
+      <string>Retiming allows you to change the FPS of your project without affecting the speed of your project. It accomplishes this by moving the frames closer together or further apart.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="inputGroup">
+     <item>
+      <widget class="QLabel" name="origLabel">
+       <property name="text">
+        <string>Original:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="origFps">
+       <property name="text">
+        <string>&lt;span style=&quot; font-weight:600;&quot;&gt;12 fps&lt;/span&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="newLabel">
+       <property name="text">
+        <string>New:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="newFpsBox">
+       <property name="suffix">
+        <string> fps</string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>90</number>
+       </property>
+       <property name="value">
+        <number>12</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="warningLabel">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:red;&quot;&gt;Warning: Retiming while decreasing the FPS may result in the loss of frames. This action cannot be undone.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>RetimeDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>RetimeDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/app/ui/retimedialog.ui
+++ b/app/ui/retimedialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>261</height>
+    <width>456</width>
+    <height>335</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,14 +17,14 @@
    <item>
     <widget class="QLabel" name="titleLabel">
      <property name="text">
-      <string>&lt;h1&gt;Retime Project&lt;/h1&gt;</string>
+      <string>&lt;h1&gt;Retime Animation&lt;/h1&gt;</string>
      </property>
     </widget>
    </item>
    <item>
     <widget class="QLabel" name="descLabel">
      <property name="text">
-      <string>Retiming allows you to change the FPS of your project without affecting the speed of your project. It accomplishes this by moving the frames closer together or further apart.</string>
+      <string>Retiming allows you to adjust the FPS and playback speed of your project independently. It accomplishes this by moving the frames closer together or further apart to reach the desired speed and frame rate.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -32,9 +32,16 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="inputGroup">
+    <widget class="QLabel" name="frameRateLabel">
+     <property name="text">
+      <string>&lt;span style=&quot; text-decoration: underline;&quot;&gt;Frame Rate&lt;/span&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="fpsGroup">
      <item>
-      <widget class="QLabel" name="origLabel">
+      <widget class="QLabel" name="origFpsLabel">
        <property name="text">
         <string>Original:</string>
        </property>
@@ -48,7 +55,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="newLabel">
+      <widget class="QLabel" name="newFpsLabel">
        <property name="text">
         <string>New:</string>
        </property>
@@ -73,9 +80,60 @@
     </layout>
    </item>
    <item>
+    <widget class="QLabel" name="speedTitle">
+     <property name="text">
+      <string>&lt;span style=&quot; text-decoration: underline;&quot;&gt;Speed&lt;/span&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="speedGroup">
+     <item>
+      <widget class="QLabel" name="origSpeedLabel">
+       <property name="text">
+        <string>Original:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="origSpeed">
+       <property name="text">
+        <string>&lt;span style=&quot; font-weight:600;&quot;&gt;1.00x&lt;/span&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="newSpeedLabel">
+       <property name="text">
+        <string>New:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="newSpeedBox">
+       <property name="suffix">
+        <string>x</string>
+       </property>
+       <property name="minimum">
+        <double>0.010000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>90.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QLabel" name="warningLabel">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:red;&quot;&gt;Warning: Retiming while decreasing the FPS may result in the loss of frames. This action cannot be undone.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:red;&quot;&gt;Warning: Retiming to a lower fps or higher speed may result in the loss of frames. This action cannot be undone.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/app/ui/retimedialog.ui
+++ b/app/ui/retimedialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Retime Animation</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/core_lib/data/resources/kb.ini
+++ b/core_lib/data/resources/kb.ini
@@ -50,6 +50,7 @@ CmdGotoNextKeyFrame=Alt+.
 CmdGotoPreviousKeyFrame=Alt+","
 CmdMoveFrameForward=Ctrl+.
 CmdMoveFrameBackward=ctrl+","
+CmdRetime=
 CmdAddFrame=F7
 CmdDuplicateFrame=F6
 CmdRemoveFrame=Shift+F5

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -126,11 +126,11 @@ void Editor::setFps(int fps)
     mPreferenceManager->set(SETTING::FPS, fps);
 }
 
-void Editor::retime(int newFps)
+void Editor::retime(int newFps, qreal speed)
 {
     const int origFps = fps();
-    if(origFps == newFps) return;
-    const qreal multiplier = static_cast<qreal>(newFps) / origFps;
+    const qreal multiplier = (static_cast<qreal>(newFps) / origFps) * (1 / speed);
+    if (qFuzzyCompare(multiplier, 1)) return;
 
     for (int i = 0; i < mObject->getLayerCount(); i++)
     {
@@ -194,6 +194,7 @@ void Editor::retime(int newFps)
     setFps(newFps);
     layers()->notifyAnimationLengthChanged();
     emit retimed(newFps);
+    emit updateTimeLine();
 }
 
 void Editor::makeConnections()

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -126,10 +126,82 @@ void Editor::setFps(int fps)
     mPreferenceManager->set(SETTING::FPS, fps);
 }
 
+void Editor::retime(int newFps)
+{
+    const int origFps = fps();
+    if(origFps == newFps) return;
+    const qreal multiplier = static_cast<qreal>(newFps) / origFps;
+
+    for (int i = 0; i < mObject->getLayerCount(); i++)
+    {
+        Layer* layer = mObject->getLayer(i);
+        QMap<int,int> frameRemap; // New frame -> old frame
+        QList<int> deleteFrames;
+        for (int origPos = layer->firstKeyFramePosition(); origPos <= layer->getMaxKeyFramePosition(); origPos++)
+        {
+            if (layer->keyExists(origPos))
+            {
+                // Scale the current position to the new fps
+                // The offset is to make sure that frame 1 stays at frame 1
+                int newPos = qRound((origPos-1)*multiplier)+1;
+                if (frameRemap.contains(newPos))
+                {
+                    // If two frames get mapped to the same new frame, choose the closer of them
+                    if (qAbs((frameRemap.value(newPos)-1)*multiplier+1-newPos) > qAbs((origPos-1)*multiplier+1-newPos))
+                    {
+                        deleteFrames.append(frameRemap.value(newPos));
+                        frameRemap.insert(newPos, origPos);
+                    }
+                    else
+                    {
+                        deleteFrames.append(origPos);
+                    }
+                }
+                else
+                {
+                    frameRemap.insert(newPos, origPos);
+                }
+            }
+        }
+
+        foreach (const int frame, deleteFrames)
+        {
+            layer->removeKeyFrame(frame);
+        }
+
+        if (multiplier < 1)
+        {
+            for (auto iter = frameRemap.constBegin(); iter != frameRemap.constEnd(); iter++)
+            {
+                if (iter.value() != iter.key())
+                {
+                    layer->swapKeyFrames(iter.value(), iter.key());
+                }
+            }
+        }
+        else
+        {
+            for (auto iter = frameRemap.keys().crbegin(); iter != frameRemap.keys().crend(); iter++)
+            {
+                if (frameRemap.value(*iter) != *iter)
+                {
+                    layer->swapKeyFrames(frameRemap.value(*iter), *iter);
+                }
+            }
+        }
+    }
+
+    setFps(newFps);
+    layers()->notifyAnimationLengthChanged();
+    emit retimed(newFps);
+}
+
 void Editor::makeConnections()
 {
     connect(mPreferenceManager, &PreferenceManager::optionChanged, this, &Editor::settingUpdated);
     connect(QApplication::clipboard(), &QClipboard::dataChanged, this, &Editor::clipboardChanged);
+
+    connect(this, &Editor::retimed, playback(), &PlaybackManager::setFps);
 }
 
 void Editor::dragEnterEvent(QDragEnterEvent* event)

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -91,7 +91,7 @@ public:
     int currentFrame();
     int fps();
     void setFps(int fps);
-    void retime(int newFps);
+    void retime(int newFps, qreal speed);
 
     int  currentLayerIndex() { return mCurrentLayerIndex; }
     void setCurrentLayerIndex(int i);

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -91,6 +91,7 @@ public:
     int currentFrame();
     int fps();
     void setFps(int fps);
+    void retime(int newFps);
 
     int  currentLayerIndex() { return mCurrentLayerIndex; }
     void setCurrentLayerIndex(int i);
@@ -130,6 +131,8 @@ signals:
     void needSave();
     void needDisplayInfo(const QString& title, const QString& body);
     void needDisplayInfoNoTitle(const QString& body);
+
+    void retimed(int newFps);
 
 public: //slots
     void clearCurrentFrame();

--- a/core_lib/src/interface/timecontrols.cpp
+++ b/core_lib/src/interface/timecontrols.cpp
@@ -18,6 +18,7 @@ GNU General Public License for more details.
 #include "timecontrols.h"
 
 #include <QLabel>
+#include <QMenu>
 #include <QSettings>
 
 #include "editor.h"
@@ -46,6 +47,11 @@ void TimeControls::initUI()
     mFpsBox->setSuffix(tr(" fps"));
     mFpsBox->setToolTip(tr("Frames per second"));
     mFpsBox->setFocusPolicy(Qt::WheelFocus);
+    mFpsBox->setContextMenuPolicy(Qt::ActionsContextMenu);
+    QMenu *mFpsMenu = new QMenu(mFpsBox);
+    QAction *retimeAction = new QAction(tr("Retime"), mFpsMenu);
+    connect(retimeAction, &QAction::triggered, this, &TimeControls::retimeTriggered);
+    mFpsBox->addAction(retimeAction);
 
     mLoopStartSpinBox = new QSpinBox(this);
     mLoopStartSpinBox->setFixedHeight(24);
@@ -207,6 +213,12 @@ void TimeControls::updatePlayState()
         mPlayButton->setIcon(mStartIcon);
         mPlayButton->setToolTip(tr("Play"));
     }
+}
+
+void TimeControls::updateFps(int fps)
+{
+    QSignalBlocker b(mFpsBox);
+    mFpsBox->setValue(fps);
 }
 
 void TimeControls::jumpToStartButtonClicked()

--- a/core_lib/src/interface/timecontrols.h
+++ b/core_lib/src/interface/timecontrols.h
@@ -52,8 +52,10 @@ signals:
     void soundScrubToggled(bool);
     void fpsChanged(int);
     void playButtonTriggered();
+    void retimeTriggered();
 
 public slots:
+    void updateFps(int fps);
     /// Work-around in case the FPS spin-box "valueChanged" signal doesn't work.
     void onFpsEditingFinished();
 

--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -209,6 +209,7 @@ void TimeLine::initUI()
     connect(mTimeControls, &TimeControls::fpsChanged, this, &TimeLine::fpsChanged);
     connect(mTimeControls, &TimeControls::fpsChanged, this, &TimeLine::updateLength);
     connect(mTimeControls, &TimeControls::playButtonTriggered, this, &TimeLine::playButtonTriggered);
+    connect(mTimeControls, &TimeControls::retimeTriggered, this, &TimeLine::retimeTriggered);
 
     connect(newBitmapLayerAct, &QAction::triggered, this, &TimeLine::newBitmapLayer);
     connect(newVectorLayerAct, &QAction::triggered, this, &TimeLine::newVectorLayer);
@@ -221,6 +222,8 @@ void TimeLine::initUI()
     connect(mTracks, &TimeLineCells::lengthChanged, this, &TimeLine::updateLength);
 
     connect(editor(), &Editor::currentFrameChanged, this, &TimeLine::updateFrame);
+
+    connect(this, &TimeLine::updateFps, mTimeControls, &TimeControls::updateFps);
 
     LayerManager* layer = editor()->layers();
     connect(layer, &LayerManager::layerCountChanged, this, &TimeLine::updateLayerNumber);

--- a/core_lib/src/interface/timeline.h
+++ b/core_lib/src/interface/timeline.h
@@ -70,6 +70,8 @@ signals:
     void onionPrevClick();
     void onionNextClick();
     void playButtonTriggered();
+    void retimeTriggered();
+    void updateFps(int fps);
 
 public:
     bool scrubbing = false;

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -151,6 +151,7 @@ const static int MaxFramesBound = 9999;
 #define CMD_REMOVE_FRAME "CmdRemoveFrame"
 #define CMD_MOVE_FRAME_BACKWARD "CmdMoveFrameBackward"
 #define CMD_MOVE_FRAME_FORWARD "CmdMoveFrameForward"
+#define CMD_RETIME "CmdRetime"
 #define CMD_TOOL_MOVE "CmdToolMove"
 #define CMD_TOOL_SELECT "CmdToolSelect"
 #define CMD_TOOL_BRUSH "CmdToolBrush"


### PR DESCRIPTION
I took a short break from my seemly endless efforts to reduce the bugginess of Pencil2D to introduce my own bug-inducing feature!

![Screenshot from 2020-09-05 23-24-00](https://user-images.githubusercontent.com/3461051/92318817-e99e7980-efce-11ea-93f1-1a42c334b977.png)

This is the retiming feature. It is accessible by right clicking on the fps timeline control or accessing it in Animation menu. In this dialog where you can change the fps and speed of the project independently. I.e. you can change the fps of a project without affecting its playback speed, and you can change the playback speed without affecting the fps, or you can change both simultaneously. For example, if you have an animation on 1s at 12 fps, you can retime it to 24 fps and the frames will be on 2s (and the same duration). If you then retimed it again at 2x speed and it would be 24 fps on 1s (and half the duration). Frames may be dropped when decreasing the fps or increasing the speed during retiming for obvious reasons.

I believe this feature, or variants of it, have been requested on multiple occasions. I don't really have a strong interest in it, but it was a simple enough to do, I can see its use, and I'm fine with it as long as it doesn't get in the way. I am open to feedback.