### PR TITLE
Handle tablet proximity

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -223,6 +223,7 @@ int handleArguments(PencilApplication& app)
     QObject::connect(&app, &PencilApplication::lostFocus, &mainWindow, &MainWindow2::appLostFocus);
     QObject::connect(&app, &PencilApplication::openFileRequested, &mainWindow, &MainWindow2::openFile);
     app.emitOpenFileRequest();
+    app.setMainWindow(&mainWindow);
 
     // If there are no output paths, open up the GUI (to the input path if there is one)
     if (outputPaths.isEmpty())

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -220,9 +220,6 @@ int handleArguments(PencilApplication& app)
 
     // Now that (almost) all possible user errors are handled, the actual program can be initialized
     MainWindow2 mainWindow;
-    QObject::connect(&app, &PencilApplication::lostFocus, &mainWindow, &MainWindow2::appLostFocus);
-    QObject::connect(&app, &PencilApplication::openFileRequested, &mainWindow, &MainWindow2::openFile);
-    app.emitOpenFileRequest();
     app.setMainWindow(&mainWindow);
 
     // If there are no output paths, open up the GUI (to the input path if there is one)

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1631,6 +1631,30 @@ void MainWindow2::startProjectRecovery(int result)
     QMessageBox::information(this, title, QString("<h4>%1</h4>%2").arg(title).arg(text));
 }
 
+bool MainWindow2::eventHandling(QEvent* event)
+{
+    if(event->type() == QEvent::ApplicationStateChange && static_cast<QApplicationStateChangeEvent*>(event)->applicationState() == Qt::ApplicationInactive) {
+        emit appLostFocus();
+        return true;
+    }
+    else if (event->type() == QEvent::FileOpen)
+    {
+        QString mStartPath = static_cast<QFileOpenEvent*>(event)->file();
+
+        if (mStartPath.size() != 0) {
+            openFile(mStartPath);
+        }
+        return true;
+    }
+    else if (event->type() == QEvent::TabletEnterProximity ||
+        event->type() == QEvent::TabletLeaveProximity ) {
+
+        onTabletProximity(static_cast<QTabletEvent *>(event));
+        return true;
+    }
+    return false;
+}
+
 void MainWindow2::onTabletProximity(QTabletEvent* event)
 {
     if (event->type() == QEvent::TabletEnterProximity) {

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1630,3 +1630,15 @@ void MainWindow2::startProjectRecovery(int result)
     const QString text = tr("Please save your work immediately to prevent loss of data");
     QMessageBox::information(this, title, QString("<h4>%1</h4>%2").arg(title).arg(text));
 }
+
+void MainWindow2::onTabletProximity(QTabletEvent* event)
+{
+    if (event->type() == QEvent::TabletEnterProximity) {
+        ui->scribbleArea->onTabletEnterProximity(event);
+    }
+    else if(event->type() == QEvent::TabletLeaveProximity) {
+        ui->scribbleArea->onTabletLeaveProximity(event);
+    }
+}
+
+

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -99,6 +99,7 @@ public:
     void openFile(QString filename);
 
     void onTabletProximity(QTabletEvent* event);
+    bool eventHandling(QEvent* event);
 
     PreferencesDialog* getPrefDialog() { return mPrefDialog; }
 

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -98,6 +98,8 @@ public:
 
     void openFile(QString filename);
 
+    void onTabletProximity(QTabletEvent* event);
+
     PreferencesDialog* getPrefDialog() { return mPrefDialog; }
 
     void displayMessageBox(const QString& title, const QString& body);

--- a/app/src/pencilapplication.cpp
+++ b/app/src/pencilapplication.cpp
@@ -42,11 +42,16 @@ bool PencilApplication::event(QEvent* event)
         emit lostFocus();
         return true;
     }
-
-    if (event->type() == QEvent::FileOpen)
+    else if (event->type() == QEvent::FileOpen)
     {
         mStartPath = static_cast<QFileOpenEvent*>(event)->file();
         emit openFileRequested(mStartPath);
+        return true;
+    }
+    else if (event->type() == QEvent::TabletEnterProximity ||
+        event->type() == QEvent::TabletLeaveProximity ) {
+
+        mMainWindow->onTabletProximity(static_cast<QTabletEvent *>(event));
         return true;
     }
     return QApplication::event(event);
@@ -58,4 +63,9 @@ void PencilApplication::emitOpenFileRequest()
     {
         emit openFileRequested(mStartPath);
     }
+}
+
+void PencilApplication::setMainWindow(MainWindow2 *mainWindow)
+{
+    mMainWindow = mainWindow;
 }

--- a/app/src/pencilapplication.cpp
+++ b/app/src/pencilapplication.cpp
@@ -38,31 +38,17 @@ PencilApplication::PencilApplication(int& argc, char** argv) :
 
 bool PencilApplication::event(QEvent* event)
 {
-    if(event->type() == QEvent::ApplicationStateChange && static_cast<QApplicationStateChangeEvent*>(event)->applicationState() == Qt::ApplicationInactive) {
-        emit lostFocus();
-        return true;
-    }
-    else if (event->type() == QEvent::FileOpen)
-    {
-        mStartPath = static_cast<QFileOpenEvent*>(event)->file();
-        emit openFileRequested(mStartPath);
-        return true;
-    }
-    else if (event->type() == QEvent::TabletEnterProximity ||
-        event->type() == QEvent::TabletLeaveProximity ) {
+    bool appEventState = false;
 
-        mMainWindow->onTabletProximity(static_cast<QTabletEvent *>(event));
-        return true;
+    if (mMainWindow) {
+        appEventState = mMainWindow->eventHandling(event);
     }
-    return QApplication::event(event);
-}
 
-void PencilApplication::emitOpenFileRequest()
-{
-    if (mStartPath.size() != 0)
-    {
-        emit openFileRequested(mStartPath);
+    // If we don't handle the event ourself, pass the event onto application
+    if (!appEventState) {
+        return QApplication::event(event);
     }
+    return appEventState;
 }
 
 void PencilApplication::setMainWindow(MainWindow2 *mainWindow)

--- a/app/src/pencilapplication.h
+++ b/app/src/pencilapplication.h
@@ -19,6 +19,7 @@ GNU General Public License for more details.
 #define PENCILAPPLICATION_H
 
 #include <QApplication>
+#include <mainwindow2.h>
 
 class PencilApplication : public QApplication
 {
@@ -30,12 +31,15 @@ public:
     bool event(QEvent* event) override;
     void emitOpenFileRequest();
 
+    void setMainWindow(MainWindow2* mainWindow);
+
 signals:
     void openFileRequested(QString filename);
     void lostFocus();
 
 private:
     QString mStartPath;
+    MainWindow2* mMainWindow = nullptr;
 };
 
 #endif // PENCILAPPLICATION_H

--- a/app/src/pencilapplication.h
+++ b/app/src/pencilapplication.h
@@ -29,16 +29,10 @@ public:
     PencilApplication(int &argc, char **argv);
 
     bool event(QEvent* event) override;
-    void emitOpenFileRequest();
 
     void setMainWindow(MainWindow2* mainWindow);
 
-signals:
-    void openFileRequested(QString filename);
-    void lostFocus();
-
 private:
-    QString mStartPath;
     MainWindow2* mMainWindow = nullptr;
 };
 

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -439,6 +439,7 @@ void ScribbleArea::tabletEvent(QTabletEvent *e)
     {
         event.accept();
         mStrokeManager->pointerPressEvent(&event);
+        mStrokeManager->setTabletInUse(true);
         if (mIsFirstClick)
         {
             mIsFirstClick = false;
@@ -474,6 +475,8 @@ void ScribbleArea::tabletEvent(QTabletEvent *e)
         {
             mStrokeManager->pointerReleaseEvent(&event);
             pointerReleaseEvent(&event);
+            mStrokeManager->setTabletInUse(false);
+            mTabletInUse = false;
         }
     }
 
@@ -614,18 +617,12 @@ bool ScribbleArea::allowSmudging()
 
 void ScribbleArea::onTabletLeaveProximity(QTabletEvent* event)
 {
-    mTabletInUse = false;
-    mMouseInUse = true;
-    mStrokeManager->setTabletInUse(false);
     event->ignore();
 }
 
 void ScribbleArea::onTabletEnterProximity(QTabletEvent *event)
 {
-    mMouseInUse = false;
-    mTabletInUse = true;
-    mStrokeManager->setTabletInUse(true);
-    if ( event->pointerType() == QTabletEvent::Eraser )
+    if (event->pointerType() == QTabletEvent::Eraser)
     {
         editor()->tools()->tabletSwitchToEraser();
     }

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -654,7 +654,7 @@ void ScribbleArea::mousePressEvent(QMouseEvent* e)
 void ScribbleArea::mouseMoveEvent(QMouseEvent* e)
 {
     // Workaround for tablet issue (#677 part 2)
-    if (mTabletInUse) { e->ignore(); return; }
+    if (mStrokeManager->isTabletInUse() || !isMouseInUse()) { e->ignore(); return; }
     PointerEvent event(e);
 
     mStrokeManager->pointerMoveEvent(&event);

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -170,6 +170,9 @@ public:
     void pointerMoveEvent(PointerEvent*);
     void pointerReleaseEvent(PointerEvent*);
 
+    void onTabletLeaveProximity(QTabletEvent *event);
+    void onTabletEnterProximity(QTabletEvent* event);
+
     void updateCanvasCursor();
 
     /// Call this when starting to use a paint tool. Checks whether we are drawing

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -170,8 +170,8 @@ public:
     void pointerMoveEvent(PointerEvent*);
     void pointerReleaseEvent(PointerEvent*);
 
-    void onTabletLeaveProximity(QTabletEvent *event);
     void onTabletEnterProximity(QTabletEvent* event);
+    void onTabletLeaveProximity(QTabletEvent *event);
 
     void updateCanvasCursor();
 


### PR DESCRIPTION
By using tablet proximity we can assume that while entered, the tablet is in use, which should avoid most weird cases where a mouse event would appear.

This should also fix some cases where the tablet would not register pressure because it didn't get registered as a tablet properly. To clarify what I'm referring to here is the fact that sometimes, when leaving the proximity zone and switching between application, Pencil2D wouldn't register the tablet properly.

Prior to this PR I was able to reproduce a bunch of mouse move events when dabbing *furiously* on my drawing tablet. This is no longer the case.