### PR TITLE
Hide dock widget title bars when "Lock Windows" is selected

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -984,9 +984,16 @@ void MainWindow2::importGIF()
 void MainWindow2::lockWidgets(bool shouldLock)
 {
     QDockWidget::DockWidgetFeatures feat = shouldLock ? QDockWidget::NoDockWidgetFeatures : QDockWidget::AllDockWidgetFeatures;
+
     for (QDockWidget* d : mDockWidgets)
     {
         d->setFeatures(feat);
+
+        // https://doc.qt.io/qt-5/qdockwidget.html#setTitleBarWidget
+        // A empty QWidget looks like the tittle bar is hidden.
+        // nullptr means removing the custom title bar and restoring the default one
+        QWidget* customTitleBarWidget = shouldLock ? (new QWidget) : nullptr;
+        d->setTitleBarWidget(customTitleBarWidget);
     }
 }
 


### PR DESCRIPTION
As title. Please see screenshots:

Go to `Windows` menu -> tick `Lock Windows`: Hide dock widget titlebar.
![hide-toolbar](https://user-images.githubusercontent.com/163800/93409572-866beb80-f8da-11ea-9246-dea91197ce37.png)

Untick `Lock Windows`: the title bar shows again
![show-toolbar](https://user-images.githubusercontent.com/163800/93409577-88ce4580-f8da-11ea-83a2-b084ab694167.png)

would love to know how it looks like on other platforms.