### PR TITLE
Fix issues caused by #1443

### DIFF
--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1703,13 +1703,6 @@ void ScribbleArea::floodFillError(int errorType)
     mEditor->deselectAll();
 }
 
-/** Check if the content of the canvas depends on the active layer.
-  *
-  * Currently layers are only affected by Onion skins are displayed only for the active layer, and the opacity of all layers
-  * is affected when relative layer visiblity is active.
-  *
-  * @return True if the active layer could potentially influence the content of the canvas. False otherwise.
-  */
 bool ScribbleArea::isAffectedByActiveLayer() const
 {
     return mPrefs->isOn(SETTING::PREV_ONION) ||

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -487,7 +487,7 @@ void ScribbleArea::tabletEvent(QTabletEvent *e)
         editor()->tools()->tabletRestorePrevTool();
     }
 
-    if (event.type() == QTabletEvent::TabletPress)
+    if (event.eventType() == QTabletEvent::TabletPress)
     {
         event.accept();
         mStrokeManager->pointerPressEvent(&event);
@@ -513,7 +513,7 @@ void ScribbleArea::tabletEvent(QTabletEvent *e)
         }
         mTabletInUse = event.isAccepted();
     }
-    else if (event.type() == QTabletEvent::TabletMove)
+    else if (event.eventType() == QTabletEvent::TabletMove)
     {
         if (!(event.buttons() & (Qt::LeftButton | Qt::RightButton)) || mTabletInUse)
         {
@@ -521,7 +521,7 @@ void ScribbleArea::tabletEvent(QTabletEvent *e)
             pointerMoveEvent(&event);
         }
     }
-    else if (event.type() == QTabletEvent::TabletRelease)
+    else if (event.eventType() == QTabletEvent::TabletRelease)
     {
         if (mTabletInUse)
         {
@@ -685,8 +685,6 @@ void ScribbleArea::mousePressEvent(QMouseEvent* e)
 
 void ScribbleArea::mouseMoveEvent(QMouseEvent* e)
 {
-    // Workaround for tablet issue (#677 part 2)
-    if (mStrokeManager->isTabletInUse() || !isMouseInUse()) { e->ignore(); return; }
     PointerEvent event(e);
 
     mStrokeManager->pointerMoveEvent(&event);
@@ -716,8 +714,6 @@ void ScribbleArea::mouseMoveEvent(QMouseEvent* e)
 
 void ScribbleArea::mouseReleaseEvent(QMouseEvent* e)
 {
-    // Workaround for tablet issue (#677 part 2)
-    if (mStrokeManager->isTabletInUse() || !isMouseInUse()) { e->ignore(); return; }
     PointerEvent event(e);
 
     mStrokeManager->pointerReleaseEvent(&event);

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -89,6 +89,7 @@ public:
 
     void updateCurrentFrame();
     void updateFrame(int frame);
+    void updateOnionSkinsAround(int frame);
     void updateAllFrames();
     void updateAllVectorLayersAtCurrentFrame();
     void updateAllVectorLayersAt(int frameNumber);

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -112,6 +112,13 @@ public:
     bool isPointerInUse() const { return mMouseInUse || mTabletInUse; }
     bool isTemporaryTool() const { return mInstantTool; }
 
+    /** Check if the content of the canvas depends on the active layer.
+      *
+      * Currently layers are only affected by Onion skins are displayed only for the active layer, and the opacity of all layers
+      * is affected when relative layer visiblity is active.
+      *
+      * @return True if the active layer could potentially influence the content of the canvas. False otherwise.
+      */
     bool isAffectedByActiveLayer() const;
 
     void keyEvent(QKeyEvent* event);

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -238,7 +238,7 @@ private:
     SelectionPainter mSelectionPainter;
 
     // Pixmap Cache keys
-    std::vector<QPixmapCache::Key> mPixmapCacheKeys;
+    QMap<unsigned int, QPixmapCache::Key> mPixmapCacheKeys;
 
     // debug
     QRectF mDebugRect;

--- a/core_lib/src/tool/brushtool.cpp
+++ b/core_lib/src/tool/brushtool.cpp
@@ -139,18 +139,18 @@ QCursor BrushTool::cursor()
     return Qt::CrossCursor;
 }
 
-void BrushTool::pointerPressEvent(PointerEvent*)
+void BrushTool::pointerPressEvent(PointerEvent *event)
 {
     mScribbleArea->setAllDirty();
     mMouseDownPoint = getCurrentPoint();
     mLastBrushPoint = getCurrentPoint();
 
-    startStroke();
+    startStroke(event->inputType());
 }
 
 void BrushTool::pointerMoveEvent(PointerEvent* event)
 {
-    if (event->buttons() & Qt::LeftButton)
+    if (event->buttons() & Qt::LeftButton && event->inputType() == mCurrentInputType)
     {
         mCurrentPressure = strokeManager()->getPressure();
         drawStroke();
@@ -159,8 +159,10 @@ void BrushTool::pointerMoveEvent(PointerEvent* event)
     }
 }
 
-void BrushTool::pointerReleaseEvent(PointerEvent*)
+void BrushTool::pointerReleaseEvent(PointerEvent *event)
 {
+    if (event->inputType() != mCurrentInputType) return;
+
     Layer* layer = mEditor->layers()->currentLayer();
     mEditor->backup(typeName());
 

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -108,17 +108,16 @@ void BucketTool::setTolerance(const int tolerance)
 
 void BucketTool::pointerPressEvent(PointerEvent* event)
 {
-    startStroke();
+    startStroke(event->inputType());
     if (event->button() == Qt::LeftButton)
     {
         mScribbleArea->setAllDirty();
     }
-    startStroke();
 }
 
 void BucketTool::pointerMoveEvent(PointerEvent* event)
 {
-    if (event->buttons() & Qt::LeftButton)
+    if (event->buttons() & Qt::LeftButton && event->inputType() == mCurrentInputType)
     {
         Layer* layer = mEditor->layers()->currentLayer();
         if (layer->type() == Layer::VECTOR)
@@ -130,6 +129,8 @@ void BucketTool::pointerMoveEvent(PointerEvent* event)
 
 void BucketTool::pointerReleaseEvent(PointerEvent* event)
 {
+    if (event->inputType() != mCurrentInputType) return;
+
     Layer* layer = editor()->layers()->currentLayer();
     if (layer == nullptr) { return; }
 

--- a/core_lib/src/tool/erasertool.cpp
+++ b/core_lib/src/tool/erasertool.cpp
@@ -147,18 +147,18 @@ QCursor EraserTool::cursor()
     return Qt::CrossCursor;
 }
 
-void EraserTool::pointerPressEvent(PointerEvent*)
+void EraserTool::pointerPressEvent(PointerEvent *event)
 {
     mScribbleArea->setAllDirty();
 
-    startStroke();
+    startStroke(event->inputType());
     mLastBrushPoint = getCurrentPoint();
     mMouseDownPoint = getCurrentPoint();
 }
 
 void EraserTool::pointerMoveEvent(PointerEvent* event)
 {
-    if (event->buttons() & Qt::LeftButton)
+    if (event->buttons() & Qt::LeftButton && event->inputType() == mCurrentInputType)
     {
         mCurrentPressure = strokeManager()->getPressure();
         updateStrokes();
@@ -167,8 +167,10 @@ void EraserTool::pointerMoveEvent(PointerEvent* event)
     }
 }
 
-void EraserTool::pointerReleaseEvent(PointerEvent*)
+void EraserTool::pointerReleaseEvent(PointerEvent *event)
 {
+    if (event->inputType() != mCurrentInputType) return;
+
     mEditor->backup(typeName());
 
     qreal distance = QLineF(getCurrentPoint(), mMouseDownPoint).length();

--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -146,14 +146,14 @@ QCursor PencilTool::cursor()
     return Qt::CrossCursor;
 }
 
-void PencilTool::pointerPressEvent(PointerEvent*)
+void PencilTool::pointerPressEvent(PointerEvent *event)
 {
     mScribbleArea->setAllDirty();
 
     mMouseDownPoint = getCurrentPoint();
     mLastBrushPoint = getCurrentPoint();
 
-    startStroke();
+    startStroke(event->inputType());
 
     // note: why are we doing this on device press event?
     if (mEditor->layers()->currentLayer()->type() == Layer::VECTOR && !mEditor->preference()->isOn(SETTING::INVISIBLE_LINES))
@@ -164,7 +164,7 @@ void PencilTool::pointerPressEvent(PointerEvent*)
 
 void PencilTool::pointerMoveEvent(PointerEvent* event)
 {
-    if (event->buttons() & Qt::LeftButton)
+    if (event->buttons() & Qt::LeftButton && event->inputType() == mCurrentInputType)
     {
         mCurrentPressure = strokeManager()->getPressure();
         drawStroke();
@@ -173,8 +173,10 @@ void PencilTool::pointerMoveEvent(PointerEvent* event)
     }
 }
 
-void PencilTool::pointerReleaseEvent(PointerEvent*)
+void PencilTool::pointerReleaseEvent(PointerEvent *event)
 {
+    if (event->inputType() != mCurrentInputType) return;
+
     mEditor->backup(typeName());
     qreal distance = QLineF(getCurrentPoint(), mMouseDownPoint).length();
     if (distance < 1)

--- a/core_lib/src/tool/pentool.cpp
+++ b/core_lib/src/tool/pentool.cpp
@@ -116,19 +116,19 @@ QCursor PenTool::cursor()
     return Qt::CrossCursor;
 }
 
-void PenTool::pointerPressEvent(PointerEvent *)
+void PenTool::pointerPressEvent(PointerEvent *event)
 {
     mScribbleArea->setAllDirty();
 
     mMouseDownPoint = getCurrentPoint();
     mLastBrushPoint = getCurrentPoint();
 
-    startStroke();
+    startStroke(event->inputType());
 }
 
 void PenTool::pointerMoveEvent(PointerEvent* event)
 {
-    if (event->buttons() & Qt::LeftButton)
+    if (event->buttons() & Qt::LeftButton && event->inputType() == mCurrentInputType)
     {
         mCurrentPressure = strokeManager()->getPressure();
         drawStroke();
@@ -137,8 +137,10 @@ void PenTool::pointerMoveEvent(PointerEvent* event)
     }
 }
 
-void PenTool::pointerReleaseEvent(PointerEvent*)
+void PenTool::pointerReleaseEvent(PointerEvent *event)
 {
+    if (event->inputType() != mCurrentInputType) return;
+
     mEditor->backup(typeName());
 
     Layer* layer = mEditor->layers()->currentLayer();

--- a/core_lib/src/tool/smudgetool.cpp
+++ b/core_lib/src/tool/smudgetool.cpp
@@ -146,7 +146,7 @@ void SmudgeTool::pointerPressEvent(PointerEvent* event)
         if (layer->type() == Layer::BITMAP)
         {
             mScribbleArea->setAllDirty();
-            startStroke();
+            startStroke(event->inputType());
             mLastBrushPoint = getCurrentPoint();
         }
         else if (layer->type() == Layer::VECTOR)
@@ -190,6 +190,8 @@ void SmudgeTool::pointerPressEvent(PointerEvent* event)
 
 void SmudgeTool::pointerMoveEvent(PointerEvent* event)
 {
+    if (event->inputType() != mCurrentInputType) return;
+
     Layer* layer = mEditor->layers()->currentLayer();
     if (layer == NULL) { return; }
 
@@ -234,6 +236,8 @@ void SmudgeTool::pointerMoveEvent(PointerEvent* event)
 
 void SmudgeTool::pointerReleaseEvent(PointerEvent* event)
 {
+    if (event->inputType() != mCurrentInputType) return;
+
     Layer* layer = mEditor->layers()->currentLayer();
     if (layer == NULL) { return; }
 

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -42,7 +42,7 @@ StrokeTool::StrokeTool(QObject* parent) : BaseTool(parent)
     detectWhichOSX();
 }
 
-void StrokeTool::startStroke()
+void StrokeTool::startStroke(PointerEvent::InputType inputType)
 {
     if (emptyFrameActionEnabled())
     {
@@ -60,6 +60,8 @@ void StrokeTool::startStroke()
 
     mStrokePressures.clear();
     mStrokePressures << strokeManager()->getPressure();
+
+    mCurrentInputType = inputType;
 
     disableCoalescing();
 }

--- a/core_lib/src/tool/stroketool.h
+++ b/core_lib/src/tool/stroketool.h
@@ -19,6 +19,7 @@ GNU General Public License for more details.
 #define STROKETOOL_H
 
 #include "basetool.h"
+#include "pointerevent.h"
 
 #include <QList>
 #include <QPointF>
@@ -31,7 +32,7 @@ class StrokeTool : public BaseTool
 public:
     explicit StrokeTool(QObject* parent);
     
-    void startStroke();
+    void startStroke(PointerEvent::InputType inputType);
     void drawStroke();
     void endStroke();
 
@@ -46,6 +47,8 @@ protected:
 
     qreal mCurrentWidth    = 0.0;
     qreal mCurrentPressure = 0.5;
+
+    PointerEvent::InputType mCurrentInputType = PointerEvent::Unknown;
 
     /// Whether to enable the "drawing on empty frame" preference.
     /// If true, then the user preference is honored.

--- a/core_lib/src/util/pointerevent.cpp
+++ b/core_lib/src/util/pointerevent.cpp
@@ -209,7 +209,7 @@ bool PointerEvent::isAccepted()
     return false;
 }
 
-QEvent::Type PointerEvent::type() const
+QEvent::Type PointerEvent::eventType() const
 {
     if (mMouseEvent)
     {
@@ -220,6 +220,18 @@ QEvent::Type PointerEvent::type() const
         return mTabletEvent->type();
     }
     return QEvent::None;
+}
+
+PointerEvent::InputType PointerEvent::inputType() const
+{
+    if (mMouseEvent) {
+        return InputType::Mouse;
+    }
+    else if (mTabletEvent)
+    {
+        return InputType::Tablet;
+    }
+    return InputType::Unknown;
 }
 
 QTabletEvent::TabletDevice PointerEvent::device() const

--- a/core_lib/src/util/pointerevent.h
+++ b/core_lib/src/util/pointerevent.h
@@ -7,6 +7,13 @@
 class PointerEvent
 {
 public:
+    enum InputType {
+        Mouse,
+        Tablet,
+        Touch,
+        Unknown
+    };
+
     PointerEvent(QMouseEvent* event);
     PointerEvent(QTabletEvent* event);
     ~PointerEvent();
@@ -63,7 +70,8 @@ public:
 
     bool isAccepted();
 
-    QEvent::Type type() const;
+    QEvent::Type eventType() const;
+    InputType inputType() const;
 
     QTabletEvent::TabletDevice device() const;
     QTabletEvent::PointerType pointerType() const;


### PR DESCRIPTION
The following issues have been identified as caused by #1443, and they are all hopefully resolved with these changes:
- Onion skins not updating when cached and a previous/next frame is changed
- Crash when scrubbing to large positions (exact cutoff where it starts to crash depends on the frame pool size)
- The workaround for the mouse move events produced by some tablets (i.e. the reed issue) broke the polyline tool and the cursor. I have changed the approach used to fix this issue, and hopefully everything is working alright now. This still needs to be tested to make sure it fixes the issue that @Jose-Moreno was having.