### PR TITLE
Implement show titlebar only while hovering widget.

### DIFF
--- a/core_lib/src/interface/basedockwidget.cpp
+++ b/core_lib/src/interface/basedockwidget.cpp
@@ -34,7 +34,7 @@ BaseDockWidget::BaseDockWidget(QWidget* pParent)
                       "border-width: 1px; }");
     }
 #endif
-
+    mNoTitlebar = new QWidget();
 }
 
 BaseDockWidget::~BaseDockWidget()
@@ -62,4 +62,32 @@ int BaseDockWidget::getMinHeightForWidth(int width)
 {
     Q_UNUSED(width)
     return -1;
+}
+
+bool BaseDockWidget::event(QEvent *event)
+{
+    QDockWidget::event(event);
+
+    // it's not good enough to only check while the wiget is not floating
+    // because the state changes several times upon being initialized and ends up
+    // showing the titlebar until you enter and leave again.
+    if (event->type() == event->WindowTitleChange) {
+        this->setTitleBarWidget(mNoTitlebar);
+        return true;
+    } else if (!this->isFloating()) {
+        if (event->type() == QEvent::Enter) {
+            this->setTitleBarWidget(nullptr);
+            return true;
+        } else if (event->type() == QEvent::Leave)  {
+            this->setTitleBarWidget(mNoTitlebar);
+            return true;
+        }
+    } else if (event->type() == QEvent::Leave) {
+        if (this->titleBarWidget()) {
+            this->setTitleBarWidget(nullptr);
+            return false;
+        }
+    }
+
+    return false;
 }

--- a/core_lib/src/interface/basedockwidget.h
+++ b/core_lib/src/interface/basedockwidget.h
@@ -26,9 +26,10 @@ class Editor;
 class BaseDockWidget : public QDockWidget
 {
     Q_OBJECT
+
 protected:
     explicit BaseDockWidget(QWidget* pParent);
-    virtual  ~BaseDockWidget();
+    virtual  ~BaseDockWidget() override;
 
     void resizeEvent(QResizeEvent *event) override;
 
@@ -40,10 +41,13 @@ public:
     void setEditor( Editor* e ) { mEditor = e; }
 
 protected:
+    bool event(QEvent* event) override;
+
     virtual int getMinHeightForWidth(int width);
 
 private:
     Editor* mEditor = nullptr;
+    QWidget* mNoTitlebar = nullptr;
 };
 
 #endif // BASEDOCKWIDGET_H


### PR DESCRIPTION
Experimental feature, and not sure how it works across windows and linux.
On mac it works alright though whether you can adjust to the bouncing is debatable... we can always make it possible through a setting.

![titlebar](https://user-images.githubusercontent.com/1045397/93622242-142fff80-f9dd-11ea-8522-e4136bbbccef.gif)
