### PR TITLE
Eyedropper improvements

### DIFF
--- a/core_lib/src/graphics/bitmap/bitmapimage.h
+++ b/core_lib/src/graphics/bitmap/bitmapimage.h
@@ -68,8 +68,8 @@ public:
     void setPixel(QPoint p, QRgb color);
     void fillNonAlphaPixels(const QRgb color);
 
-    inline QRgb constScanLine(int x, int y) const;
-    inline void scanLine(int x, int y, QRgb color);
+    QRgb constScanLine(int x, int y) const;
+    void scanLine(int x, int y, QRgb color);
     void clear();
     void clear(QRect rectangle);
     void clear(QRectF rectangle) { clear(rectangle.toRect()); }

--- a/core_lib/src/tool/eyedroppertool.cpp
+++ b/core_lib/src/tool/eyedroppertool.cpp
@@ -159,8 +159,8 @@ QColor EyedropperTool::getBitmapColor(LayerBitmap* layer)
     if (targetImage == nullptr || !targetImage->contains(getCurrentPoint())) return QColor();
 
     QColor pickedColour;
-    const QRgb pixelColor = targetImage->constScanLine(qFloor(qMin(getCurrentPoint().x(),getLastPoint().x())),
-                                                       qFloor(qMin(getCurrentPoint().y(),getLastPoint().y())));
+    const QRgb pixelColor = targetImage->constScanLine(qFloor(getCurrentPoint().x()),
+                                                       qFloor(getCurrentPoint().y()));
     pickedColour.setRgba(pixelColor);
 
     if (pickedColour.alpha() <= 0) pickedColour = QColor();

--- a/core_lib/src/tool/eyedroppertool.cpp
+++ b/core_lib/src/tool/eyedroppertool.cpp
@@ -64,22 +64,13 @@ QCursor EyedropperTool::cursor(const QColor color)
     QPixmap pixmap(32, 32);
     pixmap.fill(Qt::transparent);
 
-
-    /// Color should not blend with background
-    qreal alpha = color.alpha() / 255.0;
-    qreal oneMinusAlpha = 1.0 - alpha;
-    int red = static_cast<int>((color.red() * alpha) + (oneMinusAlpha * 255));
-    int green = static_cast<int>((color.green() * alpha) + (oneMinusAlpha * 255));
-    int blue = static_cast<int>((color.blue() * alpha) + (oneMinusAlpha * 255));
-
     QPainter painter(&pixmap);
     painter.drawPixmap(0, 0, icon);
-    painter.save();
-    painter.setPen(QPen(Qt::black, 1, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-    painter.restore();
+
+    painter.setBrush(Qt::white);
     painter.drawRect(17, 17, 13, 13);
     painter.setPen(QPen(Qt::white, 1, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-    painter.setBrush(QColor(red, green, blue));
+    painter.setBrush(color);
     painter.drawRect(16, 16, 15, 15);
     painter.end();
 


### PR DESCRIPTION
- Eyedropper will now determine the color from anywhere within the pixel instead of only from the center of the pixel.
- Preview rectangle can now be seen on all backgrounds
- Preview color is now premultiplied, meaning the color represents the inspected pixel rather than the color multiplied with the background.