### PR TITLE
1488 fix camera interpolation

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1419,17 +1419,10 @@ void MainWindow2::makeConnections(Editor* editor, ScribbleArea* scribbleArea)
 {
     connect(editor->tools(), &ToolManager::toolChanged, scribbleArea, &ScribbleArea::setCurrentTool);
     connect(editor->tools(), &ToolManager::toolPropertyChanged, scribbleArea, &ScribbleArea::updateToolCursor);
-    connect(editor->layers(), &LayerManager::currentLayerChanged, [scribbleArea]
-    {
-        // Changing the current layer will only change the frame (as viewed by the user) under the following circumstances
-        if(scribbleArea->isAffectedByActiveLayer())
-        {
-            scribbleArea->updateAllFrames();
-        }
-    });
+    connect(editor->layers(), &LayerManager::currentLayerChanged, scribbleArea, &ScribbleArea::updateAllFramesIfNeeded);
     connect(editor->layers(), &LayerManager::layerDeleted, scribbleArea, &ScribbleArea::updateAllFrames);
 
-    connect(editor, &Editor::currentFrameChanged, [scribbleArea] { scribbleArea->update(); });
+    connect(editor, &Editor::currentFrameChanged, scribbleArea, &ScribbleArea::updateCurrentFrame);
 
     connect(editor->view(), &ViewManager::viewChanged, scribbleArea, &ScribbleArea::updateAllFrames);
     //connect( editor->preference(), &PreferenceManager::preferenceChanged, scribbleArea, &ScribbleArea::onPreferencedChanged );

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -175,7 +175,11 @@ void ScribbleArea::setEffect(SETTING e, bool isOn)
 
 void ScribbleArea::updateCurrentFrame()
 {
-    updateFrame(mEditor->currentFrame());
+    if (mEditor->layers()->currentLayer()->type() == Layer::CAMERA) {
+        updateFrame(mEditor->currentFrame());
+    } else {
+        update();
+    }
 }
 
 void ScribbleArea::updateFrame(int frame)
@@ -196,6 +200,15 @@ void ScribbleArea::updateFrame(int frame)
     updateOnionSkinsAround(frame);
 
     update();
+}
+
+void ScribbleArea::updateAllFramesIfNeeded() {
+
+    // Changing the current layer will only change the frame (as viewed by the user) under the following circumstances
+    if(isAffectedByActiveLayer())
+    {
+        updateAllFrames();
+    }
 }
 
 void ScribbleArea::updateOnionSkinsAround(int frameNumber)

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -88,6 +88,10 @@ public:
     QPointF getCentralPoint();
 
     void updateCurrentFrame();
+
+    /** Check if the cache should be invalidated for all frames since the last paint operation
+     */
+    void updateAllFramesIfNeeded();
     void updateFrame(int frame);
     void updateOnionSkinsAround(int frame);
     void updateAllFrames();


### PR DESCRIPTION
fixes #1488 

To minimize painting bugs, we should keep all update within scribblearea, so that we can rely on updates always coming from inside, at least when it affects cache and the like.