### PR TITLE
Fix extra movement when moving vector objects

### DIFF
--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1430,6 +1430,7 @@ void ScribbleArea::applyTransformedSelection()
             VectorImage* vectorImage = currentVectorImage(layer);
             if (vectorImage == nullptr) { return; }
             vectorImage->applySelectionTransformation();
+            selectMan->setSelection(selectMan->myTempTransformedSelectionRect(), false);
         }
 
         setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());


### PR DESCRIPTION
A pretty simple fix (once you figure out what’s going on), but I’d still prefer to have this reviewed because I’m not that familiar with the selection / move tool code.