### PR TITLE
Sound import/export bugfixes

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -162,9 +162,6 @@ Status ActionCommands::importSound(FileType type)
     layer = mEditor->layers()->currentLayer();
     Q_ASSERT(layer->type() == Layer::SOUND);
 
-
-    int currentFrame = mEditor->currentFrame();
-
     // Adding key before getting file name just to make sure the keyframe can be insterted
     SoundClip* key = static_cast<SoundClip*>(mEditor->addNewKey());
 
@@ -194,7 +191,6 @@ Status ActionCommands::importSound(FileType type)
 
     if (!st.ok())
     {
-        layer->removeKeyFrame(currentFrame);
         mEditor->removeKey();
         emit mEditor->layers()->currentLayerChanged(mEditor->layers()->currentLayerIndex()); // trigger timeline repaint.
     }

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -203,6 +203,7 @@ Status ActionCommands::importSound()
 
     int currentFrame = mEditor->currentFrame();
 
+    // Adding key before getting file name just to make sure the keyframe can be insterted
     SoundClip* key = static_cast<SoundClip*>(mEditor->addNewKey());
 
     if (key == nullptr)
@@ -214,14 +215,13 @@ Status ActionCommands::importSound()
 
     QString strSoundFile = FileDialog::getOpenFileName(mParent, FileType::SOUND);
 
-    if (strSoundFile.isEmpty())
-    {
-        return Status::SAFE;
-    }
-
     Status st = Status::FAIL;
 
-    if (strSoundFile.endsWith(".wav"))
+    if (strSoundFile.isEmpty())
+    {
+        st = Status::CANCELED;
+    }
+    else if (strSoundFile.endsWith(".wav"))
     {
         st = mEditor->sound()->loadSound(key, strSoundFile);
     }
@@ -233,6 +233,8 @@ Status ActionCommands::importSound()
     if (!st.ok())
     {
         layer->removeKeyFrame(currentFrame);
+        mEditor->removeKey();
+        emit mEditor->layers()->currentLayerChanged(mEditor->layers()->currentLayerIndex()); // trigger timeline repaint.
     }
 
     return st;

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -631,25 +631,12 @@ void ActionCommands::GotoPrevKeyFrame()
 
 Status ActionCommands::addNewKey()
 {
-    KeyFrame* key = mEditor->addNewKey();
-
-    SoundClip* clip = dynamic_cast<SoundClip*>(key);
-    if (clip)
-    {
-        QString strSoundFile = FileDialog::getOpenFileName(mParent, FileType::SOUND);
-
-        if (strSoundFile.isEmpty())
-        {
-            mEditor->layers()->currentLayer()->removeKeyFrame(clip->pos());
-            return Status::SAFE;
-        }
-        Status st = mEditor->sound()->loadSound(clip, strSoundFile);
-        if (!st.ok())
-        {
-            mEditor->layers()->currentLayer()->removeKeyFrame(clip->pos());
-            return Status::ERROR_LOAD_SOUND_FILE;
-        }
+    // Sound keyframes should not be empty, so we try to import a sound instead
+    if (mEditor->layers()->currentLayer()->type() == Layer::SOUND) {
+        return importSound();
     }
+
+    KeyFrame* key = mEditor->addNewKey();
 
     Camera* cam = dynamic_cast<Camera*>(key);
     if (cam)

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -116,11 +116,6 @@ Status ActionCommands::importMovieVideo()
     return Status::OK;
 }
 
-Status ActionCommands::importMovieAudio()
-{
-    return importSound(FileType::MOVIE);
-}
-
 Status ActionCommands::importSound(FileType type)
 {
     Layer* layer = mEditor->layers()->currentLayer();

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -615,8 +615,9 @@ void ActionCommands::removeKey()
 {
     mEditor->removeKey();
 
+    // Add a new keyframe at the beginning if there are none, unless it is a sound layer which can't have empty keyframes but can be an empty layer
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer->keyFrameCount() == 0)
+    if (layer->keyFrameCount() == 0 && layer->type() != Layer::SOUND)
     {
         layer->addNewKeyFrameAt(1);
     }

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -38,7 +38,6 @@ public:
 
     // file
     Status importMovieVideo();
-    Status importMovieAudio();
     Status importSound(FileType type);
     Status exportMovie(bool isGif = false);
     Status exportImageSequence();

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -19,6 +19,7 @@ GNU General Public License for more details.
 
 #include <QObject>
 #include "pencilerror.h"
+#include "filetype.h"
 
 class Editor;
 class QWidget;
@@ -38,7 +39,7 @@ public:
     // file
     Status importMovieVideo();
     Status importMovieAudio();
-    Status importSound();
+    Status importSound(FileType type);
     Status exportMovie(bool isGif = false);
     Status exportImageSequence();
     Status exportImage();

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -262,7 +262,7 @@ void MainWindow2::createMenus()
     connect(ui->actionImport_MovieVideo, &QAction::triggered, this, &MainWindow2::importMovieVideo);
     connect(ui->actionImport_Gif, &QAction::triggered, this, &MainWindow2::importGIF);
 
-    connect(ui->actionImport_Sound, &QAction::triggered, mCommands, &ActionCommands::importSound);
+    connect(ui->actionImport_Sound, &QAction::triggered, [=] { mCommands->importSound(FileType::SOUND); });
     connect(ui->actionImport_MovieAudio, &QAction::triggered, mCommands, &ActionCommands::importMovieAudio);
 
     connect(ui->actionImport_Append_Palette, &QAction::triggered, this, &MainWindow2::importPalette);

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -263,7 +263,7 @@ void MainWindow2::createMenus()
     connect(ui->actionImport_Gif, &QAction::triggered, this, &MainWindow2::importGIF);
 
     connect(ui->actionImport_Sound, &QAction::triggered, [=] { mCommands->importSound(FileType::SOUND); });
-    connect(ui->actionImport_MovieAudio, &QAction::triggered, mCommands, &ActionCommands::importMovieAudio);
+    connect(ui->actionImport_MovieAudio, &QAction::triggered, [=] { mCommands->importSound(FileType::MOVIE); });
 
     connect(ui->actionImport_Append_Palette, &QAction::triggered, this, &MainWindow2::importPalette);
     connect(ui->actionImport_Replace_Palette, &QAction::triggered, this, &MainWindow2::openPalette);

--- a/core_lib/src/interface/backupelement.h
+++ b/core_lib/src/interface/backupelement.h
@@ -74,7 +74,7 @@ public:
     int layer = 0;
     int frame = 0;
     SoundClip clip;
-    QString fileName;
+    QString fileName, originalName;
 
     int type() override { return BackupElement::SOUND_MODIF; }
     void restore( Editor* ) override;

--- a/core_lib/src/movieexporter.cpp
+++ b/core_lib/src/movieexporter.cpp
@@ -177,7 +177,10 @@ Status MovieExporter::assembleAudio(const Object* obj,
     {
         layer->foreachKeyFrame([&allSoundClips](KeyFrame* key)
         {
-            allSoundClips.push_back(static_cast<SoundClip*>(key));
+            if (!key->fileName().isEmpty())
+            {
+                allSoundClips.push_back(static_cast<SoundClip*>(key));
+            }
         });
     }
 


### PR DESCRIPTION
This PR fixes multiple bugs related to importing and exporting audio. In particular it fixes:
- Different behavior between movie audio import and sound import (closes #1448, closes #1452)
- Exporting with empty sound frames causes the movie export to fail
- Fix empty sound keyframe being left when cancelling a sound import (closes #1449)
- Implement sound keyframe deletion undoing and fix empty keyframe being produced (note you may encounter #1557 when testing this, that has not been fixed and is unrelated)
- Fixed removing the wrong sound keyframe when importing a sound on an existing frame and cancelling
- Prevent empty keyframe from being created if a sound keyframe is removed and there are no other keyframes left on the layer

This should hopefully address all the issues some of our users were having adding sounds a certain way.