### PR TITLE
Rework frame updating

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -663,6 +663,7 @@ void ActionCommands::moveFrameForward()
     }
 
     mEditor->layers()->notifyAnimationLengthChanged();
+    mEditor->framesMoved();
 }
 
 void ActionCommands::moveFrameBackward()
@@ -675,6 +676,7 @@ void ActionCommands::moveFrameBackward()
             mEditor->scrubBackward();
         }
     }
+    mEditor->framesMoved();
 }
 
 Status ActionCommands::addNewBitmapLayer()

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1404,6 +1404,7 @@ void MainWindow2::makeConnections(Editor* editor, ScribbleArea* scribbleArea)
     connect(editor->layers(), &LayerManager::layerDeleted, scribbleArea, &ScribbleArea::onLayerChanged);
     connect(editor, &Editor::scrubbed, scribbleArea, &ScribbleArea::onScrubbed);
     connect(editor, &Editor::frameModified, scribbleArea, &ScribbleArea::onFrameModified);
+    connect(editor, &Editor::framesMoved, scribbleArea, &ScribbleArea::onFramesMoved);
     connect(editor, &Editor::objectChanged, scribbleArea, &ScribbleArea::onObjectChanged);
     connect(editor->view(), &ViewManager::viewChanged, scribbleArea, &ScribbleArea::onViewChanged);
 }

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -343,7 +343,7 @@ void MainWindow2::createMenus()
     connect(pPlaybackManager, &PlaybackManager::rangedPlaybackStateChanged, mTimeLine, &TimeLine::setRangeState);
     connect(pPlaybackManager, &PlaybackManager::playStateChanged, mTimeLine, &TimeLine::setPlaying);
     connect(pPlaybackManager, &PlaybackManager::playStateChanged, this, &MainWindow2::changePlayState);
-    connect(pPlaybackManager, &PlaybackManager::playStateChanged, mEditor, &Editor::updateCurrentFrame);
+    connect(pPlaybackManager, &PlaybackManager::playStateChanged, ui->scribbleArea, &ScribbleArea::onPlayStateChanged);
     connect(ui->actionFlip_inbetween, &QAction::triggered, pPlaybackManager, &PlaybackManager::playFlipInBetween);
     connect(ui->actionFlip_rolling, &QAction::triggered, pPlaybackManager, &PlaybackManager::playFlipRoll);
 
@@ -1398,12 +1398,14 @@ void MainWindow2::makeConnections(Editor* editor, ScribbleArea* scribbleArea)
 {
     connect(editor->tools(), &ToolManager::toolChanged, scribbleArea, &ScribbleArea::setCurrentTool);
     connect(editor->tools(), &ToolManager::toolPropertyChanged, scribbleArea, &ScribbleArea::updateToolCursor);
-    connect(editor->layers(), &LayerManager::currentLayerChanged, scribbleArea, &ScribbleArea::updateAllFramesIfNeeded);
-    connect(editor->layers(), &LayerManager::layerDeleted, scribbleArea, &ScribbleArea::updateAllFrames);
 
-    connect(editor, &Editor::currentFrameChanged, scribbleArea, &ScribbleArea::updateCurrentFrame);
 
-    connect(editor->view(), &ViewManager::viewChanged, scribbleArea, &ScribbleArea::updateAllFrames);
+    connect(editor->layers(), &LayerManager::currentLayerChanged, scribbleArea, &ScribbleArea::onLayerChanged);
+    connect(editor->layers(), &LayerManager::layerDeleted, scribbleArea, &ScribbleArea::onLayerChanged);
+    connect(editor, &Editor::scrubbed, scribbleArea, &ScribbleArea::onScrubbed);
+    connect(editor, &Editor::frameModified, scribbleArea, &ScribbleArea::onFrameModified);
+    connect(editor, &Editor::objectChanged, scribbleArea, &ScribbleArea::onObjectChanged);
+    connect(editor->view(), &ViewManager::viewChanged, scribbleArea, &ScribbleArea::onViewChanged);
 }
 
 void MainWindow2::makeConnections(Editor* pEditor, TimeLine* pTimeline)

--- a/app/src/pegbaralignmentdialog.cpp
+++ b/app/src/pegbaralignmentdialog.cpp
@@ -35,7 +35,7 @@ PegBarAlignmentDialog::PegBarAlignmentDialog(Editor *editor, QWidget *parent) :
 
     connect(mEditor->layers(), &LayerManager::layerCountChanged, this, &PegBarAlignmentDialog::updatePegRegLayers);
     connect(mEditor->select(), &SelectionManager::selectionChanged, this, &PegBarAlignmentDialog::updatePegRegDialog);
-    connect(mEditor, &Editor::currentFrameChanged, this, &PegBarAlignmentDialog::updatePegRegDialog);
+    connect(mEditor, &Editor::scrubbed, this, &PegBarAlignmentDialog::updatePegRegDialog);
     connect(mEditor->layers(), &LayerManager::currentLayerChanged, this, &PegBarAlignmentDialog::updatePegRegDialog);
 
     ui->btnAlign->setEnabled(false);

--- a/core_lib/src/interface/backupelement.cpp
+++ b/core_lib/src/interface/backupelement.cpp
@@ -34,8 +34,10 @@ void BackupBitmapElement::restore(Editor* editor)
     selectMan->setRotation(rotationAngle);
     selectMan->setSomethingSelected(somethingSelected);
 
-    editor->updateFrame(this->frame);
-    editor->scrubTo(this->frame);
+    if (editor->currentFrame() != this->frame) {
+        editor->scrubTo(this->frame);
+    }
+    editor->frameModified(this->frame);
 
     if (this->frame > 0 && layer->getKeyFrameAt(this->frame) == nullptr)
     {
@@ -64,8 +66,23 @@ void BackupVectorElement::restore(Editor* editor)
     selectMan->setRotation(rotationAngle);
     selectMan->setSomethingSelected(somethingSelected);
 
-    editor->updateFrameAndVector(this->frame);
-    editor->scrubTo(this->frame);
+    for (int i = 0; i < editor->object()->getLayerCount(); i++)
+    {
+        Layer* layer = editor->object()->getLayer(i);
+        if (layer->type() == Layer::VECTOR)
+        {
+            VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getVectorImageAtFrame(this->frame);
+            if (vectorImage != nullptr)
+            {
+                vectorImage->modification();
+            }
+        }
+    }
+
+    if (editor->currentFrame() != this->frame) {
+        editor->scrubTo(this->frame);
+    }
+    editor->frameModified(this->frame);
     if (this->frame > 0 && layer->getKeyFrameAt(this->frame) == nullptr)
     {
         editor->restoreKey();
@@ -86,8 +103,10 @@ void BackupVectorElement::restore(Editor* editor)
 void BackupSoundElement::restore(Editor* editor)
 {
     Layer* layer = editor->object()->getLayer(this->layer);
-    editor->updateFrame(this->frame);
-    editor->scrubTo(this->frame);
+    if (editor->currentFrame() != this->frame) {
+        editor->scrubTo(this->frame);
+    }
+    editor->frameModified(this->frame);
 
     // TODO: soundclip won't restore if overlapping on first frame
     if (this->frame > 0 && layer->getKeyFrameAt(this->frame) == nullptr)

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -164,7 +164,7 @@ void Editor::settingUpdated(SETTING setting)
         mAutosaveNumber = mPreferenceManager->getInt(SETTING::AUTO_SAVE_NUMBER);
         break;
     case SETTING::ONION_TYPE:
-        mScribbleArea->onOnionSkinChanged();
+        mScribbleArea->onOnionSkinTypeChanged();
         emit updateTimeLine();
         break;
     case SETTING::FRAME_POOL_SIZE:
@@ -923,10 +923,8 @@ void Editor::setCurrentLayerIndex(int i)
 void Editor::scrubTo(int frame)
 {
     if (frame < 1) { frame = 1; }
-    int oldFrame = mFrame;
     mFrame = frame;
 
-    emit scrubbed(oldFrame);
     emit scrubbed(frame);
 
     // FIXME: should not emit Timeline update here.

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -164,7 +164,7 @@ void Editor::settingUpdated(SETTING setting)
         mAutosaveNumber = mPreferenceManager->getInt(SETTING::AUTO_SAVE_NUMBER);
         break;
     case SETTING::ONION_TYPE:
-        mScribbleArea->updateAllFrames();
+        mScribbleArea->onOnionSkinChanged();
         emit updateTimeLine();
         break;
     case SETTING::FRAME_POOL_SIZE:
@@ -590,7 +590,7 @@ void Editor::paste()
             select()->setSelection(vectorImage->getSelectionRect(), false);
         }
     }
-    mScribbleArea->updateCurrentFrame();
+    emit frameModified(mFrame);
 }
 
 void Editor::flipSelection(bool flipVertical)
@@ -712,10 +712,7 @@ void Editor::updateObject()
     mAutosaveCounter = 0;
     mAutosaveNeverAskAgain = false;
 
-    if (mScribbleArea)
-    {
-        mScribbleArea->updateAllFrames();
-    }
+    emit objectChanged();
 
     if (mPreferenceManager)
     {
@@ -907,11 +904,6 @@ void Editor::updateFrame(int frameNumber)
     mScribbleArea->updateFrame(frameNumber);
 }
 
-void Editor::updateFrameAndVector(int frameNumber)
-{
-    mScribbleArea->updateAllVectorLayersAt(frameNumber);
-}
-
 void Editor::updateCurrentFrame()
 {
     mScribbleArea->updateCurrentFrame();
@@ -934,8 +926,8 @@ void Editor::scrubTo(int frame)
     int oldFrame = mFrame;
     mFrame = frame;
 
-    emit currentFrameChanged(oldFrame);
-    emit currentFrameChanged(frame);
+    emit scrubbed(oldFrame);
+    emit scrubbed(frame);
 
     // FIXME: should not emit Timeline update here.
     // Editor must be an individual class.
@@ -1059,7 +1051,7 @@ void Editor::switchVisibilityOfLayer(int layerNumber)
 {
     Layer* layer = mObject->getLayer(layerNumber);
     if (layer != nullptr) layer->switchVisibility();
-    mScribbleArea->updateAllFrames();
+    mScribbleArea->onLayerChanged();
 
     emit updateTimeLine();
 }
@@ -1076,7 +1068,7 @@ void Editor::swapLayers(int i, int j)
         layers()->setCurrentLayer(j - 1);
     }
     emit updateTimeLine();
-    mScribbleArea->updateAllFrames();
+    mScribbleArea->onLayerChanged();
 }
 
 Status Editor::pegBarAlignment(QStringList layers)

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -121,6 +121,9 @@ signals:
     /** This should be emitted after the object has been changed */
     void objectChanged();
 
+    /** This should be emitted after moving one or more frames */
+    void framesMoved();
+
     void updateTimeLine();
     void updateLayerCount();
     void updateBackup();

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -47,7 +47,6 @@ class ActiveFramePool;
 
 enum class SETTING;
 
-
 class Editor : public QObject
 {
     Q_OBJECT
@@ -112,6 +111,16 @@ public:
     QList<BackupElement*> mBackupList;
 
 signals:
+
+    /** This should be emitted after scrubbing */
+    void scrubbed(int frameNumber);
+
+    /** This should be emitted after modifying the frame content */
+    void frameModified(int frameNumber);
+
+    /** This should be emitted after the object has been changed */
+    void objectChanged();
+
     void updateTimeLine();
     void updateLayerCount();
     void updateBackup();
@@ -119,7 +128,6 @@ signals:
     void objectLoaded();
 
     void changeThinLinesButton(bool);
-    void currentFrameChanged(int n);
     void fpsChanged(int fps);
 
     void needSave();
@@ -127,17 +135,25 @@ signals:
     void needDisplayInfoNoTitle(const QString& body);
 
 public: //slots
+
+    /** Will call update() and update the canvas
+     * Only call this directly If you need the cache to be intact and require the frame to be repainted
+     * Convenient method that does the same as updateFrame but for the current frame
+    */
+    void updateCurrentFrame();
+
+    /** Will call update() and update the canvas
+     * Only call this directly If you need the cache to be intact and require the frame to be repainted
+    */
+    void updateFrame(int frameNumber);
+
     void clearCurrentFrame();
 
     void cut();
 
     bool importImage(QString filePath);
     bool importGIF(QString filePath, int numOfImages = 0);
-    void updateFrame(int frameNumber);
     void restoreKey();
-
-    void updateFrameAndVector(int frameNumber);
-    void updateCurrentFrame();
 
     void scrubNextKeyFrame();
     void scrubPreviousKeyFrame();

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1668,7 +1668,7 @@ void ScribbleArea::deleteSelection()
             Q_CHECK_PTR(bitmapImage);
             bitmapImage->clear(selectMan->mySelectionRect());
         }
-        invalidateAllCache();
+        setModified(mEditor->currentLayerIndex(), mEditor->currentFrame());
     }
 }
 

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -335,7 +335,7 @@ void ScribbleArea::onSelectionChanged()
 
 void ScribbleArea::onOnionSkinTypeChanged()
 {
-    invalidateAllCache();
+    invalidateLayerPixmapCache();
     updateCurrentFrame();
 }
 
@@ -1569,21 +1569,24 @@ void ScribbleArea::setLayerVisibility(LayerVisibility visibility)
 {
     mLayerVisibility = visibility;
     mPrefs->set(SETTING::LAYER_VISIBILITY, static_cast<int>(mLayerVisibility));
-    invalidateAllCache();
+
+    invalidateLayerPixmapCache();
 }
 
 void ScribbleArea::increaseLayerVisibilityIndex()
 {
     ++mLayerVisibility;
     mPrefs->set(SETTING::LAYER_VISIBILITY, static_cast<int>(mLayerVisibility));
-    invalidateAllCache();
+
+    invalidateLayerPixmapCache();
 }
 
 void ScribbleArea::decreaseLayerVisibilityIndex()
 {
     --mLayerVisibility;
     mPrefs->set(SETTING::LAYER_VISIBILITY, static_cast<int>(mLayerVisibility));
-    invalidateAllCache();
+
+    invalidateLayerPixmapCache();
 }
 
 /************************************************************************************/

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -319,30 +319,26 @@ void ScribbleArea::onFrameModified(int frameNumber)
 void ScribbleArea::onViewChanged()
 {
     invalidateLayerPixmapCache();
-    updateCurrentFrame();
 }
 
 void ScribbleArea::onLayerChanged()
 {
     invalidateLayerPixmapCache();
-    updateCurrentFrame();
 }
 
 void ScribbleArea::onSelectionChanged()
 {
-    updateCurrentFrame();
+    update();
 }
 
 void ScribbleArea::onOnionSkinTypeChanged()
 {
     invalidateLayerPixmapCache();
-    updateCurrentFrame();
 }
 
 void ScribbleArea::onObjectChanged()
 {
     invalidateAllCache();
-    updateCurrentFrame();
 }
 
 void ScribbleArea::setModified(int layerNumber, int frameNumber)

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -189,10 +189,7 @@ void ScribbleArea::updateFrame(int frame)
         if (frameNumber < 0) { return; }
 
         invalidateCacheForFrame(frameNumber);
-        invalidateCacheForDirtyFrames();
         mCurrentCacheInvalid = false;
-    } else {
-        invalidateCacheForDirtyFrames();
     }
 
     update();
@@ -289,11 +286,19 @@ void ScribbleArea::onPlayStateChanged()
 
 void ScribbleArea::onScrubbed(int frameNumber)
 {
-    invalidateCacheForDirtyFrames();
     if (mPrefs->isOn(SETTING::PREV_ONION) || mPrefs->isOn(SETTING::NEXT_ONION)) {
         invalidateLayerPixmapCache();
     }
     updateFrame(frameNumber);
+}
+
+void ScribbleArea::onFramesMoved()
+{
+    invalidateCacheForDirtyFrames();
+    if (mPrefs->isOn(SETTING::PREV_ONION) || mPrefs->isOn(SETTING::NEXT_ONION)) {
+        invalidateLayerPixmapCache();
+    }
+    update();
 }
 
 void ScribbleArea::onCurrentFrameModified()

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -766,7 +766,8 @@ void ScribbleArea::resizeEvent(QResizeEvent* event)
 
     mEditor->view()->setCanvasSize(size());
 
-    invalidateAllCache();
+    invalidateCacheForFrame(mEditor->currentFrame());
+    invalidateLayerPixmapCache();
 }
 
 void ScribbleArea::showLayerNotVisibleWarning()

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -229,7 +229,7 @@ void ScribbleArea::invalidateOnionSkinsCacheAround(int frameNumber)
 
         for(int i = 1; i <= mPrefs->getInt(SETTING::ONION_PREV_FRAMES_NUM); i++)
         {
-            onionFrameNumber = layer->getNextFrameNumber(onionFrameNumber, isOnionAbsolute);
+            onionFrameNumber = layer->getPreviousFrameNumber(onionFrameNumber, isOnionAbsolute);
             if (onionFrameNumber < 0) break;
 
             invalidateCacheForFrame(onionFrameNumber);
@@ -242,7 +242,7 @@ void ScribbleArea::invalidateOnionSkinsCacheAround(int frameNumber)
 
         for(int i = 1; i <= mPrefs->getInt(SETTING::ONION_NEXT_FRAMES_NUM); i++)
         {
-            onionFrameNumber = layer->getPreviousFrameNumber(onionFrameNumber, isOnionAbsolute);
+            onionFrameNumber = layer->getNextFrameNumber(onionFrameNumber, isOnionAbsolute);
             if (onionFrameNumber < 0) break;
 
             invalidateCacheForFrame(onionFrameNumber);
@@ -765,6 +765,7 @@ void ScribbleArea::resizeEvent(QResizeEvent* event)
     mCanvas.fill(Qt::transparent);
 
     mEditor->view()->setCanvasSize(size());
+
     invalidateAllCache();
 }
 

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1730,8 +1730,7 @@ void ScribbleArea::paletteColorChanged(QColor color)
         }
     }
 
-    mCurrentCacheInvalid = true;
-    updateCurrentFrame();
+    invalidateAllCache();
 }
 
 void ScribbleArea::floodFillError(int errorType)

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -96,6 +96,9 @@ public:
     /** Frame scrubbed, update relevant cache */
     void onScrubbed(int frameNumber);
 
+    /** Frames moved, update cache for those frames */
+    void onFramesMoved();
+
     /** Playstate changed, update relevant cache */
     void onPlayStateChanged();
 

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -86,19 +86,41 @@ public:
     QRectF getCameraRect();
     QPointF getCentralPoint();
 
+    /** Update current frame, calls update() behind the scene */
     void updateCurrentFrame();
-
-    /** Check if the cache should be invalidated for all frames since the last paint operation
-     */
-    void updateAllFramesIfNeeded();
     void updateFrame(int frame);
 
-    void updateAllFrames();
-    void updateAllVectorLayersAtCurrentFrame();
-    void updateAllVectorLayersAt(int frameNumber);
+    /** Frame was scrubbed, update relevant cache */
+    void onScrubbed(int frameNumber);
 
+    /** Playstate changed, update relevant cache */
+    void onPlayStateChanged();
+
+    /** View updated, invalidate all cache */
+    void onViewChanged();
+
+    /** Frame modified, invalidate cache for frame if any */
+    void onFrameModified(int frameNumber);
+
+    /** Current frame modified, invalidate current frame cache if any.
+     * Convenient function that does the same as onFrameModified
+    */
+    void onCurrentFrameModified();
+
+    /** Layer changed, invalidate all cache */
+    void onLayerChanged();
+
+    /** Selection was changed, keep cache */
+    void onSelectionChanged();
+
+    /** Onion skin changed, invalidate all cache */
+    void onOnionSkinChanged();
+
+    /** Object updated, invalidate all cache */
+    void onObjectChanged();
+
+    /** Set frame on layer to modified and invalidate current frame cache */
     void setModified(int layerNumber, int frameNumber);
-    void setAllDirty();
 
     void flipSelection(bool flipVertical);
 
@@ -115,20 +137,10 @@ public:
     bool isPointerInUse() const { return mMouseInUse || mTabletInUse; }
     bool isTemporaryTool() const { return mInstantTool; }
 
-    /** Check if the content of the canvas depends on the active layer.
-      *
-      * Currently layers are only affected by Onion skins are displayed only for the active layer, and the opacity of all layers
-      * is affected when relative layer visiblity is active.
-      *
-      * @return True if the active layer could potentially influence the content of the canvas. False otherwise.
-      */
-    bool isAffectedByActiveLayer() const;
-
     void keyEvent(QKeyEvent* event);
     void keyEventForSelection(QKeyEvent* event);
 
 signals:
-    void modification(int);
     void multiLayerOnionSkinChanged(bool);
     void refreshPreview();
 
@@ -195,11 +207,20 @@ public:
 
 private:
 
-    /** remove cache for dirty keyframes */
-    void removeCacheForDirtyFrames();
+    /** Invalidate the layer pixmap cache */
+    void invalidateLayerPixmapCache();
 
-    /** remove onion skin cache around frame */
-    void removeOnionSkinsCacheAround(int frame);
+    /** Invalidate cache for the given frame */
+    void invalidateCacheForFrame(int frameNumber);
+
+    /** Invalidate all cache */
+    void invalidateAllCache();
+
+    /** invalidate cache for dirty keyframes */
+    void invalidateCacheForDirtyFrames();
+
+    /** invalidate onion skin cache around frame */
+    void invalidateOnionSkinsCacheAround(int frame);
 
     void prepCanvas(int frame, QRect rect);
     void drawCanvas(int frame, QRect rect);
@@ -219,6 +240,7 @@ private:
 
     Editor* mEditor = nullptr;
 
+
     bool mIsSimplified = false;
     bool mShowThinLines = false;
     bool mQuickSizing = true;
@@ -229,6 +251,8 @@ private:
     qreal mCurveSmoothingLevel = 0.0;
     bool mMultiLayerOnionSkin = false; // future use. If required, just add a checkbox to updated it.
     QColor mOnionColor;
+
+    bool mCurrentCacheInvalid = false;
 
 private:
     bool mKeyboardInUse = false;

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -102,7 +102,7 @@ public:
     /** Playstate changed, update relevant cache */
     void onPlayStateChanged();
 
-    /** View updated, invalidate all cache */
+    /** View updated, invalidate relevant cache */
     void onViewChanged();
 
     /** Frame modified, invalidate cache for frame if any */
@@ -112,7 +112,7 @@ public:
      * Convenient function that does the same as onFrameModified */
     void onCurrentFrameModified();
 
-    /** Layer changed, invalidate all cache */
+    /** Layer changed, invalidate relevant cache */
     void onLayerChanged();
 
     /** Selection was changed, keep cache */

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -93,13 +93,13 @@ public:
      * calls update() behind the scene and update cache if necessary */
     void updateFrame(int frame);
 
-    /** Frame scrubbed, update relevant cache */
+    /** Frame scrubbed, invalidate relevant cache */
     void onScrubbed(int frameNumber);
 
-    /** Frames moved, update cache for those frames */
+    /** Frames moved, invalidate cache for affected frames */
     void onFramesMoved();
 
-    /** Playstate changed, update relevant cache */
+    /** Playstate changed, invalidate relevant cache */
     void onPlayStateChanged();
 
     /** View updated, invalidate relevant cache */

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -214,8 +214,8 @@ public:
 private:
 
     /** Invalidate the layer pixmap cache.
-     * Call this in most situations where the layer rendering order is affected
-     * Peviously known as setAllDirty, now only called on frame modifications
+     * Call this in most situations where the layer rendering order is affected.
+     * Peviously known as setAllDirty.
     */
     void invalidateLayerPixmapCache();
 

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -86,11 +86,14 @@ public:
     QRectF getCameraRect();
     QPointF getCentralPoint();
 
-    /** Update current frame, calls update() behind the scene */
+    /** Update current frame.
+     *  calls update() behind the scene and update cache if necessary */
     void updateCurrentFrame();
+    /** Update frame.
+     * calls update() behind the scene and update cache if necessary */
     void updateFrame(int frame);
 
-    /** Frame was scrubbed, update relevant cache */
+    /** Frame scrubbed, update relevant cache */
     void onScrubbed(int frameNumber);
 
     /** Playstate changed, update relevant cache */
@@ -103,8 +106,7 @@ public:
     void onFrameModified(int frameNumber);
 
     /** Current frame modified, invalidate current frame cache if any.
-     * Convenient function that does the same as onFrameModified
-    */
+     * Convenient function that does the same as onFrameModified */
     void onCurrentFrameModified();
 
     /** Layer changed, invalidate all cache */
@@ -113,8 +115,9 @@ public:
     /** Selection was changed, keep cache */
     void onSelectionChanged();
 
-    /** Onion skin changed, invalidate all cache */
-    void onOnionSkinChanged();
+    /** Onion skin type changed, all frames will be affected.
+     * All cache will be invalidated */
+    void onOnionSkinTypeChanged();
 
     /** Object updated, invalidate all cache */
     void onObjectChanged();
@@ -207,16 +210,20 @@ public:
 
 private:
 
-    /** Invalidate the layer pixmap cache */
+    /** Invalidate the layer pixmap cache.
+     * Call this in most situations where the layer rendering order is affected
+     * Peviously known as setAllDirty, now only called on frame modifications
+    */
     void invalidateLayerPixmapCache();
 
     /** Invalidate cache for the given frame */
     void invalidateCacheForFrame(int frameNumber);
 
-    /** Invalidate all cache */
+    /** Invalidate all cache.
+     * call this if you're certain that the change you've made affects all frames */
     void invalidateAllCache();
 
-    /** invalidate cache for dirty keyframes */
+    /** invalidate cache for dirty keyframes. */
     void invalidateCacheForDirtyFrames();
 
     /** invalidate onion skin cache around frame */

--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -208,7 +208,7 @@ void TimeLine::initUI()
     connect(mTimeControls, &TimeControls::fpsChanged, this, &TimeLine::fpsChanged);
     connect(mTimeControls, &TimeControls::fpsChanged, this, &TimeLine::updateLength);
     connect(mTimeControls, &TimeControls::playButtonTriggered, this, &TimeLine::playButtonTriggered);
-    connect(editor(), &Editor::currentFrameChanged, mTimeControls, &TimeControls::updateTimecodeLabel);
+    connect(editor(), &Editor::scrubbed, mTimeControls, &TimeControls::updateTimecodeLabel);
     connect(mTimeControls, &TimeControls::fpsChanged, mTimeControls, &TimeControls::setFps);
     connect(this, &TimeLine::fpsChanged, mTimeControls, &TimeControls::setFps);
 
@@ -222,7 +222,7 @@ void TimeLine::initUI()
     connect(mLayerList, &TimeLineCells::mouseMovedY, mTracks, &TimeLineCells::setMouseMoveY);
     connect(mTracks, &TimeLineCells::lengthChanged, this, &TimeLine::updateLength);
 
-    connect(editor(), &Editor::currentFrameChanged, this, &TimeLine::updateFrame);
+    connect(editor(), &Editor::scrubbed, this, &TimeLine::updateFrame);
 
     LayerManager* layer = editor()->layers();
     connect(layer, &LayerManager::layerCountChanged, this, &TimeLine::updateLayerNumber);

--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -826,7 +826,7 @@ void TimeLineCells::mouseMoveEvent(QMouseEvent* event)
                             int offset = frameNumber - mLastFrameNumber;
                             currentLayer->moveSelectedFrames(offset);
                             mEditor->layers()->notifyAnimationLengthChanged();
-                            mEditor->updateCurrentFrame();
+                            mEditor->framesMoved();
                         }
                         else if (mCanBoxSelect)
                         {

--- a/core_lib/src/managers/layermanager.h
+++ b/core_lib/src/managers/layermanager.h
@@ -67,6 +67,8 @@ public:
     int lastKeyFrameIndex();
 
     int animationLength(bool includeSounds = true);
+
+    /** This should be emitted whenever the animation length frames, eg. adding, removing, duplicating */
     void notifyAnimationLengthChanged();
 
     QString nameSuggestLayer(const QString& name);

--- a/core_lib/src/managers/viewmanager.cpp
+++ b/core_lib/src/managers/viewmanager.cpp
@@ -46,7 +46,7 @@ ViewManager::~ViewManager() {
 
 bool ViewManager::init()
 {
-    connect(editor(), &Editor::currentFrameChanged, this, &ViewManager::onCurrentFrameChanged);
+    connect(editor(), &Editor::scrubbed, this, &ViewManager::onCurrentFrameChanged);
     return true;
 }
 

--- a/core_lib/src/tool/brushtool.cpp
+++ b/core_lib/src/tool/brushtool.cpp
@@ -141,7 +141,6 @@ QCursor BrushTool::cursor()
 
 void BrushTool::pointerPressEvent(PointerEvent *event)
 {
-    mScribbleArea->setAllDirty();
     mMouseDownPoint = getCurrentPoint();
     mLastBrushPoint = getCurrentPoint();
 
@@ -304,7 +303,6 @@ void BrushTool::drawStroke()
 void BrushTool::paintBitmapStroke()
 {
     mScribbleArea->paintBitmapBuffer();
-    mScribbleArea->setAllDirty();
     mScribbleArea->clearBitmapBuffer();
 }
 
@@ -342,6 +340,5 @@ void BrushTool::paintVectorStroke()
         vectorImage->setSelected(vectorImage->getLastCurveNumber(), true);
 
         mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
-        mScribbleArea->setAllDirty();
     }
 }

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -109,10 +109,6 @@ void BucketTool::setTolerance(const int tolerance)
 void BucketTool::pointerPressEvent(PointerEvent* event)
 {
     startStroke(event->inputType());
-    if (event->button() == Qt::LeftButton)
-    {
-        mScribbleArea->setAllDirty();
-    }
 }
 
 void BucketTool::pointerMoveEvent(PointerEvent* event)
@@ -180,7 +176,6 @@ void BucketTool::paintBitmap(Layer* layer)
                            properties.tolerance);
 
     mScribbleArea->setModified(layerNumber, mEditor->currentFrame());
-    mScribbleArea->setAllDirty();
 }
 
 void BucketTool::paintVector(Layer* layer)
@@ -202,7 +197,6 @@ void BucketTool::paintVector(Layer* layer)
     applyChanges();
 
     mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
-    mScribbleArea->setAllDirty();
 }
 
 void BucketTool::applyChanges()

--- a/core_lib/src/tool/erasertool.cpp
+++ b/core_lib/src/tool/erasertool.cpp
@@ -149,8 +149,6 @@ QCursor EraserTool::cursor()
 
 void EraserTool::pointerPressEvent(PointerEvent *event)
 {
-    mScribbleArea->setAllDirty();
-
     startStroke(event->inputType());
     mLastBrushPoint = getCurrentPoint();
     mMouseDownPoint = getCurrentPoint();
@@ -299,7 +297,6 @@ void EraserTool::removeVectorPaint()
     if (layer->type() == Layer::BITMAP)
     {
         mScribbleArea->paintBitmapBuffer();
-        mScribbleArea->setAllDirty();
         mScribbleArea->clearBitmapBuffer();
     }
     else if (layer->type() == Layer::VECTOR)
@@ -313,7 +310,6 @@ void EraserTool::removeVectorPaint()
         vectorImage->deleteSelectedPoints();
 
         mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
-        mScribbleArea->setAllDirty();
     }
 }
 
@@ -335,6 +331,5 @@ void EraserTool::updateStrokes()
         {
             currKey->setSelected(nearbyVertice, true);
         }
-        mScribbleArea->setAllDirty();
     }
 }

--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -148,8 +148,6 @@ QCursor PencilTool::cursor()
 
 void PencilTool::pointerPressEvent(PointerEvent *event)
 {
-    mScribbleArea->setAllDirty();
-
     mMouseDownPoint = getCurrentPoint();
     mLastBrushPoint = getCurrentPoint();
 
@@ -297,7 +295,6 @@ void PencilTool::drawStroke()
 void PencilTool::paintBitmapStroke()
 {
     mScribbleArea->paintBitmapBuffer();
-    mScribbleArea->setAllDirty();
     mScribbleArea->clearBitmapBuffer();
 }
 
@@ -338,5 +335,4 @@ void PencilTool::paintVectorStroke(Layer* layer)
     // TODO: selection doesn't apply on enter
 
     mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
-    mScribbleArea->setAllDirty();
 }

--- a/core_lib/src/tool/pentool.cpp
+++ b/core_lib/src/tool/pentool.cpp
@@ -118,8 +118,6 @@ QCursor PenTool::cursor()
 
 void PenTool::pointerPressEvent(PointerEvent *event)
 {
-    mScribbleArea->setAllDirty();
-
     mMouseDownPoint = getCurrentPoint();
     mLastBrushPoint = getCurrentPoint();
 
@@ -263,7 +261,6 @@ void PenTool::drawStroke()
 void PenTool::paintBitmapStroke()
 {
     mScribbleArea->paintBitmapBuffer();
-    mScribbleArea->setAllDirty();
     mScribbleArea->clearBitmapBuffer();
 }
 
@@ -297,5 +294,4 @@ void PenTool::paintVectorStroke(Layer* layer)
     vectorImage->setSelected(vectorImage->getLastCurveNumber(), true);
 
     mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
-    mScribbleArea->setAllDirty();
 }

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -127,7 +127,6 @@ void PolylineTool::pointerPressEvent(PointerEvent* event)
                 }
             }
             mPoints << getCurrentPoint();
-            mScribbleArea->setAllDirty();
         }
     }
 }
@@ -270,7 +269,6 @@ void PolylineTool::endPolyline(QList<QPointF> points)
         bitmapImage->paste(mScribbleArea->mBufferImg);
     }
 
-    mScribbleArea->setAllDirty();
     mScribbleArea->clearBitmapBuffer();
     mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
 }

--- a/core_lib/src/tool/selecttool.cpp
+++ b/core_lib/src/tool/selecttool.cpp
@@ -52,8 +52,10 @@ void SelectTool::beginSelection()
     selectMan->calculateSelectionTransformation();
 
     // paint and apply the transformation
-    mScribbleArea->paintTransformedSelection();
-    mScribbleArea->applyTransformedSelection();
+    if (selectMan->transformHasBeenModified()) {
+        mScribbleArea->paintTransformedSelection();
+        mScribbleArea->applyTransformedSelection();
+    }
     mMoveMode = selectMan->validateMoveMode(getLastPoint());
 
     if (selectMan->somethingSelected() && mMoveMode != MoveMode::NONE) // there is something selected
@@ -72,7 +74,7 @@ void SelectTool::beginSelection()
     {
         selectMan->setSelection(QRectF(getCurrentPoint().x(), getCurrentPoint().y(), 1, 1), mEditor->layers()->currentLayer()->type() == Layer::BITMAP);
     }
-    mScribbleArea->update();
+    mScribbleArea->updateCurrentFrame();
 }
 
 void SelectTool::pointerPressEvent(PointerEvent* event)
@@ -146,7 +148,6 @@ void SelectTool::pointerReleaseEvent(PointerEvent* event)
 
     mScribbleArea->updateToolCursor();
     mScribbleArea->updateCurrentFrame();
-//    mScribbleArea->setAllDirty();
 }
 
 bool SelectTool::maybeDeselect()

--- a/core_lib/src/tool/smudgetool.cpp
+++ b/core_lib/src/tool/smudgetool.cpp
@@ -145,7 +145,6 @@ void SmudgeTool::pointerPressEvent(PointerEvent* event)
     {
         if (layer->type() == Layer::BITMAP)
         {
-            mScribbleArea->setAllDirty();
             startStroke(event->inputType());
             mLastBrushPoint = getCurrentPoint();
         }
@@ -231,7 +230,6 @@ void SmudgeTool::pointerMoveEvent(PointerEvent* event)
         }
     }
     mScribbleArea->update();
-    mScribbleArea->setAllDirty();
 }
 
 void SmudgeTool::pointerReleaseEvent(PointerEvent* event)
@@ -249,7 +247,6 @@ void SmudgeTool::pointerReleaseEvent(PointerEvent* event)
         {
             drawStroke();
             mScribbleArea->paintBitmapBuffer();
-            mScribbleArea->setAllDirty();
             mScribbleArea->clearBitmapBuffer();
             endStroke();
         }

--- a/core_lib/src/tool/smudgetool.cpp
+++ b/core_lib/src/tool/smudgetool.cpp
@@ -139,13 +139,13 @@ void SmudgeTool::pointerPressEvent(PointerEvent* event)
 
     Layer* layer = mEditor->layers()->currentLayer();
     auto selectMan = mEditor->select();
-    if (layer == NULL) { return; }
+    if (layer == nullptr) { return; }
 
     if (event->button() == Qt::LeftButton)
     {
+        startStroke(event->inputType());
         if (layer->type() == Layer::BITMAP)
         {
-            startStroke(event->inputType());
             mLastBrushPoint = getCurrentPoint();
         }
         else if (layer->type() == Layer::VECTOR)
@@ -192,7 +192,7 @@ void SmudgeTool::pointerMoveEvent(PointerEvent* event)
     if (event->inputType() != mCurrentInputType) return;
 
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer == NULL) { return; }
+    if (layer == nullptr) { return; }
 
     if (layer->type() != Layer::BITMAP && layer->type() != Layer::VECTOR)
     {
@@ -229,7 +229,7 @@ void SmudgeTool::pointerMoveEvent(PointerEvent* event)
             selectMan->setVertices(vectorImage->getVerticesCloseTo(getCurrentPoint(), selectMan->selectionTolerance()));
         }
     }
-    mScribbleArea->update();
+    mEditor->updateCurrentFrame();
 }
 
 void SmudgeTool::pointerReleaseEvent(PointerEvent* event)
@@ -237,7 +237,7 @@ void SmudgeTool::pointerReleaseEvent(PointerEvent* event)
     if (event->inputType() != mCurrentInputType) return;
 
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer == NULL) { return; }
+    if (layer == nullptr) { return; }
 
     if (event->button() == Qt::LeftButton)
     {

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -98,6 +98,8 @@ void StrokeTool::endStroke()
     mStrokePressures.clear();
 
     enableCoalescing();
+
+    mScribbleArea->setModified(mEditor->currentLayerIndex(), mEditor->currentFrame());
 }
 
 void StrokeTool::drawStroke()


### PR DESCRIPTION
Although we were about to have the frame update situation under somewhat control, I found many cases where the entire cache doesn't have to be invalidated, thus I've added more signals and methods to the appropriate situations where we require more control of the cache. Furthermore I found a bug where if our current frame cache is relevant, we still don't paint the rendering stack properly, eg. missing onion skin.

All cache control is now placed privately inside ScribbleArea and only through the appropriate slots, will the cache be updated. UpdateFrame and updateCurrentFrame will call update() and only invalidate frame cache when a frame is modified.

Frame cache invalidation will happen mostly automatically through all tools via ScribbleArea::setModified() which invalidates the current frame cache and updates the frame.

When modifying a frame outside the context of Scribblearea, the emitter "Editor::frameModified" should be used instead. 

I've documented signals and slots to the best of my ability, so that it hopefully makes sense when to use what signal.

closes #1560
closes #1548