### PR TITLE
Cache fixes for #1562

### DIFF
--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -996,6 +996,7 @@ KeyFrame* Editor::addKeyFrame(int layerNumber, int frameIndex)
     if (ok)
     {
         scrubTo(frameIndex); // currentFrameChanged() emit inside.
+        emit frameModified(frameIndex);
         layers()->notifyAnimationLengthChanged();
     }
     return layer->getKeyFrameAt(frameIndex);

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -183,15 +183,13 @@ void ScribbleArea::updateFrame(int frame)
 {
     Q_ASSERT(frame >= 0);
 
-    if (mCurrentCacheInvalid) {
+    if (mCurrentCacheInvalid)
+	{
+        if (frame < 0) { return; }
 
-        int frameNumber = mEditor->layers()->lastFrameAtFrame(frame);
-        if (frameNumber < 0) { return; }
-
-        invalidateCacheForFrame(frameNumber);
+        invalidateCacheForFrame(frame);
         mCurrentCacheInvalid = false;
     }
-
     update();
 }
 
@@ -1031,12 +1029,12 @@ void ScribbleArea::paintEvent(QPaintEvent* event)
             if (cacheKeyIter == mPixmapCacheKeys.end() || !QPixmapCache::find(cacheKeyIter.value(), &mCanvas))
             {
                 drawCanvas(mEditor->currentFrame(), event->rect());
-                mPixmapCacheKeys[static_cast<unsigned>(frameNumber)] = QPixmapCache::insert(mCanvas);
+                mPixmapCacheKeys[static_cast<unsigned>(currentFrame)] = QPixmapCache::insert(mCanvas);
                 //qDebug() << "Repaint canvas!";
-            } else {
-                // Current frame cache may be valid but we may still have to draw other frames eg. onion skin from cache.
-                prepCanvas(mEditor->currentFrame(), event->rect());
-                mCanvasPainter.paintCached();
+            }
+            else
+            {
+                // Simply use the cached canvas from PixmapCache
             }
         }
     }

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -284,9 +284,7 @@ void ScribbleArea::onPlayStateChanged()
 
 void ScribbleArea::onScrubbed(int frameNumber)
 {
-    if (mPrefs->isOn(SETTING::PREV_ONION) || mPrefs->isOn(SETTING::NEXT_ONION)) {
-        invalidateLayerPixmapCache();
-    }
+    invalidateLayerPixmapCache();
     updateFrame(frameNumber);
 }
 

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -182,14 +182,6 @@ void ScribbleArea::updateCurrentFrame()
 void ScribbleArea::updateFrame(int frame)
 {
     Q_ASSERT(frame >= 0);
-
-    if (mCurrentCacheInvalid)
-	{
-        if (frame < 0) { return; }
-
-        invalidateCacheForFrame(frame);
-        mCurrentCacheInvalid = false;
-    }
     update();
 }
 
@@ -304,11 +296,10 @@ void ScribbleArea::onCurrentFrameModified()
 
 void ScribbleArea::onFrameModified(int frameNumber)
 {
-    mCurrentCacheInvalid = true;
-
     if (mPrefs->isOn(SETTING::PREV_ONION) || mPrefs->isOn(SETTING::NEXT_ONION)) {
         invalidateLayerPixmapCache();
     }
+    invalidateCacheForFrame(frameNumber);
     updateFrame(frameNumber);
 }
 

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -134,7 +134,7 @@ void ScribbleArea::settingUpdated(SETTING setting)
     case SETTING::INVISIBLE_LINES:
     case SETTING::OUTLINES:
     case SETTING::ONION_TYPE:
-        invalidateLayerPixmapCache();
+        invalidateAllCache();
         break;
     case SETTING::QUICK_SIZING:
         mQuickSizing = mPrefs->isOn(SETTING::QUICK_SIZING);
@@ -316,12 +316,12 @@ void ScribbleArea::onFrameModified(int frameNumber)
 
 void ScribbleArea::onViewChanged()
 {
-    invalidateLayerPixmapCache();
+    invalidateAllCache();
 }
 
 void ScribbleArea::onLayerChanged()
 {
-    invalidateLayerPixmapCache();
+    invalidateAllCache();
 }
 
 void ScribbleArea::onSelectionChanged()
@@ -331,7 +331,7 @@ void ScribbleArea::onSelectionChanged()
 
 void ScribbleArea::onOnionSkinTypeChanged()
 {
-    invalidateLayerPixmapCache();
+    invalidateAllCache();
 }
 
 void ScribbleArea::onObjectChanged()
@@ -1564,7 +1564,7 @@ void ScribbleArea::setLayerVisibility(LayerVisibility visibility)
     mLayerVisibility = visibility;
     mPrefs->set(SETTING::LAYER_VISIBILITY, static_cast<int>(mLayerVisibility));
 
-    invalidateLayerPixmapCache();
+    invalidateAllCache();
 }
 
 void ScribbleArea::increaseLayerVisibilityIndex()
@@ -1572,7 +1572,7 @@ void ScribbleArea::increaseLayerVisibilityIndex()
     ++mLayerVisibility;
     mPrefs->set(SETTING::LAYER_VISIBILITY, static_cast<int>(mLayerVisibility));
 
-    invalidateLayerPixmapCache();
+    invalidateAllCache();
 }
 
 void ScribbleArea::decreaseLayerVisibilityIndex()
@@ -1580,7 +1580,7 @@ void ScribbleArea::decreaseLayerVisibilityIndex()
     --mLayerVisibility;
     mPrefs->set(SETTING::LAYER_VISIBILITY, static_cast<int>(mLayerVisibility));
 
-    invalidateLayerPixmapCache();
+    invalidateAllCache();
 }
 
 /************************************************************************************/

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1017,12 +1017,12 @@ void ScribbleArea::paintEvent(QPaintEvent* event)
     if (!currentTool()->isActive())
     {
         // --- we retrieve the canvas from the cache; we create it if it doesn't exist
-        int curIndex = mEditor->currentFrame();
-        int frameNumber = mEditor->layers()->lastFrameAtFrame(curIndex);
+        const int currentFrame = mEditor->currentFrame();
+        const int frameNumber = mEditor->layers()->lastFrameAtFrame(currentFrame);
 
         if (frameNumber < 0)
         {
-            drawCanvas(curIndex, event->rect());
+            drawCanvas(currentFrame, event->rect());
         }
         else
         {

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -262,8 +262,6 @@ private:
     bool mMultiLayerOnionSkin = false; // future use. If required, just add a checkbox to updated it.
     QColor mOnionColor;
 
-    bool mCurrentCacheInvalid = false;
-
 private:
     bool mKeyboardInUse = false;
     bool mMouseInUse = false;


### PR DESCRIPTION
Addressed a couple of issues found in #1562

There is still an issue and I haven't figured out how to fix. The **Show Onion Skins during Playback** checkbox doesn't work because the frame cache already has onion skins baked in. There is probably no easy fix at the moment due to the `CanvasPainter` implementation. Please let me know if you have any idea.