### PR TITLE
Fix cache rendering issue with onion skin

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -659,7 +659,7 @@ void ActionCommands::moveFrameForward()
     }
 
     mEditor->layers()->notifyAnimationLengthChanged();
-    mEditor->framesMoved();
+    mEditor->framesModified();
 }
 
 void ActionCommands::moveFrameBackward()
@@ -672,7 +672,7 @@ void ActionCommands::moveFrameBackward()
             mEditor->scrubBackward();
         }
     }
-    mEditor->framesMoved();
+    mEditor->framesModified();
 }
 
 Status ActionCommands::addNewBitmapLayer()

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1406,7 +1406,7 @@ void MainWindow2::makeConnections(Editor* editor, ScribbleArea* scribbleArea)
     connect(editor->layers(), &LayerManager::layerDeleted, scribbleArea, &ScribbleArea::onLayerChanged);
     connect(editor, &Editor::scrubbed, scribbleArea, &ScribbleArea::onScrubbed);
     connect(editor, &Editor::frameModified, scribbleArea, &ScribbleArea::onFrameModified);
-    connect(editor, &Editor::framesMoved, scribbleArea, &ScribbleArea::onFramesMoved);
+    connect(editor, &Editor::framesModified, scribbleArea, &ScribbleArea::onFramesModified);
     connect(editor, &Editor::objectChanged, scribbleArea, &ScribbleArea::onObjectChanged);
     connect(editor->view(), &ViewManager::viewChanged, scribbleArea, &ScribbleArea::onViewChanged);
 }

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -121,8 +121,8 @@ signals:
     /** This should be emitted after the object has been changed */
     void objectChanged();
 
-    /** This should be emitted after moving one or more frames */
-    void framesMoved();
+    /** This should be emitted after modifying multiple frames */
+    void framesModified();
 
     void updateTimeLine();
     void updateLayerCount();

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -188,7 +188,7 @@ void ScribbleArea::updateFrame(int frame)
 void ScribbleArea::invalidateCacheForDirtyFrames()
 {
     Layer* currentLayer = mEditor->layers()->currentLayer();
-    for (int pos : mEditor->layers()->currentLayer()->dirtyFrames()) {
+    for (int pos : currentLayer->dirtyFrames()) {
 
         invalidateCacheForFrame(pos);
         invalidateOnionSkinsCacheAround(pos);
@@ -280,7 +280,7 @@ void ScribbleArea::onScrubbed(int frameNumber)
     updateFrame(frameNumber);
 }
 
-void ScribbleArea::onFramesMoved()
+void ScribbleArea::onFramesModified()
 {
     invalidateCacheForDirtyFrames();
     if (mPrefs->isOn(SETTING::PREV_ONION) || mPrefs->isOn(SETTING::NEXT_ONION)) {
@@ -297,8 +297,11 @@ void ScribbleArea::onCurrentFrameModified()
 void ScribbleArea::onFrameModified(int frameNumber)
 {
     if (mPrefs->isOn(SETTING::PREV_ONION) || mPrefs->isOn(SETTING::NEXT_ONION)) {
+        invalidateOnionSkinsCacheAround(frameNumber);
         invalidateLayerPixmapCache();
     }
+    // We can't assume that the current frame is in the dirty frame list here
+    // therefore the extra invalidation step
     invalidateCacheForFrame(frameNumber);
     updateFrame(frameNumber);
 }

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -242,6 +242,7 @@ void ScribbleArea::invalidateAllCache()
     QPixmapCache::clear();
     mPixmapCacheKeys.clear();
     invalidateLayerPixmapCache();
+    mEditor->layers()->currentLayer()->clearDirtyFrames();
 
     update();
 }
@@ -300,8 +301,6 @@ void ScribbleArea::onFrameModified(int frameNumber)
         invalidateOnionSkinsCacheAround(frameNumber);
         invalidateLayerPixmapCache();
     }
-    // We can't assume that the current frame is in the dirty frame list here
-    // therefore the extra invalidation step
     invalidateCacheForFrame(frameNumber);
     updateFrame(frameNumber);
 }

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -97,7 +97,7 @@ public:
     void onScrubbed(int frameNumber);
 
     /** Frames moved, invalidate cache for affected frames */
-    void onFramesMoved();
+    void onFramesModified();
 
     /** Playstate changed, invalidate relevant cache */
     void onPlayStateChanged();

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -96,7 +96,7 @@ public:
     /** Frame scrubbed, invalidate relevant cache */
     void onScrubbed(int frameNumber);
 
-    /** Frames moved, invalidate cache for affected frames */
+    /** Multiple frames modified, invalidate cache for affected frames */
     void onFramesModified();
 
     /** Playstate changed, invalidate relevant cache */

--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -830,7 +830,7 @@ void TimeLineCells::mouseMoveEvent(QMouseEvent* event)
                             int offset = frameNumber - mLastFrameNumber;
                             currentLayer->moveSelectedFrames(offset);
                             mEditor->layers()->notifyAnimationLengthChanged();
-                            mEditor->framesMoved();
+                            mEditor->framesModified();
                         }
                         else if (mCanBoxSelect)
                         {

--- a/core_lib/src/structure/layer.h
+++ b/core_lib/src/structure/layer.h
@@ -121,8 +121,7 @@ public:
     QList<int> dirtyFrames() const { return mDirtyFrames; }
 
     /** Mark the frame position as dirty.
-     *  Any operation causing the frame to be modified, added, updated or removed, should call this.
-     *  The mark is cleared on the next paint buffer operation. */
+     *  Any operation causing the frame to be modified, added, updated or removed, should call this. */
     void markFrameAsDirty(const int frameNumber) { mDirtyFrames << frameNumber; }
 
     /** Clear the list of dirty keyframes */

--- a/core_lib/src/structure/layer.h
+++ b/core_lib/src/structure/layer.h
@@ -122,9 +122,8 @@ public:
 
     /** Mark the frame position as dirty.
      *  Any operation causing the frame to be modified, added, updated or removed, should call this.
-     *  The mark is cleared on the next frame update operation.
-    */
-    void markFrameAsDirty(int frameNumber) { mDirtyFrames << frameNumber; }
+     *  The mark is cleared on the next paint buffer operation. */
+    void markFrameAsDirty(const int frameNumber) { mDirtyFrames << frameNumber; }
 
     /** Clear the list of dirty keyframes */
     void clearDirtyFrames() { mDirtyFrames.clear(); }


### PR DESCRIPTION
When calling frameModified, the onion skin cache not would be updated, meaning the cache for the skinned frames would be invalid and cause the familiar residue effect...

Way to reproduce:
1. Add 2 frames or move while onion skin is enabled
2. move scrubber to the first frame you added
3. Draw on the frame
4. Now scrub to the last added frame and paint on it

result: notice the residue effect due to the onion skin cache not having been updated.

This PR fixes that problem by making sure the onion skin cache is updated when the current frame is modified.
