### PR TITLE
fix ui rendering issue when using direct2d platform on windows. (-platform direct2d)

### DIFF
--- a/app/src/colorslider.cpp
+++ b/app/src/colorslider.cpp
@@ -45,13 +45,13 @@ void ColorSlider::init(ColorSpecType specType, ColorType type, const QColor &col
 
 void ColorSlider::paintEvent(QPaintEvent *)
 {
-    QPainter painter(this);
-
     drawColorBox(mColor, size());
 
+    QPainter painter(this);
     painter.drawPixmap(0, 0, mBoxPixmapSource);
-    drawPicker(mColor);
     painter.end();
+
+    drawPicker(mColor);
 }
 
 QLinearGradient ColorSlider::setColorSpec(const QColor &color)


### PR DESCRIPTION
error message: EndDraw failed: 0x88990014
Some widgets show just blank with black color.