### PR TITLE
Pegbar refactoring and fixes

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -450,9 +450,6 @@ void MainWindow2::openPegAlignDialog()
 
     mPegAlign = new PegBarAlignmentDialog(mEditor, this);
     mPegAlign->setAttribute(Qt::WA_DeleteOnClose);
-    mPegAlign->updatePegRegLayers();
-    mPegAlign->setRefLayer(mEditor->layers()->currentLayer()->name());
-    mPegAlign->setRefKey(mEditor->currentFrame());
 
     Qt::WindowFlags flags = mPegAlign->windowFlags();
     flags |= Qt::WindowStaysOnTopHint;
@@ -591,6 +588,8 @@ bool MainWindow2::openObject(const QString& strFilePath)
         mRecentFileMenu->addRecentFile(mEditor->object()->filePath());
         mRecentFileMenu->saveToDisk();
     }
+
+    closeDialogs();
 
     setWindowTitle(mEditor->object()->filePath().prepend("[*]"));
     setWindowModified(false);
@@ -986,6 +985,8 @@ void MainWindow2::newObject()
     object->createDefaultLayers();
     mEditor->setObject(object);
 
+    closeDialogs();
+
     setWindowTitle(PENCIL_WINDOW_TITLE);
 }
 
@@ -1061,6 +1062,15 @@ bool MainWindow2::tryLoadPreset()
     });
     presetDialog->open();
     return true;
+}
+
+void MainWindow2::closeDialogs()
+{
+    for (auto widget : this->children()) {
+        if (QDialog* object = qobject_cast<QDialog*>(widget)) {
+            object->close();
+        }
+    }
 }
 
 void MainWindow2::readSettings()
@@ -1332,6 +1342,7 @@ void MainWindow2::makeConnections(Editor* editor, ColorInspector* colorInspector
 void MainWindow2::makeConnections(Editor* editor, ScribbleArea* scribbleArea)
 {
     connect(editor->tools(), &ToolManager::toolChanged, scribbleArea, &ScribbleArea::setCurrentTool);
+    connect(editor->tools(), &ToolManager::toolChanged, mToolBox, &ToolBoxWidget::onToolSetActive);
     connect(editor->tools(), &ToolManager::toolPropertyChanged, scribbleArea, &ScribbleArea::updateToolCursor);
 
 

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1066,10 +1066,8 @@ bool MainWindow2::tryLoadPreset()
 
 void MainWindow2::closeDialogs()
 {
-    for (auto widget : this->children()) {
-        if (QDialog* object = qobject_cast<QDialog*>(widget)) {
-            object->close();
-        }
+    for (auto dialog : findChildren<QDialog*>(QString(), Qt::FindDirectChildrenOnly)) {
+        dialog->close();
     }
 }
 

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -113,6 +113,7 @@ private:
     bool newObjectFromPresets(int presetIndex);
     bool openObject(const QString& strFilename);
     bool saveObject(QString strFileName);
+    void closeDialogs();
 
     void createDockWidgets();
     void createMenus();

--- a/app/src/pegbaralignmentdialog.cpp
+++ b/app/src/pegbaralignmentdialog.cpp
@@ -23,6 +23,8 @@ GNU General Public License for more details.
 #include "layermanager.h"
 #include "selectionmanager.h"
 
+#include <pegbaraligner.h>
+
 PegBarAlignmentDialog::PegBarAlignmentDialog(Editor *editor, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::PegBarAlignmentDialog)
@@ -147,7 +149,7 @@ void PegBarAlignmentDialog::alignPegs()
         return;
     }
 
-    Status result = mEditor->pegBarAlignment(bitmaplayers);
+    Status result = PegbarAligner(mEditor).align(bitmaplayers);
     if (!result.ok())
     {
         QMessageBox::information(this, "Pencil2D",

--- a/app/src/pegbaralignmentdialog.cpp
+++ b/app/src/pegbaralignmentdialog.cpp
@@ -158,7 +158,7 @@ void PegBarAlignmentDialog::alignPegs()
         return;
     }
 
-    Status result = PegbarAligner(mEditor).align(bitmaplayers);
+    Status result = PegBarAligner(mEditor).align(bitmaplayers);
     if (!result.ok())
     {
         QMessageBox::information(this, "Pencil2D",

--- a/app/src/pegbaralignmentdialog.h
+++ b/app/src/pegbaralignmentdialog.h
@@ -21,6 +21,8 @@ GNU General Public License for more details.
 #include <QStringList>
 #include "editor.h"
 
+class PegbarAligner;
+
 namespace Ui {
 class PegBarAlignmentDialog;
 }

--- a/app/src/pegbaralignmentdialog.h
+++ b/app/src/pegbaralignmentdialog.h
@@ -21,8 +21,6 @@ GNU General Public License for more details.
 #include <QStringList>
 #include "editor.h"
 
-class PegbarAligner;
-
 namespace Ui {
 class PegBarAlignmentDialog;
 }

--- a/app/src/pegbaralignmentdialog.h
+++ b/app/src/pegbaralignmentdialog.h
@@ -35,26 +35,21 @@ public:
     explicit PegBarAlignmentDialog(Editor* editor, QWidget* parent = nullptr);
     ~PegBarAlignmentDialog();
 
+public slots:
+    void updateAlignButton();
+
+private:
+    void updatePegRegLayers();
+    void updatePegRegDialog();
+    void alignPegs();
     void setLayerList(QStringList layerList);
+    void updateRefKeyLabel(QString text);
+
     QStringList getLayerList();
-    int getRefKey() { return mRefkey; }
-    QString getRefLayer() { return mRefLayer; }
-    void updateRefKeyLabelText();
 
     void setAreaSelected(bool b);
     void setReferenceSelected(bool b);
     void setLayerSelected(bool b);
-
-    void updatePegRegLayers();
-    void updatePegRegDialog();
-    void alignPegs();
-
-public slots:
-    void setBtnAlignEnabled();
-    void setRefLayer(QString s);
-    void setRefKey(int i);
-
-private:
     void closeClicked();
 
     Ui::PegBarAlignmentDialog* ui;
@@ -63,8 +58,6 @@ private:
     bool mAreaSelected = false;
     bool mReferenceSelected = false;
     bool mLayerSelected = false;
-    QString mRefLayer;
-    int mRefkey = 0;
 };
 
 #endif // PEGBARALIGNMENTDIALOG_H

--- a/app/src/toolbox.cpp
+++ b/app/src/toolbox.cpp
@@ -210,110 +210,57 @@ void ToolBoxWidget::onToolSetActive(ToolType toolType)
 
 void ToolBoxWidget::pencilOn()
 {
-    if (!leavingTool(ui->pencilButton)) { return; }
-
-    editor()->tools()->setCurrentTool(PENCIL);
-
-    deselectAllTools();
-    ui->pencilButton->setChecked(true);
+    toolOn(PENCIL, ui->pencilButton);
 }
 
 void ToolBoxWidget::eraserOn()
 {
-    if (!leavingTool(ui->eraserButton)) { return; }
-
-    editor()->tools()->setCurrentTool(ERASER);
-
-    deselectAllTools();
-    ui->eraserButton->setChecked(true);
+    toolOn(ERASER, ui->eraserButton);
 }
 
 void ToolBoxWidget::selectOn()
 {
-    if (!leavingTool(ui->selectButton)) { return; }
-
-    editor()->tools()->setCurrentTool(SELECT);
-
-    deselectAllTools();
-    ui->selectButton->setChecked(true);
+    toolOn(SELECT, ui->selectButton);
 }
 
 void ToolBoxWidget::moveOn()
 {
-    if (!leavingTool(ui->moveButton)) { return; }
-
-    editor()->tools()->setCurrentTool(MOVE);
-
-    deselectAllTools();
-    ui->moveButton->setChecked(true);
+    toolOn(MOVE, ui->moveButton);
 }
 
 void ToolBoxWidget::penOn()
 {
-    if (!leavingTool(ui->penButton)) { return; }
-
-    editor()->tools()->setCurrentTool(PEN);
-
-    deselectAllTools();
-    ui->penButton->setChecked(true);
+    toolOn(PEN, ui->penButton);
 }
 
 void ToolBoxWidget::handOn()
 {
-    if (!leavingTool(ui->handButton)) { return; }
-
-    editor()->tools()->setCurrentTool( HAND );
-
-    deselectAllTools();
-    ui->handButton->setChecked(true);
+    toolOn(HAND, ui->handButton);
 }
 
 void ToolBoxWidget::polylineOn()
 {
-    if (!leavingTool(ui->polylineButton)) { return; }
-
-    editor()->tools()->setCurrentTool(POLYLINE);
-
-    deselectAllTools();
-    ui->polylineButton->setChecked(true);
+    toolOn(POLYLINE, ui->polylineButton);
 }
 
 void ToolBoxWidget::bucketOn()
 {
-    if (!leavingTool(ui->bucketButton)) { return; }
-
-    editor()->tools()->setCurrentTool(BUCKET);
-
-    deselectAllTools();
-    ui->bucketButton->setChecked(true);
+    toolOn(BUCKET, ui->bucketButton);
 }
 
 void ToolBoxWidget::eyedropperOn()
 {
-    if (!leavingTool(ui->eyedropperButton)) { return; }
-    editor()->tools()->setCurrentTool(EYEDROPPER);
-
-    deselectAllTools();
-    ui->eyedropperButton->setChecked(true);
+    toolOn(EYEDROPPER, ui->eyedropperButton);
 }
 
 void ToolBoxWidget::brushOn()
 {
-    if (!leavingTool(ui->brushButton)) { return; }
-
-    editor()->tools()->setCurrentTool( BRUSH );
-
-    deselectAllTools();
-    ui->brushButton->setChecked(true);
+    toolOn(BRUSH, ui->brushButton);
 }
 
 void ToolBoxWidget::smudgeOn()
 {
-    if (!leavingTool(ui->smudgeButton)) { return; }
-    editor()->tools()->setCurrentTool(SMUDGE);
-
-    deselectAllTools();
-    ui->smudgeButton->setChecked(true);
+    toolOn(SMUDGE, ui->smudgeButton);
 }
 
 int ToolBoxWidget::getMinHeightForWidth(int width)
@@ -336,14 +283,13 @@ void ToolBoxWidget::deselectAllTools()
     ui->smudgeButton->setChecked(false);
 }
 
-bool ToolBoxWidget::leavingTool(QToolButton* toolButton)
+bool ToolBoxWidget::toolOn(ToolType toolType, QToolButton* toolButton)
 {
     if (!editor()->tools()->leavingThisTool())
     {
-        if (toolButton->isChecked()) {
-            toolButton->setChecked(false);
-        }
+        toolButton->setChecked(false);
         return false;
     }
+    editor()->tools()->setCurrentTool(toolType);
     return true;
 }

--- a/app/src/toolbox.cpp
+++ b/app/src/toolbox.cpp
@@ -166,6 +166,48 @@ void ToolBoxWidget::updateUI()
 {
 }
 
+void ToolBoxWidget::onToolSetActive(ToolType toolType)
+{
+    deselectAllTools();
+    switch (toolType) {
+    case ToolType::BRUSH:
+        ui->brushButton->setChecked(true);
+        break;
+    case ToolType::PEN:
+        ui->penButton->setChecked(true);
+        break;
+    case ToolType::PENCIL:
+        ui->pencilButton->setChecked(true);
+        break;
+    case ToolType::SELECT:
+        ui->selectButton->setChecked(true);
+        break;
+    case ToolType::HAND:
+        ui->handButton->setChecked(true);
+        break;
+    case ToolType::MOVE:
+        ui->moveButton->setChecked(true);
+        break;
+    case ToolType::ERASER:
+        ui->eraserButton->setChecked(true);
+        break;
+    case ToolType::POLYLINE:
+        ui->polylineButton->setChecked(true);
+        break;
+    case ToolType::SMUDGE:
+        ui->smudgeButton->setChecked(true);
+        break;
+    case ToolType::BUCKET:
+        ui->bucketButton->setChecked(true);
+        break;
+    case ToolType::EYEDROPPER:
+        ui->eyedropperButton->setChecked(true);
+        break;
+    default:
+        break;
+    }
+}
+
 void ToolBoxWidget::pencilOn()
 {
     if (!leavingTool(ui->pencilButton)) { return; }

--- a/app/src/toolbox.h
+++ b/app/src/toolbox.h
@@ -44,6 +44,9 @@ public:
     void updateUI() override;
 
 public slots:
+
+
+    void onToolSetActive(ToolType toolType);
     void pencilOn();
     void eraserOn();
     void selectOn();

--- a/app/src/toolbox.h
+++ b/app/src/toolbox.h
@@ -44,8 +44,6 @@ public:
     void updateUI() override;
 
 public slots:
-
-
     void onToolSetActive(ToolType toolType);
     void pencilOn();
     void eraserOn();

--- a/app/src/toolbox.h
+++ b/app/src/toolbox.h
@@ -65,7 +65,7 @@ signals:
 
 private:
     void deselectAllTools();
-    bool leavingTool(QToolButton*);
+    bool toolOn(ToolType toolType, QToolButton* toolButton);
 
     Ui::ToolBoxWidget* ui = nullptr;
 };

--- a/app/ui/pegbaralignmentdialog.ui
+++ b/app/ui/pegbaralignmentdialog.ui
@@ -19,20 +19,10 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QLabel" name="labHeader">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Peg Bar Alignment:</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="bottomMargin">
+      <number>2</number>
+     </property>
      <item>
       <widget class="QLabel" name="labSelectHeader">
        <property name="font">
@@ -50,14 +40,14 @@
      <item>
       <widget class="QLabel" name="labSelectCenterPegs">
        <property name="text">
-        <string>1) Select a reference area around center pegs.</string>
+        <string>1) Create or drag existing selection.</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="labSelectRefKeyframe">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>2) Select one reference keyframe from timeline.</string>
+        <string>2) Make sure all pegs are within the selection</string>
        </property>
       </widget>
      </item>
@@ -76,6 +66,21 @@
       <string>Layer selection</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>2</number>
+      </property>
+      <property name="leftMargin">
+       <number>2</number>
+      </property>
+      <property name="topMargin">
+       <number>2</number>
+      </property>
+      <property name="rightMargin">
+       <number>2</number>
+      </property>
+      <property name="bottomMargin">
+       <number>2</number>
+      </property>
       <item>
        <widget class="QListWidget" name="lwLayers">
         <property name="selectionMode">
@@ -151,7 +156,7 @@
      <item>
       <widget class="QPushButton" name="btnAlign">
        <property name="text">
-        <string>Align Peg Bars</string>
+        <string>Align</string>
        </property>
        <property name="default">
         <bool>true</bool>

--- a/app/ui/pegbaralignmentdialog.ui
+++ b/app/ui/pegbaralignmentdialog.ui
@@ -45,9 +45,27 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="labelSelectAllFrames">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="lineWidth">
+        <number>1</number>
+       </property>
        <property name="text">
-        <string>2) The selection should contain all pegs</string>
+        <string>2) The selection be large enough to contain the center pegs of all frames</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>-1</number>
        </property>
       </widget>
      </item>
@@ -55,6 +73,9 @@
       <widget class="QLabel" name="labSelectLayers">
        <property name="text">
         <string>3) At least one layer should be selected (Bitmaps only!)</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/app/ui/pegbaralignmentdialog.ui
+++ b/app/ui/pegbaralignmentdialog.ui
@@ -40,21 +40,21 @@
      <item>
       <widget class="QLabel" name="labSelectCenterPegs">
        <property name="text">
-        <string>1) Create or drag existing selection.</string>
+        <string>1) A selection should exist</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>2) Make sure all pegs are within the selection</string>
+        <string>2) The selection should contain all pegs</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QLabel" name="labSelectLayers">
        <property name="text">
-        <string>3) Select at least one layer to align. (Bitmaps only!)</string>
+        <string>3) At least one layer should be selected (Bitmaps only!)</string>
        </property>
       </widget>
      </item>

--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -67,6 +67,7 @@ HEADERS +=  \
     src/structure/layercamera.h \
     src/structure/layersound.h \
     src/structure/layervector.h \
+    src/structure/pegbaraligner.h \
     src/structure/soundclip.h \
     src/structure/object.h \
     src/structure/objectdata.h \
@@ -143,6 +144,7 @@ SOURCES +=  src/graphics/bitmap/bitmapimage.cpp \
     src/structure/layersound.cpp \
     src/structure/layervector.cpp \
     src/structure/object.cpp \
+    src/structure/pegbaraligner.cpp \
     src/structure/soundclip.cpp \
     src/structure/objectdata.cpp \
     src/structure/filemanager.cpp \

--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -675,54 +675,6 @@ void BitmapImage::drawPath(QPainterPath path, QPen pen, QBrush brush,
     modification();
 }
 
-PegbarResult BitmapImage::findLeft(QRectF rect, int grayValue)
-{
-    PegbarResult result;
-    result.value = -1;
-    result.errorcode = Status::FAIL;
-    int left = static_cast<int>(rect.left());
-    int right = static_cast<int>(rect.right());
-    int top = static_cast<int>(rect.top());
-    int bottom = static_cast<int>(rect.bottom());
-    for (int x = left; x <= right; x++)
-    {
-        for (int y = top; y <= bottom; y++)
-        {
-            if (qAlpha(constScanLine(x,y)) == 255 && qGray(constScanLine(x,y)) < grayValue)
-            {
-                result.value = x;
-                result.errorcode = Status::OK;
-                return result;
-            }
-        }
-    }
-    return result;
-}
-
-PegbarResult BitmapImage::findTop(QRectF rect, int grayValue)
-{
-    PegbarResult result;
-    result.value = -1;
-    result.errorcode = Status::FAIL;
-    int left = static_cast<int>(rect.left());
-    int right = static_cast<int>(rect.right());
-    int top = static_cast<int>(rect.top());
-    int bottom = static_cast<int>(rect.bottom());
-    for (int y = top; y <= bottom; y++)
-    {
-        for (int x = left; x <= right; x++)
-        {
-            if (qAlpha(constScanLine(x,y)) == 255 && qGray(constScanLine(x,y)) < grayValue)
-            {
-                result.value = y;
-                result.errorcode = Status::OK;
-                return result;
-            }
-        }
-    }
-    return result;
-}
-
 Status BitmapImage::writeFile(const QString& filename)
 {
     if (mImage && !mImage->isNull())

--- a/core_lib/src/graphics/bitmap/bitmapimage.h
+++ b/core_lib/src/graphics/bitmap/bitmapimage.h
@@ -94,10 +94,6 @@ public:
     int height() { autoCrop(); return mBounds.height(); }
     QSize size() { autoCrop(); return mBounds.size(); }
 
-    // peg bar alignment
-    PegbarResult findLeft(QRectF rect, int grayValue);
-    PegbarResult findTop(QRectF rect, int grayValue);
-
 
     QRect& bounds() { autoCrop(); return mBounds; }
 

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -1065,52 +1065,6 @@ void Editor::swapLayers(int i, int j)
     mScribbleArea->onLayerChanged();
 }
 
-Status Editor::pegBarAlignment(const QStringList& layers)
-{
-    PegbarResult retLeft;
-    PegbarResult retRight;
-
-    LayerBitmap* layerBitmap = static_cast<LayerBitmap*>(mLayerManager->currentLayer());
-    BitmapImage* img = layerBitmap->getBitmapImageAtFrame(currentFrame());
-    QRectF rect = select()->mySelectionRect();
-    retLeft = img->findLeft(rect, 121);
-    retRight = img->findTop(rect, 121);
-    if (STATUS_FAILED(retLeft.errorcode) || STATUS_FAILED(retRight.errorcode))
-    {
-        return Status(Status::FAIL, "", tr("Peg hole not found!\nCheck selection, and please try again.", "PegBar error message"));
-    }
-    const int peg_x = retLeft.value;
-    const int peg_y = retRight.value;
-
-    // move other layers
-    for (int i = 0; i < layers.count(); i++)
-    {
-        layerBitmap = static_cast<LayerBitmap*>(mLayerManager->findLayerByName(layers.at(i)));
-        for (int k = layerBitmap->firstKeyFramePosition(); k <= layerBitmap->getMaxKeyFramePosition(); k++)
-        {
-            if (layerBitmap->keyExists(k))
-            {
-                img = layerBitmap->getBitmapImageAtFrame(k);
-                retLeft = img->findLeft(rect, 121);
-                const QString errorDescription = tr("Peg bar not found at %1, %2").arg(layerBitmap->name()).arg(k);
-                if (STATUS_FAILED(retLeft.errorcode))
-                {
-                    return Status(retLeft.errorcode, "", errorDescription);
-                }
-                retRight = img->findTop(rect, 121);
-                if (STATUS_FAILED(retRight.errorcode))
-                {
-                    return Status(retRight.errorcode, "", errorDescription);
-                }
-                img->moveTopLeft(QPoint(img->left() + (peg_x - retLeft.value), img->top() + (peg_y - retRight.value)));
-            }
-        }
-    }
-    deselectAll();
-
-    return retLeft.errorcode;
-}
-
 void Editor::prepareSave()
 {
     for (auto mgr : mAllManagers)

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -163,7 +163,6 @@ public: //slots
 
     void switchVisibilityOfLayer(int layerNumber);
     void swapLayers(int i, int j);
-    Status pegBarAlignment(const QStringList& layers);
 
     void backup(const QString& undoText);
     void backup(int layerNumber, int frameNumber, const QString& undoText);

--- a/core_lib/src/structure/pegbaraligner.cpp
+++ b/core_lib/src/structure/pegbaraligner.cpp
@@ -1,3 +1,19 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
 #include "pegbaraligner.h"
 
 #include <QDebug>
@@ -7,17 +23,15 @@
 #include <bitmapimage.h>
 #include <layerbitmap.h>
 #include <layermanager.h>
-#include <selectionmanager.h>
 
 PegStatus::PegStatus(ErrorCode code, QPoint point)
     : Status(code), point(point)
 {
 }
 
-PegBarAligner::PegBarAligner(Editor* editor) :
-    mEditor(editor)
+PegBarAligner::PegBarAligner(Editor* editor, QRect searchRect) :
+    mEditor(editor), mPegSearchRect(searchRect)
 {
-    mPegSearchRect = mEditor->select()->mySelectionRect().toAlignedRect();
 }
 
 

--- a/core_lib/src/structure/pegbaraligner.cpp
+++ b/core_lib/src/structure/pegbaraligner.cpp
@@ -1,0 +1,117 @@
+#include "pegbaraligner.h"
+
+#include <QDebug>
+#include <editor.h>
+#include <pencilerror.h>
+
+#include <bitmapimage.h>
+#include <layerbitmap.h>
+#include <layermanager.h>
+#include <selectionmanager.h>
+
+PegStatus::PegStatus(ErrorCode code)
+    : Status(code)
+{
+}
+
+PegbarAligner::PegbarAligner(Editor* editor) :
+    mEditor(editor),
+    mGrayThreshold(121)
+{
+    mPegSearchRect = mEditor->select()->mySelectionRect().toAlignedRect();
+}
+
+
+Status PegbarAligner::align(const QStringList layers)
+{
+    PegStatus result = Status::OK;
+
+    LayerBitmap* layerbitmap = static_cast<LayerBitmap*>(mEditor->layers()->currentLayer());
+    BitmapImage* img = layerbitmap->getBitmapImageAtFrame(mEditor->currentFrame());
+    result = findPoint(*img);
+
+    if (!result.ok())
+    {
+        return Status(Status::FAIL, "", QObject::tr("Peg hole not found!\nCheck selection, and please try again.", "PegBar error message"));
+    }
+
+    const int pegX = result.point.x();
+    const int pegY = result.point.y();
+
+    for (int i = 0; i < layers.count(); i++)
+    {
+        layerbitmap = static_cast<LayerBitmap*>(mEditor->layers()->findLayerByName(layers.at(i)));
+        for (int k = layerbitmap->firstKeyFramePosition(); k <= layerbitmap->getMaxKeyFramePosition(); k++)
+        {
+            if (!layerbitmap->keyExists(k)) { continue; }
+
+            img = layerbitmap->getBitmapImageAtFrame(k);
+            img->enableAutoCrop(false);
+
+            result = findPoint(*img);
+            if (!result.ok())
+            {
+                const QString errorDescription = QObject::tr("Peg bar not found at %1, %2").arg(layerbitmap->name()).arg(k);
+                return Status(result.code(), "", errorDescription);
+            }
+            img->moveTopLeft(QPoint(img->left() + (pegX - result.point.x()), img->top() + (pegY - result.point.y())));
+
+            mEditor->frameModified(img->pos());
+        }
+    }
+
+    mEditor->deselectAll();
+
+    return Status::OK;
+}
+
+
+PegStatus PegbarAligner::findPoint(const BitmapImage& image) const
+{
+    PegStatus result = Status::FAIL;
+    const int left = mPegSearchRect.left();
+    const int right = mPegSearchRect.right();
+    const int top = mPegSearchRect.top();
+    const int bottom = mPegSearchRect.bottom();
+    const int grayValue = mGrayThreshold;
+
+    bool foundX = false;
+
+    for (int x = left; x <= right; x++)
+    {
+        for (int y = top; y <= bottom; y++)
+        {
+            const QRgb& scan = image.constScanLine(x,y);
+            if (qAlpha(scan) == 255 && qGray(scan) < grayValue)
+            {
+                foundX = true;
+                result.point.setX(x);
+
+                break;
+            }
+        }
+        if (foundX) { break; }
+    }
+
+    bool foundY = false;
+    for (int y = top; y <= bottom; y++)
+    {
+        for (int x = left; x <= right; x++)
+        {
+            const QRgb& scan = image.constScanLine(x,y);
+            if (qAlpha(scan) == 255 && qGray(scan) < grayValue)
+            {
+                foundY = true;
+                result.point.setY(y);
+
+                break;
+            }
+        }
+        if (foundY) { break; }
+    }
+
+    if (foundX && foundY) {
+        result.updateStatus(Status::OK);
+    }
+    return result;
+}

--- a/core_lib/src/structure/pegbaraligner.h
+++ b/core_lib/src/structure/pegbaraligner.h
@@ -1,3 +1,19 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
 #ifndef PEGBARALIGNER_H
 #define PEGBARALIGNER_H
 
@@ -20,7 +36,7 @@ class PegBarAligner
 {
     Q_DECLARE_TR_FUNCTIONS(PegBarAligner)
 public:
-    PegBarAligner(Editor* editor);
+    PegBarAligner(Editor* editor, QRect searchRect);
 
     Status align(const QStringList& layers);
 

--- a/core_lib/src/structure/pegbaraligner.h
+++ b/core_lib/src/structure/pegbaraligner.h
@@ -1,0 +1,35 @@
+#ifndef PEGBARALIGNER_H
+#define PEGBARALIGNER_H
+
+#include <pencilerror.h>
+
+#include <QPoint>
+#include <QRectF>
+
+class BitmapImage;
+class Editor;
+
+class PegStatus : public Status
+{
+public:
+    PegStatus(const ErrorCode code);
+    QPoint point;
+};
+
+class PegbarAligner
+{
+public:
+    PegbarAligner(Editor* editor);
+
+    Status align(QStringList layers);
+
+private:
+    PegStatus findPoint(const BitmapImage& image) const;
+
+    Editor* mEditor = nullptr;
+
+    const int mGrayThreshold;
+    QRect mPegSearchRect;
+};
+
+#endif // PEGBARALIGNER_H

--- a/core_lib/src/structure/pegbaraligner.h
+++ b/core_lib/src/structure/pegbaraligner.h
@@ -12,23 +12,24 @@ class Editor;
 class PegStatus : public Status
 {
 public:
-    PegStatus(const ErrorCode code);
+    PegStatus(ErrorCode code, QPoint point = {});
     QPoint point;
 };
 
-class PegbarAligner
+class PegBarAligner
 {
+    Q_DECLARE_TR_FUNCTIONS(PegBarAligner)
 public:
-    PegbarAligner(Editor* editor);
+    PegBarAligner(Editor* editor);
 
-    Status align(QStringList layers);
+    Status align(const QStringList& layers);
 
 private:
     PegStatus findPoint(const BitmapImage& image) const;
 
     Editor* mEditor = nullptr;
 
-    const int mGrayThreshold;
+    const int mGrayThreshold = 121;
     QRect mPegSearchRect;
 };
 

--- a/core_lib/src/util/pencilerror.cpp
+++ b/core_lib/src/util/pencilerror.cpp
@@ -25,10 +25,6 @@ DebugDetails::DebugDetails()
 {
 }
 
-DebugDetails::~DebugDetails()
-{
-}
-
 void DebugDetails::collect(const DebugDetails& d)
 {
     for (const QString& s : d.mDetails)

--- a/core_lib/src/util/pencilerror.h
+++ b/core_lib/src/util/pencilerror.h
@@ -91,17 +91,13 @@ public:
     bool operator==(ErrorCode code) const;
     bool operator!=(ErrorCode code) const;
 
+    virtual void updateStatus(const ErrorCode code) { mCode = code; }
+
 private:
     ErrorCode mCode = OK;
     QString mTitle;
     QString mDescription;
     DebugDetails mDetails;
-};
-
-struct PegbarResult
-{
-    int value = 0;
-    Status::ErrorCode errorcode = Status::OK;
 };
 
 #ifndef STATUS_CHECK

--- a/core_lib/src/util/pencilerror.h
+++ b/core_lib/src/util/pencilerror.h
@@ -25,7 +25,6 @@ class DebugDetails
 {
 public:
     DebugDetails();
-    ~DebugDetails();
 
     void collect(const DebugDetails& d);
     QString str();
@@ -91,7 +90,7 @@ public:
     bool operator==(ErrorCode code) const;
     bool operator!=(ErrorCode code) const;
 
-    virtual void updateStatus(const ErrorCode code) { mCode = code; }
+    void updateStatus(const ErrorCode code) { mCode = code; }
 
 private:
     ErrorCode mCode = OK;

--- a/core_lib/src/util/pencilerror.h
+++ b/core_lib/src/util/pencilerror.h
@@ -90,8 +90,6 @@ public:
     bool operator==(ErrorCode code) const;
     bool operator!=(ErrorCode code) const;
 
-    void updateStatus(const ErrorCode code) { mCode = code; }
-
 private:
     ErrorCode mCode = OK;
     QString mTitle;


### PR DESCRIPTION
The PR is focused on moving pegbar related code into its own core class but it contains a bunch of improvements and fixes too.

Among the list of changes:
- Fix cache issue caused by not calling frameModified.
- PegStatus now inherits from Status to make use of existing functionality.
- Implemented the ability to update a status object while keeping data.
- Wording
<img width="394" alt="image" src="https://user-images.githubusercontent.com/1045397/109428544-bfff6180-79f7-11eb-88af-bf82f078418c.png">



Quality of life improvements:
- "Select" tool will be set upon opening the dialog
- A selection will be made unless one already exists
- First layer will be pre-selected

Other:
- Make sure dialogs are being closed when starting a new project context.
Cleanup code...