### PR TITLE
Fix keyframe undo that would cause crash or double undo in some cases (issue #1557)

### DIFF
--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -199,7 +199,7 @@ void Editor::backup(const QString& undoText)
     }
 }
 
-void Editor::backup(int backupLayer, int backupFrame, const QString& undoText)
+bool Editor::backup(int backupLayer, int backupFrame, const QString& undoText)
 {
     while (mBackupList.size() - 1 > mBackupIndex && !mBackupList.empty())
     {
@@ -236,6 +236,7 @@ void Editor::backup(int backupLayer, int backupFrame, const QString& undoText)
                 mBackupList.append(element);
                 mBackupIndex++;
             }
+            else { return false; }
         }
         else if (layer->type() == Layer::VECTOR)
         {
@@ -254,6 +255,7 @@ void Editor::backup(int backupLayer, int backupFrame, const QString& undoText)
                 mBackupList.append(element);
                 mBackupIndex++;
             }
+            else { return false; }
         }
         else if (layer->type() == Layer::SOUND)
         {
@@ -280,12 +282,15 @@ void Editor::backup(int backupLayer, int backupFrame, const QString& undoText)
                     mBackupIndex++;
                 }
             }
+            else { return false; }
         }
     }
 
     updateAutoSaveCounter();
 
     emit updateBackup();
+
+    return true;
 }
 
 void Editor::sanitizeBackupElementsAfterLayerDeletion(int layerIndex)
@@ -410,20 +415,23 @@ void Editor::undo()
             if (lastBackupElement->type() == BackupElement::BITMAP_MODIF)
             {
                 BackupBitmapElement* lastBackupBitmapElement = static_cast<BackupBitmapElement*>(lastBackupElement);
-                backup(lastBackupBitmapElement->layer, lastBackupBitmapElement->frame, "NoOp");
-                mBackupIndex--;
+                if (backup(lastBackupBitmapElement->layer, lastBackupBitmapElement->frame, "NoOp")) {
+                    mBackupIndex--;
+                }
             }
             if (lastBackupElement->type() == BackupElement::VECTOR_MODIF)
             {
                 BackupVectorElement* lastBackupVectorElement = static_cast<BackupVectorElement*>(lastBackupElement);
-                backup(lastBackupVectorElement->layer, lastBackupVectorElement->frame, "NoOp");
-                mBackupIndex--;
+                if (backup(lastBackupVectorElement->layer, lastBackupVectorElement->frame, "NoOp")) {
+                    mBackupIndex--;
+                }
             }
             if (lastBackupElement->type() == BackupElement::SOUND_MODIF)
             {
                 BackupSoundElement* lastBackupSoundElement = static_cast<BackupSoundElement*>(lastBackupElement);
-                backup(lastBackupSoundElement->layer, lastBackupSoundElement->frame, "NoOp");
-                mBackupIndex--;
+                if (backup(lastBackupSoundElement->layer, lastBackupSoundElement->frame, "NoOp")) {
+                    mBackupIndex--;
+                }
             }
         }
 

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -165,7 +165,7 @@ public: //slots
     void swapLayers(int i, int j);
 
     void backup(const QString& undoText);
-    void backup(int layerNumber, int frameNumber, const QString& undoText);
+    bool backup(int layerNumber, int frameNumber, const QString& undoText);
     /**
      * Restores integrity of the backup elements after a layer has been deleted.
      * Removes backup elements affecting the deleted layer and adjusts the layer


### PR DESCRIPTION
Add boolean return value on backup function so that we can check if the backup was *actually* successful.

Fixes #1557 