### PR TITLE
Prevent stuck cursor icon when transitioning from MMB to RMB

### DIFF
--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -669,7 +669,6 @@ void ScribbleArea::pointerReleaseEvent(PointerEvent* event)
 
     if (event->buttons() & (Qt::RightButton | Qt::MiddleButton))
     {
-        getTool(HAND)->pointerReleaseEvent(event);
         mMouseRightButtonInUse = false;
         return;
     }


### PR DESCRIPTION
Removes call to `HandTool::pointerReleaseEvent`, which would call `ScribbleArea::setPrevTool`, which would call `ToolManager::setCurrentTool` where it would set the previously used tool, but the `HandTool::pointerReleaseEvent` would go on, causing an icon-function mismatch.

Fixes #1198 