### PR TITLE
Upgrade Linux builds to Xenial and Qt 5.15

### DIFF
--- a/.github/actions/install-dependencies/install-dependencies.sh
+++ b/.github/actions/install-dependencies/install-dependencies.sh
@@ -3,31 +3,31 @@
 setup_linux() {
   # Because of how bare-bones our docker image is
   echo "::group::Install prerequisites"
-  sudo apt-get -yq install software-properties-common
+  apt-get -yq install software-properties-common
   echo "::endgroup::"
 
   echo "::group::Add APT sources"
   for ppa in ppa:ubuntu-toolchain-r/test ppa:ubuntu-sdk-team/ppa \
-             ppa:git-core/ppa ppa:mc3man/trusty-media \
-             ppa:beineri/opt-qt597-trusty; do
-    sudo apt-add-repository -y "${ppa}"
+             ppa:git-core/ppa ppa:beineri/opt-qt-5.15.2-xenial; do
+    apt-add-repository -y "${ppa}"
   done
   echo "::endgroup::"
 
   echo "::group::Fetch APT updates"
-  sudo apt-get update -yq
+  apt-get update -yq
   echo "::endgroup::"
 
   echo "::group::Install APT packages"
-  sudo apt-get install -yq --no-install-suggests --no-install-recommends \
-    build-essential qt59tools qt59base qt59multimedia qt59svg qt59xmlpatterns \
-    libgl1-mesa-dev bsdtar ffmpeg gstreamer1.0-plugins-base \
-    gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-alsa \
-    gstreamer1.0-pulseaudio git curl libfuse2 python3 python3-pip
+  apt-get install -yq --no-install-suggests --no-install-recommends \
+    build-essential qt515tools qt515base qt515multimedia qt515svg \
+    qt515xmlpatterns libgl1-mesa-dev bsdtar ffmpeg gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly gstreamer1.0-alsa gstreamer1.0-pulseaudio git \
+    curl libfuse2 python3 python3-pip
   echo "::endgroup::"
 
   echo "::group::Install Python packages"
-  sudo pip3 install --upgrade oauth2client google-api-python-client typing 'setuptools<44'
+  pip3 install --upgrade oauth2client google-api-python-client typing 'setuptools<44'
   echo "::endgroup::"
 }
 

--- a/.github/actions/setup-environment/setup-environment.sh
+++ b/.github/actions/setup-environment/setup-environment.sh
@@ -5,11 +5,11 @@ setup_linux() {
   # Our container image uses the non-Unicode C locale by default
   echo "LANG=C.UTF-8" >> "${GITHUB_ENV}"
   # Set up Qt environment variables and export them to the GitHub Actions workflow
-  (printenv; (. /opt/qt59/bin/qt59-env.sh; printenv)) | sort -st= -k1,1 | uniq -u >> "${GITHUB_ENV}"
+  (printenv; (. /opt/qt515/bin/qt515-env.sh; printenv)) | sort -st= -k1,1 | uniq -u >> "${GITHUB_ENV}"
 }
 
 setup_macos() {
-  echo "MAKEFLAGS=-j2" >> "${GITHUB_ENV}"
+  echo "MAKEFLAGS=-j3" >> "${GITHUB_ENV}"
 }
 
 setup_windows() {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           # XXX: --privileged is sort of a brute-force solution to get FUSE
           #      working inside Docker, however so far I haven’t been able to
           #      figure out precisely *which* privileges are needed.
-          container: { image: "ubuntu:14.04", options: --privileged }
+          container: { image: "ubuntu:16.04", options: --privileged }
           upload-parent: linux_x86_64_parent
         - name: macOS x86_64
           os: macos-10.15
@@ -56,10 +56,11 @@ jobs:
       # container image does not
       if: runner.os == 'Linux'
       run: |
-        sudo apt-get -yq install software-properties-common
-        sudo apt-add-repository -y ppa:git-core/ppa
-        sudo apt-get update -yq
-        sudo apt-get install -yq --no-install-suggests --no-install-recommends git
+        apt-get update -yq
+        apt-get -yq install software-properties-common
+        apt-add-repository -y ppa:git-core/ppa
+        apt-get update -yq
+        apt-get install -yq --no-install-suggests --no-install-recommends git
     - name: Check out repository
       uses: actions/checkout@v2
     - name: Install Qt (Windows)

--- a/app/src/checkupdatesdialog.cpp
+++ b/app/src/checkupdatesdialog.cpp
@@ -16,6 +16,7 @@ GNU General Public License for more details.
 */
 
 #include "checkupdatesdialog.h"
+#include <QDebug>
 #include <QNetworkReply>
 #include <QNetworkAccessManager>
 #include <QHBoxLayout>


### PR DESCRIPTION
[Time to ditch Trusty, it seems!](https://github.com/probonopd/linuxdeployqt/commit/58cbda4aeab0d71b859be59a3eef59df2dd415c6) The code changes in this PR aren’t that interesting, the main focus for review should be testing [the build](https://drive.google.com/file/d/1VtA0n4GEFSVVSodQIFhCT5chveHervtm/view) and making sure all those different dependency versions don‘t cause any regressions (especially for multimedia, since I switched from an unofficial PPA to Ubuntu’s official repositories there). Personally, I haven’t found any issues during my brief test, in fact it confirmed my suspicion that a newer Qt version would finally fix #1017 for good. With any luck, it might also fix some of the other Linux issues such as #1032 which we’ve never been able to reproduce. Still, I think it would be good to have it tested on more systems than just my own.

BTW, I noticed that the AppImage gets noticeably larger with this change. Probably due to additional dependencies being pulled in or something, but I haven’t been able to look into it yet. I don’t want to block this PR over that since this upgrade is necessary to get our Linux builds working again.

I also noticed that macOS runners on GHA actually have 3 cores rather than 2 like the Windows and Linux runners, so I adjusted the MAKEFLAGS accordingly.