### PR TITLE
Selection transformation fixes

### DIFF
--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -157,6 +157,14 @@ BitmapImage BitmapImage::copy(QRect rectangle)
     if (rectangle.isEmpty() || mBounds.isEmpty()) return BitmapImage();
 
     QRect intersection2 = rectangle.translated(-mBounds.topLeft());
+
+    // If the region goes out of bounds, make sure the image is formatted in ARGB
+    // so that the area beyond the image bounds is transparent.
+    if (!mBounds.contains(rectangle) && !image()->hasAlphaChannel())
+    {
+        image()->convertTo(QImage::Format_ARGB32);
+    }
+
     BitmapImage result(rectangle.topLeft(), image()->copy(intersection2));
     return result;
 }

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -908,6 +908,8 @@ void Editor::selectAll() const
 
 void Editor::deselectAll() const
 {
+    select()->resetSelectionProperties();
+
     Layer* layer = layers()->currentLayer();
     if (layer == nullptr) { return; }
 
@@ -919,8 +921,6 @@ void Editor::deselectAll() const
             vectorImage->deselectAll();
         }
     }
-
-    select()->resetSelectionProperties();
 }
 
 void Editor::updateFrame(int frameNumber)

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -411,8 +411,8 @@ void ScribbleArea::keyEventForSelection(QKeyEvent* event)
         mEditor->deselectAll();
         break;
     case Qt::Key_Escape:
-        mEditor->deselectAll();
         cancelTransformedSelection();
+        mEditor->deselectAll();
         break;
     case Qt::Key_Backspace:
         deleteSelection();
@@ -1502,6 +1502,9 @@ void ScribbleArea::cancelTransformedSelection()
         mEditor->select()->setSelection(selectMan->mySelectionRect(), false);
 
         selectMan->resetSelectionProperties();
+
+        setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
+        updateCurrentFrame();
     }
 }
 

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -289,9 +289,7 @@ void MoveTool::setAnchorToLastPoint()
 
 void MoveTool::cancelChanges()
 {
-    auto selectMan = mEditor->select();
     mScribbleArea->cancelTransformedSelection();
-    selectMan->resetSelectionProperties();
     mEditor->deselectAll();
 }
 


### PR DESCRIPTION
This PR contains small fixes for two issues:
1. Transparent areas turning black when transformed (#1641)
2. The view does not update after cancelling a selection with the escape shortcut.