### PR TITLE
Run tests without window system integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
       run: test "${{runner.os}}" != "Windows" && make || nmake
 
     - name: Run tests
+      env: { QT_QPA_PLATFORM: minimal }
       run: build/tests/bin/tests
 
     - name: Create package


### PR DESCRIPTION
As long as we don’t do anything in the tests that actually requires window system integration, this should be enough to make the tests run on CI. Otherwise we’ll need to run an actual display server for the Linux tests, which seems like something of a hassle.