### PR TITLE
WIP Auto save in background (wihtout window popping up)

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -74,6 +74,7 @@ GNU General Public License for more details.
 #include "app_util.h"
 #include "presetdialog.h"
 #include "pegbaralignmentdialog.h"
+#include "backgroundtasks.h"
 
 
 #ifdef GIT_TIMESTAMP
@@ -741,36 +742,12 @@ bool MainWindow2::maybeSave()
 
 bool MainWindow2::autoSave()
 {
-    if (!mEditor->object()->filePath().isEmpty())
-    {
-        return saveDocument();
-    }
+	if (mSuppressAutoSaveDialog)
+		return false;
 
-    if (mEditor->autoSaveNeverAskAgain())
-        return false;
-
-    if(mSuppressAutoSaveDialog)
-        return false;
-
-    QMessageBox msgBox(this);
-    msgBox.setIcon(QMessageBox::Question);
-    msgBox.setWindowTitle(tr("AutoSave Reminder"));
-    msgBox.setText(tr("The animation is not saved yet.\n Do you want to save now?"));
-    msgBox.addButton(tr("Never ask again", "AutoSave reminder button"), QMessageBox::RejectRole);
-    msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-    msgBox.setDefaultButton(QMessageBox::Yes);
-
-    int ret = msgBox.exec();
-    if (ret == QMessageBox::Yes)
-    {
-        return saveDocument();
-    }
-    if (ret != QMessageBox::No) // Never ask again
-    {
-        mEditor->dontAskAutoSave(true);
-    }
-
-    return false;
+    BackgroundTasks* bgTasks = mEditor->backgroundTasks();
+    bgTasks->writeMainXmlToWorkingFolder(mEditor->object());
+    return true;
 }
 
 void MainWindow2::emptyDocumentWhenErrorOccurred()

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -747,6 +747,7 @@ bool MainWindow2::autoSave()
 
     BackgroundTasks* bgTasks = mEditor->backgroundTasks();
     bgTasks->writeMainXmlToWorkingFolder(mEditor->object());
+    bgTasks->writeCurrentFrameToWorkingFolder(mEditor->object(), mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
     return true;
 }
 

--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -31,6 +31,8 @@ INCLUDEPATH += src \
 PRECOMPILED_HEADER = src/corelib-pch.h
 
 HEADERS +=  \
+    src/backgroundtasks.h \
+    src/backgroundworker.h \
     src/corelib-pch.h \
     src/graphics/bitmap/bitmapbucket.h \
     src/graphics/bitmap/bitmapimage.h \
@@ -114,6 +116,8 @@ HEADERS +=  \
 
 
 SOURCES +=  src/graphics/bitmap/bitmapimage.cpp \
+    src/backgroundtasks.cpp \
+    src/backgroundworker.cpp \
     src/graphics/bitmap/bitmapbucket.cpp \
     src/graphics/vector/bezierarea.cpp \
     src/graphics/vector/beziercurve.cpp \

--- a/core_lib/src/backgroundtasks.cpp
+++ b/core_lib/src/backgroundtasks.cpp
@@ -10,56 +10,56 @@
 
 BackgroundTasks::BackgroundTasks(QObject* parent) : QObject(parent)
 {
-	// Need to register QDomDocument so it can be used in multi-threaded signal/slot connections
-	qRegisterMetaType<QDomDocument>("QDomDocument");
+    // Need to register QDomDocument so it can be used in multi-threaded signal/slot connections
+    qRegisterMetaType<QDomDocument>("QDomDocument");
 
-	mWorker = new BackgroundWorker;
-	mWorker->moveToThread(&mWorkerThread);
+    mWorker = new BackgroundWorker;
+    mWorker->moveToThread(&mWorkerThread);
     connect(this, &BackgroundTasks::writeXmlAsync, mWorker, &BackgroundWorker::writeXMLAsync);
     connect(mWorker, &BackgroundWorker::writeXMLAsyncDone, this, &BackgroundTasks::writeXMLAsyncDone);
 
-	connect(this, &BackgroundTasks::writeCurrentFrameAsync, mWorker, &BackgroundWorker::writeKeyFrameAsync);
-	connect(mWorker, &BackgroundWorker::writeKeyFrameDone, this, &BackgroundTasks::writeCurrentFrameDone);
+    connect(this, &BackgroundTasks::writeCurrentFrameAsync, mWorker, &BackgroundWorker::writeKeyFrameAsync);
+    connect(mWorker, &BackgroundWorker::writeKeyFrameDone, this, &BackgroundTasks::writeCurrentFrameDone);
 
-	mWorkerThread.start();
+    mWorkerThread.start();
 }
 
 BackgroundTasks::~BackgroundTasks()
 {
-	mWorkerThread.quit();
-	mWorkerThread.wait(); // Wait until the thread is properly terminated by OS
-	delete mWorker;
+    mWorkerThread.quit();
+    mWorkerThread.wait(); // Wait until the thread is properly terminated by OS
+    delete mWorker;
 }
 
 void BackgroundTasks::writeMainXmlToWorkingFolder(const Object* object)
 {
-	FileManager fm;
-	QDomDocument xmlDoc = fm.generateXMLFromObject(object);
+    FileManager fm;
+    QDomDocument xmlDoc = fm.generateXMLFromObject(object);
 
-	emit writeXmlAsync(xmlDoc, object->mainXMLFile());
+    emit writeXmlAsync(xmlDoc, object->mainXMLFile());
 }
 
 void BackgroundTasks::writeXMLAsyncDone(bool ok, const QString& msg)
 {
-	qDebug() << ok << msg;
+    qDebug() << ok << msg;
 }
 
 void BackgroundTasks::writeCurrentFrameToWorkingFolder(const Object* object, int layerIndex, int frame)
 {
-	Layer* layer = object->getLayer(layerIndex);
-	KeyFrame* key = layer->getKeyFrameAt(frame);
+    Layer* layer = object->getLayer(layerIndex);
+    KeyFrame* key = layer->getKeyFrameAt(frame);
 
-	if (layer->type() == Layer::BITMAP || layer->type() == Layer::VECTOR)
-	{
-		QString keyFramePath = layer->keyFrameFilePath(key, object->dataDir());
-		KeyFrame* copiedKey = key->clone();
+    if (layer->type() == Layer::BITMAP || layer->type() == Layer::VECTOR)
+    {
+        QString keyFramePath = layer->keyFrameFilePath(key, object->dataDir());
+        KeyFrame* copiedKey = key->clone();
 
-		Q_ASSERT(QFileInfo(keyFramePath).isAbsolute());
-		emit writeCurrentFrameAsync(copiedKey, keyFramePath);
-	}
+        Q_ASSERT(QFileInfo(keyFramePath).isAbsolute());
+        emit writeCurrentFrameAsync(copiedKey, keyFramePath);
+    }
 }
 
 void BackgroundTasks::writeCurrentFrameDone(bool ok, const QString& msg)
 {
-	qDebug() << ok << msg;
+    qDebug() << ok << msg;
 }

--- a/core_lib/src/backgroundtasks.cpp
+++ b/core_lib/src/backgroundtasks.cpp
@@ -1,0 +1,40 @@
+#include "backgroundtasks.h"
+#include <QDebug>
+#include <QFile>
+#include "object.h"
+#include "filemanager.h"
+#include "backgroundworker.h"
+
+
+
+BackgroundTasks::BackgroundTasks(QObject* parent) : QObject(parent)
+{
+	// Need to register QDomDocument so it can be used in multi-threaded signal/slot connections
+	qRegisterMetaType<QDomDocument>("QDomDocument");
+
+	mWorker = new BackgroundWorker;
+	mWorker->moveToThread(&mWorkerThread);
+    connect(this, &BackgroundTasks::writeXmlAsync, mWorker, &BackgroundWorker::writeXMLAsync);
+    connect(mWorker, &BackgroundWorker::writeXMLAsyncDone, this, &BackgroundTasks::writeXMLAsyncDone);
+	mWorkerThread.start();
+}
+
+BackgroundTasks::~BackgroundTasks()
+{
+	mWorkerThread.quit();
+	mWorkerThread.wait(); // Wait until the thread is properly terminated by OS
+	delete mWorker;
+}
+
+void BackgroundTasks::writeMainXmlToWorkingFolder(const Object* object)
+{
+	FileManager fm;
+	QDomDocument xmlDoc = fm.generateXMLFromObject(object);
+
+	emit writeXmlAsync(xmlDoc, object->mainXMLFile());
+}
+
+void BackgroundTasks::writeXMLAsyncDone(bool ok, const QString& msg)
+{
+	qDebug() << ok << msg;
+}

--- a/core_lib/src/backgroundtasks.cpp
+++ b/core_lib/src/backgroundtasks.cpp
@@ -1,10 +1,11 @@
 #include "backgroundtasks.h"
 #include <QDebug>
 #include <QFile>
+#include <QFileInfo>
 #include "object.h"
 #include "filemanager.h"
 #include "backgroundworker.h"
-
+#include "keyframe.h"
 
 
 BackgroundTasks::BackgroundTasks(QObject* parent) : QObject(parent)
@@ -16,6 +17,10 @@ BackgroundTasks::BackgroundTasks(QObject* parent) : QObject(parent)
 	mWorker->moveToThread(&mWorkerThread);
     connect(this, &BackgroundTasks::writeXmlAsync, mWorker, &BackgroundWorker::writeXMLAsync);
     connect(mWorker, &BackgroundWorker::writeXMLAsyncDone, this, &BackgroundTasks::writeXMLAsyncDone);
+
+	connect(this, &BackgroundTasks::writeCurrentFrameAsync, mWorker, &BackgroundWorker::writeKeyFrameAsync);
+	connect(mWorker, &BackgroundWorker::writeKeyFrameDone, this, &BackgroundTasks::writeCurrentFrameDone);
+
 	mWorkerThread.start();
 }
 
@@ -35,6 +40,26 @@ void BackgroundTasks::writeMainXmlToWorkingFolder(const Object* object)
 }
 
 void BackgroundTasks::writeXMLAsyncDone(bool ok, const QString& msg)
+{
+	qDebug() << ok << msg;
+}
+
+void BackgroundTasks::writeCurrentFrameToWorkingFolder(const Object* object, int layerIndex, int frame)
+{
+	Layer* layer = object->getLayer(layerIndex);
+	KeyFrame* key = layer->getKeyFrameAt(frame);
+
+	if (layer->type() == Layer::BITMAP || layer->type() == Layer::VECTOR)
+	{
+		QString keyFramePath = layer->keyFrameFilePath(key, object->dataDir());
+		KeyFrame* copiedKey = key->clone();
+
+		Q_ASSERT(QFileInfo(keyFramePath).isAbsolute());
+		emit writeCurrentFrameAsync(copiedKey, keyFramePath);
+	}
+}
+
+void BackgroundTasks::writeCurrentFrameDone(bool ok, const QString& msg)
 {
 	qDebug() << ok << msg;
 }

--- a/core_lib/src/backgroundtasks.h
+++ b/core_lib/src/backgroundtasks.h
@@ -1,0 +1,32 @@
+#ifndef BACKGROUNDTASKS_H
+#define BACKGROUNDTASKS_H
+
+#include <QObject>
+#include <QThread>
+#include <QDomDocument>
+class Object;
+class QDomDocument;
+class BackgroundWorker;
+
+
+class BackgroundTasks : public QObject
+{
+    Q_OBJECT
+public:
+    BackgroundTasks(QObject* parent);
+    ~BackgroundTasks();
+
+    void writeMainXmlToWorkingFolder(const Object* object);
+
+signals:
+    void writeXmlAsync(const QDomDocument& doc, const QString mainXMLPath);
+
+private:
+    void writeXMLAsyncDone(bool ok, const QString& msg);
+
+private:
+    QThread mWorkerThread;
+    BackgroundWorker* mWorker = nullptr;
+};
+
+#endif // BACKGROUNDTASKS_H

--- a/core_lib/src/backgroundtasks.h
+++ b/core_lib/src/backgroundtasks.h
@@ -3,11 +3,10 @@
 
 #include <QObject>
 #include <QThread>
-#include <QDomDocument>
 class Object;
 class QDomDocument;
 class BackgroundWorker;
-
+class KeyFrame;
 
 class BackgroundTasks : public QObject
 {
@@ -17,12 +16,15 @@ public:
     ~BackgroundTasks();
 
     void writeMainXmlToWorkingFolder(const Object* object);
+    void writeCurrentFrameToWorkingFolder(const Object* object, int layerIndex, int frame);
 
 signals:
     void writeXmlAsync(const QDomDocument& doc, const QString mainXMLPath);
+    void writeCurrentFrameAsync(KeyFrame* key, const QString filePath);
 
 private:
     void writeXMLAsyncDone(bool ok, const QString& msg);
+    void writeCurrentFrameDone(bool ok, const QString& msg);
 
 private:
     QThread mWorkerThread;

--- a/core_lib/src/backgroundworker.cpp
+++ b/core_lib/src/backgroundworker.cpp
@@ -1,0 +1,33 @@
+#include "backgroundworker.h"
+#include <QFile>
+#include <QTextStream>
+#include <QDebug>
+#include <QDomDocument>
+#include <QThread>
+
+// The parent is intentionally set as null because The object cannot be moved to a thread if it has a parent.
+// ref: https://doc.qt.io/qt-5/qobject.html#moveToThread
+BackgroundWorker::BackgroundWorker() : QObject(nullptr)
+{
+
+}
+
+void BackgroundWorker::writeXMLAsync(const QDomDocument& doc, const QString filePath)
+{
+    Q_ASSERT(!filePath.isEmpty());
+
+    QFile file(filePath);
+    if (!file.open(QFile::WriteOnly | QFile::Text))
+    {
+        emit writeXMLAsyncDone(false, "Cannot open the file");
+        return;
+    }
+
+    const int indentSize = 2;
+
+    QTextStream out(&file);
+    doc.save(out, indentSize);
+    out.flush();
+    file.close();
+    emit writeXMLAsyncDone(true, QString("Done writing %1").arg(filePath));
+}

--- a/core_lib/src/backgroundworker.cpp
+++ b/core_lib/src/backgroundworker.cpp
@@ -52,8 +52,8 @@ void BackgroundWorker::writeKeyFrameAsync(KeyFrame* key, const QString filePath)
         Q_ASSERT(filePath.endsWith(".vec"));
         Status st = vecImg->write(filePath, "VEC");
 
-		QString msg = QString("Done Writing %1").arg(filePath);
-		emit writeKeyFrameDone(st.ok(), msg);
+        QString msg = QString("Done Writing %1").arg(filePath);
+        emit writeKeyFrameDone(st.ok(), msg);
     }
     delete key;
 }

--- a/core_lib/src/backgroundworker.cpp
+++ b/core_lib/src/backgroundworker.cpp
@@ -4,8 +4,11 @@
 #include <QDebug>
 #include <QDomDocument>
 #include <QThread>
+#include "bitmapimage.h"
+#include "vectorimage.h"
 
-// The parent is intentionally set as null because The object cannot be moved to a thread if it has a parent.
+
+// The object cannot be moved to a thread if it has a parent, so leave it as null
 // ref: https://doc.qt.io/qt-5/qobject.html#moveToThread
 BackgroundWorker::BackgroundWorker() : QObject(nullptr)
 {
@@ -30,4 +33,27 @@ void BackgroundWorker::writeXMLAsync(const QDomDocument& doc, const QString file
     out.flush();
     file.close();
     emit writeXMLAsyncDone(true, QString("Done writing %1").arg(filePath));
+}
+
+void BackgroundWorker::writeKeyFrameAsync(KeyFrame* key, const QString filePath)
+{
+    auto bitmapImg = dynamic_cast<BitmapImage*>(key);
+    if (bitmapImg)
+    {
+        Q_ASSERT(filePath.endsWith(".png"));
+        Status st = bitmapImg->writeFile(filePath);
+
+        QString msg = QString("Done writing %1").arg(filePath);
+        emit writeKeyFrameDone(st.ok(), msg);
+    }
+    auto vecImg = dynamic_cast<VectorImage*>(key);
+    if (vecImg)
+    {
+        Q_ASSERT(filePath.endsWith(".vec"));
+        Status st = vecImg->write(filePath, "VEC");
+
+		QString msg = QString("Done Writing %1").arg(filePath);
+		emit writeKeyFrameDone(st.ok(), msg);
+    }
+    delete key;
 }

--- a/core_lib/src/backgroundworker.h
+++ b/core_lib/src/backgroundworker.h
@@ -2,7 +2,9 @@
 #define BACKGROUNDWORKER_H
 
 #include <QObject>
-#include <QDomDocument>
+class QDomDocument;
+class KeyFrame;
+
 
 class BackgroundWorker : public QObject
 {
@@ -12,9 +14,10 @@ public:
 
 public slots:
     void writeXMLAsync(const QDomDocument& doc, const QString filePath);
-
+    void writeKeyFrameAsync(KeyFrame* key, const QString filePath);
 signals:
-    void writeXMLAsyncDone(bool ok, const QString& result);
+    void writeXMLAsyncDone(bool ok, const QString& msg);
+    void writeKeyFrameDone(bool ok, const QString& msg);
 
 };
 

--- a/core_lib/src/backgroundworker.h
+++ b/core_lib/src/backgroundworker.h
@@ -1,0 +1,22 @@
+#ifndef BACKGROUNDWORKER_H
+#define BACKGROUNDWORKER_H
+
+#include <QObject>
+#include <QDomDocument>
+
+class BackgroundWorker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit BackgroundWorker();
+
+public slots:
+    void writeXMLAsync(const QDomDocument& doc, const QString filePath);
+
+signals:
+    void writeXMLAsyncDone(bool ok, const QString& result);
+
+};
+
+
+#endif // BACKGROUNDWORKER_H

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -44,6 +44,7 @@ GNU General Public License for more details.
 #include "soundmanager.h"
 #include "selectionmanager.h"
 #include "overlaymanager.h"
+#include "backgroundtasks.h"
 
 #include "scribblearea.h"
 #include "timeline.h"
@@ -98,6 +99,8 @@ bool Editor::init()
     {
         pManager->init();
     }
+
+    mBgTasks = new BackgroundTasks(this);
 
     makeConnections();
 
@@ -765,7 +768,6 @@ void Editor::updateObject()
     scrubTo(mObject->data()->getCurrentFrame());
 
     mAutosaveCounter = 0;
-    mAutosaveNeverAskAgain = false;
 
     if (mPreferenceManager)
     {

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -44,6 +44,7 @@ class ScribbleArea;
 class TimeLine;
 class BackupElement;
 class ActiveFramePool;
+class BackgroundTasks;
 
 enum class SETTING;
 
@@ -87,7 +88,9 @@ public:
     void prepareSave();
 
     void setScribbleArea(ScribbleArea* pScirbbleArea) { mScribbleArea = pScirbbleArea; }
-    ScribbleArea* getScribbleArea() { return mScribbleArea; }
+    ScribbleArea* getScribbleArea() const { return mScribbleArea; }
+
+    BackgroundTasks* backgroundTasks() const { return mBgTasks; }
 
     int currentFrame() const;
     int fps();
@@ -114,7 +117,6 @@ public:
     QList<BackupElement*> mBackupList;
 
 signals:
-
     /** This should be emitted after scrubbing */
     void scrubbed(int frameNumber);
 
@@ -196,9 +198,6 @@ public: //slots
     void addTemporaryDir(QTemporaryDir* dir);
 
     void settingUpdated(SETTING);
-
-    void dontAskAutoSave(bool b) { mAutosaveNeverAskAgain = b; }
-    bool autoSaveNeverAskAgain() const { return mAutosaveNeverAskAgain; }
     void resetAutoSaveCounter();
 
 private:
@@ -225,10 +224,11 @@ private:
 
     std::vector< BaseManager* > mAllManagers;
 
+    BackgroundTasks* mBgTasks = nullptr;
+
     bool mIsAutosave = true;
     int mAutosaveNumber = 12;
     int mAutosaveCounter = 0;
-    bool mAutosaveNeverAskAgain = false;
 
     void makeConnections();
     KeyFrame* addKeyFrame(int layerNumber, int frameNumber);

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -176,7 +176,7 @@ bool FileManager::loadObject(Object* object, const QDomElement& root)
 
         if (element.tagName() == "object")
         {
-            ok = object->loadXML(element, [this]{ progressForward(); });
+            ok = object->loadXML(element, [this] { progressForward(); });
             if (!ok) FILEMANAGER_LOG("Failed to Load object");
 
         }
@@ -638,24 +638,24 @@ Status FileManager::writeMainXml(const Object* object, const QString& mainXmlPat
 
 QDomDocument FileManager::generateXMLFromObject(const Object* object)
 {
-	QDomDocument xmlDoc("PencilDocument");
-	QDomElement root = xmlDoc.createElement("document");
-	QDomProcessingInstruction encoding = xmlDoc.createProcessingInstruction("xml", "version=\"1.0\" encoding=\"UTF-8\"");
-	xmlDoc.appendChild(encoding);
-	xmlDoc.appendChild(root);
+    QDomDocument xmlDoc("PencilDocument");
+    QDomElement root = xmlDoc.createElement("document");
+    QDomProcessingInstruction encoding = xmlDoc.createProcessingInstruction("xml", "version=\"1.0\" encoding=\"UTF-8\"");
+    xmlDoc.appendChild(encoding);
+    xmlDoc.appendChild(root);
 
-	// save editor information
-	QDomElement projDataXml = saveProjectData(object->data(), xmlDoc);
-	root.appendChild(projDataXml);
+    // save editor information
+    QDomElement projDataXml = saveProjectData(object->data(), xmlDoc);
+    root.appendChild(projDataXml);
 
-	// save object
-	QDomElement objectElement = object->saveXML(xmlDoc);
-	root.appendChild(objectElement);
+    // save object
+    QDomElement objectElement = object->saveXML(xmlDoc);
+    root.appendChild(objectElement);
 
-	// save Pencil2D version
-	QDomElement versionElem = xmlDoc.createElement("version");
-	versionElem.appendChild(xmlDoc.createTextNode(QString(APP_VERSION)));
-	root.appendChild(versionElem);
+    // save Pencil2D version
+    QDomElement versionElem = xmlDoc.createElement("version");
+    versionElem.appendChild(xmlDoc.createTextNode(QString(APP_VERSION)));
+    root.appendChild(versionElem);
     return xmlDoc;
 }
 

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -617,26 +617,9 @@ Status FileManager::writeMainXml(const Object* object, const QString& mainXmlPat
         return Status(Status::ERROR_FILE_CANNOT_OPEN, dd);
     }
 
-    QDomDocument xmlDoc("PencilDocument");
-    QDomElement root = xmlDoc.createElement("document");
-    QDomProcessingInstruction encoding = xmlDoc.createProcessingInstruction("xml", "version=\"1.0\" encoding=\"UTF-8\"");
-    xmlDoc.appendChild(encoding);
-    xmlDoc.appendChild(root);
-
     progressForward();
 
-    // save editor information
-    QDomElement projDataXml = saveProjectData(object->data(), xmlDoc);
-    root.appendChild(projDataXml);
-
-    // save object
-    QDomElement objectElement = object->saveXML(xmlDoc);
-    root.appendChild(objectElement);
-
-    // save Pencil2D version
-    QDomElement versionElem = xmlDoc.createElement("version");
-    versionElem.appendChild(xmlDoc.createTextNode(QString(APP_VERSION)));
-    root.appendChild(versionElem);
+    QDomDocument xmlDoc = generateXMLFromObject(object);
 
     dd << "Writing main xml file...";
 
@@ -651,6 +634,29 @@ Status FileManager::writeMainXml(const Object* object, const QString& mainXmlPat
 
     filesWritten.append(mainXmlPath);
     return Status(Status::OK, dd);
+}
+
+QDomDocument FileManager::generateXMLFromObject(const Object* object)
+{
+	QDomDocument xmlDoc("PencilDocument");
+	QDomElement root = xmlDoc.createElement("document");
+	QDomProcessingInstruction encoding = xmlDoc.createProcessingInstruction("xml", "version=\"1.0\" encoding=\"UTF-8\"");
+	xmlDoc.appendChild(encoding);
+	xmlDoc.appendChild(root);
+
+	// save editor information
+	QDomElement projDataXml = saveProjectData(object->data(), xmlDoc);
+	root.appendChild(projDataXml);
+
+	// save object
+	QDomElement objectElement = object->saveXML(xmlDoc);
+	root.appendChild(objectElement);
+
+	// save Pencil2D version
+	QDomElement versionElem = xmlDoc.createElement("version");
+	versionElem.appendChild(xmlDoc.createTextNode(QString(APP_VERSION)));
+	root.appendChild(versionElem);
+    return xmlDoc;
 }
 
 Status FileManager::writePalette(const Object* object, const QString& dataFolder, QStringList& filesWritten)

--- a/core_lib/src/structure/filemanager.h
+++ b/core_lib/src/structure/filemanager.h
@@ -50,6 +50,8 @@ public:
     QStringList searchForUnsavedProjects();
     Object* recoverUnsavedProject(QString projectIntermediatePath);
 
+    QDomDocument generateXMLFromObject(const Object* obj);
+
 signals:
     void progressChanged(int progress);
     void progressRangeChanged(int maxValue);

--- a/core_lib/src/structure/layer.h
+++ b/core_lib/src/structure/layer.h
@@ -69,6 +69,7 @@ public:
     void setVisible(bool b) { mVisible = b; }
 
     virtual Status saveKeyFrameFile(KeyFrame*, QString dataPath) = 0;
+    virtual QString keyFrameFilePath(KeyFrame*, const QString dataPath) = 0;
     virtual void loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressForward) = 0;
     virtual QDomElement createDomElement(QDomDocument& doc) const = 0;
     QDomElement createBaseDomElement(QDomDocument& doc) const;

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -57,7 +57,7 @@ void LayerBitmap::loadImageAtFrame(QString path, QPoint topLeft, int frameNumber
 
 Status LayerBitmap::saveKeyFrameFile(KeyFrame* keyframe, QString path)
 {
-    QString strFilePath = filePath(keyframe, QDir(path));
+    QString strFilePath = keyFrameFilePath(keyframe, path);
 
     BitmapImage* bitmapImage = static_cast<BitmapImage*>(keyframe);
 
@@ -87,6 +87,11 @@ Status LayerBitmap::saveKeyFrameFile(KeyFrame* keyframe, QString path)
     return Status::OK;
 }
 
+QString LayerBitmap::keyFrameFilePath(KeyFrame* key, QString dataPath)
+{
+    return QDir(dataPath).filePath(fileName(key));
+}
+
 KeyFrame* LayerBitmap::createKeyFrame(int position, Object*)
 {
     BitmapImage* b = new BitmapImage;
@@ -106,7 +111,7 @@ Status LayerBitmap::presave(const QString& sDataFolder)
         // (b->fileName() != fileName(b) && !modified => the keyframe has been moved, but users didn't draw on it.
         if (!bitmap->fileName().isEmpty()
             && !bitmap->isModified()
-            && bitmap->fileName() != filePath(bitmap, dataFolder))
+            && bitmap->fileName() != keyFrameFilePath(bitmap, dataFolder.absolutePath()))
         {
             movedOnlyBitmaps.push_back(bitmap);
         }
@@ -129,7 +134,7 @@ Status LayerBitmap::presave(const QString& sDataFolder)
 
     for (BitmapImage* b : movedOnlyBitmaps)
     {
-        QString dest = filePath(b, dataFolder);
+        QString dest = keyFrameFilePath(b, sDataFolder);
         QFile::remove(dest);
 
         QFile::rename(b->fileName(), dest);
@@ -137,11 +142,6 @@ Status LayerBitmap::presave(const QString& sDataFolder)
     }
 
     return Status::OK;
-}
-
-QString LayerBitmap::filePath(KeyFrame* key, const QDir& dataFolder) const
-{
-    return dataFolder.filePath(fileName(key));
 }
 
 QString LayerBitmap::fileName(KeyFrame* key) const

--- a/core_lib/src/structure/layerbitmap.h
+++ b/core_lib/src/structure/layerbitmap.h
@@ -30,6 +30,9 @@ public:
     LayerBitmap(Object* object);
     ~LayerBitmap() override;
 
+	Status saveKeyFrameFile(KeyFrame*, QString strPath) override;
+    QString keyFrameFilePath(KeyFrame*, const QString dataPath) override;
+
     QDomElement createDomElement(QDomDocument& doc) const override;
     void loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressStep) override;
     Status presave(const QString& sDataFolder) override;
@@ -38,12 +41,10 @@ public:
     BitmapImage* getLastBitmapImageAtFrame(int frameNumber, int increment = 0);
 
 protected:
-    Status saveKeyFrameFile(KeyFrame*, QString strPath) override;
     KeyFrame* createKeyFrame(int position, Object*) override;
 
 private:
     void loadImageAtFrame(QString strFilePath, QPoint topLeft, int frameNumber, qreal opacity);
-    QString filePath(KeyFrame* key, const QDir& dataFolder) const;
     QString fileName(KeyFrame* key) const;
     bool needSaveFrame(KeyFrame* key, const QString& strSavePath);
 };

--- a/core_lib/src/structure/layerbitmap.h
+++ b/core_lib/src/structure/layerbitmap.h
@@ -30,7 +30,7 @@ public:
     LayerBitmap(Object* object);
     ~LayerBitmap() override;
 
-	Status saveKeyFrameFile(KeyFrame*, QString strPath) override;
+    Status saveKeyFrameFile(KeyFrame*, QString strPath) override;
     QString keyFrameFilePath(KeyFrame*, const QString dataPath) override;
 
     QDomElement createDomElement(QDomDocument& doc) const override;

--- a/core_lib/src/structure/layercamera.h
+++ b/core_lib/src/structure/layercamera.h
@@ -33,6 +33,7 @@ public:
 
     QDomElement createDomElement(QDomDocument& doc) const override;
     void loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressStep) override;
+    QString keyFrameFilePath(KeyFrame*, const QString dataPath) override { return QString(); }
 
     Camera* getCameraAtFrame(int frameNumber);
     Camera* getLastCameraAtFrame(int frameNumber, int increment);

--- a/core_lib/src/structure/layersound.h
+++ b/core_lib/src/structure/layersound.h
@@ -31,6 +31,7 @@ public:
     ~LayerSound();
     QDomElement createDomElement(QDomDocument& doc) const override;
     void loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressStep) override;
+    QString keyFrameFilePath(KeyFrame*, const QString dataPath) override { return QString(); }
 
     Status loadSoundClipAtFrame( const QString& sSoundClipName, const QString& filePathString, int frame );
     void updateFrameLengths(int fps);

--- a/core_lib/src/structure/layervector.cpp
+++ b/core_lib/src/structure/layervector.cpp
@@ -78,7 +78,7 @@ void LayerVector::loadImageAtFrame(QString path, int frameNumber)
 Status LayerVector::saveKeyFrameFile(KeyFrame* keyFrame, QString path)
 {
     QString theFileName = fileName(keyFrame);
-    QString strFilePath = QDir(path).filePath(theFileName);
+    QString strFilePath = keyFrameFilePath(keyFrame, path);
 
     VectorImage* vecImage = static_cast<VectorImage*>(keyFrame);
 
@@ -185,6 +185,11 @@ void LayerVector::loadDomElement(const QDomElement& element, QString dataDirPath
         }
         imageTag = imageTag.nextSibling();
     }
+}
+
+QString LayerVector::keyFrameFilePath(KeyFrame* key, QString dataPath)
+{
+    return QDir(dataPath).filePath(fileName(key));
 }
 
 VectorImage* LayerVector::getVectorImageAtFrame(int frameNumber) const

--- a/core_lib/src/structure/layervector.h
+++ b/core_lib/src/structure/layervector.h
@@ -30,11 +30,10 @@ public:
     LayerVector(Object* object);
     ~LayerVector();
 
-    // method from layerImage
     void loadImageAtFrame(QString strFileName, int);
-
     QDomElement createDomElement(QDomDocument& doc) const override;
     void loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressStep) override;
+    QString keyFrameFilePath(KeyFrame*, QString dataPath) override;
 
     VectorImage* getVectorImageAtFrame(int frameNumber) const;
     VectorImage* getLastVectorImageAtFrame(int frameNumber, int increment) const;

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -60,6 +60,7 @@ Object::~Object()
 void Object::init()
 {
     createWorkingDir();
+    mMainXMLFile = QDir(mWorkingDirPath).filePath(PFF_XML_FILE_NAME);
 
     // default palette
     loadDefaultPalette();


### PR DESCRIPTION
A new autosave implementation. The goal is to minimize the interruption and run the auto-save mostly in background. 

The main differences are:

1.  When an auto-save is triggered, write only the `main.xml` and the current bitmap/vector frame to the working directory, rather than running a complete save process.
2. Using a background worker thread writing files to disks without blocking the main thread.
3. No window popup anymore.

This is the first attempt to use a background thread in Pencil2D. Basically, I followed the [QThread official example](https://doc.qt.io/qt-5/qthread.html) to implement this feature. The `BackgroundTasks` object is where all the async tasks are managed, and the actual work is done in `BackgroundWorker` running on another thread. Async tasks are driven by Qt's cross-thread signal/slot connections between `BackgroundTasks` and `BackgroundWorker`.

To avoid a data race between threads, the data preparation, including generating XML doc object of `main.xml` and bitmap/vector frame data copy are still in the main thread. The worker thread then takes the data and does the time-consuming part: writing to the disk.

I have done some benchmarking with a 1000-frame project. 

Here is the time measured in milliseconds for each step:

1. Preparing data: 4-5ms
2. Writing `main.xml` to disk: 16-34ms
3. Writing a bitmap frame PNG to disk: 8-100ms (depends on the image size)
4. Writing a vector frame `.VEC` to disk: 4-30ms (depends on the complexity of the vector image)

As you can see, only **step 1** is in the main thread, so the new auto-save will only block users around 4-5ms. **step 2** to **step 4** is in the background so users will not be aware of it.

I hope this improvement can encourage everyone to enable the auto-save without being interrupted regularly.