### PR TITLE
Implement device pixel ratio for canvas

### DIFF
--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -761,10 +761,9 @@ void ScribbleArea::mouseDoubleClickEvent(QMouseEvent* e)
 void ScribbleArea::resizeEvent(QResizeEvent* event)
 {
     QWidget::resizeEvent(event);
-    const qreal dpr = devicePixelRatioF();
-    mCanvas = QPixmap(QSizeF(size() * dpr).toSize());
+    mDevicePixelRatio = devicePixelRatioF();
+    mCanvas = QPixmap(QSizeF(size() * mDevicePixelRatio).toSize());
     mCanvas.fill(Qt::transparent);
-    mDevicePixelRatio = dpr;
 
     mEditor->view()->setCanvasSize(size());
 

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -761,8 +761,10 @@ void ScribbleArea::mouseDoubleClickEvent(QMouseEvent* e)
 void ScribbleArea::resizeEvent(QResizeEvent* event)
 {
     QWidget::resizeEvent(event);
-    mCanvas = QPixmap(size());
+    const qreal dpr = devicePixelRatioF();
+    mCanvas = QPixmap(QSizeF(size() * dpr).toSize());
     mCanvas.fill(Qt::transparent);
+    mDevicePixelRatio = dpr;
 
     mEditor->view()->setCanvasSize(size());
 
@@ -1239,6 +1241,7 @@ void ScribbleArea::prepCanvas(int frame, QRect rect)
 void ScribbleArea::drawCanvas(int frame, QRect rect)
 {
     mCanvas.fill(Qt::transparent);
+    mCanvas.setDevicePixelRatio(mDevicePixelRatio);
     prepCanvas(frame, rect);
     mCanvasPainter.paint();
     prepOverlays();

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -271,6 +271,7 @@ private:
     bool mMouseInUse = false;
     bool mMouseRightButtonInUse = false;
     bool mTabletInUse = false;
+    qreal mDevicePixelRatio = 1.;
 
     // Double click handling for tablet input
     void handleDoubleClick();

--- a/core_lib/src/overlaypainter.cpp
+++ b/core_lib/src/overlaypainter.cpp
@@ -27,6 +27,7 @@ void OverlayPainter::setViewTransform(const QTransform view)
 void OverlayPainter::renderOverlays(QPainter &painter, MoveMode mode)
 {
     mMoveMode = mode;
+    painter.save();
 
     if (mOptions.bCenter)
     {
@@ -67,6 +68,7 @@ void OverlayPainter::renderOverlays(QPainter &painter, MoveMode mode)
         painter.setWorldTransform(mViewTransform);
         paintOverlayPerspective3(painter);
     }
+    painter.restore();
 }
 
 void OverlayPainter::paintOverlayCenter(QPainter &painter)


### PR DESCRIPTION
This will make anything painted on the canvas pixmap much crisper, on high resolutions screens.

The change will be noticeable as soon as we begin to draw more elements eg. (the work done in #1587), it might also improve the overall image quality of the drawings on said screens. 