### PR TITLE
Upload nightly builds only if key is available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,8 @@ jobs:
         arch: ${{matrix.arch}}
 
     - name: Upload package
+      env: { GOOGLE_PRIVATE_KEY: "${{secrets.google_private_key}}" }
+      if: env.GOOGLE_PRIVATE_KEY != null
       uses: ./.github/actions/upload-package
       with:
         google-private-key: ${{secrets.google_private_key}}


### PR DESCRIPTION
Should hopefully fix the failing PR builds. Let’s see if this works.