### PR TITLE
[WIP] Add AppImageUpdate support to Linux AppImage releases

### DIFF
--- a/.github/actions/create-package/action.yml
+++ b/.github/actions/create-package/action.yml
@@ -19,3 +19,4 @@ runs:
     env:
       RUNNER_OS: ${{runner.os}}
       INPUT_ARCH: ${{inputs.arch}}
+      IS_RELEASE: ${{ github.ref == 'refs/heads/release' }}

--- a/.github/actions/create-package/create-package.sh
+++ b/.github/actions/create-package/create-package.sh
@@ -25,6 +25,10 @@ create_package_linux() {
   done
   curl -fsSLO https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
   chmod 755 linuxdeployqt-continuous-x86_64.AppImage
+  local update_info="" # Currently no appimageupdate support for nightly builds
+  if [ $IS_RELEASE = "true" ]; then
+    update_info='-updateinformation=gh-releases-zsync|pencil2d|pencil|latest|pencil2d-linux-amd64-*.AppImage.zsync'
+  fi
   LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/lib/x86_64-linux-gnu/pulseaudio" \
     ./linuxdeployqt-continuous-x86_64.AppImage \
     Pencil2D/usr/share/applications/org.pencil2d.Pencil2D.desktop \
@@ -33,9 +37,17 @@ create_package_linux() {
     -extra-plugins=platforms/libqwayland-egl.so,platforms/libqwayland-generic.so,\
 platforms/libqwayland-xcomposite-egl.so,platforms/libqwayland-xcomposite-glx.so,\
 wayland-decoration-client,wayland-graphics-integration-client,wayland-shell-integration \
+    ${update_info} \
     -appimage
-  mv Pencil2D*.AppImage* "pencil2d-linux-$1-$(date +%F).AppImage"
-  echo "::set-output name=package-name::pencil2d-linux-$1-$(date +%F).AppImage"
+  local output_name="pencil2d-linux-$1-$(date +%F)"
+  mv Pencil2D*.AppImage "$output_name.AppImage"
+  mv Pencil2D*.AppImage.zsync "$output_name.AppImage.zsync" || true
+  if [ $IS_RELEASE = "true" ] && [ -e "$output_name.AppImage.zsync" ]; then
+    zip "$output_name.zip" "$output_name.AppImage" "$output_name.AppImage.zsync"
+    echo "::set-output name=package-name::$output_name.zip"
+  else
+    echo "::set-output name=package-name::$output_name.AppImage"
+  fi
   echo "::endgroup::"
 }
 

--- a/.github/actions/install-dependencies/install-dependencies.sh
+++ b/.github/actions/install-dependencies/install-dependencies.sh
@@ -23,7 +23,7 @@ setup_linux() {
     qt515xmlpatterns qt515wayland libgl1-mesa-dev bsdtar ffmpeg \
     gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-alsa \
-    gstreamer1.0-pulseaudio git curl libfuse2 python3 python3-pip
+    gstreamer1.0-pulseaudio git curl libfuse2 python3 python3-pip zip
   echo "::endgroup::"
 
   echo "::group::Install Python packages"


### PR DESCRIPTION
This adds the update information to the appimage through linuxdeploy's `updateinformation` parameter when building from the release branch. This should cause it to generate a .zsync file which is zipped together with the AppImage for release uploads. In future releases this file will be included with the other release assets on Github.

This is marked WIP because I do not have the ability to full test this (my fork's CI environment is not set up to support uploads). I need someone to test that it uploads the files correctly still for the Linux builds, particularly on a release branch. I have tested enough to tell that it will work up until the upload step at least on both release and non-release branches. If someone could share the uploaded or link the release zip here, that would also be helpful as someone needs to verify that the update information is correctly embedded in the appimage and I should be able to do that if I get a copy of the appimage.