### PR TITLE
Removed two lines of code that made the software crash #1684

### DIFF
--- a/core_lib/src/structure/layercamera.cpp
+++ b/core_lib/src/structure/layercamera.cpp
@@ -111,11 +111,9 @@ void LayerCamera::linearInterpolateTransform(Camera* cam)
 
     int frameNumber = cam->pos();
     Camera* camera1 = static_cast<Camera*>(getLastKeyFrameAtPosition(frameNumber - 1));
-    camera1->setEasingType(camera1->getEasingType());
 
     int nextFrame = getNextKeyFramePosition(frameNumber);
     Camera* camera2 = static_cast<Camera*>(getLastKeyFrameAtPosition(nextFrame));
-    camera2->setEasingType(camera2->getEasingType());
 
     if (camera1 == nullptr && camera2 == nullptr)
     {


### PR DESCRIPTION
Realized that since the camera is born with a EasingType, there was no need to add it, so the two lines of code, that made the software crash under certain circumstances, have been deleted.
The function containing the two lines of code is heavily improved in a PR #1587, and this PR is hopefully merged into the master branch soon, so just deleting the two lines of code if sufficient now, in my opinion.
Solves #1684