### PR TITLE
Duplicate layer function added to layer buttons. 

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -700,7 +700,7 @@ void ActionCommands::duplicateLayer()
 
     Layer* toLayer = Lmgr->createLayer(fromLayer->type(), fromLayer->name() + tr("_copy"));
     fromLayer->foreachKeyFrame([&] (KeyFrame* key) {
-       key = fromLayer->getKeyFrameAt(key->pos());
+       key = fromLayer->getKeyFrameAt(key->pos())->clone();
        toLayer->addKeyFrame(key->pos(), key);
     });
 }

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -23,7 +23,7 @@ GNU General Public License for more details.
 #include <QDesktopServices>
 #include <QStandardPaths>
 #include <QFileDialog>
-
+#include <QDebug>
 #include "pencildef.h"
 #include "editor.h"
 #include "object.h"
@@ -691,6 +691,38 @@ void ActionCommands::removeKey()
     if (layer->keyFrameCount() == 0 && layer->type() != Layer::SOUND)
     {
         layer->addNewKeyFrameAt(1);
+    }
+}
+
+void ActionCommands::duplicateLayer()
+{
+    LayerManager* Lmgr = mEditor->layers();
+    Layer* fromLayer = Lmgr->currentLayer();
+    if (fromLayer->type() == Layer::BITMAP)
+    {
+        mEditor->scrubTo(fromLayer->firstKeyFramePosition());
+        Layer* toLayer = Lmgr->createBitmapLayer(fromLayer->name() + "_copy");
+        fromLayer->foreachKeyFrame([&] (KeyFrame* key){
+           key = fromLayer->getKeyFrameAt(key->pos());
+           if (toLayer->keyExists(key->pos()))
+               toLayer->removeKeyFrame(key->pos());
+           toLayer->addKeyFrame(key->pos(), key);
+        });
+    }
+    else if (fromLayer->type() == Layer::VECTOR)
+    {
+        mEditor->scrubTo(fromLayer->firstKeyFramePosition());
+        Layer* toLayer = Lmgr->createVectorLayer(fromLayer->name() + "_copy");
+        fromLayer->foreachKeyFrame([&] (KeyFrame* key){
+           key = fromLayer->getKeyFrameAt(key->pos());
+           if (toLayer->keyExists(key->pos()))
+               toLayer->removeKeyFrame(key->pos());
+           toLayer->addKeyFrame(key->pos(), key);
+        });
+    }
+    else
+    {
+        return;
     }
 }
 

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -697,54 +697,12 @@ void ActionCommands::duplicateLayer()
 {
     LayerManager* Lmgr = mEditor->layers();
     Layer* fromLayer = Lmgr->currentLayer();
-    if (fromLayer->type() == Layer::BITMAP)
-    {
-        mEditor->scrubTo(fromLayer->firstKeyFramePosition());
-        Layer* toLayer = Lmgr->createBitmapLayer(fromLayer->name() + "_copy");
-        fromLayer->foreachKeyFrame([&] (KeyFrame* key){
-           key = fromLayer->getKeyFrameAt(key->pos());
-           if (toLayer->keyExists(key->pos()))
-               toLayer->removeKeyFrame(key->pos());
-           toLayer->addKeyFrame(key->pos(), key);
-        });
-    }
-    else if (fromLayer->type() == Layer::VECTOR)
-    {
-        mEditor->scrubTo(fromLayer->firstKeyFramePosition());
-        Layer* toLayer = Lmgr->createVectorLayer(fromLayer->name() + "_copy");
-        fromLayer->foreachKeyFrame([&] (KeyFrame* key){
-           key = fromLayer->getKeyFrameAt(key->pos());
-           if (toLayer->keyExists(key->pos()))
-               toLayer->removeKeyFrame(key->pos());
-           toLayer->addKeyFrame(key->pos(), key);
-        });
-    }
-    else if (fromLayer->type() == Layer::SOUND)
-    {
-        mEditor->scrubTo(fromLayer->firstKeyFramePosition());
-        Layer* toLayer = Lmgr->createSoundLayer(fromLayer->name() + "_copy");
-        fromLayer->foreachKeyFrame([&] (KeyFrame* key){
-           key = fromLayer->getKeyFrameAt(key->pos());
-           if (toLayer->keyExists(key->pos()))
-               toLayer->removeKeyFrame(key->pos());
-           toLayer->addKeyFrame(key->pos(), key);
-        });
-    }
-    else if (fromLayer->type() == Layer::CAMERA)
-    {
-        mEditor->scrubTo(fromLayer->firstKeyFramePosition());
-        Layer* toLayer = Lmgr->createCameraLayer(fromLayer->name() + "_copy");
-        fromLayer->foreachKeyFrame([&] (KeyFrame* key){
-           key = fromLayer->getKeyFrameAt(key->pos());
-           if (toLayer->keyExists(key->pos()))
-               toLayer->removeKeyFrame(key->pos());
-           toLayer->addKeyFrame(key->pos(), key);
-        });
-    }
-    else
-    {
-        return;
-    }
+
+    Layer* toLayer = Lmgr->createLayer(fromLayer->type(), fromLayer->name() + tr("_copy"));
+    fromLayer->foreachKeyFrame([&] (KeyFrame* key) {
+       key = fromLayer->getKeyFrameAt(key->pos());
+       toLayer->addKeyFrame(key->pos(), key);
+    });
 }
 
 void ActionCommands::duplicateKey()

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -23,7 +23,6 @@ GNU General Public License for more details.
 #include <QDesktopServices>
 #include <QStandardPaths>
 #include <QFileDialog>
-#include <QDebug>
 #include "pencildef.h"
 #include "editor.h"
 #include "object.h"
@@ -713,6 +712,28 @@ void ActionCommands::duplicateLayer()
     {
         mEditor->scrubTo(fromLayer->firstKeyFramePosition());
         Layer* toLayer = Lmgr->createVectorLayer(fromLayer->name() + "_copy");
+        fromLayer->foreachKeyFrame([&] (KeyFrame* key){
+           key = fromLayer->getKeyFrameAt(key->pos());
+           if (toLayer->keyExists(key->pos()))
+               toLayer->removeKeyFrame(key->pos());
+           toLayer->addKeyFrame(key->pos(), key);
+        });
+    }
+    else if (fromLayer->type() == Layer::SOUND)
+    {
+        mEditor->scrubTo(fromLayer->firstKeyFramePosition());
+        Layer* toLayer = Lmgr->createSoundLayer(fromLayer->name() + "_copy");
+        fromLayer->foreachKeyFrame([&] (KeyFrame* key){
+           key = fromLayer->getKeyFrameAt(key->pos());
+           if (toLayer->keyExists(key->pos()))
+               toLayer->removeKeyFrame(key->pos());
+           toLayer->addKeyFrame(key->pos(), key);
+        });
+    }
+    else if (fromLayer->type() == Layer::CAMERA)
+    {
+        mEditor->scrubTo(fromLayer->firstKeyFramePosition());
+        Layer* toLayer = Lmgr->createCameraLayer(fromLayer->name() + "_copy");
         fromLayer->foreachKeyFrame([&] (KeyFrame* key){
            key = fromLayer->getKeyFrameAt(key->pos());
            if (toLayer->keyExists(key->pos()))

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -103,7 +103,6 @@ private:
     void exposeSelectedFrames(int offset);
 
     Status convertSoundToWav(const QString& filePath);
-    Status loadSoundClipOnDuplicating(const QString& filePath);
 
     Editor* mEditor = nullptr;
     QWidget* mParent = nullptr;

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -103,6 +103,7 @@ private:
     void exposeSelectedFrames(int offset);
 
     Status convertSoundToWav(const QString& filePath);
+    Status loadSoundClipOnDuplicating(const QString& filePath);
 
     Editor* mEditor = nullptr;
     QWidget* mParent = nullptr;

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -67,6 +67,7 @@ public:
     /** Will insert a keyframe at the current position and push connected frames to the right */
     Status insertKeyFrameAtCurrentPosition();
     void removeKey();
+    void duplicateLayer();
     void duplicateKey();
     void moveFrameForward();
     void moveFrameBackward();

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1396,6 +1396,7 @@ void MainWindow2::makeConnections(Editor* editor, ScribbleArea* scribbleArea)
 void MainWindow2::makeConnections(Editor* pEditor, TimeLine* pTimeline)
 {
     PlaybackManager* pPlaybackManager = pEditor->playback();
+    connect(pTimeline, &TimeLine::duplicateLayerClick, mCommands, &ActionCommands::duplicateLayer);
     connect(pTimeline, &TimeLine::duplicateKeyClick, mCommands, &ActionCommands::duplicateKey);
 
     connect(pTimeline, &TimeLine::soundClick, pPlaybackManager, &PlaybackManager::enableSound);

--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -81,9 +81,15 @@ void TimeLine::initUI()
     removeLayerButton->setToolTip(tr("Remove Layer"));
     removeLayerButton->setFixedSize(24, 24);
 
+    QToolButton* duplicateLayerButton = new QToolButton(this);
+    duplicateLayerButton->setIcon(QIcon(":icons/controls/duplicate.png"));
+    duplicateLayerButton->setToolTip(tr("Duplicate Layer (Artwork layers only)"));
+    duplicateLayerButton->setFixedSize(24, 24);
+
     layerButtons->addWidget(layerLabel);
     layerButtons->addWidget(addLayerButton);
     layerButtons->addWidget(removeLayerButton);
+    layerButtons->addWidget(duplicateLayerButton);
     layerButtons->setFixedHeight(30);
 
     QHBoxLayout* leftToolBarLayout = new QHBoxLayout();
@@ -200,6 +206,7 @@ void TimeLine::initUI()
 
     connect(addKeyButton, &QToolButton::clicked, this, &TimeLine::insertKeyClick);
     connect(removeKeyButton, &QToolButton::clicked, this, &TimeLine::removeKeyClick);
+    connect(duplicateLayerButton, &QToolButton::clicked, this , &TimeLine::duplicateLayerClick);
     connect(duplicateKeyButton, &QToolButton::clicked, this, &TimeLine::duplicateKeyClick);
     connect(zoomSlider, &QSlider::valueChanged, mTracks, &TimeLineCells::setFrameSize);
 

--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -83,7 +83,7 @@ void TimeLine::initUI()
 
     QToolButton* duplicateLayerButton = new QToolButton(this);
     duplicateLayerButton->setIcon(QIcon(":icons/controls/duplicate.png"));
-    duplicateLayerButton->setToolTip(tr("Duplicate Layer (Artwork layers only)"));
+    duplicateLayerButton->setToolTip(tr("Duplicate Layer"));
     duplicateLayerButton->setFixedSize(24, 24);
 
     layerButtons->addWidget(layerLabel);

--- a/core_lib/src/interface/timeline.h
+++ b/core_lib/src/interface/timeline.h
@@ -59,6 +59,7 @@ signals:
 
     void insertKeyClick();
     void removeKeyClick();
+    void duplicateLayerClick();
     void duplicateKeyClick();
 
     void newBitmapLayer();

--- a/core_lib/src/managers/layermanager.cpp
+++ b/core_lib/src/managers/layermanager.cpp
@@ -182,6 +182,34 @@ QString LayerManager::nameSuggestLayer(const QString& name)
     return newName;
 }
 
+Layer* LayerManager::createLayer(Layer::LAYER_TYPE type, const QString& strLayerName)
+{
+    Layer* layer = nullptr;
+    switch (type) {
+    case Layer::BITMAP:
+        layer = object()->addNewBitmapLayer();
+        break;
+    case Layer::VECTOR:
+        layer = object()->addNewVectorLayer();
+        break;
+    case Layer::SOUND:
+        layer = object()->addNewSoundLayer();
+        break;
+    case Layer::CAMERA:
+        layer = object()->addNewCameraLayer();
+        break;
+    default:
+        Q_ASSERT(true);
+        return nullptr;
+    }
+
+    layer->setName(strLayerName);
+    emit layerCountChanged(count());
+    setCurrentLayer(getLastLayerIndex());
+
+    return layer;
+}
+
 LayerBitmap* LayerManager::createBitmapLayer(const QString& strLayerName)
 {
     LayerBitmap* layer = object()->addNewBitmapLayer();

--- a/core_lib/src/managers/layermanager.h
+++ b/core_lib/src/managers/layermanager.h
@@ -56,6 +56,8 @@ public:
     void gotoNextLayer();
     void gotoPreviouslayer();
 
+    /** Returns a new Layer with the given LAYER_TYPE */
+    Layer* createLayer(Layer::LAYER_TYPE type, const QString& strLayerName);
     LayerBitmap* createBitmapLayer(const QString& strLayerName);
     LayerVector* createVectorLayer(const QString& strLayerName);
     LayerCamera* createCameraLayer(const QString& strLayerName);


### PR DESCRIPTION
I made a small PR that can duplicate Bitmap and Vector layers. I've only tested it on bitmap layers, but the code should work with both.
I can't find any reason to duplicate camera or sound layers, so until anyone can see a use-case for that, it is only artwork layers.

Solves #498
![billede](https://user-images.githubusercontent.com/1292931/150870043-91a67e4b-571a-44fa-a6ec-eff4559f02b6.png)
