### PR TITLE
Add mimetype to pclx files

### DIFF
--- a/core_lib/src/qminiz.h
+++ b/core_lib/src/qminiz.h
@@ -17,11 +17,13 @@ GNU General Public License for more details.
 #define QMINIZ_H
 
 #include <QString>
+#include "miniz.h"
 #include "pencilerror.h"
 
 namespace MiniZ
 {
     bool isZip(const QString& sZipFilePath);
+    size_t istreamReadCallback(void *pOpaque, mz_uint64 file_ofs, void * pBuf, size_t n);
     Status compressFolder(QString zipFilePath, QString srcFolderPath, const QStringList& fileList, QString mimetype);
     Status uncompressFolder(QString zipFilePath, QString destPath);
 }

--- a/core_lib/src/qminiz.h
+++ b/core_lib/src/qminiz.h
@@ -22,7 +22,7 @@ GNU General Public License for more details.
 namespace MiniZ
 {
     bool isZip(const QString& sZipFilePath);
-    Status compressFolder(QString zipFilePath, QString srcFolderPath, const QStringList& fileList);
+    Status compressFolder(QString zipFilePath, QString srcFolderPath, const QStringList& fileList, QString mimetype);
     Status uncompressFolder(QString zipFilePath, QString destPath);
 }
 #endif

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -317,7 +317,7 @@ Status FileManager::save(const Object* object, const QString& sFileName)
 
         QString sBackupFile = backupPreviousFile(sFileName);
 
-        Status stMiniz = MiniZ::compressFolder(sFileName, sTempWorkingFolder, filesToZip);
+        Status stMiniz = MiniZ::compressFolder(sFileName, sTempWorkingFolder, filesToZip, "application/x-pencil2d-pclx");
         if (!stMiniz.ok())
         {
             dd.collect(stMiniz.details());


### PR DESCRIPTION
This includes a special "mimetype" file at the beginning of the zip archive of pclx files containing the mime type used for pclx files. Many common zip-based file formats (epub, openraster, openoffice, krita, and more) use this specific approach to help distinguish their files from other zip files. This provides a unique file signature for pclx projects and allows them to be identified by other programs such as the "file" utility on linux, and possibly file association on other platforms as well. This should not impact the reading of project files in any way since the file is outside the data directory and in fact won't even appear in the temporary directory.