### PR TITLE
Sound clip count warning

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -191,6 +191,13 @@ Status ActionCommands::importSound(FileType type)
         mEditor->removeKey();
         emit mEditor->layers()->currentLayerChanged(mEditor->layers()->currentLayerIndex()); // trigger timeline repaint.
     }
+    else
+    {
+        int clipCount = mEditor->sound()->soundClipCount();
+        if (clipCount >= 63) {
+            showSoundClipWarning(clipCount);
+        }
+    }
 
     return st;
 }
@@ -721,6 +728,10 @@ void ActionCommands::duplicateKey()
     if (layer->type() == Layer::SOUND)
     {
         mEditor->sound()->processSound(dynamic_cast<SoundClip*>(dupKey));
+        int clipCount = mEditor->sound()->soundClipCount();
+        if (clipCount >= 63) {
+            showSoundClipWarning(clipCount);
+        }
     }
     else
     {
@@ -929,4 +940,13 @@ void ActionCommands::about()
     aboutBox->setAttribute(Qt::WA_DeleteOnClose);
     aboutBox->init();
     aboutBox->exec();
+}
+
+void ActionCommands::showSoundClipWarning(int clipCount)
+{
+    if (mSuppressSoundWarning) return;
+
+    QMessageBox::warning(mParent, tr("Warning"), tr("You currently have a total of %1 sound clips. Due to current limitations, you will be unable to export any animation exceeding 63 sound clips. We recommend splitting up larger projects into multiple smaller project to stay within this limit.").arg(clipCount));
+
+    mSuppressSoundWarning = true;
 }

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -241,6 +241,15 @@ Status ActionCommands::exportGif()
 Status ActionCommands::exportMovie(bool isGif)
 {
     FileType fileType = (isGif) ? FileType::GIF : FileType::MOVIE;
+
+    int clipCount = mEditor->sound()->soundClipCount();
+    if (fileType == FileType::MOVIE && clipCount >= 63)
+    {
+        ErrorDialog errorDialog(tr("Something went wrong"), tr("You currently have a total of %1 sound clips. Due to current limitations, you will be unable to export any animation exceeding 63 sound clips. We recommend splitting up larger projects into multiple smaller project to stay within this limit.").arg(clipCount), QString(), mParent);
+        errorDialog.exec();
+        return Status::FAIL;
+    }
+
     ExportMovieDialog* dialog = new ExportMovieDialog(mParent, ImportExportDialog::Export, fileType);
     OnScopeExit(dialog->deleteLater());
 

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -190,13 +190,8 @@ Status ActionCommands::importSound(FileType type)
     {
         mEditor->removeKey();
         emit mEditor->layers()->currentLayerChanged(mEditor->layers()->currentLayerIndex()); // trigger timeline repaint.
-    }
-    else
-    {
-        int clipCount = mEditor->sound()->soundClipCount();
-        if (clipCount >= MovieExporter::MAX_SOUND_FRAMES) {
-            showSoundClipWarning(clipCount);
-        }
+    } else {
+        showSoundClipWarningIfNeeded();
     }
 
     return st;
@@ -737,10 +732,7 @@ void ActionCommands::duplicateKey()
     if (layer->type() == Layer::SOUND)
     {
         mEditor->sound()->processSound(dynamic_cast<SoundClip*>(dupKey));
-        int clipCount = mEditor->sound()->soundClipCount();
-        if (clipCount >= MovieExporter::MAX_SOUND_FRAMES) {
-            showSoundClipWarning(clipCount);
-        }
+        showSoundClipWarningIfNeeded();
     }
     else
     {
@@ -951,11 +943,13 @@ void ActionCommands::about()
     aboutBox->exec();
 }
 
-void ActionCommands::showSoundClipWarning(int clipCount)
+void ActionCommands::showSoundClipWarningIfNeeded()
 {
-    if (mSuppressSoundWarning) return;
-
-    QMessageBox::warning(mParent, tr("Warning"), tr("You currently have a total of %1 sound clips. Due to current limitations, you will be unable to export any animation exceeding 63 sound clips. We recommend splitting up larger projects into multiple smaller project to stay within this limit.").arg(clipCount));
-
-    mSuppressSoundWarning = true;
+    int clipCount = mEditor->sound()->soundClipCount();
+    if (clipCount >= MovieExporter::MAX_SOUND_FRAMES && !mSuppressSoundWarning) {
+        QMessageBox::warning(mParent, tr("Warning"), tr("You currently have a total of %1 sound clips. Due to current limitations, you will be unable to export any animation exceeding %2 sound clips. We recommend splitting up larger projects into multiple smaller project to stay within this limit.").arg(clipCount).arg(MovieExporter::MAX_SOUND_FRAMES));
+        mSuppressSoundWarning = true;
+    } else {
+        mSuppressSoundWarning = false;
+    }
 }

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -194,7 +194,7 @@ Status ActionCommands::importSound(FileType type)
     else
     {
         int clipCount = mEditor->sound()->soundClipCount();
-        if (clipCount >= 63) {
+        if (clipCount >= MovieExporter::MAX_SOUND_FRAMES) {
             showSoundClipWarning(clipCount);
         }
     }
@@ -243,9 +243,9 @@ Status ActionCommands::exportMovie(bool isGif)
     FileType fileType = (isGif) ? FileType::GIF : FileType::MOVIE;
 
     int clipCount = mEditor->sound()->soundClipCount();
-    if (fileType == FileType::MOVIE && clipCount >= 63)
+    if (fileType == FileType::MOVIE && clipCount >= MovieExporter::MAX_SOUND_FRAMES)
     {
-        ErrorDialog errorDialog(tr("Something went wrong"), tr("You currently have a total of %1 sound clips. Due to current limitations, you will be unable to export any animation exceeding 63 sound clips. We recommend splitting up larger projects into multiple smaller project to stay within this limit.").arg(clipCount), QString(), mParent);
+        ErrorDialog errorDialog(tr("Something went wrong"), tr("You currently have a total of %1 sound clips. Due to current limitations, you will be unable to export any animation exceeding %2 sound clips. We recommend splitting up larger projects into multiple smaller project to stay within this limit.").arg(clipCount).arg(MovieExporter::MAX_SOUND_FRAMES), QString(), mParent);
         errorDialog.exec();
         return Status::FAIL;
     }
@@ -738,7 +738,7 @@ void ActionCommands::duplicateKey()
     {
         mEditor->sound()->processSound(dynamic_cast<SoundClip*>(dupKey));
         int clipCount = mEditor->sound()->soundClipCount();
-        if (clipCount >= 63) {
+        if (clipCount >= MovieExporter::MAX_SOUND_FRAMES) {
             showSoundClipWarning(clipCount);
         }
     }

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -98,6 +98,7 @@ public:
     void about();
 
 private:
+    void showSoundClipWarning(int clipCount);
 
     void exposeSelectedFrames(int offset);
 
@@ -105,6 +106,8 @@ private:
 
     Editor* mEditor = nullptr;
     QWidget* mParent = nullptr;
+
+    bool mSuppressSoundWarning = false;
 };
 
 #endif // COMMANDCENTER_H

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -98,7 +98,7 @@ public:
     void about();
 
 private:
-    void showSoundClipWarning(int clipCount);
+    void showSoundClipWarningIfNeeded();
 
     void exposeSelectedFrames(int offset);
 

--- a/core_lib/src/managers/soundmanager.cpp
+++ b/core_lib/src/managers/soundmanager.cpp
@@ -172,10 +172,12 @@ Status SoundManager::processSound(SoundClip* soundClip)
     return Status::OK;
 }
 
-int SoundManager::soundClipCount()
+int SoundManager::soundClipCount() const
 {
     LayerManager *layerManager = editor()->layers();
     int totalCount = 0;
+
+
     for (int i = 0; i < layerManager->count(); ++i)
     {
         Layer* layer = layerManager->getLayer(i);

--- a/core_lib/src/managers/soundmanager.cpp
+++ b/core_lib/src/managers/soundmanager.cpp
@@ -172,6 +172,23 @@ Status SoundManager::processSound(SoundClip* soundClip)
     return Status::OK;
 }
 
+int SoundManager::soundClipCount()
+{
+    LayerManager *layerManager = editor()->layers();
+    int totalCount = 0;
+    for (int i = 0; i < layerManager->count(); ++i)
+    {
+        Layer* layer = layerManager->getLayer(i);
+        if (layer->type() != Layer::SOUND)
+        {
+            continue;
+        }
+
+        totalCount += layer->keyFrameCount();
+    }
+    return totalCount;
+}
+
 void SoundManager::onDurationChanged(SoundPlayer* player, int64_t duration)
 {
     SoundClip* clip = player->clip();

--- a/core_lib/src/managers/soundmanager.h
+++ b/core_lib/src/managers/soundmanager.h
@@ -42,6 +42,8 @@ public:
     Status loadSound(SoundClip* soundClip, QString strSoundFile);
     Status processSound(SoundClip* soundClip);
 
+    int soundClipCount();
+
 signals:
     void soundClipDurationChanged();
 

--- a/core_lib/src/managers/soundmanager.h
+++ b/core_lib/src/managers/soundmanager.h
@@ -42,7 +42,7 @@ public:
     Status loadSound(SoundClip* soundClip, QString strSoundFile);
     Status processSound(SoundClip* soundClip);
 
-    int soundClipCount();
+    int soundClipCount() const;
 
 signals:
     void soundClipDurationChanged();

--- a/core_lib/src/movieexporter.h
+++ b/core_lib/src/movieexporter.h
@@ -56,6 +56,9 @@ public:
 
     void cancel() { mCanceled = true; }
 
+    // The maximum number of sound frames that can be successfully rendered
+    static const int MAX_SOUND_FRAMES = 63;
+
     static Status executeFFmpeg(const QString& cmd, const QStringList& args, std::function<bool(int)> progress);
 private:
     Status assembleAudio(const Object* obj, QString ffmpegPath, std::function<void(float)> progress);


### PR DESCRIPTION
Currently Pencil2D can't export animations with >= 63 frames due to limitations with the ffmpeg filter inputs. This warns the user when they've added too many sound clips, and produces a more specific error when attempting to export an animation with too many sound clips.

This could be improved, but I think it's good enough for a temporary solution. I have a movie exporter rewrite partially finished which I would like to complete before making changes to the ffmpeg command to allow for any number of sound clips to be exported. This could be a while out though, so I think this is a reasonable solution in the mean time.