### PR TITLE
Check for multiple application instances

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -39,9 +39,11 @@ int main(int argc, char* argv[])
 
     Pencil2D app(argc, argv);
 
+    #ifndef QT_DEBUG
     if (app.isInstanceOpen()) {
         return EXIT_SUCCESS;
     }
+    #endif
 
     switch (app.handleCommandLineOptions().code())
     {

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -38,6 +38,11 @@ int main(int argc, char* argv[])
     initCategoryLogging();
 
     Pencil2D app(argc, argv);
+
+    if (app.isInstanceOpen()) {
+        return EXIT_SUCCESS;
+    }
+
     switch (app.handleCommandLineOptions().code())
     {
         case Status::OK:

--- a/app/src/pencil2d.h
+++ b/app/src/pencil2d.h
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 #include "pencilerror.h"
 
 class MainWindow2;
+class QLockFile;
 
 /**
  * A pointer to the unique @ref Pencil2D instance.
@@ -59,6 +60,16 @@ public:
      */
     Status handleCommandLineOptions();
 
+    /**
+     * Checks if multiple instances of Pencil2D are open.
+     *
+     * If multiple instances of Pencil2D are open (indicated by a process holding the lock to a specific file in the
+     * application data directory) then the user will be warned of the issues with running multiple instances.
+     *
+     * @return True if there are multiple instances running and the user has not chosen to ignore the warning, false otherwise.
+     */
+    bool isInstanceOpen();
+
     bool event(QEvent* event) override;
 
 signals:
@@ -83,6 +94,8 @@ private:
     void prepareGuiStartup(const QString &inputPath);
 
     std::unique_ptr<MainWindow2> mainWindow;
+
+    std::unique_ptr<QLockFile> mProcessLock;
 };
 
 #endif // PENCIL2D_H


### PR DESCRIPTION
On startup this will check if there is another instance of Pencil2D already running. If there is, the user will be warned of the issues that can arise from running multiple instances of Pencil2D simultaneously (as a result of the shared temporary folder directory and shared preferences file).

This check is done by creating a lock file and lock it on startup. If the locking fails, the warning is shown. If Pencil2D crashes, the lock file will remain and will be stale, however Qt has some checks under the hood that will check for running processes and match the process id and name so that in this case, the next instance of Pencil2D will still be able to successfully acquire the lock and no warning will be produced.

![Screenshot from 2022-03-21 22-13-28](https://user-images.githubusercontent.com/3461051/159452629-ab1cffb1-8cd7-412a-b141-209e9a920a62.png)