### PR TITLE
Fix inconsistent usage of apply transform dialog

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1205,7 +1205,7 @@ void MainWindow2::setupKeyboardShortcuts()
     ui->actionFlip_inbetween->setShortcut(cmdKeySeq(CMD_FLIP_INBETWEEN));
     ui->actionFlip_rolling->setShortcut(cmdKeySeq(CMD_FLIP_ROLLING));
 
-    ShortcutFilter* shortcutFilter = new ShortcutFilter(ui->scribbleArea, this);
+    ShortcutFilter* shortcutFilter = new ShortcutFilter(ui->scribbleArea, mEditor, this);
     ui->actionMove->setShortcut(cmdKeySeq(CMD_TOOL_MOVE));
     ui->actionSelect->setShortcut(cmdKeySeq(CMD_TOOL_SELECT));
     ui->actionBrush->setShortcut(cmdKeySeq(CMD_TOOL_BRUSH));

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1362,7 +1362,7 @@ void MainWindow2::makeConnections(Editor* editor)
         ui->actionCut->setEnabled(canCopy);
     });
     connect(editor, &Editor::canPasteChanged, ui->actionPaste, &QAction::setEnabled);
-
+    connect(editor, &Editor::blockUI, this, &MainWindow2::onBlockUI);
 }
 
 void MainWindow2::makeConnections(Editor* editor, ColorBox* colorBox)
@@ -1504,12 +1504,34 @@ void MainWindow2::importMovieVideo()
     mSuppressAutoSaveDialog = false;
 }
 
+void MainWindow2::onBlockUI(bool block) {
+
+    if (mEditor->tools()->currentTool()->type() == MOVE) {
+        for (BaseDockWidget* widget : mDockWidgets) {
+            if (widget == nullptr) { continue; }
+            widget->blockUI(block);
+        }
+
+        ui->menuFile->setDisabled(block);
+        ui->menuAnimation->setDisabled(block);
+        ui->menuTools->setDisabled(block);
+        ui->menuLayer->setDisabled(block);
+        ui->menuEdit->setDisabled(block);
+
+        // We explicitly enable the selection menu
+        ui->menuSelection->setEnabled(true);
+    } else {
+        ui->menuBar->setEnabled(true);
+    }
+}
+
 bool MainWindow2::event(QEvent* event)
 {
     if(event->type() == QEvent::WindowActivate) {
         emit windowActivated();
         return true;
     }
+
     return QMainWindow::event(event);
 }
 

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1517,7 +1517,7 @@ void MainWindow2::onBlockUI(bool block) {
         ui->menuSelection->setEnabled(true);
     }
 
-    ui->menuFile->setDisabled(block);
+    ui->menuImport->setDisabled(block);
     ui->menuAnimation->setDisabled(block);
     ui->menuTools->setDisabled(block);
     ui->menuLayer->setDisabled(block);

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1506,23 +1506,22 @@ void MainWindow2::importMovieVideo()
 
 void MainWindow2::onBlockUI(bool block) {
 
-    if (mEditor->tools()->currentTool()->type() == MOVE) {
-        for (BaseDockWidget* widget : mDockWidgets) {
-            if (widget == nullptr) { continue; }
-            widget->blockUI(block);
-        }
-
-        ui->menuFile->setDisabled(block);
-        ui->menuAnimation->setDisabled(block);
-        ui->menuTools->setDisabled(block);
-        ui->menuLayer->setDisabled(block);
-        ui->menuEdit->setDisabled(block);
-
-        // We explicitly enable the selection menu
-        ui->menuSelection->setEnabled(true);
-    } else {
-        ui->menuBar->setEnabled(true);
+    for (BaseDockWidget* widget : mDockWidgets) {
+        if (widget == nullptr) { continue; }
+        widget->blockUI(block);
     }
+
+    if (block &&
+       (mEditor->tools()->currentTool()->type() == MOVE || mEditor->tools()->currentTool()->type() == SELECT)) {
+        // We explicitly enable the selection menu to allow transform modifications
+        ui->menuSelection->setEnabled(true);
+    }
+
+    ui->menuFile->setDisabled(block);
+    ui->menuAnimation->setDisabled(block);
+    ui->menuTools->setDisabled(block);
+    ui->menuLayer->setDisabled(block);
+    ui->menuEdit->setDisabled(block);
 }
 
 bool MainWindow2::event(QEvent* event)

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1530,7 +1530,6 @@ bool MainWindow2::event(QEvent* event)
         emit windowActivated();
         return true;
     }
-
     return QMainWindow::event(event);
 }
 

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -99,6 +99,8 @@ public:
     void displayMessageBox(const QString& title, const QString& body);
     void displayMessageBoxNoTitle(const QString& body);
 
+    void onBlockUI(bool block);
+
 signals:
     void updateRecentFilesList(bool b);
 

--- a/app/src/pencil2d.cpp
+++ b/app/src/pencil2d.cpp
@@ -100,6 +100,7 @@ bool Pencil2D::event(QEvent* event)
         emit openFileRequested(fileOpenEvent->file());
         return true;
     }
+
     return QApplication::event(event);
 }
 

--- a/app/src/pencil2d.cpp
+++ b/app/src/pencil2d.cpp
@@ -100,7 +100,6 @@ bool Pencil2D::event(QEvent* event)
         emit openFileRequested(fileOpenEvent->file());
         return true;
     }
-
     return QApplication::event(event);
 }
 

--- a/app/src/shortcutfilter.cpp
+++ b/app/src/shortcutfilter.cpp
@@ -17,14 +17,24 @@ GNU General Public License for more details.
 
 #include "shortcutfilter.h"
 
-ShortcutFilter::ShortcutFilter(ScribbleArea* scribbleArea , QObject* parent) :
+#include "scribblearea.h"
+#include "editor.h"
+
+ShortcutFilter::ShortcutFilter(ScribbleArea* scribbleArea, Editor* editor, QObject* parent) :
     QObject(parent)
 {
     mScribbleArea = scribbleArea;
+    mEditor = editor;
 }
 
 bool ShortcutFilter::eventFilter(QObject* obj, QEvent* event)
 {
+    if (mEditor->isUserActionRequired())
+    {
+        mEditor->requestUserActionIfNeeded();
+        return true;
+    }
+
     if (mScribbleArea->isMouseInUse())
     {
         return true;

--- a/app/src/shortcutfilter.h
+++ b/app/src/shortcutfilter.h
@@ -18,17 +18,20 @@ GNU General Public License for more details.
 #define SHORTCUTFILTER_H
 
 #include <QObject>
-#include "scribblearea.h"
+
+class ScribbleArea;
+class Editor;
 
 class ShortcutFilter : public QObject
 {
     Q_OBJECT
 
 public:
-    ShortcutFilter(ScribbleArea* scribbleArea, QObject* parent);
+    ShortcutFilter(ScribbleArea* scribbleArea, Editor*, QObject* parent);
 protected:
     bool eventFilter(QObject* obj, QEvent* event) override;
     ScribbleArea* mScribbleArea = nullptr;
+    Editor* mEditor = nullptr;
 };
 
 #endif

--- a/app/src/toolbox.cpp
+++ b/app/src/toolbox.cpp
@@ -166,6 +166,21 @@ void ToolBoxWidget::updateUI()
 {
 }
 
+void ToolBoxWidget::blockUI(bool block)
+{
+    setDisabled(block);
+    blockWidget(block);
+}
+
+bool ToolBoxWidget::event(QEvent* event)
+{
+    if (event->type() == QEvent::MouseButtonPress && editor()->userActionRequired()) {
+        editor()->requestUserAction();
+    }
+
+    return BaseDockWidget::event(event);
+}
+
 void ToolBoxWidget::onToolSetActive(ToolType toolType)
 {
     deselectAllTools();

--- a/app/src/toolbox.cpp
+++ b/app/src/toolbox.cpp
@@ -168,7 +168,6 @@ void ToolBoxWidget::updateUI()
 
 void ToolBoxWidget::blockUI(bool block)
 {
-    setDisabled(block);
     blockWidget(block);
 }
 

--- a/app/src/toolbox.cpp
+++ b/app/src/toolbox.cpp
@@ -173,8 +173,8 @@ void ToolBoxWidget::blockUI(bool block)
 
 bool ToolBoxWidget::event(QEvent* event)
 {
-    if (event->type() == QEvent::MouseButtonPress && editor()->userActionRequired()) {
-        editor()->requestUserAction();
+    if (event->type() == QEvent::MouseButtonPress) {
+        editor()->requestUserActionIfNeeded();
     }
 
     return BaseDockWidget::event(event);

--- a/app/src/toolbox.h
+++ b/app/src/toolbox.h
@@ -42,6 +42,7 @@ public:
 
     void initUI() override;
     void updateUI() override;
+    void blockUI(bool block) override;
 
 public slots:
     void onToolSetActive(ToolType toolType);
@@ -59,6 +60,7 @@ public slots:
 
 protected:
     int getMinHeightForWidth(int width) override;
+    bool event(QEvent* event) override;
 
 signals:
     void clearButtonClicked();

--- a/core_lib/src/interface/basedockwidget.cpp
+++ b/core_lib/src/interface/basedockwidget.cpp
@@ -49,9 +49,7 @@ void BaseDockWidget::resizeEvent(QResizeEvent *event)
 {
     QDockWidget::resizeEvent(event);
 
-    if (mBlockUIWidget) {
-        mBlockUIWidget->setGeometry(QRect(QPoint(), event->size()));
-    }
+    mBlockUIWidget->resize(event->size());
 
     // Not sure where the -2 comes from, but the event width is always 2 more than what is passed to FlowLayout::setGeometry
     int minHeight = getMinHeightForWidth(event->size().width() - 2);

--- a/core_lib/src/interface/basedockwidget.cpp
+++ b/core_lib/src/interface/basedockwidget.cpp
@@ -35,6 +35,10 @@ BaseDockWidget::BaseDockWidget(QWidget* pParent)
     }
 #endif
 
+    mBlockUIWidget = new QWidget(this);
+
+    mBlockUIWidget->setHidden(true);
+    layout()->addWidget(mBlockUIWidget);
 }
 
 BaseDockWidget::~BaseDockWidget()
@@ -44,6 +48,10 @@ BaseDockWidget::~BaseDockWidget()
 void BaseDockWidget::resizeEvent(QResizeEvent *event)
 {
     QDockWidget::resizeEvent(event);
+
+    if (mBlockUIWidget) {
+        mBlockUIWidget->setGeometry(QRect(QPoint(), event->size()));
+    }
 
     // Not sure where the -2 comes from, but the event width is always 2 more than what is passed to FlowLayout::setGeometry
     int minHeight = getMinHeightForWidth(event->size().width() - 2);
@@ -62,4 +70,15 @@ int BaseDockWidget::getMinHeightForWidth(int width)
 {
     Q_UNUSED(width)
     return -1;
+}
+
+void BaseDockWidget::blockWidget(bool block)
+{
+    if (block) {
+        mBlockUIWidget->raise();
+        mBlockUIWidget->setHidden(false);
+    } else {
+        mBlockUIWidget->setHidden(true);
+        mBlockUIWidget->lower();
+    }
 }

--- a/core_lib/src/interface/basedockwidget.h
+++ b/core_lib/src/interface/basedockwidget.h
@@ -35,6 +35,9 @@ protected:
 public:
     virtual void initUI() = 0;
     virtual void updateUI() = 0;
+    virtual void blockUI(bool block) { Q_UNUSED(block) };
+
+    void blockWidget(bool block);
 
     Editor* editor() const { return mEditor; }
     void setEditor( Editor* e ) { mEditor = e; }
@@ -43,6 +46,8 @@ protected:
     virtual int getMinHeightForWidth(int width);
 
 private:
+
+    QWidget* mBlockUIWidget = nullptr;
     Editor* mEditor = nullptr;
 };
 

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -974,7 +974,7 @@ void Editor::selectAll() const
     select()->setSelection(rect, false);
 }
 
-void Editor::deselectAll() const
+void Editor::deselectAll()
 {
     select()->resetSelectionProperties();
 
@@ -990,10 +990,31 @@ void Editor::deselectAll() const
         }
     }
 
+    requireUserAction(false);
+
     if (layer->hasAnySelectedFrames()) {
         layer->deselectAll();
         emit updateTimeLine();
     }
+}
+
+void Editor::requireUserAction(bool b)
+{
+    mActionRequired = b;
+
+    emit blockUI(b);
+}
+
+bool Editor::userActionRequired()
+{
+    return mActionRequired;
+}
+
+bool Editor::requestUserAction()
+{
+    if (!mActionRequired) { return false; }
+    tools()->currentTool()->requestAction();
+    return mActionRequired;
 }
 
 void Editor::updateFrame(int frameNumber)

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -1005,16 +1005,11 @@ void Editor::requireUserAction(bool b)
     emit blockUI(b);
 }
 
-bool Editor::userActionRequired()
+void Editor::requestUserActionIfNeeded()
 {
-    return mActionRequired;
-}
-
-bool Editor::requestUserAction()
-{
-    if (!mActionRequired) { return false; }
-    tools()->currentTool()->requestAction();
-    return mActionRequired;
+    if (mActionRequired) {
+        tools()->currentTool()->requestAction();
+    }
 }
 
 void Editor::updateFrame(int frameNumber)

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -217,11 +217,17 @@ public: //slots
     bool autoSaveNeverAskAgain() const { return mAutosaveNeverAskAgain; }
     void resetAutoSaveCounter();
 
+    /**
+     * Does nothing on its own but can be used to require user action if a tool requires it.
+     * @param b True if user action should be required otherwise false
+     */
     void requireUserAction(bool b);
-    bool userActionRequired();
 
-    /** Use this to request user action before proceeding, and block the execution cycle if required */
-    bool requestUserAction();
+    /**
+     * Notifies the current tool that the user needs to take action before proceeding
+     * Currently used by the move tool for applying transformations.
+     * Calling this method when `mActionRequired` is false does nothing */
+    void requestUserActionIfNeeded();
 
 private:
     bool importBitmapImage(const QString&, int space = 0);

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -218,10 +218,13 @@ public: //slots
     void resetAutoSaveCounter();
 
     /**
-     * Does nothing on its own but can be used to require user action if a tool requires it.
+     * Use this method to prevent user interaction until a certain action has been made.
      * @param b True if user action should be required otherwise false
      */
     void requireUserAction(bool b);
+
+    /** Use this for checking whether a user action is required to continue */
+    bool isUserActionRequired() { return mActionRequired; }
 
     /**
      * Notifies the current tool that the user needs to take action before proceeding

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -112,7 +112,7 @@ public:
     LayerVisibility layerVisibility();
 
     qreal viewScaleInversed();
-    void deselectAll() const;
+    void deselectAll();
     void selectAll() const;
 
     void clipboardChanged();
@@ -123,6 +123,8 @@ public:
     QList<BackupElement*> mBackupList;
 
 signals:
+
+    void blockUI(bool b);
 
     /** This should be emitted after scrubbing */
     void scrubbed(int frameNumber);
@@ -215,6 +217,12 @@ public: //slots
     bool autoSaveNeverAskAgain() const { return mAutosaveNeverAskAgain; }
     void resetAutoSaveCounter();
 
+    void requireUserAction(bool b);
+    bool userActionRequired();
+
+    /** Use this to request user action before proceeding, and block the execution cycle if required */
+    bool requestUserAction();
+
 private:
     bool importBitmapImage(const QString&, int space = 0);
     bool importVectorImage(const QString&);
@@ -252,6 +260,7 @@ private:
     int mAutosaveNumber = 12;
     int mAutosaveCounter = 0;
     bool mAutosaveNeverAskAgain = false;
+    bool mActionRequired = false;
 
     void makeConnections();
     KeyFrame* addKeyFrame(int layerNumber, int frameNumber);

--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -252,8 +252,8 @@ void TimeLine::blockUI(bool block)
 
 bool TimeLine::event(QEvent* event)
 {
-    if (event->type() == QEvent::MouseButtonPress && editor()->userActionRequired()) {
-        editor()->requestUserAction();
+    if (event->type() == QEvent::MouseButtonPress) {
+        editor()->requestUserActionIfNeeded();
     }
 
     return BaseDockWidget::event(event);

--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -247,7 +247,6 @@ void TimeLine::updateUI()
 
 void TimeLine::blockUI(bool block)
 {
-    setDisabled(block);
     blockWidget(block);
 }
 

--- a/core_lib/src/interface/timeline.cpp
+++ b/core_lib/src/interface/timeline.cpp
@@ -245,6 +245,21 @@ void TimeLine::updateUI()
     updateContent();
 }
 
+void TimeLine::blockUI(bool block)
+{
+    setDisabled(block);
+    blockWidget(block);
+}
+
+bool TimeLine::event(QEvent* event)
+{
+    if (event->type() == QEvent::MouseButtonPress && editor()->userActionRequired()) {
+        editor()->requestUserAction();
+    }
+
+    return BaseDockWidget::event(event);
+}
+
 int TimeLine::getLength()
 {
     return mTracks->getFrameLength();
@@ -275,8 +290,9 @@ void TimeLine::extendLength(int frame)
     }
 }
 
-void TimeLine::resizeEvent(QResizeEvent*)
+void TimeLine::resizeEvent(QResizeEvent* event)
 {
+    BaseDockWidget::resizeEvent(event);
     updateLayerView();
 }
 

--- a/core_lib/src/interface/timeline.h
+++ b/core_lib/src/interface/timeline.h
@@ -34,6 +34,7 @@ public:
 
     void initUI() override;
     void updateUI() override;
+    void blockUI(bool block) override;
 
     void updateFrame( int frameNumber );
     void updateLayerNumber( int number );
@@ -79,6 +80,7 @@ public:
 protected:
     void resizeEvent( QResizeEvent* event ) override;
     void wheelEvent( QWheelEvent* ) override;
+    bool event(QEvent* event) override;
 
 private:
     void deleteCurrentLayer();

--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -882,9 +882,12 @@ void TimeLineCells::resizeEvent(QResizeEvent* event)
 
 bool TimeLineCells::event(QEvent* event)
 {
-    if (event->type() == QEvent::Leave) {
-        onDidLeaveWidget();
+    if (event->type() == QEvent::Leave || event->type() == QEvent::Enter) {
+        // There's no guarantee that a release event is send after a press event...
+        // Therefore to avoid any weird states, we reset when leaving and entering the widget
+        onMouseFocusChange();
     }
+
 
     return QWidget::event(event);
 }
@@ -1307,9 +1310,11 @@ void TimeLineCells::trackScrubber()
     }
 }
 
-void TimeLineCells::onDidLeaveWidget()
+void TimeLineCells::onMouseFocusChange()
 {
     // Reset last known frame pos to avoid wrong UI states when leaving the widget
     mFramePosMoveX = 0;
+    primaryButton = Qt::NoButton;
+    mTimeLine->scrubbing = false;
     update();
 }

--- a/core_lib/src/interface/timelinecells.cpp
+++ b/core_lib/src/interface/timelinecells.cpp
@@ -915,9 +915,6 @@ void TimeLineCells::mousePressEvent(QMouseEvent* event)
 
     primaryButton = event->button();
 
-    bool switchLayer = mEditor->tools()->currentTool()->switchingLayer();
-    if (!switchLayer) { return; }
-
     switch (mType)
     {
     case TIMELINE_CELL_TYPE::Layers:

--- a/core_lib/src/interface/timelinecells.h
+++ b/core_lib/src/interface/timelinecells.h
@@ -99,7 +99,7 @@ private:
     int getFrameX(int frameNumber) const;
     int getFrameNumber(int x) const;
 
-    void onDidLeaveWidget();
+    void onMouseFocusChange();
 
     void trackScrubber();
     void drawContent();
@@ -129,7 +129,6 @@ private:
     int mFrameLength = 1;
     int mFrameSize = 0;
     int mFontSize = 10;
-    bool mScrubbing = false;
     int mLayerHeight = 20;
     int mStartY = 0;
     int mEndY   = 0;

--- a/core_lib/src/managers/playbackmanager.cpp
+++ b/core_lib/src/managers/playbackmanager.cpp
@@ -100,10 +100,6 @@ void PlaybackManager::play()
     updateStartFrame();
     updateEndFrame();
 
-    // This is probably not the right place or function to be calling this, but it's the easiest thing to do right now that works
-    // TODO make a new tool function to handle playing (or perhaps generic scrubbing)
-    bool switchLayer = editor()->tools()->currentTool()->switchingLayer();
-    if (!switchLayer) return;
 
     int frame = editor()->currentFrame();
     if (frame >= mEndFrame || frame < mStartFrame)

--- a/core_lib/src/managers/selectionmanager.cpp
+++ b/core_lib/src/managers/selectionmanager.cpp
@@ -78,7 +78,7 @@ void SelectionManager::resetSelectionTransform()
 
 bool SelectionManager::isOutsideSelectionArea(const QPointF point)
 {
-    return (!mTransformedSelection.contains(point)
+    return (!mTempTransformedSelection.contains(point)
             && validateMoveMode(point) == MoveMode::NONE);
 }
 

--- a/core_lib/src/managers/toolmanager.cpp
+++ b/core_lib/src/managers/toolmanager.cpp
@@ -373,6 +373,9 @@ void ToolManager::setTemporaryTool(ToolType eToolType)
 
 void ToolManager::clearTemporaryTool()
 {
+    if (mTemporaryTool) {
+        mTemporaryTool->leavingThisTool();
+    }
     mTemporaryTool = nullptr;
     mTemporaryTriggerKeys = {};
     mTemporaryTriggerModifiers = Qt::NoModifier;

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -130,7 +130,7 @@ public:
     virtual void setUseFillContour(const bool useFillContour);
 
     virtual bool leavingThisTool() { return true; }
-    virtual bool switchingLayer() { return true; } // default state should be true
+    virtual void requestAction() { return; }
 
     Properties properties;
 

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -168,9 +168,8 @@ void MoveTool::pointerReleaseEvent(PointerEvent*)
     mScribbleArea->updateToolCursor();
     mScribbleArea->updateCurrentFrame();
 
-    if (selectMan->transformHasBeenModified()) {
-        mEditor->requireUserAction(true);
-    }
+    mEditor->requireUserAction(selectMan->transformHasBeenModified());
+
 }
 
 void MoveTool::updateTransformation()

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -369,8 +369,6 @@ bool MoveTool::leavingThisTool()
 
 void MoveTool::requestAction()
 {
-    if (mWarningShown) { return; }
-
     bool requireAction = false;
     int returnValue = showTransformWarning();
 
@@ -395,12 +393,10 @@ void MoveTool::requestAction()
     {
         requireAction = true;
     }
-    mWarningShown = false;
 }
 
 int MoveTool::showTransformWarning()
 {
-    mWarningShown = true;
     return QMessageBox::warning(nullptr, tr("Action required", "Windows title of pop-up."),
                                         tr("Do you wish to apply the transformation changes before continuing?"),
                                         QMessageBox::No | QMessageBox::Cancel | QMessageBox::Yes,

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -370,7 +370,6 @@ bool MoveTool::leavingThisTool()
 
 void MoveTool::requestAction()
 {
-    bool requireAction = false;
     int returnValue = showTransformWarning();
 
     if (returnValue == QMessageBox::Yes)
@@ -389,10 +388,6 @@ void MoveTool::requestAction()
     else if (returnValue == QMessageBox::No)
     {
         cancelChanges();
-    }
-    else if (returnValue == QMessageBox::Cancel)
-    {
-        requireAction = true;
     }
 }
 

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -341,6 +341,7 @@ void MoveTool::applySelectionChanges()
     mRotatedAngle = 0;
 
     mScribbleArea->applySelectionChanges();
+    mEditor->requireUserAction(false);
 }
 
 void MoveTool::applyTransformation()

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -40,7 +40,7 @@ public:
     void pointerMoveEvent(PointerEvent*) override;
 
     bool leavingThisTool() override;
-    bool switchingLayer() override;
+    void requestAction() override;
 
 private:
     void cancelChanges();
@@ -64,6 +64,8 @@ private:
     QPointF offsetFromPressPos();
 
     Layer* currentPaintableLayer();
+
+    bool mWarningShown = false;
 
     QPointF anchorOriginPoint;
     Layer* mCurrentLayer = nullptr;

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -65,8 +65,6 @@ private:
 
     Layer* currentPaintableLayer();
 
-    bool mWarningShown = false;
-
     QPointF anchorOriginPoint;
     Layer* mCurrentLayer = nullptr;
     qreal mRotatedAngle = 0.0;


### PR DESCRIPTION
Implement UI block logic for when an action is required

While the main problem I sought to fix was that while using the move tool, you couldn't drag a keyframe on the timeline, the underlying issue was caused by the layerSwitching logic which wasn't fully thought through.

The new logic depends on the tool or widget to tell the editor that a user action is required before the execution can continue, this should be done using the new "requireUserAction" and "RequestUserAction" function. The "RequestUserAction" method will check if the flag has been enabled and in that case, call the respective tool that requires it. It's then up to the tool to create a dialog for the said action.

To make the dialog appear consistently when interacting with widgets that would apply the transformation, we apply an invisible widget on top of the base dock widget which will appear when the UI should be blocked. This makes it possible for the respective QWidget to get the QEvent instead of its children.

Fixes:
- Fix move tool blocking timeline keyframe dragging action
- Fix many other cases where the transform dialog should have appeared but didn't.
- Fixed that when the action popup disappears, the the timeline press event would be called but not the release event, leaving the widget in a pressed state where the scrubber would be moved upon hover.