### PR TITLE
Fix first backup malfunctioning after switching frames

### DIFF
--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -125,6 +125,7 @@ void Editor::makeConnections()
     connect(mPreferenceManager, &PreferenceManager::optionChanged, this, &Editor::settingUpdated);
     // XXX: This is a hack to prevent crashes until #864 is done (see #1412)
     connect(mLayerManager, &LayerManager::layerDeleted, this, &Editor::sanitizeBackupElementsAfterLayerDeletion);
+    connect(mScribbleArea, &ScribbleArea::modified, this, &Editor::onModified);
 }
 
 void Editor::settingUpdated(SETTING setting)
@@ -151,6 +152,12 @@ void Editor::settingUpdated(SETTING setting)
     default:
         break;
     }
+}
+
+void Editor::onModified(int layer, int frame)
+{
+    mLastModifiedLayer = layer;
+    mLastModifiedFrame = frame;
 }
 
 BackupElement* Editor::currentBackup()

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -179,6 +179,7 @@ public: //slots
     void switchVisibilityOfLayer(int layerNumber);
     void swapLayers(int i, int j);
 
+    void onModified(int layer, int frame);
     void backup(const QString& undoText);
     bool backup(int layerNumber, int frameNumber, const QString& undoText);
     /**

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -349,6 +349,7 @@ void ScribbleArea::setModified(int layerNumber, int frameNumber)
     if (layer == nullptr) { return; }
 
     setModified(layer, frameNumber);
+    emit modified(layerNumber, frameNumber);
 }
 
 bool ScribbleArea::event(QEvent *event)

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -148,6 +148,7 @@ public:
     void keyEventForSelection(QKeyEvent* event);
 
 signals:
+    void modified(int, int);
     void multiLayerOnionSkinChanged(bool);
     void refreshPreview();
     void selectionUpdated();


### PR DESCRIPTION
This fixes #1687. I feel like there isn’t quite a perfect place to put this code, but until the undo rewrite is here, this should serve us well enough. Also, I gotta say, this bug has been around for a really long time!