### PR TITLE
Assorted fixes

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -15,8 +15,6 @@ GNU General Public License for more details.
 
 */
 
-#include <clocale>
-
 #include "log.h"
 #include "pencil2d.h"
 #include "pencilerror.h"
@@ -28,11 +26,6 @@ GNU General Public License for more details.
  */
 int main(int argc, char* argv[])
 {
-    // iss #940
-    // Force dot separator on numbers because some localizations
-    // use comma as separator.
-    std::setlocale(LC_NUMERIC, "en_US.UTF-8");
-
     Q_INIT_RESOURCE(core_lib);
     PlatformHandler::initialise();
     initCategoryLogging();

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -39,12 +39,6 @@ int main(int argc, char* argv[])
 
     Pencil2D app(argc, argv);
 
-    #ifndef QT_DEBUG
-    if (app.isInstanceOpen()) {
-        return EXIT_SUCCESS;
-    }
-    #endif
-
     switch (app.handleCommandLineOptions().code())
     {
         case Status::OK:

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1634,6 +1634,7 @@ void MainWindow2::startProjectRecovery(int result)
 void MainWindow2::createToolbars()
 {
     mMainToolbar = addToolBar(tr("Main Toolbar"));
+    mMainToolbar->setObjectName("mMainToolbar");
     mMainToolbar->addAction(ui->actionNew);
     mMainToolbar->addAction(ui->actionOpen);
     mMainToolbar->addAction(ui->actionSave);
@@ -1646,6 +1647,7 @@ void MainWindow2::createToolbars()
     mMainToolbar->addAction(ui->actionPaste);
 
     mViewToolbar = addToolBar(tr("View Toolbar"));
+    mViewToolbar->setObjectName("mViewToolbar");
     mViewToolbar->addAction(ui->actionZoom_In);
     mViewToolbar->addAction(ui->actionZoom_Out);
     mViewToolbar->addAction(ui->actionReset_View);
@@ -1653,6 +1655,7 @@ void MainWindow2::createToolbars()
     mViewToolbar->addAction(ui->actionVertical_Flip);
 
     mOverlayToolbar = addToolBar(tr("Overlay Toolbar"));
+    mOverlayToolbar->setObjectName("mOverlayToolbar");
     mOverlayToolbar->addAction(ui->actionGrid);
 
     mToolbars = { mMainToolbar, mViewToolbar, mOverlayToolbar };

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -273,6 +273,7 @@ void MainWindow2::createMenus()
     connect(ui->actionImport_Replace_Palette, &QAction::triggered, this, &MainWindow2::openPalette);
 
     //--- Edit Menu ---
+    connect(mEditor, &Editor::updateBackup, this, &MainWindow2::undoActSetText);
     connect(ui->actionUndo, &QAction::triggered, mEditor, &Editor::undo);
     connect(ui->actionRedo, &QAction::triggered, mEditor, &Editor::redo);
     connect(ui->actionCut, &QAction::triggered, mEditor, &Editor::copyAndCut);
@@ -425,9 +426,6 @@ void MainWindow2::createMenus()
     ui->menuFile->insertMenu(ui->actionSave, mRecentFileMenu);
 
     connect(mRecentFileMenu, &RecentFileMenu::loadRecentFile, this, &MainWindow2::openFile);
-
-    connect(ui->menuEdit, &QMenu::aboutToShow, this, &MainWindow2::undoActSetText);
-    connect(ui->menuEdit, &QMenu::aboutToHide, this, &MainWindow2::undoActSetEnabled);
 }
 
 void MainWindow2::setOpacity(int opacity)
@@ -659,6 +657,7 @@ bool MainWindow2::openObject(const QString& strFilePath)
     progress.setValue(progress.maximum());
 
     updateSaveState();
+    undoActSetText();
 
     if (!QFileInfo(strFilePath).isWritable())
     {
@@ -1058,6 +1057,7 @@ void MainWindow2::newObject()
     closeDialogs();
 
     setWindowTitle(PENCIL_WINDOW_TITLE);
+    undoActSetText();
 }
 
 bool MainWindow2::newObjectFromPresets(int presetIndex)
@@ -1082,6 +1082,7 @@ bool MainWindow2::newObjectFromPresets(int presetIndex)
 
     setWindowTitle(PENCIL_WINDOW_TITLE);
     updateSaveState();
+    undoActSetText();
 
     return true;
 }
@@ -1332,12 +1333,6 @@ void MainWindow2::undoActSetText()
         ui->actionRedo->setText(tr("Redo", "Menu item text"));
         ui->actionRedo->setEnabled(false);
     }
-}
-
-void MainWindow2::undoActSetEnabled()
-{
-    ui->actionUndo->setEnabled(true);
-    ui->actionRedo->setEnabled(true);
 }
 
 void MainWindow2::exportPalette()
@@ -1625,6 +1620,7 @@ void MainWindow2::startProjectRecovery(int result)
     Q_ASSERT(o);
     mEditor->setObject(o);
     updateSaveState();
+    undoActSetText();
 
     const QString title = tr("Recovery Succeeded!");
     const QString text = tr("Please save your work immediately to prevent loss of data");

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -557,18 +557,6 @@ void MainWindow2::closeEvent(QCloseEvent* event)
     m2ndCloseEvent = true;
 }
 
-void MainWindow2::showEvent(QShowEvent*)
-{
-    static bool firstShowEvent = true;
-    if (!firstShowEvent)
-    {
-        return;
-    }
-    firstShowEvent = false;
-    if (tryRecoverUnsavedProject() || loadMostRecent() || tryLoadPreset()) { return; }
-    newObject();
-}
-
 void MainWindow2::tabletEvent(QTabletEvent* event)
 {
     event->ignore();
@@ -603,6 +591,21 @@ bool MainWindow2::saveAsNewDocument()
         return false;
     }
     return saveObject(fileName);
+}
+
+void MainWindow2::openStartupFile(const QString& filename)
+{
+    if (tryRecoverUnsavedProject())
+    {
+        return;
+    }
+
+    if (!filename.isEmpty() && openObject(filename))
+    {
+        return;
+    }
+
+    loadMostRecent() || tryLoadPreset();
 }
 
 void MainWindow2::openFile(const QString& filename)

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -68,7 +68,6 @@ public:
 
 public slots:
     void undoActSetText();
-    void undoActSetEnabled();
     void updateSaveState();
     void openPegAlignDialog();
     void openRepositionDialog();

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -100,21 +100,19 @@ public:
     void setOpacity(int opacity);
     void preferences();
 
+    void openStartupFile(const QString& filename);
     void openFile(const QString& filename);
 
     void displayMessageBox(const QString& title, const QString& body);
     void displayMessageBoxNoTitle(const QString& body);
 
 signals:
-    void updateRecentFilesList(bool b);
-
     /** Emitted when window regains focus */
     void windowActivated();
 
 protected:
     void tabletEvent(QTabletEvent*) override;
     void closeEvent(QCloseEvent*) override;
-    void showEvent(QShowEvent*) override;
     bool event(QEvent*) override;
 
 private slots:

--- a/app/src/pencil2d.cpp
+++ b/app/src/pencil2d.cpp
@@ -151,8 +151,5 @@ void Pencil2D::prepareGuiStartup(const QString& inputPath)
     connect(this, &Pencil2D::openFileRequested, mainWindow.get(), &MainWindow2::openFile);
     mainWindow->show();
 
-    if (!inputPath.isEmpty())
-    {
-        mainWindow->openFile(inputPath);
-    }
+    mainWindow->openStartupFile(inputPath);
 }

--- a/app/src/pencil2d.cpp
+++ b/app/src/pencil2d.cpp
@@ -136,6 +136,14 @@ void Pencil2D::installTranslators()
     QLocale locale = userLocale.isEmpty() ? QLocale::system() : QLocale(userLocale);
     QLocale::setDefault(locale);
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    // In versions prior to 5.14, Qt's DOM implementation erroneously used
+    // locale-dependent string conversion for double attributes (QTBUG-80068).
+    // To work around this, we override the numeric locale category to use the
+    // C locale.
+    std::setlocale(LC_NUMERIC, "C");
+#endif
+
     std::unique_ptr<QTranslator> qtTranslator(new QTranslator(this));
     if (qtTranslator->load(locale, "qt", "_", QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
     {

--- a/app/src/pencil2d.cpp
+++ b/app/src/pencil2d.cpp
@@ -69,6 +69,12 @@ Status Pencil2D::handleCommandLineOptions()
     CommandLineParser parser;
     parser.process(arguments());
 
+#ifndef QT_DEBUG
+    if (isInstanceOpen()) {
+        return Status::SAFE;
+    }
+#endif
+
     QString inputPath = parser.inputPath();
     QStringList outputPaths = parser.outputPaths();
 

--- a/app/src/pencil2d.cpp
+++ b/app/src/pencil2d.cpp
@@ -102,7 +102,7 @@ bool Pencil2D::isInstanceOpen()
     mProcessLock.reset(new QLockFile(appDir.absoluteFilePath("pencil2d-process.lock")));
     if (!mProcessLock->tryLock(10))
     {
-        QMessageBox::StandardButton clickedButton = QMessageBox::warning(nullptr, QObject::tr("Warning"), QObject::tr("An instance of Pencil2D is already open. Running multiple instances of Pencil2D simultaneously is not recommended and could potentially result in data loss and other unexpected behavior."), QMessageBox::Close | QMessageBox::Open, QMessageBox::Close);
+        QMessageBox::StandardButton clickedButton = QMessageBox::warning(nullptr, tr("Warning"), tr("An instance of Pencil2D is already open. Running multiple instances of Pencil2D simultaneously is not recommended and could potentially result in data loss and other unexpected behavior."), QMessageBox::Close | QMessageBox::Open, QMessageBox::Close);
         if (clickedButton != QMessageBox::Open)
         {
             return true;

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -177,8 +177,7 @@ bool FileManager::loadObject(Object* object, const QDomElement& root)
         }
         else if (element.tagName() == "editor" || element.tagName() == "projectdata")
         {
-            ObjectData* projectData = loadProjectData(element);
-            object->setData(projectData);
+            object->setData(loadProjectData(element));
         }
         else if (element.tagName() == "version")
         {
@@ -384,9 +383,9 @@ Status FileManager::writeToWorkingFolder(const Object* object)
     return Status(errorCode, dd);
 }
 
-ObjectData* FileManager::loadProjectData(const QDomElement& docElem)
+ObjectData FileManager::loadProjectData(const QDomElement& docElem)
 {
-    ObjectData* data = new ObjectData;
+    ObjectData data;
     if (docElem.isNull())
     {
         return data;
@@ -468,14 +467,12 @@ QDomElement FileManager::saveProjectData(const ObjectData* data, QDomDocument& x
     return rootTag;
 }
 
-void FileManager::extractProjectData(const QDomElement& element, ObjectData* data)
+void FileManager::extractProjectData(const QDomElement& element, ObjectData& data)
 {
-    Q_ASSERT(data);
-
     QString strName = element.tagName();
     if (strName == "currentFrame")
     {
-        data->setCurrentFrame(element.attribute("value").toInt());
+        data.setCurrentFrame(element.attribute("value").toInt());
     }
     else  if (strName == "currentColor")
     {
@@ -484,11 +481,11 @@ void FileManager::extractProjectData(const QDomElement& element, ObjectData* dat
         int b = element.attribute("b", "255").toInt();
         int a = element.attribute("a", "255").toInt();
 
-        data->setCurrentColor(QColor(r, g, b, a));
+        data.setCurrentColor(QColor(r, g, b, a));
     }
     else if (strName == "currentLayer")
     {
-        data->setCurrentLayer(element.attribute("value", "0").toInt());
+        data.setCurrentLayer(element.attribute("value", "0").toInt());
     }
     else if (strName == "currentView")
     {
@@ -499,27 +496,27 @@ void FileManager::extractProjectData(const QDomElement& element, ObjectData* dat
         double dx = element.attribute("dx", "0").toDouble();
         double dy = element.attribute("dy", "0").toDouble();
 
-        data->setCurrentView(QTransform(m11, m12, m21, m22, dx, dy));
+        data.setCurrentView(QTransform(m11, m12, m21, m22, dx, dy));
     }
     else if (strName == "fps" || strName == "currentFps")
     {
-        data->setFrameRate(element.attribute("value", "12").toInt());
+        data.setFrameRate(element.attribute("value", "12").toInt());
     }
     else if (strName == "isLoop")
     {
-        data->setLooping(element.attribute("value", "false") == "true");
+        data.setLooping(element.attribute("value", "false") == "true");
     }
     else if (strName == "isRangedPlayback")
     {
-        data->setRangedPlayback((element.attribute("value", "false") == "true"));
+        data.setRangedPlayback((element.attribute("value", "false") == "true"));
     }
     else if (strName == "markInFrame")
     {
-        data->setMarkInFrameNumber(element.attribute("value", "0").toInt());
+        data.setMarkInFrameNumber(element.attribute("value", "0").toInt());
     }
     else if (strName == "markOutFrame")
     {
-        data->setMarkOutFrameNumber(element.attribute("value", "15").toInt());
+        data.setMarkOutFrameNumber(element.attribute("value", "15").toInt());
     }
 }
 

--- a/core_lib/src/structure/filemanager.h
+++ b/core_lib/src/structure/filemanager.h
@@ -65,10 +65,10 @@ private:
     Status writeMainXml(const Object* obj, const QString& mainXmlPath, QStringList& filesWritten);
     Status writePalette(const Object* obj, const QString& dataFolder, QStringList& filesWritten);
 
-    ObjectData* loadProjectData(const QDomElement& element);
+    ObjectData loadProjectData(const QDomElement& element);
     QDomElement saveProjectData(const ObjectData*, QDomDocument& xmlDoc);
 
-    void extractProjectData(const QDomElement& element, ObjectData* data);
+    void extractProjectData(const QDomElement& element, ObjectData& data);
     void handleOpenProjectError(Status::ErrorCode, const DebugDetails&);
 
     QString backupPreviousFile(const QString& fileName);

--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -37,7 +37,7 @@ Layer::Layer(Object* object, LAYER_TYPE eType)
 
     mObject = object;
     meType = eType;
-    mName = QString(QObject::tr("Undefined Layer"));
+    mName = QString(tr("Undefined Layer"));
 
     mId = object->getUniqueLayerID();
 }

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -25,7 +25,7 @@ GNU General Public License for more details.
 
 LayerBitmap::LayerBitmap(Object* object) : Layer(object, Layer::BITMAP)
 {
-    setName(QObject::tr("Bitmap Layer"));
+    setName(tr("Bitmap Layer"));
 }
 
 LayerBitmap::~LayerBitmap()

--- a/core_lib/src/structure/layercamera.cpp
+++ b/core_lib/src/structure/layercamera.cpp
@@ -26,7 +26,7 @@ GNU General Public License for more details.
 
 LayerCamera::LayerCamera(Object* object) : Layer(object, Layer::CAMERA)
 {
-    setName(QObject::tr("Camera Layer"));
+    setName(tr("Camera Layer"));
 
     QSettings settings(PENCIL2D, PENCIL2D);
     mFieldW = settings.value("FieldW").toInt();

--- a/core_lib/src/structure/layersound.cpp
+++ b/core_lib/src/structure/layersound.cpp
@@ -26,7 +26,7 @@ GNU General Public License for more details.
 
 LayerSound::LayerSound(Object* object) : Layer(object, Layer::SOUND)
 {
-    setName(QObject::tr("Sound Layer"));
+    setName(tr("Sound Layer"));
 }
 
 LayerSound::~LayerSound()

--- a/core_lib/src/structure/layervector.cpp
+++ b/core_lib/src/structure/layervector.cpp
@@ -24,7 +24,7 @@ GNU General Public License for more details.
 
 LayerVector::LayerVector(Object* object) : Layer(object, Layer::VECTOR)
 {
-    setName(QObject::tr("Vector Layer"));
+    setName(tr("Vector Layer"));
 }
 
 LayerVector::~LayerVector()

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -33,7 +33,6 @@ GNU General Public License for more details.
 #include "layercamera.h"
 
 #include "util.h"
-#include "editor.h"
 #include "bitmapimage.h"
 #include "vectorimage.h"
 #include "fileformat.h"
@@ -42,7 +41,6 @@ GNU General Public License for more details.
 
 Object::Object()
 {
-    setData(new ObjectData());
     mActiveFramePool.reset(new ActiveFramePool);
 }
 
@@ -853,10 +851,9 @@ int Object::getLayerCount() const
     return mLayers.size();
 }
 
-void Object::setData(const ObjectData* d)
+void Object::setData(const ObjectData& d)
 {
-    Q_ASSERT(d != nullptr);
-    mData = *d;
+    mData = d;
 }
 
 int Object::totalKeyFrameCount() const

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -141,7 +141,7 @@ public:
 
     ObjectData* data() { return &mData; }
     const ObjectData* data() const { return &mData; }
-    void setData(const ObjectData*);
+    void setData(const ObjectData&);
 
     int totalKeyFrameCount() const;
     void updateActiveFrames(int frame) const;


### PR DESCRIPTION
This PR is a collection of various unrelated fixes and enhancements. I don’t think any of them have been (formally) reported. Here’s a list of the issues:

- An issue where the project recovery dialog was not modal, which caused it to appear behind the main window on my system
- Some runtime warnings about missing object names for the toolbars. This didn’t seem to cause any actual issues, but I figured I should fix it anyway
- An issue that caused the undo/redo shortcuts not to work under certain circumstances, for example right after program startup
- An issue where the translation context was set incorrectly for some strings due to inappropriate use of QObject::tr()
- An issue where Pencil2D ignored even the --help and --version options in release builds when another instance was already running
- A memory leak related to object data

I also took another look at the setlocale() workaround for #940 because I always felt like there must be a better solution. And I was right! Not only that, but the Qt devs already implemented it some time ago in 5.14 – because as it turns out, this was [a bug in Qt](https://bugreports.qt.io/browse/QTBUG-80068) all along. I’ve verified that the bug is indeed gone in current Qt versions and updated the code accordingly. I also updated it to use the C locale instead of US English (because the latter might not always be available) and moved the code so that it is run after QCoreApplication has been initialised, [as recommended in the documentation](https://doc.qt.io/qt-5/qcoreapplication.html#locale-settings).