### PR TITLE
Visualize selection rotation properly

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1402,7 +1402,6 @@ void MainWindow2::makeConnections(Editor* editor)
         ui->actionCut->setEnabled(canCopy);
     });
     connect(editor, &Editor::canPasteChanged, ui->actionPaste, &QAction::setEnabled);
-
 }
 
 void MainWindow2::makeConnections(Editor* editor, ColorBox* colorBox)

--- a/app/src/repositionframesdialog.cpp
+++ b/app/src/repositionframesdialog.cpp
@@ -56,7 +56,7 @@ void RepositionFramesDialog::initUI()
     connect(mEditor->getScribbleArea(), &ScribbleArea::selectionUpdated, this, &RepositionFramesDialog::updateDialogText);
     connect(mEditor->select(), &SelectionManager::selectionReset, this, &RepositionFramesDialog::closeClicked);
     mEndPoint = mStartPoint = QPoint(0,0);
-    mOriginalPolygonF = mEditor->select()->currentSelectionPolygonF();
+    mOriginalPolygonF = mEditor->select()->mySelectionRect();
     updateDialogSelectedFrames();
     updateDialogText();
 }
@@ -65,9 +65,9 @@ void RepositionFramesDialog::updateDialogText()
 {
     if (mOriginalPolygonF.boundingRect().isEmpty())
     {
-        mOriginalPolygonF = mEditor->select()->currentSelectionPolygonF();
+        mOriginalPolygonF = mEditor->select()->mySelectionRect();
     }
-    mCurrentPolygonF = mEditor->select()->currentSelectionPolygonF();
+    mCurrentPolygonF = mEditor->select()->selectionTransform().map(mEditor->select()->mySelectionRect());
     QPoint point = getRepositionPoint();
     ui->labRepositioned->setText(tr("Repositioned: ( %1, %2 )").arg(point.x()).arg(point.y()));
 }
@@ -94,7 +94,6 @@ void RepositionFramesDialog::repositionFrames()
         return;
     }
 
-    mEditor->getScribbleArea()->updateOriginalPolygonF();
     QList<int> frames = mEditor->layers()->currentLayer()->getSelectedFramesByPos();
     for (int i = 0; i < frames.size(); i++)
     {
@@ -147,7 +146,7 @@ void RepositionFramesDialog::repositionFrames()
             layerManager->setCurrentLayer(currLayer);
         }
     }
-    mEditor->getScribbleArea()->applySelectionChanges();
+    mEditor->getScribbleArea()->applyTransformedSelection();
     mEditor->select()->resetSelectionProperties();
     mEditor->scrubTo(mRepositionFrame);
     

--- a/core_lib/src/canvaspainter.cpp
+++ b/core_lib/src/canvaspainter.cpp
@@ -421,6 +421,11 @@ void CanvasPainter::paintVectorFrame(QPainter& painter,
     }
 
     QImage* strokeImage = new QImage(mCanvas->size(), QImage::Format_ARGB32_Premultiplied);
+
+    if (mRenderTransform) {
+        vectorImage->setSelectionTransformation(mSelectionTransform);
+    }
+
     vectorImage->outputImage(strokeImage, mViewTransform, mOptions.bOutlines, mOptions.bThinLines, mOptions.bAntiAlias);
 
     // Go through a Bitmap image to paint the onion skin colour
@@ -457,10 +462,6 @@ void CanvasPainter::paintVectorFrame(QPainter& painter,
     // Paint buffer pasted on top of vector image:
     // fixes polyline not being rendered properly
     rasterizedVectorImage.paintImage(painter);
-
-    if (mRenderTransform && !mSelectionTransform.isIdentity()) {
-        vectorImage->setSelectionTransformation(mSelectionTransform);
-    }
 }
 
 void CanvasPainter::paintTransformedSelection(QPainter& painter)

--- a/core_lib/src/canvaspainter.cpp
+++ b/core_lib/src/canvaspainter.cpp
@@ -457,6 +457,10 @@ void CanvasPainter::paintVectorFrame(QPainter& painter,
     // Paint buffer pasted on top of vector image:
     // fixes polyline not being rendered properly
     rasterizedVectorImage.paintImage(painter);
+
+    if (mRenderTransform && !mSelectionTransform.isIdentity()) {
+        vectorImage->setSelectionTransformation(mSelectionTransform);
+    }
 }
 
 void CanvasPainter::paintTransformedSelection(QPainter& painter)

--- a/core_lib/src/interface/backupelement.cpp
+++ b/core_lib/src/interface/backupelement.cpp
@@ -47,7 +47,6 @@ void BackupBitmapElement::restore(Editor* editor)
     selectMan->setSelection(mySelection, true);
     selectMan->setTransformAnchor(selectionAnchor);
     selectMan->setRotation(rotationAngle);
-    selectMan->setSomethingSelected(somethingSelected);
     selectMan->setScale(scaleX, scaleY);
     selectMan->setTranslation(translation);
 
@@ -95,7 +94,6 @@ void BackupVectorElement::restore(Editor* editor)
     selectMan->setSelection(mySelection, false);
     selectMan->setTransformAnchor(selectionAnchor);
     selectMan->setRotation(rotationAngle);
-    selectMan->setSomethingSelected(somethingSelected);
     selectMan->setScale(scaleX, scaleY);
     selectMan->setTranslation(translation);
     selectMan->calculateSelectionTransformation();

--- a/core_lib/src/interface/backupelement.cpp
+++ b/core_lib/src/interface/backupelement.cpp
@@ -27,18 +27,6 @@ GNU General Public License for more details.
 void BackupBitmapElement::restore(Editor* editor)
 {
     Layer* layer = editor->object()->findLayerById(this->layerId);
-    auto selectMan = editor->select();
-    selectMan->setSelection(mySelection, true);
-    selectMan->setTransformedSelectionRect(myTransformedSelection);
-    selectMan->setTempTransformedSelectionRect(myTempTransformedSelection);
-    selectMan->setRotation(rotationAngle);
-    selectMan->setSomethingSelected(somethingSelected);
-
-    if (editor->currentFrame() != this->frame) {
-        editor->scrubTo(this->frame);
-    }
-    editor->frameModified(this->frame);
-
     if (this->frame > 0 && layer->getKeyFrameAt(this->frame) == nullptr)
     {
         editor->restoreKey();
@@ -54,18 +42,26 @@ void BackupBitmapElement::restore(Editor* editor)
             }
         }
     }
+
+    auto selectMan = editor->select();
+    selectMan->setSelection(mySelection, true);
+    selectMan->setTransformAnchor(selectionAnchor);
+    selectMan->setRotation(rotationAngle);
+    selectMan->setSomethingSelected(somethingSelected);
+    selectMan->setScale(scaleX, scaleY);
+    selectMan->setTranslation(translation);
+
+    selectMan->calculateSelectionTransformation();
+
+    if (editor->currentFrame() != this->frame) {
+        editor->scrubTo(this->frame);
+    }
+    editor->frameModified(this->frame);
 }
 
 void BackupVectorElement::restore(Editor* editor)
 {
     Layer* layer = editor->object()->findLayerById(this->layerId);
-    auto selectMan = editor->select();
-    selectMan->setSelection(mySelection, false);
-    selectMan->setTransformedSelectionRect(myTransformedSelection);
-    selectMan->setTempTransformedSelectionRect(myTempTransformedSelection);
-    selectMan->setRotation(rotationAngle);
-    selectMan->setSomethingSelected(somethingSelected);
-
     for (int i = 0; i < editor->object()->getLayerCount(); i++)
     {
         Layer* layer = editor->object()->getLayer(i);
@@ -98,6 +94,15 @@ void BackupVectorElement::restore(Editor* editor)
             }
         }
     }
+
+    auto selectMan = editor->select();
+    selectMan->setSelection(mySelection, false);
+    selectMan->setTransformAnchor(selectionAnchor);
+    selectMan->setRotation(rotationAngle);
+    selectMan->setSomethingSelected(somethingSelected);
+    selectMan->setScale(scaleX, scaleY);
+    selectMan->setTranslation(translation);
+    selectMan->calculateSelectionTransformation();
 }
 
 void BackupSoundElement::restore(Editor* editor)

--- a/core_lib/src/interface/backupelement.cpp
+++ b/core_lib/src/interface/backupelement.cpp
@@ -23,10 +23,18 @@ GNU General Public License for more details.
 #include "layervector.h"
 #include "object.h"
 #include "selectionmanager.h"
+#include "layermanager.h"
 
 void BackupBitmapElement::restore(Editor* editor)
 {
     Layer* layer = editor->object()->findLayerById(this->layerId);
+
+    if (editor->currentFrame() != this->frame) {
+        editor->scrubTo(this->frame);
+    }
+
+    editor->layers()->setCurrentLayer(layer);
+
     if (this->frame > 0 && layer->getKeyFrameAt(this->frame) == nullptr)
     {
         editor->restoreKey();
@@ -52,9 +60,6 @@ void BackupBitmapElement::restore(Editor* editor)
 
     selectMan->calculateSelectionTransformation();
 
-    if (editor->currentFrame() != this->frame) {
-        editor->scrubTo(this->frame);
-    }
     editor->frameModified(this->frame);
 }
 
@@ -73,6 +78,12 @@ void BackupVectorElement::restore(Editor* editor)
             }
         }
     }
+
+    if (editor->currentFrame() != this->frame) {
+        editor->scrubTo(this->frame);
+    }
+
+    editor->layers()->setCurrentLayer(layer);
 
     if (this->frame > 0 && layer->getKeyFrameAt(this->frame) == nullptr)
     {
@@ -98,9 +109,6 @@ void BackupVectorElement::restore(Editor* editor)
     selectMan->setTranslation(translation);
     selectMan->calculateSelectionTransformation();
 
-    if (editor->currentFrame() != this->frame) {
-        editor->scrubTo(this->frame);
-    }
     editor->frameModified(this->frame);
 
 }
@@ -108,6 +116,9 @@ void BackupVectorElement::restore(Editor* editor)
 void BackupSoundElement::restore(Editor* editor)
 {
     Layer* layer = editor->object()->findLayerById(this->layerId);
+
+    editor->layers()->setCurrentLayer(layer);
+
     if (editor->currentFrame() != this->frame) {
         editor->scrubTo(this->frame);
     }

--- a/core_lib/src/interface/backupelement.cpp
+++ b/core_lib/src/interface/backupelement.cpp
@@ -75,10 +75,6 @@ void BackupVectorElement::restore(Editor* editor)
         }
     }
 
-    if (editor->currentFrame() != this->frame) {
-        editor->scrubTo(this->frame);
-    }
-    editor->frameModified(this->frame);
     if (this->frame > 0 && layer->getKeyFrameAt(this->frame) == nullptr)
     {
         editor->restoreKey();
@@ -103,6 +99,12 @@ void BackupVectorElement::restore(Editor* editor)
     selectMan->setScale(scaleX, scaleY);
     selectMan->setTranslation(translation);
     selectMan->calculateSelectionTransformation();
+
+    if (editor->currentFrame() != this->frame) {
+        editor->scrubTo(this->frame);
+    }
+    editor->frameModified(this->frame);
+
 }
 
 void BackupSoundElement::restore(Editor* editor)

--- a/core_lib/src/interface/backupelement.h
+++ b/core_lib/src/interface/backupelement.h
@@ -34,7 +34,11 @@ public:
     QString undoText;
     bool somethingSelected = false;
     qreal rotationAngle = 0.0;
-    QRectF mySelection, myTransformedSelection, myTempTransformedSelection;
+    qreal scaleX = 1.0;
+    qreal scaleY = 1.0;
+    QPointF translation;
+    QRectF mySelection;
+    QPointF selectionAnchor;
 
     virtual int type() { return UNDEFINED; }
     virtual void restore(Editor*) { Q_ASSERT(false); }

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -463,15 +463,6 @@ void Editor::undo()
         mBackupList[mBackupIndex]->restore(this);
         mBackupIndex--;
 
-        Layer* layer = layers()->currentLayer();
-        if (layer == nullptr) { return; }
-
-        if (layer->type() == Layer::VECTOR)
-        {
-            VectorImage *vectorImage = static_cast<VectorImage*>(layer->getKeyFrameAt(mFrame));
-            vectorImage->calculateSelectionRect();
-            select()->setSelection(vectorImage->getSelectionRect(), false);
-        }
         emit updateBackup();
     }
 }

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -196,6 +196,8 @@ public: //slots
      *          (see #1412).
      */
     void sanitizeBackupElementsAfterLayerDeletion(int layerIndex);
+
+    void onCurrentLayerWillChange(int index);
     void undo();
     void redo();
 

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -162,6 +162,9 @@ public: //slots
     */
     void updateFrame(int frameNumber);
 
+    void setModified(const Layer* layer, int frameNumber);
+    void setModified(int layerNumber, int frameNumber);
+
     void clearCurrentFrame();
 
     bool importImage(const QString& filePath);

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -389,15 +389,23 @@ void ScribbleArea::keyEventForSelection(QKeyEvent* event)
     {
     case Qt::Key_Right:
         selectMan->translate(QPointF(1, 0));
+        selectMan->calculateSelectionTransformation();
+        mEditor->frameModified(mEditor->currentFrame());
         return;
     case Qt::Key_Left:
         selectMan->translate(QPointF(-1, 0));
+        selectMan->calculateSelectionTransformation();
+        mEditor->frameModified(mEditor->currentFrame());
         return;
     case Qt::Key_Up:
         selectMan->translate(QPointF(0, -1));
+        selectMan->calculateSelectionTransformation();
+        mEditor->frameModified(mEditor->currentFrame());
         return;
     case Qt::Key_Down:
         selectMan->translate(QPointF(0, 1));
+        selectMan->calculateSelectionTransformation();
+        mEditor->frameModified(mEditor->currentFrame());
         return;
     case Qt::Key_Return:
         applyTransformedSelection();

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -66,7 +66,6 @@ bool ScribbleArea::init()
     connect(mDoubleClickTimer, &QTimer::timeout, this, &ScribbleArea::handleDoubleClick);
 
     connect(mEditor->select(), &SelectionManager::selectionChanged, this, &ScribbleArea::onSelectionChanged);
-    connect(mEditor->select(), &SelectionManager::needPaintAndApply, this, &ScribbleArea::applySelectionChanges);
     connect(mEditor->select(), &SelectionManager::needDeleteSelection, this, &ScribbleArea::deleteSelection);
 
     mDoubleClickTimer->setInterval(50);
@@ -335,24 +334,6 @@ void ScribbleArea::onObjectLoaded()
     invalidateAllCache();
 }
 
-void ScribbleArea::setModified(const Layer* layer, int frameNumber)
-{
-    if (layer == nullptr) { return; }
-
-    layer->setModified(frameNumber, true);
-
-    onFrameModified(frameNumber);
-}
-
-void ScribbleArea::setModified(int layerNumber, int frameNumber)
-{
-    Layer* layer = mEditor->object()->getLayer(layerNumber);
-    if (layer == nullptr) { return; }
-
-    setModified(layer, frameNumber);
-    emit modified(layerNumber, frameNumber);
-}
-
 bool ScribbleArea::event(QEvent *event)
 {
     if (event->type() == QEvent::WindowDeactivate)
@@ -408,19 +389,15 @@ void ScribbleArea::keyEventForSelection(QKeyEvent* event)
     {
     case Qt::Key_Right:
         selectMan->translate(QPointF(1, 0));
-        paintTransformedSelection();
         return;
     case Qt::Key_Left:
         selectMan->translate(QPointF(-1, 0));
-        paintTransformedSelection();
         return;
     case Qt::Key_Up:
         selectMan->translate(QPointF(0, -1));
-        paintTransformedSelection();
         return;
     case Qt::Key_Down:
         selectMan->translate(QPointF(0, 1));
-        paintTransformedSelection();
         return;
     case Qt::Key_Return:
         applyTransformedSelection();
@@ -777,14 +754,6 @@ void ScribbleArea::showLayerNotVisibleWarning()
                          tr("You are trying to modify a hidden layer! Please select another layer (or make the current layer visible)."),
                          QMessageBox::Ok,
                          QMessageBox::Ok);
-}
-
-void ScribbleArea::updateOriginalPolygonF()
-{
-    if (mEditor->select()->somethingSelected() && mOriginalPolygonF.isEmpty())
-        mOriginalPolygonF = mEditor->select()->currentSelectionPolygonF();
-    else
-        mOriginalPolygonF = QPolygonF();
 }
 
 void ScribbleArea::paintBitmapBuffer()
@@ -1158,6 +1127,7 @@ void ScribbleArea::paintEvent(QPaintEvent* event)
         mCanvasPainter.renderGrid(painter);
         mOverlayPainter.renderOverlays(painter, editor()->overlays()->getMoveMode());
 
+
         // paints the selection outline
         if (mEditor->select()->somethingSelected())
         {
@@ -1181,28 +1151,13 @@ void ScribbleArea::paintSelectionVisuals(QPainter &painter)
     Object* object = mEditor->object();
 
     auto selectMan = mEditor->select();
-    selectMan->updatePolygons();
 
-    if (selectMan->currentSelectionPolygonF().isEmpty()) { return; }
-    if (selectMan->currentSelectionPolygonF().count() < 4) { return; }
+    if (selectMan->mySelectionRect().isEmpty()) { return; }
 
-    QPolygonF lastSelectionPolygon = editor()->view()->mapPolygonToScreen(selectMan->lastSelectionPolygonF());
-    QPolygonF currentSelectionPolygon = selectMan->currentSelectionPolygonF();
-    if (mEditor->layers()->currentLayer()->type() == Layer::BITMAP)
-    {
-        currentSelectionPolygon = currentSelectionPolygon.toPolygon();
-    }
-    currentSelectionPolygon = editor()->view()->mapPolygonToScreen(currentSelectionPolygon);
+    QRectF currentSelectionRect = selectMan->mySelectionRect();
 
-    if (mOriginalPolygonF.isEmpty())
-    {
-        mOriginalPolygonF = selectMan->currentSelectionPolygonF();
-    }
-
-    TransformParameters params = { lastSelectionPolygon, currentSelectionPolygon };
-    mSelectionPainter.paint(painter, object, mEditor->currentLayerIndex(),
-                            currentTool(), params, mOriginalPolygonF, selectMan->currentSelectionPolygonF());
-    emit selectionUpdated();
+    TransformParameters params = { currentSelectionRect, editor()->view()->getView(), selectMan->selectionTransform() };
+    mSelectionPainter.paint(painter, object, mEditor->currentLayerIndex(), currentTool(), params);
 }
 
 BitmapImage* ScribbleArea::currentBitmapImage(Layer* layer) const
@@ -1251,7 +1206,9 @@ void ScribbleArea::prepCanvas(int frame, QRect rect)
     mCanvasPainter.setCanvas(&mCanvas);
 
     ViewManager* vm = mEditor->view();
+    SelectionManager* sm = mEditor->select();
     mCanvasPainter.setViewTransform(vm->getView(), vm->getViewInverse());
+    mCanvasPainter.setTransformedSelection(sm->mySelectionRect().toRect(), sm->selectionTransform());
 
     mCanvasPainter.setPaintSettings(object, mEditor->layers()->currentLayerIndex(), frame, rect, mBufferImg);
 }
@@ -1320,7 +1277,6 @@ void ScribbleArea::drawBrush(QPointF thePoint, qreal brushWidth, qreal mOffset, 
 void ScribbleArea::flipSelection(bool flipVertical)
 {
     mEditor->select()->flipSelection(flipVertical);
-    paintTransformedSelection();
 }
 
 void ScribbleArea::renderOverlays()
@@ -1452,55 +1408,6 @@ QPointF ScribbleArea::getCentralPoint()
     return mEditor->view()->mapScreenToCanvas(QPointF(width() / 2, height() / 2));
 }
 
-void ScribbleArea::paintTransformedSelection()
-{
-    Layer* layer = mEditor->layers()->currentLayer();
-    if (layer == nullptr) { return; }
-
-    auto selectMan = mEditor->select();
-    if (selectMan->somethingSelected())    // there is something selected
-    {
-        if (layer->type() == Layer::BITMAP)
-        {
-            mCanvasPainter.setTransformedSelection(selectMan->mySelectionRect().toRect(), selectMan->selectionTransform());
-        }
-        else if (layer->type() == Layer::VECTOR)
-        {
-            // vector transformation
-            VectorImage* vectorImage = currentVectorImage(layer);
-            if (vectorImage == nullptr) { return; }
-            vectorImage->setSelectionTransformation(selectMan->selectionTransform());
-
-        }
-        setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
-    }
-    updateCurrentFrame();
-}
-
-void ScribbleArea::applySelectionChanges()
-{
-    // we haven't applied our last modifications yet
-    // therefore apply the transformed selection first.
-    applyTransformedSelection();
-
-    auto selectMan = mEditor->select();
-
-    // make sure the current transformed selection is valid
-    if (!selectMan->myTempTransformedSelectionRect().isValid())
-    {
-        const QRectF& normalizedRect = selectMan->myTempTransformedSelectionRect().normalized();
-        selectMan->setTempTransformedSelectionRect(normalizedRect);
-    }
-    selectMan->setSelection(selectMan->myTempTransformedSelectionRect(), false);
-    paintTransformedSelection();
-
-    // Calculate the new transformation based on the new selection
-    selectMan->calculateSelectionTransformation();
-
-    // apply the transformed selection to make the selection modification absolute.
-    applyTransformedSelection();
-}
-
 void ScribbleArea::applyTransformedSelection()
 {
     mCanvasPainter.ignoreTransformedSelection();
@@ -1520,6 +1427,7 @@ void ScribbleArea::applyTransformedSelection()
             if (bitmapImage == nullptr) { return; }
             BitmapImage transformedImage = bitmapImage->transformed(selectMan->mySelectionRect().toRect(), selectMan->selectionTransform(), true);
 
+
             bitmapImage->clear(selectMan->mySelectionRect());
             bitmapImage->paste(&transformedImage, QPainter::CompositionMode_SourceOver);
         }
@@ -1530,11 +1438,11 @@ void ScribbleArea::applyTransformedSelection()
             //handleDrawingOnEmptyFrame();
             VectorImage* vectorImage = currentVectorImage(layer);
             if (vectorImage == nullptr) { return; }
+
             vectorImage->applySelectionTransformation();
-            selectMan->setSelection(selectMan->myTempTransformedSelectionRect(), false);
         }
 
-        setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
+        mEditor->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
     }
 
     update();
@@ -1564,7 +1472,7 @@ void ScribbleArea::cancelTransformedSelection()
         selectMan->resetSelectionProperties();
         mOriginalPolygonF = QPolygonF();
 
-        setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
+        mEditor->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
         updateCurrentFrame();
     }
 }
@@ -1655,6 +1563,7 @@ void ScribbleArea::setCurrentTool(ToolType eToolMode)
     // change cursor
     setCursor(currentTool()->cursor());
     updateCanvasCursor();
+    updateCurrentFrame();
 }
 
 void ScribbleArea::deleteSelection()
@@ -1682,7 +1591,7 @@ void ScribbleArea::deleteSelection()
             Q_CHECK_PTR(bitmapImage);
             bitmapImage->clear(selectMan->mySelectionRect());
         }
-        setModified(mEditor->currentLayerIndex(), mEditor->currentFrame());
+        mEditor->setModified(mEditor->currentLayerIndex(), mEditor->currentFrame());
     }
 }
 
@@ -1715,7 +1624,7 @@ void ScribbleArea::clearImage()
     {
         return; // skip updates when nothing changes
     }
-    setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
+    mEditor->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
 }
 
 void ScribbleArea::paletteColorChanged(QColor color)

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -66,10 +66,8 @@ public:
     Editor* editor() const { return mEditor; }
 
     void deleteSelection();
-    void applySelectionChanges();
     void displaySelectionProperties();
 
-    void paintTransformedSelection();
     void applyTransformedSelection();
     void cancelTransformedSelection();
 
@@ -126,10 +124,6 @@ public:
     /** Object updated, invalidate all cache */
     void onObjectLoaded();
 
-    /** Set frame on layer to modified and invalidate current frame cache */
-    void setModified(int layerNumber, int frameNumber);
-    void setModified(const Layer* layer, int frameNumber);
-
     void flipSelection(bool flipVertical);
     void renderOverlays();
     void prepOverlays();
@@ -148,7 +142,6 @@ public:
     void keyEventForSelection(QKeyEvent* event);
 
 signals:
-    void modified(int, int);
     void multiLayerOnionSkinChanged(bool);
     void refreshPreview();
     void selectionUpdated();
@@ -166,10 +159,6 @@ public slots:
     void paletteColorChanged(QColor);
 
     void showLayerNotVisibleWarning();
-    void updateOriginalPolygonF();
-    void setOriginalPolygonF(QPolygonF polygon) { mOriginalPolygonF = polygon; }
-    QPolygonF getOriginalPolygonF() { return mOriginalPolygonF; }
-
 
 protected:
     bool event(QEvent *event) override;

--- a/core_lib/src/managers/layermanager.cpp
+++ b/core_lib/src/managers/layermanager.cpp
@@ -117,6 +117,8 @@ void LayerManager::setCurrentLayer(int layerIndex)
         previousLayer->deselectAll();
     }
 
+    emit currentLayerWillChange(layerIndex);
+
     // Do not check if layer index has changed
     // because the current layer may have changed either way
     editor()->setCurrentLayerIndex(layerIndex);

--- a/core_lib/src/managers/layermanager.h
+++ b/core_lib/src/managers/layermanager.h
@@ -77,6 +77,7 @@ public:
     int getLastLayerIndex() { return count() - 1; }
 
 signals:
+    void currentLayerWillChange(int index);
     void currentLayerChanged(int index);
     void layerCountChanged(int count);
     void animationLengthChanged(int length);

--- a/core_lib/src/managers/selectionmanager.cpp
+++ b/core_lib/src/managers/selectionmanager.cpp
@@ -281,7 +281,6 @@ void SelectionManager::setSelection(QRectF rect, bool roundPixels)
     }
     mSelectionPolygon = rect;
     mOriginalRect = rect;
-    mSomethingSelected = (rect.isValid() ? true : false);
     mScaleX = 1;
     mScaleY = 1;
     mRotatedAngle = 0;
@@ -362,7 +361,7 @@ void SelectionManager::resetSelectionProperties()
 {
     resetSelectionTransformProperties();
     mSelectionPolygon = QPolygonF();
-    mSomethingSelected = false;
+    mOriginalRect = QRectF();
     emit selectionChanged();
 }
 

--- a/core_lib/src/managers/selectionmanager.cpp
+++ b/core_lib/src/managers/selectionmanager.cpp
@@ -90,7 +90,7 @@ void SelectionManager::deleteSelection()
 
 qreal SelectionManager::selectionTolerance() const
 {
-    return 10;
+    return 10 * editor()->viewScaleInversed();
 }
 
 QPointF SelectionManager::getSelectionAnchorPoint() const

--- a/core_lib/src/managers/selectionmanager.h
+++ b/core_lib/src/managers/selectionmanager.h
@@ -120,6 +120,7 @@ public:
     const QList<int> closestCurves() { return mClosestCurves; }
     const QList<VertexRef> closestVertices() { return mClosestVertices; }
 
+    /// This should be called to update the selection transform
     void calculateSelectionTransformation();
 
 signals:

--- a/core_lib/src/managers/selectionmanager.h
+++ b/core_lib/src/managers/selectionmanager.h
@@ -59,7 +59,7 @@ public:
     MoveMode getMoveMode() const { return mMoveMode; }
     void setMoveMode(MoveMode moveMode) { mMoveMode = moveMode; }
 
-    bool somethingSelected() const { return mSomethingSelected; }
+    bool somethingSelected() const { return mOriginalRect.isValid(); }
 
     void adjustSelection(const QPointF& currentPoint, qreal offsetX, qreal offsetY, qreal rotationOffset, int rotationIncrement=0);
 
@@ -88,7 +88,6 @@ public:
     QPointF currentTransformAnchor() const { return mAnchorPoint; }
     QPointF getSelectionAnchorPoint() const;
 
-    void setSomethingSelected(bool selected) { mSomethingSelected = selected; }
     void setTransformAnchor(QPointF point);
 
     const QRectF& mySelectionRect() { return mOriginalRect; }
@@ -132,7 +131,6 @@ signals:
 private:
     int constrainRotationToAngle(const qreal& rotatedAngle, const int& rotationIncrement) const;
 
-    bool mSomethingSelected = false;
     bool mAspectRatioFixed = false;
     QPolygonF mSelectionPolygon;
     QRectF mOriginalRect;

--- a/core_lib/src/managers/selectionmanager.h
+++ b/core_lib/src/managers/selectionmanager.h
@@ -26,6 +26,7 @@ GNU General Public License for more details.
 #include <QPointF>
 #include <QRectF>
 #include <QPolygonF>
+#include <QVector2D>
 #include <QTransform>
 
 class Editor;
@@ -42,46 +43,31 @@ public:
     Status save(Object*) override;
     void workingLayerChanged(Layer*) override;
 
-    QVector<QPointF> calcSelectionCenterPoints() const;
-
-    void updatePolygons();
-    void updateTransformedSelection() { mTransformedSelection = mTempTransformedSelection; }
-
-    QPointF whichAnchorPoint(QPointF currentPoint) const;
-    QPointF getTransformOffset() const { return mOffset; }
-    QPointF offsetFromAspectRatio(qreal offsetX, qreal offsetY) const;
+    QPointF getTransformOffset() { return mOffset; }
+    QPointF offsetFromAspectRatio(qreal offsetX, qreal offsetY);
 
     void flipSelection(bool flipVertical);
 
     void setSelection(QRectF rect, bool roundPixels=false);
 
     void translate(QPointF point);
+    void rotate(qreal angle, qreal lockedAngle);
+    void scale(qreal sX, qreal sY);
+    void maintainAspectRatio(bool state) { mAspectRatioFixed = state; }
 
-    MoveMode getMoveModeForSelectionAnchor(const QPointF pos) const;
-    MoveMode validateMoveMode(const QPointF pos);
+    void setMoveModeForAnchorInRange(QPointF point);
     MoveMode getMoveMode() const { return mMoveMode; }
-    void setMoveMode(const MoveMode moveMode) { mMoveMode = moveMode; }
+    void setMoveMode(MoveMode moveMode) { mMoveMode = moveMode; }
 
     bool somethingSelected() const { return mSomethingSelected; }
 
-    void calculateSelectionTransformation();
-    void adjustSelection(const QPointF& currentPoint, qreal offsetX, qreal offsetY, qreal rotationOffset, int rotationIncrement);
-    MoveMode moveModeForAnchorInRange(const QPointF lastPos);
-    void setCurves(const QList<int>& curves) { mClosestCurves = curves; }
-    void setVertices(const QList<VertexRef>& vertices) { mClosestVertices = vertices; }
+    void adjustSelection(const QPointF& currentPoint, qreal offsetX, qreal offsetY, qreal rotationOffset, int rotationIncrement=0);
 
-    void clearCurves();
-    void clearVertices();
-
-    const QList<int> closestCurves() const { return mClosestCurves; }
-    const QList<VertexRef> closestVertices() const { return mClosestVertices; }
-
-    QTransform selectionTransform() const { return mSelectionTransform; }
-    void setSelectionTransform(const QTransform& transform) { mSelectionTransform = transform; }
+    QTransform selectionTransform() { return mSelectionTransform; }
+    void setSelectionTransform(QTransform transform) { mSelectionTransform = transform; }
     void resetSelectionTransform();
 
-    bool transformHasBeenModified() const;
-    bool rotationHasBeenModified() const;
+    bool transformHasBeenModified();
 
     /** @brief SelectionManager::resetSelectionTransformProperties
      * should be used whenever translate, rotate, transform, scale
@@ -92,27 +78,50 @@ public:
     void resetSelectionProperties();
     void deleteSelection();
 
-    bool isOutsideSelectionArea(const QPointF point);
+    bool isOutsideSelectionArea(QPointF point);
 
     qreal selectionTolerance() const;
 
+    qreal selectionWidth() const { return (mSelectionPolygon[1] - mSelectionPolygon[0]).x(); }
+    qreal selectionHeight() const { return (mSelectionPolygon[3] - mSelectionPolygon[0]).y(); }
 
-    QPolygonF currentSelectionPolygonF() const { return mCurrentSelectionPolygonF; }
-    QPolygonF lastSelectionPolygonF() const { return mLastSelectionPolygonF; }
+    QPointF currentTransformAnchor() const { return mAnchorPoint; }
+    QPointF getSelectionAnchorPoint() const;
 
     void setSomethingSelected(bool selected) { mSomethingSelected = selected; }
+    void setTransformAnchor(QPointF point);
 
+    const QRectF& mySelectionRect() { return mOriginalRect; }
+    const qreal& myRotation() { return mRotatedAngle; }
+    const qreal& myScaleX() { return mScaleX; }
+    const qreal& myScaleY() { return mScaleY; }
+    const QPointF& myTranslation() { return mTranslation; }
+
+    void setRotation(const qreal& rotation) { mRotatedAngle = rotation; }
+    void setScale(const qreal scaleX, const qreal scaleY) { mScaleX = scaleX; mScaleY = scaleY; }
+    void setTranslation(const QPointF& translation) { mTranslation = translation; }
+
+    qreal angleFromPoint(QPointF point, QPointF anchorPoint) const;
+
+    QPointF mapToSelection(QPointF point) const { return mSelectionTransform.map(point); };
+    QPointF mapFromLocalSpace(QPointF point) const { return mSelectionTransform.inverted().map(point); }
+    QPolygonF mapToSelection(QPolygonF polygon) const { return mSelectionTransform.map(polygon); }
+    QPolygonF mapFromLocalSpace(QPolygonF polygon) const { return mSelectionTransform.inverted().map(polygon); }
+
+
+    // Vector selection
     VectorSelection vectorSelection;
 
-    const QRectF& mySelectionRect() { return mSelection; }
-    const QRectF& myTempTransformedSelectionRect() { return mTempTransformedSelection; }
-    const QRectF& myTransformedSelectionRect() { return mTransformedSelection; }
-    const qreal& myRotation() { return mRotatedAngle; }
+    void setCurves(QList<int> curves) { mClosestCurves = curves; }
+    void setVertices(QList<VertexRef> vertices) { mClosestVertices = vertices; }
 
-    void setSelectionRect(const QRectF& rect) { mSelection = rect; }
-    void setTempTransformedSelectionRect(const QRectF& rect) { mTempTransformedSelection = rect; }
-    void setTransformedSelectionRect(const QRectF& rect) { mTransformedSelection = rect; }
-    void setRotation(const qreal& rotation) { mRotatedAngle = rotation; }
+    void clearCurves() { mClosestCurves.clear(); };
+    void clearVertices() { mClosestVertices.clear(); };
+
+    const QList<int> closestCurves() { return mClosestCurves; }
+    const QList<VertexRef> closestVertices() { return mClosestVertices; }
+
+    void calculateSelectionTransformation();
 
 signals:
     void selectionChanged();
@@ -121,17 +130,18 @@ signals:
     void needDeleteSelection();
 
 private:
-    int constrainRotationToAngle(const qreal rotatedAngle, const int rotationIncrement) const;
-
-    QRectF mSelection;
-    QRectF mTempTransformedSelection;
-    QRectF mTransformedSelection;
-    qreal mRotatedAngle = 0.0;
+    int constrainRotationToAngle(const qreal& rotatedAngle, const int& rotationIncrement) const;
 
     bool mSomethingSelected = false;
-    QPolygonF mLastSelectionPolygonF;
-    QPolygonF mCurrentSelectionPolygonF;
+    bool mAspectRatioFixed = false;
+    QPolygonF mSelectionPolygon;
+    QRectF mOriginalRect;
+
     QPointF mOffset;
+    qreal mScaleX;
+    qreal mScaleY;
+    QPointF mTranslation;
+    qreal mRotatedAngle = 0.0;
 
     QList<int> mClosestCurves;
     QList<VertexRef> mClosestVertices;
@@ -139,6 +149,10 @@ private:
     MoveMode mMoveMode = MoveMode::NONE;
     QTransform mSelectionTransform;
     const qreal mSelectionTolerance = 8.0;
+
+    QPointF mAnchorPoint;
+
+    bool mUpdateView = false;
 };
 
 #endif // SELECTIONMANAGER_H

--- a/core_lib/src/selectionpainter.cpp
+++ b/core_lib/src/selectionpainter.cpp
@@ -20,7 +20,6 @@ GNU General Public License for more details.
 #include "qpainter.h"
 #include "basetool.h"
 
-
 SelectionPainter::SelectionPainter()
 {
 }
@@ -29,73 +28,74 @@ void SelectionPainter::paint(QPainter& painter,
                              const Object* object,
                              int layerIndex,
                              BaseTool* tool,
-                             TransformParameters& tParams,
-                             QPolygonF original,
-                             QPolygonF currentNotMapped)
+                             TransformParameters& tParams)
 {
     Layer* layer = object->getLayer(layerIndex);
 
     if (layer == nullptr) { return; }
+
+    QTransform transform = tParams.selectionTransform * tParams.viewTransform;
+    QPolygonF projectedSelectionPolygon = transform.map(tParams.originalSelectionRectF);
 
     if (layer->type() == Layer::BITMAP)
     {
         painter.setBrush(Qt::NoBrush);
         painter.setPen(QPen(Qt::DashLine));
 
-        // Draw previous selection
-        painter.drawPolygon(tParams.lastSelectionPolygonF.toPolygon());
-
         // Draw current selection
-        painter.drawPolygon(tParams.currentSelectionPolygonF.toPolygon());
+        painter.drawPolygon(projectedSelectionPolygon.toPolygon());
 
     }
     if (layer->type() == Layer::VECTOR)
     {
         painter.setBrush(QColor(0, 0, 0, 20));
         painter.setPen(Qt::gray);
-        painter.drawPolygon(tParams.currentSelectionPolygonF);
+        painter.drawPolygon(projectedSelectionPolygon);
     }
 
-    if (layer->type() != Layer::VECTOR || tool->type() != SELECT)
+    if (tool->type() == SELECT || tool->type() == MOVE)
     {
         painter.setPen(Qt::SolidLine);
         painter.setBrush(QBrush(Qt::gray));
-        int width = 6;
-        int radius = width / 2;
+        int radius = HANDLE_WIDTH / 2;
 
-        const QRectF topLeftCorner = QRectF(tParams.currentSelectionPolygonF[0].x() - radius,
-                                            tParams.currentSelectionPolygonF[0].y() - radius,
-                                            width, width);
+        const QRectF topLeftCorner = QRectF(projectedSelectionPolygon[0].x() - radius,
+                                            projectedSelectionPolygon[0].y() - radius,
+                                            HANDLE_WIDTH, HANDLE_WIDTH);
         painter.drawRect(topLeftCorner);
 
-        const QRectF topRightCorner = QRectF(tParams.currentSelectionPolygonF[1].x() - radius,
-                                             tParams.currentSelectionPolygonF[1].y() - radius,
-                                             width, width);
+        const QRectF topRightCorner = QRectF(projectedSelectionPolygon[1].x() - radius,
+                                             projectedSelectionPolygon[1].y() - radius,
+                                             HANDLE_WIDTH, HANDLE_WIDTH);
         painter.drawRect(topRightCorner);
 
-        const QRectF bottomRightCorner = QRectF(tParams.currentSelectionPolygonF[2].x() - radius,
-                                                tParams.currentSelectionPolygonF[2].y() - radius,
-                                                width, width);
+        const QRectF bottomRightCorner = QRectF(projectedSelectionPolygon[2].x() - radius,
+                                                projectedSelectionPolygon[2].y() - radius,
+                                                HANDLE_WIDTH, HANDLE_WIDTH);
         painter.drawRect(bottomRightCorner);
 
-        const QRectF bottomLeftCorner = QRectF(tParams.currentSelectionPolygonF[3].x() - radius,
-                                               tParams.currentSelectionPolygonF[3].y() - radius,
-                                               width, width);
+        const QRectF bottomLeftCorner = QRectF(projectedSelectionPolygon[3].x() - radius,
+                                               projectedSelectionPolygon[3].y() - radius,
+                                               HANDLE_WIDTH, HANDLE_WIDTH);
         painter.drawRect(bottomLeftCorner);
-
-        if (tool->properties.showSelectionInfo)
-        {
-            int diffX = static_cast<int>(currentNotMapped.boundingRect().x() - original.boundingRect().x());
-            int diffY = static_cast<int>(currentNotMapped.boundingRect().y() - original.boundingRect().y());
-            painter.drawText(static_cast<int>(tParams.currentSelectionPolygonF[0].x()),
-                    static_cast<int>(tParams.currentSelectionPolygonF[0].y() - width),
-                    QString("Size: %1x%2. Diff: %3, %4.").arg(QString::number(currentNotMapped.boundingRect().width()),
-                                                              QString::number(currentNotMapped.boundingRect().height()),
-                                                              QString::number(diffX),
-                                                              QString::number(diffY)));
-        }
-
-        painter.setBrush(QColor(0, 255, 0, 50));
-        painter.setPen(Qt::green);
     }
+
+    paintSelectionInfo(painter, transform, tParams.viewTransform, tParams.originalSelectionRectF, projectedSelectionPolygon);
+}
+
+void SelectionPainter::paintSelectionInfo(QPainter& painter, const QTransform& mergedTransform, const QTransform& viewTransform, const QRectF& selectionRect, const QPolygonF projectedPolygonF)
+{
+    QRect projectedSelectionRect = mergedTransform.mapRect(selectionRect).toAlignedRect();
+    QRect originalSelectionRect = viewTransform.mapRect(selectionRect).toAlignedRect();
+    QPolygon projectedPolygon = projectedPolygonF.toPolygon();
+
+    QPoint projectedCenter = projectedSelectionRect.center();
+    QPoint originalCenter = originalSelectionRect.center();
+    int diffX = static_cast<int>(projectedCenter.x() - originalCenter.x());
+    int diffY = static_cast<int>(originalCenter.y() - projectedCenter.y());
+    painter.drawText(projectedPolygon[0] - QPoint(HANDLE_WIDTH, HANDLE_WIDTH),
+                    QString("Size: %1x%2. Diff: %3, %4.").arg(QString::number(selectionRect.width()),
+                                                      QString::number(selectionRect.height()),
+                                                      QString::number(diffX),
+                                                      QString::number(diffY)));
 }

--- a/core_lib/src/selectionpainter.h
+++ b/core_lib/src/selectionpainter.h
@@ -17,8 +17,9 @@ GNU General Public License for more details.
 #ifndef SelectionPainter_H
 #define SelectionPainter_H
 
-#include "QRectF"
-#include "QPolygonF"
+#include <QRectF>
+#include <QPolygonF>
+#include <QTransform>
 
 class QPainter;
 class Object;
@@ -26,8 +27,10 @@ class BaseTool;
 
 struct TransformParameters
 {
-    QPolygonF lastSelectionPolygonF;
-    QPolygonF currentSelectionPolygonF;
+    QRectF originalSelectionRectF;
+
+    QTransform viewTransform;
+    QTransform selectionTransform;
 };
 
 class SelectionPainter
@@ -35,10 +38,12 @@ class SelectionPainter
 public:
     SelectionPainter();
 
-    void paint(QPainter& painter, const Object* object, int layerIndex, BaseTool* tool,
-               TransformParameters& transformParameters, QPolygonF original, QPolygonF currentNotMapped);
-
     void paint(QPainter& painter, const Object* object, int layerIndex, BaseTool* tool, TransformParameters& transformParameters);
+
+private:
+    void paintSelectionInfo(QPainter& painter, const QTransform& mergedTransform, const QTransform& viewTransform, const QRectF& selectionRect, const QPolygonF projectedPolygonF);
+
+    const static int HANDLE_WIDTH = 6;
 };
 
 #endif // SelectionPainter_H

--- a/core_lib/src/tool/brushtool.cpp
+++ b/core_lib/src/tool/brushtool.cpp
@@ -339,6 +339,6 @@ void BrushTool::paintVectorStroke()
 
         vectorImage->setSelected(vectorImage->getLastCurveNumber(), true);
 
-        mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
+        mEditor->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
     }
 }

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -267,7 +267,7 @@ void BucketTool::paintBitmap()
         }
         else if (progress == BucketState::DidFillTarget)
         {
-            mScribbleArea->setModified(layerIndex, frameIndex);
+            mEditor->setModified(layerIndex, frameIndex);
 
             // Need to invalidate layer pixmap cache when filling anything else but current layer
             // otherwise dragging won't show until release event
@@ -297,7 +297,7 @@ void BucketTool::paintVector(Layer* layer)
 
     applyChanges();
 
-    mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
+    mEditor->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
 }
 
 void BucketTool::applyChanges()

--- a/core_lib/src/tool/erasertool.cpp
+++ b/core_lib/src/tool/erasertool.cpp
@@ -309,7 +309,7 @@ void EraserTool::removeVectorPaint()
         // Clear the temporary pixel path
         vectorImage->deleteSelectedPoints();
 
-        mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
+        mEditor->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
     }
 }
 

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -22,6 +22,8 @@ GNU General Public License for more details.
 #include "movemode.h"
 #include "preferencemanager.h"
 
+#include <QTransform>
+
 class Layer;
 class VectorImage;
 
@@ -40,7 +42,6 @@ public:
     void pointerMoveEvent(PointerEvent*) override;
 
     bool leavingThisTool() override;
-    bool switchingLayer() override;
 
     void resetToDefault() override;
     void setShowSelectionInfo(const bool b) override;
@@ -48,10 +49,7 @@ public:
 private:
     void cancelChanges();
     void applyTransformation();
-    void applySelectionChanges();
-    void paintTransformedSelection();
     void setAnchorToLastPoint();
-    void updateTransformation();
     void updateSettings(const SETTING setting);
 
     int showTransformWarning();
@@ -71,8 +69,10 @@ private:
     QPointF anchorOriginPoint;
     Layer* mCurrentLayer = nullptr;
     qreal mRotatedAngle = 0.0;
+    qreal mPreviousAngle = 0.0;
     int mRotationIncrement = 0;
     MoveMode mPerspMode;
+    QPointF mOffset;
 };
 
 #endif

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -52,8 +52,6 @@ private:
     void setAnchorToLastPoint();
     void updateSettings(const SETTING setting);
 
-    int showTransformWarning();
-
     void beginInteraction(Qt::KeyboardModifiers keyMod, Layer* layer);
     void createVectorSelection(Qt::KeyboardModifiers keyMod, Layer* layer);
     void transformSelection(Qt::KeyboardModifiers keyMod, Layer* layer);

--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -334,5 +334,5 @@ void PencilTool::paintVectorStroke(Layer* layer)
 
     // TODO: selection doesn't apply on enter
 
-    mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
+    mEditor->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
 }

--- a/core_lib/src/tool/pentool.cpp
+++ b/core_lib/src/tool/pentool.cpp
@@ -293,5 +293,5 @@ void PenTool::paintVectorStroke(Layer* layer)
 
     vectorImage->setSelected(vectorImage->getLastCurveNumber(), true);
 
-    mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
+    mEditor->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
 }

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -282,5 +282,5 @@ void PolylineTool::endPolyline(QList<QPointF> points)
     }
 
     mScribbleArea->clearBitmapBuffer();
-    mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
+    mEditor->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
 }

--- a/core_lib/src/tool/selecttool.h
+++ b/core_lib/src/tool/selecttool.h
@@ -20,6 +20,8 @@ GNU General Public License for more details.
 
 #include "basetool.h"
 
+#include <QRectF>
+
 class Layer;
 class SelectionManager;
 
@@ -59,6 +61,8 @@ private:
     // the selection rectangle in mousePressEvent.
     QPointF mAnchorOriginPoint;
     MoveMode mMoveMode;
+    MoveMode mStartMoveMode = MoveMode::NONE;
+    QRectF mSelectionRect;
     Layer* mCurrentLayer = nullptr;
 };
 

--- a/core_lib/src/tool/smudgetool.cpp
+++ b/core_lib/src/tool/smudgetool.cpp
@@ -171,7 +171,6 @@ void SmudgeTool::pointerPressEvent(PointerEvent* event)
                 //qDebug() << "closestCurves:" << closestCurves << " | closestVertices" << closestVertices;
                 if (event->modifiers() != Qt::ShiftModifier && !vectorImage->isSelected(selectMan->closestVertices()))
                 {
-                    mScribbleArea->paintTransformedSelection();
                     mEditor->deselectAll();
                 }
 
@@ -179,7 +178,7 @@ void SmudgeTool::pointerPressEvent(PointerEvent* event)
                 selectMan->vectorSelection.add(selectMan->closestCurves());
                 selectMan->vectorSelection.add(selectMan->closestVertices());
 
-                mScribbleArea->update();
+                mEditor->frameModified(mEditor->currentFrame());
             }
             else
             {
@@ -265,7 +264,7 @@ void SmudgeTool::pointerReleaseEvent(PointerEvent* event)
                 int curveNumber = selectMan->vectorSelection.curve.at(k);
                 vectorImage->curve(curveNumber).smoothCurve();
             }
-            mScribbleArea->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
+            mEditor->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
         }
     }
 }

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -100,7 +100,7 @@ void StrokeTool::endStroke()
 
     enableCoalescing();
 
-    mScribbleArea->setModified(mEditor->currentLayerIndex(), mEditor->currentFrame());
+    mEditor->setModified(mEditor->currentLayerIndex(), mEditor->currentFrame());
 }
 
 void StrokeTool::drawStroke()


### PR DESCRIPTION
This PR sought to fix that a selection would be drawn correct, however to make this viable a lot of assumptions had to be changed about the current implementation.

Main points:
- A selection is always based on a transform now, there's no hacking using multiple selection rects as we previously had.
- The selection box will now be properly visualized when rotated
- When in transform mode, the selection can be modified as much as needed even in a rotated state. Previously the transform wasn't calculated properly so the result would be skewed in continuous attempts to transform.
- A selection is always applied after deselecting, meaning that the apply dialog is no more. I had tried various attempts to keep it but in the end found it too difficult fit it in without making huge modifications, see #1712 - This also fixes https://github.com/pencil2d/pencil/issues/1671

Known issues:
- Anchor arrows does not take rotation into effect (cosmetic)

Mitigations:
- Added setCurrentLayer to undo/redo
Reason:
A lot of our core logic assumes the current layer changes when painting and applying changes, meaning you can't apply vector transformations while you're on bitmap layer and vise versa. This will fix that, by making sure you are on the correct layer.

In the future we should figure out how we want this to behave...

There's still room for improvement, especially when it comes to QRect vs QRectF... this is a mess tbh... but it's not something i'm going to fix with this PR. I believe that the selectionManager should be purely for bitmap and vector should either have its own or be kept to the VectorImage object.