### PR TITLE
Fix recently reported issues

### DIFF
--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -51,7 +51,7 @@ BitmapImage::BitmapImage(const QPoint& topLeft, const QImage& image)
 {
     mBounds = QRect(topLeft, image.size());
     mMinBound = true;
-    mImage = image;
+    mImage = image.convertToFormat(QImage::Format_ARGB32_Premultiplied);
 }
 
 BitmapImage::BitmapImage(const QPoint& topLeft, const QString& path)
@@ -70,7 +70,7 @@ BitmapImage::~BitmapImage()
 
 void BitmapImage::setImage(QImage* img)
 {
-    Q_ASSERT(img);
+    Q_ASSERT(img && img->format() == QImage::Format_ARGB32_Premultiplied);
     mImage = *img;
     mMinBound = false;
 
@@ -125,7 +125,7 @@ void BitmapImage::loadFile()
 {
     if (!fileName().isEmpty() && !isLoaded())
     {
-        mImage = QImage(fileName());
+        mImage = QImage(fileName()).convertToFormat(QImage::Format_ARGB32_Premultiplied);
         mBounds.setSize(mImage.size());
         mMinBound = false;
     }
@@ -181,13 +181,6 @@ BitmapImage BitmapImage::copy(QRect rectangle)
     if (rectangle.isEmpty() || mBounds.isEmpty()) return BitmapImage();
 
     QRect intersection2 = rectangle.translated(-mBounds.topLeft());
-
-    // If the region goes out of bounds, make sure the image is formatted in ARGB
-    // so that the area beyond the image bounds is transparent.
-    if (!mBounds.contains(rectangle) && !image()->hasAlphaChannel())
-    {
-        mImage = mImage.convertToFormat(QImage::Format_ARGB32);
-    }
 
     BitmapImage result(rectangle.topLeft(), image()->copy(intersection2));
     return result;

--- a/core_lib/src/managers/clipboardmanager.cpp
+++ b/core_lib/src/managers/clipboardmanager.cpp
@@ -34,10 +34,14 @@ void ClipboardManager::setFromSystemClipboard(const QPointF& pos, const Layer* l
 {
     // We intentially do not call resetStates here because we can only store image changes to the clipboard
     // otherwise we break pasting for vector.
+    // Only bitmap is supported currently...
+    // Only update clipboard data if it was stored by other applications
+    if (layer->type() != Layer::BITMAP || mClipboard->ownsClipboard()) {
+        return;
+    }
 
     QImage image = mClipboard->image(QClipboard::Clipboard);
-    // Only bitmap is supported currently...
-    if (layer->type() == Layer::BITMAP && !image.isNull()) {
+    if (!image.isNull()) {
         mBitmapImage = BitmapImage(pos.toPoint()-QPoint(image.size().width()/2, image.size().height()/2), image);
     }
 }

--- a/core_lib/src/structure/layercamera.cpp
+++ b/core_lib/src/structure/layercamera.cpp
@@ -61,11 +61,9 @@ QTransform LayerCamera::getViewAtFrame(int frameNumber) const
     }
 
     Camera* camera1 = static_cast<Camera*>(getLastKeyFrameAtPosition(frameNumber));
-    camera1->setEasingType(camera1->getEasingType());
 
     int nextFrame = getNextKeyFramePosition(frameNumber);
     Camera* camera2 = static_cast<Camera*>(getLastKeyFrameAtPosition(nextFrame));
-    camera2->setEasingType(camera2->getEasingType());
 
     if (camera1 == nullptr && camera2 == nullptr)
     {

--- a/tests/src/test_bitmapbucket.cpp
+++ b/tests/src/test_bitmapbucket.cpp
@@ -90,7 +90,7 @@ TEST_CASE("BitmapBucket - Fill drag logic")
 
         image->writeFile(resultsPath + "test1.png");
 
-        verifyPixels(pressPoint, image, fillColor.rgba());
+        verifyPixels(pressPoint, image, qPremultiply(fillColor.rgba()));
     }
 
     SECTION("FillTo: Layer below - reference: current layer")
@@ -133,6 +133,6 @@ TEST_CASE("BitmapBucket - Fill drag logic")
 
         image->writeFile(resultsPath + "test4.png");
 
-        verifyPixels(pressPoint, image, fillColor.rgba());
+        verifyPixels(pressPoint, image, qPremultiply(fillColor.rgba()));
     }
 }


### PR DESCRIPTION
This PR fixes the three issues Jose reported recently:
- Fixes #1726 by reading from the system clipboard only when its contents were written by other applications
- Fixes #1727 by simply removing two noop lines
- Fixes #1728 by ensuring that BitmapImage always uses the premultiplied ARGB32 format. There was already an “on-demand” conversion that scribble added a while back but I figured it’d be a good idea to prevent BitmapImage from ever using unintended formats to begin with. That should also take care of any other potential issues in that area, like Jose suggested in the report.