### PR TITLE
Fix crash when deleting sound layer after scrubbing

### DIFF
--- a/core_lib/src/soundplayer.cpp
+++ b/core_lib/src/soundplayer.cpp
@@ -25,6 +25,10 @@ SoundPlayer::SoundPlayer()
 
 SoundPlayer::~SoundPlayer()
 {
+#ifdef Q_OS_WIN
+    // Qt Multimedia's DirectShow backend segfaults when it is destroyed while paused
+    stop();
+#endif
 }
 
 void SoundPlayer::init(SoundClip* clip)


### PR DESCRIPTION
I had another look at the sound layer deletion crash and I think I finally did figure how to fix it – or work around it, rather. Looks like it’s a bug in the DirectShow backend of Qt Multimedia that results in a segfault when it is destroyed while paused. Neither the GStreamer backend nor the Windows Media Foundation backend exhibit this behaviour. Fortunately, it’s pretty easy to work around.