### PR TITLE
Camera - painting changes and fixes

### DIFF
--- a/core_lib/src/camerapainter.h
+++ b/core_lib/src/camerapainter.h
@@ -21,6 +21,7 @@ GNU General Public License for more details.
 #include <memory>
 #include <QColor>
 #include <QTransform>
+#include <QPen>
 
 #include "onionskinpainteroptions.h"
 #include "onionskinsubpainter.h"
@@ -75,7 +76,9 @@ private:
     bool mIsPlaying = false;
     bool mShowHandles = false;
 
+    QPen mHandlePen;
     QColor mHandleColor;
+    QColor mHandleDisabledColor;
     QColor mHandleTextColor;
 };
 

--- a/core_lib/src/camerapainter.h
+++ b/core_lib/src/camerapainter.h
@@ -31,6 +31,7 @@ class Object;
 class QPalette;
 class QPixmap;
 class QRect;
+class KeyFrame;
 
 class CameraPainter
 {
@@ -49,9 +50,12 @@ private:
     void initializePainter(QPainter& painter, QPixmap& pixmap) const;
     void paintVisuals(QPainter& painter) const;
     void paintBorder(QPainter& painter, const QTransform& camTransform, const QRect& camRect) const;
-    void paintInterpolations(QPainter& painter, const LayerCamera* cameraLayer) const;
+    void paintOnionSkinning(QPainter& painter, const LayerCamera* cameraLayer) const;
+    void paintInterpolations(QPainter& painter, const LayerCamera* cameraLayer, const KeyFrame* keyframe) const;
     void paintHandles(QPainter& painter, const QTransform& camTransform, const QRect& cameraRect, const QPointF translation, const qreal scale, const qreal rotation, bool hollowHandles) const;
-    void paintPath(QPainter& painter, const LayerCamera* cameraLayer, const int frameIndex, const QPointF& pathPoint, bool hollowHandle) const;
+    void paintControlPoint(QPainter& painter, const LayerCamera* cameraLayer, const int frameIndex, const QPointF& pathPoint, bool hollowHandle) const;
+
+    bool ignoreLayer(const Layer* cameraLayer, bool isCurrentLayerCamera) const;
 
     const Object* mObject = nullptr;
     QPixmap* mCanvas = nullptr;

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -143,6 +143,7 @@ void ScribbleArea::settingUpdated(SETTING setting)
     case SETTING::INVISIBLE_LINES:
     case SETTING::OUTLINES:
     case SETTING::ONION_TYPE:
+    case SETTING::ONION_WHILE_PLAYBACK:
         invalidateAllCache();
         break;
     case SETTING::QUICK_SIZING:

--- a/core_lib/src/structure/layercamera.cpp
+++ b/core_lib/src/structure/layercamera.cpp
@@ -432,22 +432,6 @@ bool LayerCamera::hasSameTranslation(int frame1, int frame2) const
     return camera1->translation() == camera2->translation();
 }
 
-QList<QPointF> LayerCamera::getBezierPointsAtFrame(int frame) const
-{
-    QList<QPointF> points;
-    int prevFrame = getPreviousKeyFramePosition(frame);
-    int nextFrame = getNextKeyFramePosition(frame);
-    if (prevFrame < nextFrame)
-    {
-        Camera* prevCam = getCameraAtFrame(prevFrame);
-        Camera* nextCam = getCameraAtFrame(nextFrame);
-        points.append(QPointF(-prevCam->translation()));
-        points.append(QPointF(prevCam->getPathControlPoint()));
-        points.append(QPointF(-nextCam->translation()));
-    }
-    return points;
-}
-
 void LayerCamera::centerPathControlPointAtFrame(int frame) const
 {
     Camera* cam1 = getCameraAtFrame(frame);

--- a/core_lib/src/structure/layercamera.h
+++ b/core_lib/src/structure/layercamera.h
@@ -59,7 +59,6 @@ public:
     QString getInterpolationTextAtFrame(int frame) const;
     QPointF getPathControlPointAtFrame(int frame) const;
     bool hasSameTranslation(int frame1, int frame2) const;
-    QList<QPointF> getBezierPointsAtFrame(int frame) const;
     void centerPathControlPointAtFrame(int frame) const;
     QPointF getNewPathControlPointAtFrame(int frame) const;
     void updatePathControlPointAtFrame(const QPointF& point, int frame) const;


### PR DESCRIPTION
### UI change:
- Handles are now white with thicker outline, to differentiate better between active/disabled state
Active:
<img width="634" alt="image" src="https://user-images.githubusercontent.com/1045397/197574703-af41f3ff-8fa7-4878-b6b0-cb04285c333d.png">
Disabled:
<img width="613" alt="image" src="https://user-images.githubusercontent.com/1045397/197574757-432990e9-4b8a-4986-9de2-fc7a37a44e1d.png">

### Fixes:
- Only show skinning under playback if enabled
- Don't paint handles unless we can interact with them
- Fix onion skinning was applied per keyframe.
- Only draw interpolations while handles are active