### PR TITLE
Fix truncated playback for converted audio clips on Windows

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -177,12 +177,10 @@ Status ActionCommands::importSound(FileType type)
     {
         st = Status::CANCELED;
     }
-    else if (strSoundFile.endsWith(".wav"))
-    {
-        st = mEditor->sound()->loadSound(key, strSoundFile);
-    }
     else
     {
+        // Convert even if it already is a WAV file to strip metadata that the
+        // DirectShow media player backend on Windows can't handle
         st = convertSoundToWav(strSoundFile);
     }
 

--- a/core_lib/src/movieimporter.cpp
+++ b/core_lib/src/movieimporter.cpp
@@ -342,7 +342,7 @@ Status MovieImporter::importMovieAudio(const QString& filePath, std::function<bo
 
     QString audioPath = QDir(mTempDir->path()).filePath("audio.wav");
 
-    QStringList args{ "-i", filePath, audioPath };
+    QStringList args{ "-i", filePath, "-map_metadata", "-1", "-bitexact", audioPath };
 
     status = MovieExporter::executeFFmpeg(ffmpegLocation(), args, [&progress, this] (int frame) {
         Q_UNUSED(frame)


### PR DESCRIPTION
I took a look at the truncated audio issue for certain file formats and figured out how to fix it – or work around it, rather. Once again, it’s an issue that is specific to the DirectShow multimedia backend on Windows. This backend seems to have trouble properly playing WAV files containing certain metadata that FFmpeg includes. I actually looked at the files in a hex editor and the format of the metadata looks completely fine, so FFmpeg doesn’t do anything wrong here AFAICT. I also tried both the GStreamer backend and the Windows Media Foundation backend and both of those worked fine. It’s really just the DirectShow backend that doesn’t work properly. As a workaround I simply added some FFmpeg options to strip all metadata. Because users could conceivably import problematic WAV files directly, I also made it so that WAV files too are processed through FFmpeg to strip any and all metadata.