### PR TITLE
Ensure export file path always contains a valid file name extension

### DIFF
--- a/app/src/filedialog.cpp
+++ b/app/src/filedialog.cpp
@@ -95,6 +95,11 @@ QString FileDialog::getSaveFileName(QWidget* parent, FileType fileType, const QS
 
     if (filePath.isEmpty()) { return QString(); }
 
+    if (!hasValidSuffix(strFilter, filePath))
+    {
+        filePath += getDefaultExtensionByFileType(fileType);
+    }
+
     if (fileType == FileType::ANIMATION)
     {
         // When we save a new project, change default path for all other filetypes
@@ -102,12 +107,6 @@ QString FileDialog::getSaveFileName(QWidget* parent, FileType fileType, const QS
     }
 
     setLastSavePath(fileType, filePath);
-
-    QFileInfo info(filePath);
-    if (info.suffix().isEmpty() && strSelectedFilter.isEmpty())
-    {
-        filePath += getDefaultExtensionByFileType(fileType);
-    }
 
     return filePath;
 }
@@ -218,6 +217,22 @@ QString FileDialog::saveFileFilters(FileType fileType)
     case FileType::PALETTE: return PFF_PALETTE_EXT_FILTER;
     }
     return "";
+}
+
+bool FileDialog::hasValidSuffix(const QString& filters, const QString& filePath)
+{
+    QString fileName = QFileInfo(filePath).fileName();
+    for (const QString& filter : filters.split(";;"))
+    {
+        int start = filter.indexOf("(") + 1;
+        int end = filter.indexOf(")");
+        Q_ASSERT(start >= 1 && end >= 0);
+
+        if (QDir::match(filter.mid(start, end - start), fileName)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 QString FileDialog::getFilterForFile(const QString& filters, QString filePath)

--- a/app/src/filedialog.h
+++ b/app/src/filedialog.h
@@ -107,6 +107,7 @@ private:
     static QString getFilterForFile( const QString& fileType, QString filePath );
     static QString defaultFileName(FileType fileType , QString baseName = QString());
 
+    static bool hasValidSuffix(const QString& filters, const QString& filePath);
     static QString getDefaultExtensionByFileType(FileType fileType);
 
     static QString toSettingKey( FileType fileType );

--- a/core_lib/src/util/fileformat.h
+++ b/core_lib/src/util/fileformat.h
@@ -59,7 +59,7 @@ GNU General Public License for more details.
     QString(".pclx")
 
 #define PFF_DEFAULT_IMAGE_EXT \
-   QString(".png")
+    QString(".png")
 
 #define PFF_DEFAULT_IMAGE_SEQ_EXT \
     QString(".png")


### PR DESCRIPTION
On Windows, it is possible to select an export file path with an invalid file name extension by manually typing the name of a pre-existing file into the text field. That will then confuse the movie exporter because it doesn’t know how to handle the unknown extension, as seen in [this forum thread](https://discuss.pencil2d.org/t/cant-export-animation-as-video/6755?u=j5lx). To avoid this, it is necessary to manually check the extension of the selected file path.