### PR TITLE
Camera: calculate control points on the fly

### DIFF
--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -107,6 +107,7 @@ HEADERS +=  \
     src/util/pencildef.h \
     src/util/pencilerror.h \
     src/util/pencilsettings.h \
+    src/util/transform.h \
     src/util/util.h \
     src/util/log.h \
     src/util/movemode.h \
@@ -186,6 +187,7 @@ SOURCES +=  src/graphics/bitmap/bitmapimage.cpp \
     src/util/pencilerror.cpp \
     src/util/pencilsettings.cpp \
     src/util/log.cpp \
+    src/util/transform.cpp \
     src/util/util.cpp \
     src/util/pointerevent.cpp \
     src/canvaspainter.cpp \

--- a/core_lib/src/camerapainter.cpp
+++ b/core_lib/src/camerapainter.cpp
@@ -25,11 +25,9 @@ GNU General Public License for more details.
 #include "camera.h"
 #include "keyframe.h"
 
+#include "transform.h"
 
 #include "painterutils.h"
-
-const int DOT_WIDTH = 6;
-const int HANDLE_WIDTH = 12;
 
 CameraPainter::CameraPainter()
 {
@@ -41,7 +39,6 @@ void CameraPainter::preparePainter(const Object* object,
                                    int frameIndex,
                                    const QTransform& transform,
                                    bool isPlaying,
-                                   bool showHandles,
                                    LayerVisibility layerVisibility,
                                    float relativeLayerOpacityThreshold,
                                    qreal viewScale)
@@ -51,19 +48,9 @@ void CameraPainter::preparePainter(const Object* object,
     mFrameIndex = frameIndex;
     mViewTransform = transform;
     mIsPlaying = isPlaying;
-    mShowHandles = showHandles;
     mLayerVisibility = layerVisibility;
     mRelativeLayerOpacityThreshold = relativeLayerOpacityThreshold;
     mViewScale = viewScale;
-
-    mHandleColor = Qt::white;
-    mHandleDisabledColor = Qt::black;
-    mHandleTextColor = QColor(0, 0, 0);
-
-    mHandlePen = QPen();
-    mHandlePen.setColor(QColor(0, 0, 0, 255));
-    mHandlePen.setWidth(2);
-
 }
 
 void CameraPainter::paint() const
@@ -148,24 +135,6 @@ void CameraPainter::paintVisuals(QPainter& painter) const
     QTransform camTransform = cameraLayerBelow->getViewAtFrame(mFrameIndex);
     QRect cameraRect = cameraLayerBelow->getViewRect();
     paintBorder(painter, camTransform, cameraRect);
-
-    // Show handles while we're on a camera layer and not doing playback
-    if (!mIsPlaying && mShowHandles) {
-        int frame = cameraLayerBelow->getPreviousKeyFramePosition(mFrameIndex);
-        Camera* cam = cameraLayerBelow->getLastCameraAtFrame(qMax(frame, mFrameIndex), 0);
-        Q_ASSERT(cam);
-        qreal scale = cam->scaling();
-        qreal rotation = cam->rotation();
-        QPointF translation = cam->translation();
-        paintHandles(painter, camTransform, cameraRect, translation, scale, rotation, !cameraLayerBelow->keyExists(mFrameIndex));
-    }
-
-    if (mShowHandles) {
-        const LayerCamera* layerCamera = static_cast<const LayerCamera*>(currentLayer);
-        currentLayer->foreachKeyFrame([&] (KeyFrame* keyframe) {
-            paintInterpolations(painter, layerCamera, keyframe);
-        });
-    }
 }
 
 void CameraPainter::paintBorder(QPainter& painter, const QTransform& camTransform, const QRect& camRect) const
@@ -192,127 +161,6 @@ void CameraPainter::paintBorder(QPainter& painter, const QTransform& camTransfor
     painter.restore();
 }
 
-void CameraPainter::paintHandles(QPainter& painter, const QTransform& camTransform, const QRect& cameraRect, const QPointF translation, const qreal scale, const qreal rotation, bool hollowHandles) const
-{
-    painter.save();
-
-    // if the current view is narrower than the camera field
-    // Indicates that the quality of the output will be degraded
-    if (scale > 1)
-    {
-        painter.setPen(Qt::red);
-    }
-    else
-    {
-        painter.setPen(QColor(0, 0, 0, 255));
-    }
-
-    QPolygonF camPolygon = mViewTransform.map(camTransform.inverted().map(QPolygon(cameraRect)));
-    painter.drawPolygon(camPolygon);
-
-    QTransform scaleT;
-    scaleT.scale(1, 1);
-    scaleT.rotate(rotation);
-    scaleT.translate(translation.x(), translation.y());
-
-    QPolygon nonScaledCamPoly = mViewTransform.map(scaleT.inverted().map(QPolygon(cameraRect)));
-    painter.drawPolygon(nonScaledCamPoly);
-    painter.drawText(nonScaledCamPoly[0]-QPoint(0, 2), "100%");
-
-    if (hollowHandles) {
-        painter.setPen(mHandleDisabledColor);
-        painter.setBrush(Qt::gray);
-    } else {
-        painter.setPen(mHandlePen);
-        painter.setBrush(mHandleColor);
-    }
-    int handleW = HANDLE_WIDTH;
-    int radius = handleW / 2;
-
-    const QRectF topRightCorner = QRectF(camPolygon.at(1).x() - radius,
-                                            camPolygon.at(1).y() - radius,
-                                            handleW, handleW);
-    painter.drawRect(topRightCorner);
-
-    const QRectF bottomRightCorner = QRectF(camPolygon.at(2).x() - radius,
-                                            camPolygon.at(2).y() - radius,
-                                            handleW, handleW);
-    painter.drawRect(bottomRightCorner);
-    const QRectF topLeftCorner = QRectF(camPolygon.at(0).x() - radius,
-                                            camPolygon.at(0).y() - radius,
-                                            handleW, handleW);
-    painter.drawRect(topLeftCorner);
-
-    const QRectF bottomLeftCorner = QRectF(camPolygon.at(3).x() - radius,
-                                            camPolygon.at(3).y() - radius,
-                                            handleW, handleW);
-    painter.drawRect(bottomLeftCorner);
-
-    // Paint rotation handle
-    QPointF topCenter = QLineF(camPolygon.at(0), camPolygon.at(1)).pointAt(.5);
-
-    qreal offsetLimiter = (0.8 * mViewScale);
-    QPointF rotationHandle = mViewTransform.map(camTransform.inverted().map(QPoint(0, (-cameraRect.height()*0.5 - (offsetLimiter) * RotationHandleOffset))));
-
-    painter.drawLine(topCenter, QPoint(rotationHandle.x(),
-                                       (rotationHandle.y())));
-
-    painter.drawEllipse(QRectF((rotationHandle.x() - handleW*0.5),
-                               (rotationHandle.y() - handleW*0.5),
-                               handleW, handleW));
-
-    painter.restore();
-}
-
-void CameraPainter::paintInterpolations(QPainter& painter, const LayerCamera* cameraLayer, const KeyFrame* keyframe) const
-{
-    QColor cameraDotColor = cameraLayer->getDotColor();
-    int frame = keyframe->pos();
-    int nextFrame = cameraLayer->getNextKeyFramePosition(frame);
-
-    if (cameraLayer->getShowCameraPath() && !cameraLayer->hasSameTranslation(frame, nextFrame)) {
-        painter.save();
-
-        QPointF cameraPathPoint = mViewTransform.map(cameraLayer->getPathControlPointAtFrame(mFrameIndex));
-        painter.setBrush(cameraDotColor);
-        painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
-
-        // Highlight current dot
-        QPen pen(Qt::black);
-        pen.setWidth(2);
-        painter.setPen(pen);
-        cameraPathPoint = mViewTransform.map(cameraLayer->getViewAtFrame(mFrameIndex).inverted().map(QRectF(cameraLayer->getViewRect()).center()));
-        painter.drawEllipse(cameraPathPoint, DOT_WIDTH/2., DOT_WIDTH/2.);
-
-        cameraPathPoint = mViewTransform.map(cameraLayer->getPathControlPointAtFrame(frame + 1));
-
-        painter.save();
-        QColor color = cameraDotColor;
-        if (mFrameIndex > frame && mFrameIndex < nextFrame)
-            color.setAlphaF(0.5);
-        else
-            color.setAlphaF(0.2);
-        painter.setPen(Qt::black);
-        painter.setBrush(color);
-
-        for (int frameInBetween = frame; frameInBetween <= nextFrame ; frameInBetween++)
-        {
-            QTransform transform = cameraLayer->getViewAtFrame(frameInBetween);
-            QPointF center = mViewTransform.map(transform.inverted().map(QRectF(cameraLayer->getViewRect()).center()));
-            painter.drawEllipse(center, DOT_WIDTH/2., DOT_WIDTH/2.);
-        }
-        painter.restore();
-
-        int distance = nextFrame - frame;
-        // It makes no sense to paint the path when there's no interpolation.
-        if (distance >= 2 && !mIsPlaying) {
-            paintControlPoint(painter, cameraLayer, frame, cameraPathPoint, cameraLayer->keyExists(mFrameIndex));
-        }
-
-        painter.restore();
-    }
-}
-
 void CameraPainter::paintOnionSkinning(QPainter& painter, const LayerCamera* cameraLayer) const
 {
     QPolygon cameraViewPoly = cameraLayer->getViewRect();
@@ -324,7 +172,8 @@ void CameraPainter::paintOnionSkinning(QPainter& painter, const LayerCamera* cam
     onionSkinPen.setStyle(Qt::PenStyle::DashLine);
     mOnionSkinPainter.paint(painter, cameraLayer, mOnionSkinOptions, mFrameIndex, [&] (OnionSkinPaintState state, int onionSkinNumber) {
 
-        QPolygon cameraPoly = mViewTransform.map(cameraLayer->getViewAtFrame(onionSkinNumber).inverted().map(cameraViewPoly));
+        const QTransform& cameraTransform = cameraLayer->getViewAtFrame(onionSkinNumber);
+        const QPolygonF& cameraPolygon = Transform::mapToWorldPolygon(cameraTransform, mViewTransform, cameraLayer->getViewRect());
         if (state == OnionSkinPaintState::PREV) {
 
             if (mOnionSkinOptions.colorizePrevFrames) {
@@ -332,67 +181,20 @@ void CameraPainter::paintOnionSkinning(QPainter& painter, const LayerCamera* cam
             }
 
             painter.setPen(onionSkinPen);
-            painter.drawPolygon(cameraPoly);
+            painter.drawPolygon(cameraPolygon);
         } else if (state == OnionSkinPaintState::NEXT) {
             if (mOnionSkinOptions.colorizeNextFrames) {
                 onionSkinPen.setColor(Qt::blue);
             }
 
             painter.setPen(onionSkinPen);
-            painter.drawPolygon(cameraPoly);
+            painter.drawPolygon(cameraPolygon);
         } else if (state == OnionSkinPaintState::CURRENT) {
             painter.save();
             painter.setPen(Qt::black);
-            painter.drawPolygon(cameraPoly);
+            painter.drawPolygon(cameraPolygon);
             painter.restore();
         }
     });
-    painter.restore();
-}
-
-void CameraPainter::paintControlPoint(QPainter& painter, const LayerCamera* cameraLayer, const int frameIndex, const QPointF& pathPoint, bool hollowHandle) const
-{
-    painter.save();
-
-    // if active path, draw bezier help lines for active path
-    QList<QPointF> points = cameraLayer->getBezierPointsAtFrame(frameIndex + 1);
-
-    if (!points.empty())
-    {
-        Q_ASSERT(points.size() == 3);
-        QPointF p0 = mViewTransform.map(points.at(0));
-        QPointF p1 = mViewTransform.map(points.at(1));
-        QPointF p2 = mViewTransform.map(points.at(2));
-
-        painter.save();
-        QPen pen (Qt::black, 0.5, Qt::PenStyle::DashLine);
-        painter.setPen(pen);
-        painter.drawLine(p0, p1);
-        painter.drawLine(p1, p2);
-        painter.restore();
-    }
-
-    // draw movemode in text
-    painter.setPen(Qt::black);
-    QString pathType = cameraLayer->getInterpolationTextAtFrame(frameIndex);
-
-    // Space text according to path point so it doesn't overlap
-    painter.drawText(pathPoint - QPoint(0, HANDLE_WIDTH), pathType);
-    painter.restore();
-
-    // if active path, draw move handle
-    painter.save();
-    painter.setPen(mHandleTextColor);
-
-    if (hollowHandle) {
-        painter.setPen(mHandleDisabledColor);
-        painter.setBrush(Qt::gray);
-    } else {
-        painter.setPen(mHandlePen);
-        painter.setBrush(mHandleColor);
-    }
-    painter.drawRect(static_cast<int>(pathPoint.x() - HANDLE_WIDTH/2),
-                     static_cast<int>(pathPoint.y() - HANDLE_WIDTH/2),
-                     HANDLE_WIDTH, HANDLE_WIDTH);
     painter.restore();
 }

--- a/core_lib/src/camerapainter.h
+++ b/core_lib/src/camerapainter.h
@@ -44,7 +44,7 @@ public:
 
     void setOnionSkinPainterOptions(const OnionSkinPainterOptions& options) { mOnionSkinOptions = options; }
     void setCanvas(QPixmap* canvas);
-    void preparePainter(const Object* object, int layerIndex, int frameIndex, const QTransform& transform, bool isPlaying, bool showHandles, LayerVisibility layerVisibility, float relativeLayerOpacityThreshold, qreal viewScale);
+    void preparePainter(const Object* object, int layerIndex, int frameIndex, const QTransform& transform, bool isPlaying, LayerVisibility layerVisibility, float relativeLayerOpacityThreshold, qreal viewScale);
     void resetCache();
 
 private:
@@ -52,9 +52,6 @@ private:
     void paintVisuals(QPainter& painter) const;
     void paintBorder(QPainter& painter, const QTransform& camTransform, const QRect& camRect) const;
     void paintOnionSkinning(QPainter& painter, const LayerCamera* cameraLayer) const;
-    void paintInterpolations(QPainter& painter, const LayerCamera* cameraLayer, const KeyFrame* keyframe) const;
-    void paintHandles(QPainter& painter, const QTransform& camTransform, const QRect& cameraRect, const QPointF translation, const qreal scale, const qreal rotation, bool hollowHandles) const;
-    void paintControlPoint(QPainter& painter, const LayerCamera* cameraLayer, const int frameIndex, const QPointF& pathPoint, bool hollowHandle) const;
 
     const Object* mObject = nullptr;
     QPixmap* mCanvas = nullptr;
@@ -72,12 +69,6 @@ private:
     qreal mViewScale = 0;
 
     bool mIsPlaying = false;
-    bool mShowHandles = false;
-
-    QPen mHandlePen;
-    QColor mHandleColor;
-    QColor mHandleDisabledColor;
-    QColor mHandleTextColor;
 };
 
 #endif // CAMERAPAINTER_H

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1079,6 +1079,8 @@ void ScribbleArea::paintEvent(QPaintEvent* event)
     painter.setWorldMatrixEnabled(false);
     painter.drawPixmap(QPoint(0, 0), mCanvas);
 
+    currentTool()->paint(painter);
+
     Layer* layer = mEditor->layers()->currentLayer();
 
     if (!editor()->playback()->isPlaying())    // we don't need to display the following when the animation is playing
@@ -1216,7 +1218,6 @@ void ScribbleArea::prepCameraPainter(int frame)
                                   frame,
                                   mEditor->view()->getView(),
                                   mEditor->playback()->isPlaying(),
-                                  mEditor->tools()->currentTool()->type() == CAMERA,
                                   mLayerVisibility,
                                   mPrefs->getFloat(SETTING::LAYER_VISIBILITY_THRESHOLD),
                                   mEditor->view()->getViewScaleInverse());

--- a/core_lib/src/structure/layercamera.cpp
+++ b/core_lib/src/structure/layercamera.cpp
@@ -485,10 +485,11 @@ QPointF LayerCamera::getNewPathControlPointAtFrame(int frame) const
 
 void LayerCamera::updatePathControlPointAtFrame(const QPointF& point, int frame) const
 {
-    Camera* camera = getCameraAtFrame(getPreviousKeyFramePosition(frame));
+    Camera* camera = getLastCameraAtFrame(frame, 0);
     Q_ASSERT(camera);
 
     camera->setPathControlPoint(point);
+    camera->setPathControlPointMoved(true);
 }
 
 void LayerCamera::loadImageAtFrame(int frameNumber, qreal dx, qreal dy, qreal rotate, qreal scale, CameraEasingType easing, const QPointF& pathPoint, bool pathMoved)

--- a/core_lib/src/structure/layercamera.h
+++ b/core_lib/src/structure/layercamera.h
@@ -60,8 +60,7 @@ public:
     QPointF getPathControlPointAtFrame(int frame) const;
     bool hasSameTranslation(int frame1, int frame2) const;
     QList<QPointF> getBezierPointsAtFrame(int frame) const;
-    void centerPathControlPointAtFrame(int frame) const;
-    QPointF getNewPathControlPointAtFrame(int frame) const;
+    QPointF getCenteredPathPoint(int frame) const;
     void updatePathControlPointAtFrame(const QPointF& point, int frame) const;
     void setPathMovedAtFrame(int frame, bool moved) const;
 

--- a/core_lib/src/structure/layercamera.h
+++ b/core_lib/src/structure/layercamera.h
@@ -64,8 +64,8 @@ public:
     void updatePathControlPointAtFrame(const QPointF& point, int frame) const;
     void setPathMovedAtFrame(int frame, bool moved) const;
 
-    void updateControlPointOnDeleteFrame(int frame) const;
-    void approximateControlPointFor(int frame) const;
+    void splitControlPointIfNeeded(int frame) const;
+    void mergeControlPointIfNeeded(int frame) const;
 
 protected:
     Status saveKeyFrameFile(KeyFrame*, QString path) override;
@@ -83,6 +83,8 @@ private:
     bool mShowPath = false;
     QColor mDotColor = Qt::red;
     DotColorType mDotColorType = DotColorType::RED;
+
+    const int mControlPointMergeThreshold = 2000;
 };
 
 #endif

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -134,6 +134,8 @@ public:
     virtual void setPathDotColorType(const DotColorType dotColorType);
     virtual void resetCameraPath();
 
+    virtual void paint(QPainter& painter) { Q_UNUSED(painter) };
+
     virtual bool leavingThisTool() { return true; }
 
     Properties properties;

--- a/core_lib/src/tool/cameratool.cpp
+++ b/core_lib/src/tool/cameratool.cpp
@@ -284,7 +284,6 @@ void CameraTool::pointerPressEvent(PointerEvent*)
     updateUIAssists(mEditor->layers()->currentLayer());
 
     mStartAngle = getAngleBetween(getCurrentPoint(), mCameraRect.center()) - mCurrentAngle;
-    mDragPathFrame = mEditor->currentFrame();
     mTransformOffset = getCurrentPoint();
 }
 

--- a/core_lib/src/tool/cameratool.h
+++ b/core_lib/src/tool/cameratool.h
@@ -24,6 +24,10 @@ GNU General Public License for more details.
 #include "camerafieldoption.h"
 #include "preferencemanager.h"
 
+#include "transform.h"
+
+#include <QPen>
+
 enum class CameraMoveType {
     PATH,
     TOPLEFT,
@@ -37,6 +41,7 @@ enum class CameraMoveType {
 
 class PointerEvent;
 class LayerCamera;
+class KeyFrame;
 
 class CameraTool : public BaseTool
 {
@@ -47,6 +52,8 @@ public:
 
     QCursor cursor() override;
     ToolType type() override { return ToolType::CAMERA; }
+
+    void paint(QPainter& painter) override;
 
     void loadSettings() override;
 
@@ -62,6 +69,14 @@ public:
     void transformView(LayerCamera* layerCamera, CameraMoveType mode, const QPointF& point, const QPointF& offset, qreal angle, int frameNumber) const;
 
 private:
+
+    QPointF localRotationHandlePoint(const QPoint& origin, const QTransform& localT, const qreal objectScale, float worldScale) const;
+    QPointF worldRotationHandlePoint(const QPoint& origin, const QTransform& localT, const qreal objectScale, const QTransform& worldT, float worldScale) const;
+
+    void paintHandles(QPainter& painter, const QTransform& worldTransform, const QTransform& camTransform, const QRect& cameraRect, const QPointF translation, const qreal scale, const qreal rotation, bool hollowHandles) const;
+    void paintInterpolations(QPainter& painter, const QTransform& worldTransform, int currentFrame, const LayerCamera* cameraLayer, const KeyFrame* keyframe, bool isPlaying) const;
+    void paintControlPoint(QPainter& painter, const QTransform& worldTransform, const LayerCamera* cameraLayer, const int frameIndex, const QPointF& pathPoint, bool hollowHandle) const;
+
     CameraMoveType moveMode();
     void transformCamera(Qt::KeyboardModifiers keyMod);
     void transformCameraPath();
@@ -69,10 +84,11 @@ private:
     int constrainedRotation(const qreal rotatedAngle, const int rotationIncrement) const;
 
     void updateProperties();
+    void updateUIAssists(const Layer* layer);
 
     qreal getAngleBetween(const QPointF& pos1, const QPointF& pos2) const;
 
-    CameraMoveType getCameraMoveMode(const LayerCamera* layerCamera, int frameNumber, const QPointF& point, qreal tolerance) const;
+    CameraMoveType getCameraMoveMode(const QPointF& point, qreal tolerance) const;
     CameraMoveType getPathMoveMode(const LayerCamera* layerCamera, int frameNumber, const QPointF& point, qreal tolerance) const;
 
     QPointF mTransformOffset;
@@ -81,8 +97,21 @@ private:
     int mDragPathFrame = 1;
     int mRotationIncrement = 0;
 
+    QRectF mCameraRect;
+    QPolygonF mCameraPolygon;
+    QPointF mRotationHandlePoint;
+
     qreal mStartAngle = 0;
     qreal mCurrentAngle = 0;
+
+    const int mDotWidth = 6;
+    const int mHandleWidth = 12;
+    const qreal mRotationHandleOffsetPercentage = 0.05;
+
+    QPen mHandlePen;
+    QColor mHandleColor;
+    QColor mHandleDisabledColor;
+    QColor mHandleTextColor;
 };
 
 #endif // CAMERATOOL_H

--- a/core_lib/src/tool/cameratool.h
+++ b/core_lib/src/tool/cameratool.h
@@ -42,6 +42,7 @@ enum class CameraMoveType {
 class PointerEvent;
 class LayerCamera;
 class KeyFrame;
+class Camera;
 
 class CameraTool : public BaseTool
 {
@@ -74,7 +75,7 @@ private:
     QPointF worldRotationHandlePoint(const QPoint& origin, const QTransform& localT, const qreal objectScale, const QTransform& worldT, float worldScale) const;
 
     void paintHandles(QPainter& painter, const QTransform& worldTransform, const QTransform& camTransform, const QRect& cameraRect, const QPointF translation, const qreal scale, const qreal rotation, bool hollowHandles) const;
-    void paintInterpolations(QPainter& painter, const QTransform& worldTransform, int currentFrame, const LayerCamera* cameraLayer, const KeyFrame* keyframe, bool isPlaying) const;
+    void paintInterpolations(QPainter& painter, const QTransform& worldTransform, int currentFrame, const LayerCamera* cameraLayer, const Camera* keyframe, bool isPlaying) const;
     void paintControlPoint(QPainter& painter, const QTransform& worldTransform, const LayerCamera* cameraLayer, const int frameIndex, const QPointF& pathPoint, bool hollowHandle) const;
 
     CameraMoveType moveMode();

--- a/core_lib/src/util/transform.cpp
+++ b/core_lib/src/util/transform.cpp
@@ -1,0 +1,54 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+#include "transform.h"
+
+/* The Transform class is meant to be used for mapping between the local and world coordinate spaces
+ * mapFrom(...) will take the input and and return the inverted point in the mapped space.
+ * mapToWorld(...) functions will take the input and first map it from the local space and then to the world space.
+ *
+ * Note: It is assumed that the rect, polygon, point etc... hasn't been transformed when inputted.
+*/
+
+QRectF Transform::mapFromLocalRect(const QTransform& transform, const QRect& rect)
+{
+    return QRectF(transform.inverted().mapRect(QRectF(rect)));
+}
+
+QRectF Transform::mapToWorldRect(const QTransform& transform, const QTransform& worldT, const QRect rect)
+{
+    return worldT.mapRect(mapFromLocalRect(transform, rect));
+}
+
+QPointF Transform::mapFromLocalPoint(const QTransform& transform, const QPoint& point)
+{
+    return QPointF(transform.inverted().map(QPointF(point)));
+}
+
+QPointF Transform::mapToWorldPoint(const QTransform& transform, const QTransform& worldT, const QPoint& point)
+{
+    return worldT.map(mapFromLocalPoint(transform, point));
+}
+
+QPolygonF Transform::mapFromLocalPolygon(const QTransform& transform, const QRect& rect)
+{
+    return QPolygonF(transform.inverted().map(QPolygonF(QRectF(rect))));
+}
+
+QPolygonF Transform::mapToWorldPolygon(const QTransform& transform, const QTransform& worldT, const QRect& rect)
+{
+    return worldT.map(mapFromLocalPolygon(transform, rect));
+}

--- a/core_lib/src/util/transform.h
+++ b/core_lib/src/util/transform.h
@@ -1,0 +1,38 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+#ifndef TRANSFORM_H
+#define TRANSFORM_H
+
+#include <QTransform>
+#include <QPolygonF>
+
+class Transform
+{
+public:
+    Transform() {};
+
+    static QRectF mapFromLocalRect(const QTransform& transform, const QRect& rect);
+    static QRectF mapToWorldRect(const QTransform& transform, const QTransform& worldT, const QRect rect);
+
+    static QPointF mapFromLocalPoint(const QTransform& transform, const QPoint& point);
+    static QPointF mapToWorldPoint(const QTransform& transform, const QTransform& worldT, const QPoint& point);
+
+    static QPolygonF mapFromLocalPolygon(const QTransform& transform, const QRect& rect);
+    static QPolygonF mapToWorldPolygon(const QTransform& transform, const QTransform& worldT, const QRect& rect);
+};
+
+#endif // TRANSFORM_H


### PR DESCRIPTION
For this PR the goal has been to create stronger coupling between the camera tool and the painter that handled the interactive parts. This has been done by introducing a BaseTool::paint(...) method which allows us to perform calculations that can both be used by the tool and its painter without addition branching to Scribbearea. One example where we benefit from this when calculating the centered control point without explicitly setting it. Another example calculating the distance between the rotation anchor, its line and the camera frame, and this has to be done two places, locally in the tool and in the world coordinate space.

### Fixes
- Rotation anchor would not keep a fixed distance from the camera frame
How to reproduce: 
1. Load a project, select the camera tool and the camera layer
2. Zoom in and out, notice the distance of the rotation anchor being slightly off
3. Now increase the size of the camera frame and repeat the steps
Result: The rotation anchor has been positioned further away from the frame
- Sometimes dragging the last control handle would drag the previous instead...

- Reworked recovery logic for splitting and merging control points

### Changes
- Camera tool painter logic has been moved to camera tool
- PathCPM has been removed as its not necessary anymore