### PR TITLE
Fix emtpy frame on position 1 when duplicating layer

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -704,7 +704,7 @@ void ActionCommands::duplicateLayer()
     Layer* toLayer = layerMgr->createLayer(fromLayer->type(), tr("%1 (copy)", "Default duplicate layer name").arg(fromLayer->name()));
     fromLayer->foreachKeyFrame([&] (KeyFrame* key) {
         key = key->clone();
-        toLayer->loadKey(key);
+        toLayer->addOrReplaceKeyFrame(key->pos(), key);
         if (toLayer->type() == Layer::SOUND)
         {
             mEditor->sound()->processSound(static_cast<SoundClip*>(key));

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -55,7 +55,6 @@ GNU General Public License for more details.
 #include "aboutdialog.h"
 #include "doubleprogressdialog.h"
 #include "checkupdatesdialog.h"
-#include "layeropacitydialog.h"
 #include "errordialog.h"
 
 
@@ -703,10 +702,9 @@ void ActionCommands::duplicateLayer()
     int currFrame = mEditor->currentFrame();
 
     Layer* toLayer = layerMgr->createLayer(fromLayer->type(), tr("%1 (copy)", "Default duplicate layer name").arg(fromLayer->name()));
-    toLayer->removeKeyFrame(1);
     fromLayer->foreachKeyFrame([&] (KeyFrame* key) {
         key = key->clone();
-        toLayer->addKeyFrame(key->pos(), key);
+        toLayer->loadKey(key);
         if (toLayer->type() == Layer::SOUND)
         {
             mEditor->sound()->processSound(static_cast<SoundClip*>(key));
@@ -716,6 +714,9 @@ void ActionCommands::duplicateLayer()
             key->modification();
         }
     });
+    if (!fromLayer->keyExists(1)) {
+        toLayer->removeKeyFrame(1);
+    }
     mEditor->scrubTo(currFrame);
 }
 

--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -184,20 +184,24 @@ bool Layer::addNewKeyFrameAt(int position)
     return addKeyFrame(position, key);
 }
 
-bool Layer::addKeyFrame(int position, KeyFrame* pKeyFrame)
+void Layer::addOrReplaceKeyFrame(int position, KeyFrame* pKeyFrame)
 {
     Q_ASSERT(position > 0);
-    auto it = mKeyFrames.find(position);
-    if (it != mKeyFrames.end())
+    pKeyFrame->setPos(position);
+    loadKey(pKeyFrame);
+    markFrameAsDirty(position);
+}
+
+bool Layer::addKeyFrame(int position, KeyFrame* pKeyFrame)
+{
+    if (keyExists(position))
     {
         return false;
     }
 
     pKeyFrame->setPos(position);
-    mKeyFrames.insert(std::make_pair(position, pKeyFrame));
-
+    mKeyFrames.emplace(position, pKeyFrame);
     markFrameAsDirty(position);
-
     return true;
 }
 

--- a/core_lib/src/structure/layer.h
+++ b/core_lib/src/structure/layer.h
@@ -23,7 +23,6 @@ GNU General Public License for more details.
 #include <QString>
 #include <QDomElement>
 #include "pencilerror.h"
-#include "pencildef.h"
 
 class QMouseEvent;
 class QPainter;
@@ -99,11 +98,11 @@ public:
     bool insertExposureAt(int position);
 
     bool addNewKeyFrameAt(int position);
-    virtual bool addKeyFrame(int position, KeyFrame*);
+    void addOrReplaceKeyFrame(int position, KeyFrame* pKeyFrame);
+    virtual bool addKeyFrame(int position, KeyFrame* pKeyFrame);
     virtual bool removeKeyFrame(int position);
     bool swapKeyFrames(int position1, int position2);
     bool moveKeyFrame(int position, int offset);
-    bool loadKey(KeyFrame*);
     KeyFrame* getKeyFrameAt(int position) const;
     KeyFrame* getLastKeyFrameAtPosition(int position) const;
     bool keyExistsWhichCovers(int frameNumber);
@@ -171,6 +170,7 @@ public:
 protected:
     void setId(int LayerId) { mId = LayerId; }
     virtual KeyFrame* createKeyFrame(int position, Object*) = 0;
+    bool loadKey(KeyFrame*);
 
 private:
     void removeFromSelectionList(int position);

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -47,12 +47,14 @@ BitmapImage* LayerBitmap::getLastBitmapImageAtFrame(int frameNumber, int increme
 void LayerBitmap::repositionFrame(QPoint point, int frame)
 {
     BitmapImage* image = getBitmapImageAtFrame(frame);
+    Q_ASSERT(image);
     image->moveTopLeft(point);
 }
 
 QRect LayerBitmap::getFrameBounds(int frame)
 {
     BitmapImage* image = getBitmapImageAtFrame(frame);
+    Q_ASSERT(image);
     return image->bounds();
 }
 

--- a/core_lib/src/structure/layercamera.h
+++ b/core_lib/src/structure/layercamera.h
@@ -22,6 +22,7 @@ GNU General Public License for more details.
 #include "layer.h"
 #include "camerafieldoption.h"
 #include "cameraeasingtype.h"
+#include "pencildef.h"
 
 class Camera;
 


### PR DESCRIPTION
As reported by Nelphy [on Discord](https://discord.com/channels/342369662710972417/395346048727515137/1074501500103036988). I also thought about renaming loadKey()… fundamentally, it’s more general-purpose than what we’re using it for so far IMO.

In the future, I think we should reconsider how we enforce the “min. one keyframe per layer” requirement. It’s a bit inconsistent right now with different assumptions made in different places, which is fundamentally what led to this issue.