### PR TITLE
Fix crash when switching away from vector layer while not on a keyframe

### DIFF
--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -161,7 +161,11 @@ void Editor::onCurrentLayerWillChange(int index)
         mScribbleArea->applyTransformedSelection();
 
         if (currentLayer->type() == Layer::VECTOR) {
-            static_cast<VectorImage*>(currentLayer->getKeyFrameAt(mFrame))->deselectAll();
+            auto keyFrame = static_cast<VectorImage*>(currentLayer->getLastKeyFrameAtPosition(mFrame));
+            if (keyFrame)
+            {
+                keyFrame->deselectAll();
+            }
         }
 
         select()->resetSelectionProperties();
@@ -702,7 +706,7 @@ void Editor::paste()
 }
 
 void Editor::flipSelection(bool flipVertical)
-{   
+{
     if (flipVertical) {
         backup(tr("Flip selection vertically"));
     } else {


### PR DESCRIPTION
Stumbled across this bug purely by chance. Seems to be another issue I missed while reviewing #1724. Steps to reproduce:

1. Create a vector layer (or switch to an existing one)
2. Go to any frame that does not have a keyframe on that vector layer
3. Switch to any other layer → Segfault