### PR TITLE
Fix view freezing when both rotating camera and view

### DIFF
--- a/core_lib/src/camerapainter.cpp
+++ b/core_lib/src/camerapainter.cpp
@@ -19,6 +19,7 @@ GNU General Public License for more details.
 
 #include <QPainter>
 #include <QPixmap>
+#include <QPainterPath>
 #include "object.h"
 #include "layercamera.h"
 #include "camera.h"
@@ -139,7 +140,7 @@ void CameraPainter::paintVisuals(QPainter& painter) const
 void CameraPainter::paintBorder(QPainter& painter, const QTransform& camTransform, const QRect& camRect) const
 {
     painter.save();
-    QRectF viewRect = painter.viewport();
+    QRect viewRect = painter.viewport();
 
     painter.setOpacity(1.0);
     painter.setWorldMatrixEnabled(true);
@@ -148,14 +149,13 @@ void CameraPainter::paintBorder(QPainter& painter, const QTransform& camTransfor
     painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
 
     QTransform viewInverse = mViewTransform.inverted();
-    QRect boundingRect = viewInverse.mapRect(viewRect).toAlignedRect();
+    QRect boundingRect = viewInverse.mapRect(viewRect);
 
-    QRegion rg1(boundingRect);
-    QRegion rg2 = camTransform.inverted().map(QRegion(camRect));
-    QRegion rg3 = rg1.subtracted(rg2);
+    QPolygon camPoly = camTransform.inverted().map(QPolygon(camRect));
+    QPolygon outerPoly = boundingRect;
+    QPolygon clipped = outerPoly.subtracted(camPoly);
 
-    painter.setClipRegion(rg3);
-    painter.drawRect(boundingRect);
+    painter.drawPolygon(clipped);
 
     painter.restore();
 }


### PR DESCRIPTION
The problem was caused by QRegion ending up cutting the transformed rect/polygon into thousand of smaller slices (anywhere between 4 with no transformation to 9000 cuts after transforming to certain angles!), make the application freeze for several seconds.

Fortunately the problem can be fixed rather trivially. We don't need to clip at all, instead we simply create a polygon that matches the look we want, in this case the passpartout effect.