### PR TITLE
Replace -bitexact FFmpeg option with more compatible -(f)flags

### DIFF
--- a/core_lib/src/movieimporter.cpp
+++ b/core_lib/src/movieimporter.cpp
@@ -342,7 +342,7 @@ Status MovieImporter::importMovieAudio(const QString& filePath, std::function<bo
 
     QString audioPath = QDir(mTempDir->path()).filePath("audio.wav");
 
-    QStringList args{ "-i", filePath, "-map_metadata", "-1", "-bitexact", audioPath };
+    QStringList args{ "-i", filePath, "-map_metadata", "-1", "-flags", "bitexact", "-fflags", "bitexact", audioPath };
 
     status = MovieExporter::executeFFmpeg(ffmpegLocation(), args, [&progress, this] (int frame) {
         Q_UNUSED(frame)


### PR DESCRIPTION
The -bitexact option was only added in FFmpeg 4 and is not available in older versions. Luckily, it is no more than a convenient shortcut for the bitexact codec and format flags, which should be old enough.