### PR TITLE
Fix reference layer UI not being shown on bitmap layer

### DIFF
--- a/app/src/bucketoptionswidget.cpp
+++ b/app/src/bucketoptionswidget.cpp
@@ -129,6 +129,8 @@ void BucketOptionsWidget::updatePropertyVisibility()
 
         ui->fillToLayerComboBox->show();
         ui->fillToDescLabel->show();
+        ui->referenceLayerComboBox->show();
+        ui->referenceLayerDescLabel->show();
         ui->colorToleranceCheckbox->show();
         ui->colorToleranceSlider->show();
         ui->colorToleranceSpinbox->show();


### PR DESCRIPTION
I was made aware of this bug through the forum. https://discuss.pencil2d.org/t/why-is-the-fill-to-layer-option-deprecated/7106/4