### PR TITLE
Fix three point perspective overlay anchors

### DIFF
--- a/core_lib/src/managers/overlaymanager.cpp
+++ b/core_lib/src/managers/overlaymanager.cpp
@@ -80,11 +80,11 @@ MoveMode OverlayManager::getMoveModeForPoint(const QPointF& pos, const QTransfor
     {
         mode = MoveMode::PERSP_SINGLE;
     }
-    else if (mTwoPointPerspectiveEnabled && QLineF(pos, transform.inverted().map(mLeftPerspectivePoint)).length() < calculatedSelectionTol)
+    else if ((mTwoPointPerspectiveEnabled || mThreePointPerspectiveEnabled) && QLineF(pos, transform.inverted().map(mLeftPerspectivePoint)).length() < calculatedSelectionTol)
     {
         mode = MoveMode::PERSP_LEFT;
     }
-    else if (mTwoPointPerspectiveEnabled && QLineF(pos, transform.inverted().map(mRightPerspectivePoint)).length() < calculatedSelectionTol)
+    else if ((mTwoPointPerspectiveEnabled || mThreePointPerspectiveEnabled) && QLineF(pos, transform.inverted().map(mRightPerspectivePoint)).length() < calculatedSelectionTol)
     {
         mode = MoveMode::PERSP_RIGHT;
     }

--- a/core_lib/src/managers/overlaymanager.cpp
+++ b/core_lib/src/managers/overlaymanager.cpp
@@ -101,23 +101,6 @@ double OverlayManager::selectionTolerance()
     return qAbs(mSelectionTolerance * mEditor->viewScaleInversed());
 }
 
-void OverlayManager::updatePerspective(int persp)
-{
-    switch (persp) {
-    case 1:
-        setMoveMode(MoveMode::PERSP_SINGLE);
-        break;
-    case 2:
-        setMoveMode(MoveMode::PERSP_LEFT);
-        break;
-    case 3:
-        setMoveMode(MoveMode::PERSP_LEFT);
-        break;
-    default:
-        break;
-    }
-}
-
 void OverlayManager::updatePerspective(const QPointF& point)
 {
     switch (mMoveMode) {

--- a/core_lib/src/managers/overlaymanager.h
+++ b/core_lib/src/managers/overlaymanager.h
@@ -47,7 +47,6 @@ public:
     MoveMode getMoveModeForPoint(const QPointF& pos, const QTransform& transform);
     double selectionTolerance();
 
-    void updatePerspective(const int persp);
     void updatePerspective(const QPointF& point);
 
     MoveMode getMoveMode() const { return mMoveMode; }


### PR DESCRIPTION
### How to reproduce:
1. Enable the three point perspective overlay 
2. Select the move tool
3. Hover and click on the left or right anchor

### Expected result
Being able to move the left and right anchor point

### Actual result
Only being able to drag the bottom anchor point