### PR TITLE
Ignore hidden sound layers when exporting video

### DIFF
--- a/core_lib/src/movieexporter.cpp
+++ b/core_lib/src/movieexporter.cpp
@@ -175,6 +175,7 @@ Status MovieExporter::assembleAudio(const Object* obj,
     std::vector< LayerSound* > allSoundLayers = obj->getLayersByType<LayerSound>();
     for (LayerSound* layer : allSoundLayers)
     {
+        if (!layer->visible()) { continue; }
         layer->foreachKeyFrame([&allSoundClips](KeyFrame* key)
         {
             if (!key->fileName().isEmpty())


### PR DESCRIPTION
Feature or bug... you decide 😄 

https://discuss.pencil2d.org/t/how-to-mute-one-track-when-exporting/7182/4