### PR TITLE
Invert canvas rotation direction if view is flipped

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -547,30 +547,16 @@ void ActionCommands::ZoomOut()
 
 void ActionCommands::rotateClockwise()
 {
-    float currentRotation = mEditor->view()->rotation();
-    // Invert rotation direction if view is flipped either vertically or horizontally
-    if (mEditor->view()->isFlipHorizontal() ^ mEditor->view()->isFlipVertical())
-    {
-        mEditor->view()->rotate(currentRotation - 15.f);
-    }
-    else
-    {
-        mEditor->view()->rotate(currentRotation + 15.f);
-    }
+    // Rotation direction is inverted if view is flipped either vertically or horizontally
+    const float delta = mEditor->view()->isFlipHorizontal() == !mEditor->view()->isFlipVertical() ? -15.f : 15.f;
+    mEditor->view()->rotateRelative(delta);
 }
 
 void ActionCommands::rotateCounterClockwise()
 {
-    float currentRotation = mEditor->view()->rotation();
-    // Invert rotation direction if view is flipped either vertically or horizontally
-    if (mEditor->view()->isFlipHorizontal() ^ mEditor->view()->isFlipVertical())
-    {
-        mEditor->view()->rotate(currentRotation + 15.f);
-    }
-    else
-    {
-        mEditor->view()->rotate(currentRotation - 15.f);
-    }
+    // Rotation direction is inverted if view is flipped either vertically or horizontally
+    const float delta = mEditor->view()->isFlipHorizontal() == !mEditor->view()->isFlipVertical() ? 15.f : -15.f;
+    mEditor->view()->rotateRelative(delta);
 }
 
 void ActionCommands::PlayStop()

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -548,13 +548,29 @@ void ActionCommands::ZoomOut()
 void ActionCommands::rotateClockwise()
 {
     float currentRotation = mEditor->view()->rotation();
-    mEditor->view()->rotate(currentRotation + 15.f);
+    // Invert rotation direction if view is flipped either vertically or horizontally
+    if (mEditor->view()->isFlipHorizontal() ^ mEditor->view()->isFlipVertical())
+    {
+        mEditor->view()->rotate(currentRotation - 15.f);
+    }
+    else
+    {
+        mEditor->view()->rotate(currentRotation + 15.f);
+    }
 }
 
 void ActionCommands::rotateCounterClockwise()
 {
     float currentRotation = mEditor->view()->rotation();
-    mEditor->view()->rotate(currentRotation - 15.f);
+    // Invert rotation direction if view is flipped either vertically or horizontally
+    if (mEditor->view()->isFlipHorizontal() ^ mEditor->view()->isFlipVertical())
+    {
+        mEditor->view()->rotate(currentRotation + 15.f);
+    }
+    else
+    {
+        mEditor->view()->rotate(currentRotation - 15.f);
+    }
 }
 
 void ActionCommands::PlayStop()

--- a/core_lib/src/managers/viewmanager.cpp
+++ b/core_lib/src/managers/viewmanager.cpp
@@ -171,6 +171,14 @@ void ViewManager::rotate(float degree)
     emit viewChanged();
 }
 
+void ViewManager::rotateRelative(float delta)
+{
+    mRotation = mRotation + delta;
+    updateViewTransforms();
+
+    emit viewChanged();
+}
+
 void ViewManager::resetRotation()
 {
     rotate(0);

--- a/core_lib/src/managers/viewmanager.h
+++ b/core_lib/src/managers/viewmanager.h
@@ -58,6 +58,7 @@ public:
 
     float rotation();
     void rotate(float degree);
+    void rotateRelative(float delta);
     void resetRotation();
 
     qreal scaling();

--- a/core_lib/src/tool/handtool.cpp
+++ b/core_lib/src/tool/handtool.cpp
@@ -107,7 +107,7 @@ void HandTool::transformView(Qt::KeyboardModifiers keyMod, Qt::MouseButtons butt
         angleOffset = qRadiansToDegrees(angleOffset);
         float newAngle = 0.0;
         // Invert rotation direction if view is flipped either vertically or horizontally
-        if (viewMgr->isFlipHorizontal() ^ viewMgr->isFlipVertical())
+        if (viewMgr->isFlipHorizontal() == !viewMgr->isFlipVertical())
         {
             newAngle = viewMgr->rotation() - static_cast<float>(angleOffset);
         }

--- a/core_lib/src/tool/handtool.cpp
+++ b/core_lib/src/tool/handtool.cpp
@@ -105,7 +105,16 @@ void HandTool::transformView(Qt::KeyboardModifiers keyMod, Qt::MouseButtons butt
 
         qreal angleOffset = static_cast<qreal>(std::atan2(curV.y(), curV.x()) - std::atan2(startV.y(), startV.x()));
         angleOffset = qRadiansToDegrees(angleOffset);
-        float newAngle = viewMgr->rotation() + static_cast<float>(angleOffset);
+        float newAngle = 0.0;
+        // Invert rotation direction if view is flipped either vertically or horizontally
+        if (viewMgr->isFlipHorizontal() ^ viewMgr->isFlipVertical())
+        {
+            newAngle = viewMgr->rotation() - static_cast<float>(angleOffset);
+        }
+        else
+        {
+            newAngle = viewMgr->rotation() + static_cast<float>(angleOffset);
+        }
         viewMgr->rotate(newAngle);
     }
     else if (isScale)

--- a/core_lib/src/tool/handtool.cpp
+++ b/core_lib/src/tool/handtool.cpp
@@ -105,17 +105,10 @@ void HandTool::transformView(Qt::KeyboardModifiers keyMod, Qt::MouseButtons butt
 
         qreal angleOffset = static_cast<qreal>(std::atan2(curV.y(), curV.x()) - std::atan2(startV.y(), startV.x()));
         angleOffset = qRadiansToDegrees(angleOffset);
-        float newAngle = 0.0;
         // Invert rotation direction if view is flipped either vertically or horizontally
-        if (viewMgr->isFlipHorizontal() == !viewMgr->isFlipVertical())
-        {
-            newAngle = viewMgr->rotation() - static_cast<float>(angleOffset);
-        }
-        else
-        {
-            newAngle = viewMgr->rotation() + static_cast<float>(angleOffset);
-        }
-        viewMgr->rotate(newAngle);
+        const float delta = viewMgr->isFlipHorizontal() == !viewMgr->isFlipVertical()
+            ? static_cast<float>(angleOffset * -1) : static_cast<float>(angleOffset);
+        viewMgr->rotateRelative(delta);
     }
     else if (isScale)
     {


### PR DESCRIPTION
Fixes #1777.

_Please note that I am not an experienced C++ developer, so please let me know if something can be improved!_

This PR adds a check to `ActionCommands::rotateClockwise()`, `ActionCommands::rotateCounterClockwise()` and `HandTool::transformView()` that inverts the rotation direction if the view is flipped either horizontally or vertically (but not both), so it's more intuitive:

Shortcuts (Z then R):
https://github.com/pencil2d/pencil/assets/75134774/ac722475-312d-4ac9-aeee-42c81653dcd6

Hand Tool:
https://github.com/pencil2d/pencil/assets/75134774/5e6d216b-31dd-4e88-844d-06c87b3a86c9
