### PR TITLE
Fix OpenSSL build failure

### DIFF
--- a/.github/actions/create-package/create-package.sh
+++ b/.github/actions/create-package/create-package.sh
@@ -104,9 +104,11 @@ create_package_windows() {
   windeployqt Pencil2D/pencil2d.exe
   echo "::endgroup::"
   echo "Copy OpenSSL DLLs"
-  local xbits="-x${platform#win}"
-  local _xbits="_x${platform#win}"
-  cp "${IQTA_TOOLS}\\OpenSSL\\Win${_xbits/32/86}\\bin\\lib"{ssl,crypto}"-1_1${xbits/-x32/}.dll" Pencil2D/
+  curl -fsSLO https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-1.1.1w.zip
+  "${WINDIR}\\System32\\tar" xf openssl-1.1.1w.zip
+  local xbits="x${platform#win}"
+  local _xbits="-${xbits}"
+  cp "openssl-1.1\\${xbits/32/86}\\bin\\lib"{ssl,crypto}"-1_1${_xbits/-x32/}.dll" Pencil2D/
   echo "Create ZIP"
   local qtsuffix="-qt${INPUT_QT}"
   "${WINDIR}\\System32\\tar" caf "pencil2d${qtsuffix/-qt5/}-${platform}-$1-$(date +%F).zip" Pencil2D

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -19,6 +19,5 @@ runs:
     uses: jurplel/install-qt-action@v3
     with:
       arch: ${{inputs.arch}}
-      tools: tools_openssl_x${{endsWith(inputs.arch, '_64') && '64' || '86'}}
       version: ${{matrix.qt == 6 && '6.4.2' || '5.15.2'}}
       modules: ${{matrix.qt == 6 && 'qtmultimedia' || ''}}


### PR DESCRIPTION
This switches from the (now unavailable) OpenSSL builds provided by Qt to those provided by FireDaemon. For more info on those builds see [here](https://kb.firedaemon.com/support/solutions/articles/4000121705). These builds seem to be the best option right now, others are either the wrong version (1.0 or 3.x), are not up-to-date or do not provide 32-bit binaries.