### PR TITLE
Fix perspective overlays not always covering the entire view

### DIFF
--- a/core_lib/src/canvaspainter.cpp
+++ b/core_lib/src/canvaspainter.cpp
@@ -159,9 +159,8 @@ void CanvasPainter::renderPostLayers(QPainter& painter, const QRect& blitRect)
     }
 }
 
-void CanvasPainter::setPaintSettings(const Object* object, int currentLayer, int frame, QRect rect, TiledBuffer* tiledBuffer)
+void CanvasPainter::setPaintSettings(const Object* object, int currentLayer, int frame, TiledBuffer* tiledBuffer)
 {
-    Q_UNUSED(rect)
     Q_ASSERT(object);
     mObject = object;
 

--- a/core_lib/src/canvaspainter.h
+++ b/core_lib/src/canvaspainter.h
@@ -67,7 +67,7 @@ public:
     void setTransformedSelection(QRect selection, QTransform transform);
     void ignoreTransformedSelection();
 
-    void setPaintSettings(const Object* object, int currentLayer, int frame, QRect rect, TiledBuffer* tilledBuffer);
+    void setPaintSettings(const Object* object, int currentLayer, int frame, TiledBuffer* tilledBuffer);
     void paint(const QRect& blitRect);
     void paintCached(const QRect& blitRect);
     void resetLayerCache();

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1005,7 +1005,7 @@ void ScribbleArea::paintEvent(QPaintEvent* event)
     }
     else
     {
-        prepCanvas(currentFrame, event->rect());
+        prepCanvas(currentFrame);
         prepCameraPainter(currentFrame);
         prepOverlays(currentFrame);
 
@@ -1117,7 +1117,7 @@ void ScribbleArea::paintEvent(QPaintEvent* event)
 
         paintCanvasCursor(painter);
 
-        mOverlayPainter.paint(painter);
+        mOverlayPainter.paint(painter, rect());
 
         // paints the selection outline
         if (mEditor->select()->somethingSelected())
@@ -1196,7 +1196,7 @@ void ScribbleArea::prepCameraPainter(int frame)
     mCameraPainter.setCanvas(&mCanvas);
 }
 
-void ScribbleArea::prepCanvas(int frame, QRect rect)
+void ScribbleArea::prepCanvas(int frame)
 {
     Object* object = mEditor->object();
 
@@ -1231,12 +1231,12 @@ void ScribbleArea::prepCanvas(int frame, QRect rect)
     mCanvasPainter.setViewTransform(vm->getView(), vm->getViewInverse());
     mCanvasPainter.setTransformedSelection(sm->mySelectionRect().toRect(), sm->selectionTransform());
 
-    mCanvasPainter.setPaintSettings(object, mEditor->layers()->currentLayerIndex(), frame, rect, &mTiledBuffer);
+    mCanvasPainter.setPaintSettings(object, mEditor->layers()->currentLayerIndex(), frame, &mTiledBuffer);
 }
 
 void ScribbleArea::drawCanvas(int frame, QRect rect)
 {
-    prepCanvas(frame, rect);
+    prepCanvas(frame);
     prepCameraPainter(frame);
     prepOverlays(frame);
     mCanvasPainter.paint(rect);

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -215,7 +215,7 @@ private:
 
     void prepOverlays(int frame);
     void prepCameraPainter(int frame);
-    void prepCanvas(int frame, QRect rect);
+    void prepCanvas(int frame);
     void drawCanvas(int frame, QRect rect);
     void settingUpdated(SETTING setting);
     void paintSelectionVisuals(QPainter &painter);

--- a/core_lib/src/overlaypainter.cpp
+++ b/core_lib/src/overlaypainter.cpp
@@ -65,17 +65,18 @@ void OverlayPainter::paint(QPainter &painter, const QRect& viewport)
         paintOverlaySafeAreas(painter, *camera, camTransform, cameraRect);
     }
 
+    const QRect mappedViewport = mViewTransform.inverted().mapRect(viewport);
     if (mOptions.bPerspective1)
     {
-        paintOverlayPerspectiveOnePoint(painter, viewport, camTransform);
+        paintOverlayPerspectiveOnePoint(painter, mappedViewport, camTransform);
     }
     if (mOptions.bPerspective2 || mOptions.bPerspective3)
     {
-        paintOverlayPerspectiveTwoPoints(painter, viewport, *camera, camTransform);
+        paintOverlayPerspectiveTwoPoints(painter, mappedViewport, *camera, camTransform);
     }
     if (mOptions.bPerspective3)
     {
-        paintOverlayPerspectiveThreePoints(painter, viewport, *camera, camTransform);
+        paintOverlayPerspectiveThreePoints(painter, mappedViewport, *camera, camTransform);
     }
 
     if (mOptions.bGrid)
@@ -250,7 +251,7 @@ void OverlayPainter::paintOverlayPerspectiveOnePoint(QPainter& painter, const QR
     qreal degrees = static_cast<qreal>(mOptions.nOverlayAngle);
     if (degrees == 7.0) { degrees = 7.5; }
 
-    QPointF singlePoint = mViewTransform.map(camTransform.inverted().map(mOptions.mSinglePerspPoint));
+    QPointF singlePoint = camTransform.inverted().map(mOptions.mSinglePerspPoint);
     QLineF angleLine(singlePoint.x(), singlePoint.y(), singlePoint.x() + 1, singlePoint.y());
 
     QVector<QLineF> lines;
@@ -262,10 +263,11 @@ void OverlayPainter::paintOverlayPerspectiveOnePoint(QPainter& painter, const QR
 
     painter.save();
     painter.setRenderHint(QPainter::Antialiasing, true);
-    painter.setWorldMatrixEnabled(false);
     painter.drawLines(lines);
 
     if (mOptions.bShowHandle) {
+        singlePoint = mViewTransform.map(singlePoint);
+        painter.setWorldMatrixEnabled(false);
         painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
         painter.setPen(mPalette.color(QPalette::HighlightedText));
         painter.setBrush(mPalette.color(QPalette::Highlight));
@@ -280,8 +282,8 @@ void OverlayPainter::paintOverlayPerspectiveTwoPoints(QPainter& painter, const Q
     qreal degrees = static_cast<qreal>(mOptions.nOverlayAngle);
     if (degrees == 7.0) { degrees = 7.5; }
 
-    QPointF leftPoint = mViewTransform.map(camTransform.inverted().map(mOptions.mLeftPerspPoint));
-    QPointF rightPoint = mViewTransform.map(camTransform.inverted().map(mOptions.mRightPerspPoint));
+    QPointF leftPoint = camTransform.inverted().map(mOptions.mLeftPerspPoint);
+    QPointF rightPoint = camTransform.inverted().map(mOptions.mRightPerspPoint);
     QLineF angleLineLeft(leftPoint.x(), leftPoint.y(), leftPoint.x() + 1, leftPoint.y());
     QLineF angleLineRight(rightPoint.x(), rightPoint.y(), rightPoint.x() + 1, rightPoint.y());
 
@@ -296,10 +298,12 @@ void OverlayPainter::paintOverlayPerspectiveTwoPoints(QPainter& painter, const Q
 
     painter.save();
     painter.setRenderHint(QPainter::Antialiasing, true);
-    painter.setWorldMatrixEnabled(false);
     painter.drawLines(lines);
 
     if (mOptions.bShowHandle) {
+        leftPoint = mViewTransform.map(leftPoint);
+        rightPoint = mViewTransform.map(rightPoint);
+        painter.setWorldMatrixEnabled(false);
         painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
         painter.setPen(mPalette.color(QPalette::HighlightedText));
         painter.setBrush(mPalette.color(QPalette::Highlight));
@@ -315,7 +319,7 @@ void OverlayPainter::paintOverlayPerspectiveThreePoints(QPainter& painter, const
     qreal degrees = static_cast<qreal>(mOptions.nOverlayAngle);
     if (degrees == 7.0) { degrees = 7.5; }
 
-    QPointF middlePoint = mViewTransform.map(camTransform.inverted().map(mOptions.mMiddlePerspPoint));
+    QPointF middlePoint = camTransform.inverted().map(mOptions.mMiddlePerspPoint);
     QLineF angleLine(middlePoint.x(), middlePoint.y(), middlePoint.x() + 1, middlePoint.y());
 
     const int middleAngleOffset = mOptions.mLeftPerspPoint.y() < mOptions.mMiddlePerspPoint.y() ? 180 : 0;
@@ -328,10 +332,11 @@ void OverlayPainter::paintOverlayPerspectiveThreePoints(QPainter& painter, const
 
     painter.save();
     painter.setRenderHint(QPainter::Antialiasing, true);
-    painter.setWorldMatrixEnabled(false);
     painter.drawLines(lines);
 
     if (mOptions.bShowHandle) {
+        middlePoint = mViewTransform.map(middlePoint);
+        painter.setWorldMatrixEnabled(false);
         painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
         painter.setPen(mPalette.color(QPalette::HighlightedText));
         painter.setBrush(mPalette.color(QPalette::Highlight));

--- a/core_lib/src/overlaypainter.cpp
+++ b/core_lib/src/overlaypainter.cpp
@@ -3,10 +3,10 @@
 #include "layercamera.h"
 #include "camera.h"
 #include "layer.h"
+#include "util.h"
 
-Q_CONSTEXPR static qreal LINELENGTHFACTOR = 2.0;
-Q_CONSTEXPR static int LEFTANGLEOFFSET = 90;
-Q_CONSTEXPR static int RIGHTANGLEOFFSET = -90;
+Q_CONSTEXPR static int LEFT_ANGLE_OFFSET = 90;
+Q_CONSTEXPR static int RIGHT_ANGLE_OFFSET = -90;
 Q_CONSTEXPR static int HANDLE_WIDTH = 12;
 
 OverlayPainter::OverlayPainter()
@@ -33,7 +33,7 @@ void OverlayPainter::setViewTransform(const QTransform view)
     mViewTransform = view;
 }
 
-void OverlayPainter::paint(QPainter &painter)
+void OverlayPainter::paint(QPainter &painter, const QRect& viewport)
 {
     if (mCameraLayer == nullptr) { return; }
 
@@ -67,15 +67,15 @@ void OverlayPainter::paint(QPainter &painter)
 
     if (mOptions.bPerspective1)
     {
-        paintOverlayPerspectiveOnePoint(painter, camTransform, cameraRect);
+        paintOverlayPerspectiveOnePoint(painter, viewport, camTransform);
     }
-    if (mOptions.bPerspective2)
+    if (mOptions.bPerspective2 || mOptions.bPerspective3)
     {
-        paintOverlayPerspectiveTwoPoints(painter, *camera, camTransform, cameraRect);
+        paintOverlayPerspectiveTwoPoints(painter, viewport, *camera, camTransform);
     }
     if (mOptions.bPerspective3)
     {
-        paintOverlayPerspectiveThreePoints(painter, *camera, camTransform, cameraRect);
+        paintOverlayPerspectiveThreePoints(painter, viewport, *camera, camTransform);
     }
 
     if (mOptions.bGrid)
@@ -211,7 +211,7 @@ void OverlayPainter::paintOverlaySafeAreas(QPainter &painter, const Camera& came
 
             QTransform t = scale.inverted() * rot * trans;
             painter.setTransform(t, true);
-            painter.drawText(QPoint(), QObject::tr("Safe Action area %1 %").arg(action));
+            painter.drawText(QPoint(), tr("Safe Action area %1 %").arg(action));
             painter.restore();
         }
     }
@@ -238,43 +238,32 @@ void OverlayPainter::paintOverlaySafeAreas(QPainter &painter, const Camera& came
 
             QTransform t = scale.inverted() * rot * trans;
             painter.setTransform(t, true);
-            painter.drawText(QPoint(), QObject::tr("Safe Title area %1 %").arg(title));
+            painter.drawText(QPoint(), tr("Safe Title area %1 %").arg(title));
             painter.restore();
         }
     }
     painter.restore();
 }
 
-void OverlayPainter::paintOverlayPerspectiveOnePoint(QPainter& painter, const QTransform& camTransform, const QRect& camRect) const
+void OverlayPainter::paintOverlayPerspectiveOnePoint(QPainter& painter, const QRect& viewport, const QTransform& camTransform) const
 {
-    painter.save();
-    painter.setRenderHint(QPainter::Antialiasing, true);
-
     qreal degrees = static_cast<qreal>(mOptions.nOverlayAngle);
     if (degrees == 7.0) { degrees = 7.5; }
-    int repeats = static_cast<int>(360 / degrees);
-    QLineF angleLine;
 
-    QPointF singlePoint = camTransform.inverted().map(mOptions.mSinglePerspPoint);
-    if (singlePoint == QPointF(0, 0))
-    {
-        // TODO: bug in Qt prevents points from being (0,0)...
-        singlePoint = QPointF(0.1, 0.1);
-    }
+    QPointF singlePoint = mViewTransform.map(camTransform.inverted().map(mOptions.mSinglePerspPoint));
+    QLineF angleLine(singlePoint.x(), singlePoint.y(), singlePoint.x() + 1, singlePoint.y());
 
-    angleLine.setP1(singlePoint);
     QVector<QLineF> lines;
-    for (int i = 0; i < repeats; i++)
+    for (qreal angle = 0; angle < 180; angle += degrees)
     {
-        angleLine.setAngle(i * degrees);
-        angleLine.setLength(camRect.width() * 2.0);
-        lines.append(angleLine);
+        angleLine.setAngle(angle);
+        lines.append(clipLine(angleLine, viewport, -qInf(), qInf()));
     }
-    painter.drawLines(lines);
 
+    painter.save();
+    painter.setRenderHint(QPainter::Antialiasing, true);
     painter.setWorldMatrixEnabled(false);
-
-    singlePoint = mViewTransform.map(singlePoint);
+    painter.drawLines(lines);
 
     if (mOptions.bShowHandle) {
         painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
@@ -284,55 +273,31 @@ void OverlayPainter::paintOverlayPerspectiveOnePoint(QPainter& painter, const QT
     }
 
     painter.restore();
-
 }
 
-void OverlayPainter::paintOverlayPerspectiveTwoPoints(QPainter& painter, const Camera& camera, const QTransform& camTransform, const QRect& camRect) const
+void OverlayPainter::paintOverlayPerspectiveTwoPoints(QPainter& painter, const QRect& viewport, const Camera& camera, const QTransform& camTransform) const
 {
-    painter.save();
-    painter.setRenderHint(QPainter::Antialiasing, true);
-
     qreal degrees = static_cast<qreal>(mOptions.nOverlayAngle);
     if (degrees == 7.0) { degrees = 7.5; }
-    int repeats = static_cast<int>(180 / degrees);
 
-    QPointF leftPoint = camTransform.inverted().map(mOptions.mLeftPerspPoint);
-    QPointF rightPoint = camTransform.inverted().map(mOptions.mRightPerspPoint);
-    if (leftPoint == QPointF(0.0, 0.0))
-    {
-        // TODO: bug in Qt prevents points from being (0,0)...
-        leftPoint = QPointF(0.1, 0.1);
-    }
+    QPointF leftPoint = mViewTransform.map(camTransform.inverted().map(mOptions.mLeftPerspPoint));
+    QPointF rightPoint = mViewTransform.map(camTransform.inverted().map(mOptions.mRightPerspPoint));
+    QLineF angleLineLeft(leftPoint.x(), leftPoint.y(), leftPoint.x() + 1, leftPoint.y());
+    QLineF angleLineRight(rightPoint.x(), rightPoint.y(), rightPoint.x() + 1, rightPoint.y());
 
-    if (rightPoint == QPointF(0.0, 0.0))
-    {
-        // TODO: bug in Qt prevents points from being (0,0)...
-        rightPoint = QPointF(0.1, 0.1);
-    }
-
-    QLineF angleLineLeft;
-    QLineF angleLineRight;
-    angleLineLeft.setAngle(LEFTANGLEOFFSET);
-    angleLineLeft.setP1(leftPoint);
-    angleLineLeft.setLength(camRect.width() * LINELENGTHFACTOR);
-    angleLineRight.setAngle(RIGHTANGLEOFFSET);
-    angleLineRight.setP1(rightPoint);
-    angleLineRight.setLength(camRect.width() * LINELENGTHFACTOR);
     QVector<QLineF> lines;
-    for (int i = 0; i <= repeats; i++)
+    for (qreal angle = 0; angle <= 180; angle += degrees)
     {
-        angleLineLeft.setAngle((LEFTANGLEOFFSET - i * degrees) + camera.rotation());
-        angleLineRight.setAngle((RIGHTANGLEOFFSET - i * degrees) + camera.rotation());
-        lines.append(angleLineRight);
-        lines.append(angleLineLeft);
+        angleLineLeft.setAngle(LEFT_ANGLE_OFFSET - angle + camera.rotation());
+        angleLineRight.setAngle(RIGHT_ANGLE_OFFSET - angle + camera.rotation());
+        lines.append(clipLine(angleLineLeft, viewport, 0, qInf()));
+        lines.append(clipLine(angleLineRight, viewport, 0, qInf()));
     }
 
-    painter.drawLines(lines);
-
+    painter.save();
+    painter.setRenderHint(QPainter::Antialiasing, true);
     painter.setWorldMatrixEnabled(false);
-
-    leftPoint = mViewTransform.map(leftPoint);
-    rightPoint = mViewTransform.map(rightPoint);
+    painter.drawLines(lines);
 
     if (mOptions.bShowHandle) {
         painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
@@ -345,42 +310,26 @@ void OverlayPainter::paintOverlayPerspectiveTwoPoints(QPainter& painter, const C
     painter.restore();
 }
 
-void OverlayPainter::paintOverlayPerspectiveThreePoints(QPainter& painter, const Camera& camera, const QTransform& camTransform, const QRect& camRect) const
+void OverlayPainter::paintOverlayPerspectiveThreePoints(QPainter& painter, const QRect& viewport, const Camera& camera, const QTransform& camTransform) const
 {
-    if (!mOptions.bPerspective2)
-        paintOverlayPerspectiveTwoPoints(painter, camera, camTransform, camRect);
+    qreal degrees = static_cast<qreal>(mOptions.nOverlayAngle);
+    if (degrees == 7.0) { degrees = 7.5; }
+
+    QPointF middlePoint = mViewTransform.map(camTransform.inverted().map(mOptions.mMiddlePerspPoint));
+    QLineF angleLine(middlePoint.x(), middlePoint.y(), middlePoint.x() + 1, middlePoint.y());
+
+    const int middleAngleOffset = mOptions.mLeftPerspPoint.y() < mOptions.mMiddlePerspPoint.y() ? 180 : 0;
+    QVector<QLineF> lines;
+    for (qreal angle = 0; angle <= 180; angle += degrees)
+    {
+        angleLine.setAngle(middleAngleOffset - angle + camera.rotation());
+        lines.append(clipLine(angleLine, viewport, 0, qInf()));
+    }
 
     painter.save();
     painter.setRenderHint(QPainter::Antialiasing, true);
-
-    qreal degrees = static_cast<qreal>(mOptions.nOverlayAngle);
-    if (degrees == 7.0) { degrees = 7.5; }
-    int repeats = static_cast<int>(180 / degrees);
-
-    QPointF middlePoint = camTransform.inverted().map(mOptions.mMiddlePerspPoint);
-    if (middlePoint == QPointF(0.0, 0.0))
-    {
-        // TODO: bug in Qt prevents points from being (0,0)...
-        middlePoint = QPointF(0.1, 0.1);
-    }
-
-    const int middleAngleOffset = mOptions.mLeftPerspPoint.y() < mOptions.mMiddlePerspPoint.y() ? 180 : 0;
-
-    QLineF angleLine;
-    angleLine.setAngle(middleAngleOffset);
-    angleLine.setP1(middlePoint);
-    angleLine.setLength(camRect.width() * LINELENGTHFACTOR);
-    QVector<QLineF> lines;
-    for (int i = 0; i <= repeats; i++)
-    {
-        angleLine.setAngle((middleAngleOffset - i * degrees) + camera.rotation());
-        lines.append(angleLine);
-    }
-    painter.drawLines(lines);
-
     painter.setWorldMatrixEnabled(false);
-
-    middlePoint = mViewTransform.map(middlePoint);
+    painter.drawLines(lines);
 
     if (mOptions.bShowHandle) {
         painter.setCompositionMode(QPainter::CompositionMode_SourceOver);

--- a/core_lib/src/overlaypainter.h
+++ b/core_lib/src/overlaypainter.h
@@ -32,8 +32,6 @@ struct OverlayPainterOptions
     QPointF mLeftPerspPoint;
     QPointF mRightPerspPoint;
     QPointF mMiddlePerspPoint;
-
-    QPainter::CompositionMode cmBufferBlendMode = QPainter::CompositionMode_SourceOver;
 };
 
 class OverlayPainter
@@ -47,7 +45,7 @@ public:
 
     void preparePainter(const LayerCamera* cameraLayer, const QPalette& palette);
 
-    void paint(QPainter& painter);
+    void paint(QPainter& painter, const QRect& viewport);
 private:
     void initializePainter(QPainter& painter);
 
@@ -56,9 +54,9 @@ private:
     void paintOverlayThirds(QPainter& painter, const QTransform& camTransform, const QRect& camRect) const;
     void paintOverlayGolden(QPainter& painter, const QTransform& camTransform, const QRect& camRect) const;
     void paintOverlaySafeAreas(QPainter& painter, const Camera& camera, const QTransform& camTransform, const QRect& camRect) const;
-    void paintOverlayPerspectiveOnePoint(QPainter& painter, const QTransform& camTransform, const QRect& camRect) const;
-    void paintOverlayPerspectiveTwoPoints(QPainter& painter, const Camera& camera, const QTransform& camTransform, const QRect& camRect) const;
-    void paintOverlayPerspectiveThreePoints(QPainter& painter, const Camera& camera, const QTransform& camTransform, const QRect& camRect) const;
+    void paintOverlayPerspectiveOnePoint(QPainter& painter, const QRect& viewport, const QTransform& camTransform) const;
+    void paintOverlayPerspectiveTwoPoints(QPainter& painter, const QRect& viewport, const Camera& camera, const QTransform& camTransform) const;
+    void paintOverlayPerspectiveThreePoints(QPainter& painter, const QRect& viewport, const Camera& camera, const QTransform& camTransform) const;
 
     int round100(double f, int gridSize) const;
 

--- a/core_lib/src/util/util.h
+++ b/core_lib/src/util/util.h
@@ -22,7 +22,17 @@ GNU General Public License for more details.
 
 class QAbstractSpinBox;
 
-QTransform RectMapTransform( QRectF source, QRectF target );
+/**
+ * Clips a given line to a clipping window using the Liang-Barsky algorithm.
+ * @see https://www2.eecs.berkeley.edu/Pubs/TechRpts/1992/6271.html
+ *
+ * @param line The line to be clipped
+ * @param clip The clipping window to use
+ * @param t0 The starting point of the line to check, as a percentage
+ * @param t0 The ending point of the line to check, as a percentage
+ * @return The clipped line, or a null line if the line is completely outside the clipping window
+ */
+QLineF clipLine(const QLineF& line, const QRect& clip, qreal t0, qreal t1);
 
 void clearFocusOnFinished(QAbstractSpinBox *spinBox);
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -9,7 +9,7 @@
 TEMPLATE = app
 CONFIG += console
 CONFIG -= app_bundle
-QT += core widgets gui xml multimedia svg testlib
+QT += core widgets gui xml multimedia svg
 
 TARGET = tests
 


### PR DESCRIPTION
This approach uses its own line clipping implementation since Qt doesn’t seem to provide any functionality for this sort of use case.