### PR TITLE
Fix heap use after free in MoveTool

### DIFF
--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -101,12 +101,12 @@ void MoveTool::updateSettings(const SETTING setting)
 
 void MoveTool::pointerPressEvent(PointerEvent* event)
 {
-    mCurrentLayer = currentPaintableLayer();
-    if (mCurrentLayer == nullptr) return;
+    Layer* currentLayer = currentPaintableLayer();
+    if (currentLayer == nullptr) return;
 
     if (mEditor->select()->somethingSelected())
     {
-        beginInteraction(event->modifiers(), mCurrentLayer);
+        beginInteraction(event->modifiers(), currentLayer);
     }
     if (mEditor->overlays()->anyOverlayEnabled())
     {
@@ -124,8 +124,8 @@ void MoveTool::pointerPressEvent(PointerEvent* event)
 
 void MoveTool::pointerMoveEvent(PointerEvent* event)
 {
-    mCurrentLayer = currentPaintableLayer();
-    if (mCurrentLayer == nullptr) return;
+    Layer* currentLayer = currentPaintableLayer();
+    if (currentLayer == nullptr) return;
 
     if (mScribbleArea->isPointerInUse())   // the user is also pressing the mouse (dragging)
     {
@@ -149,9 +149,9 @@ void MoveTool::pointerMoveEvent(PointerEvent* event)
         mEditor->select()->setMoveModeForAnchorInRange(getCurrentPoint());
         mScribbleArea->updateToolCursor();
 
-        if (mCurrentLayer->type() == Layer::VECTOR)
+        if (currentLayer->type() == Layer::VECTOR)
         {
-            storeClosestVectorCurve(mCurrentLayer);
+            storeClosestVectorCurve(currentLayer);
         }
     }
     mEditor->updateFrame();
@@ -305,12 +305,6 @@ void MoveTool::storeClosestVectorCurve(Layer* layer)
     selectMan->setCurves(pVecImg->getCurvesCloseTo(getCurrentPoint(), selectMan->selectionTolerance()));
 }
 
-void MoveTool::cancelChanges()
-{
-    mScribbleArea->cancelTransformedSelection();
-    mEditor->deselectAll();
-}
-
 void MoveTool::applyTransformation()
 {
     SelectionManager* selectMan = mEditor->select();
@@ -325,14 +319,9 @@ void MoveTool::applyTransformation()
 
 bool MoveTool::leavingThisTool()
 {
-    if (mCurrentLayer)
+    if (currentPaintableLayer())
     {
-        switch (mCurrentLayer->type())
-        {
-        case Layer::BITMAP: applyTransformation(); break;
-        case Layer::VECTOR: applyTransformation(); break;
-        default: break;
-        }
+        applyTransformation();
     }
     return true;
 }
@@ -406,7 +395,6 @@ QCursor MoveTool::cursor(MoveMode mode) const
     }
     default:
         return Qt::ArrowCursor;
-        break;
     }
     cursorPainter.end();
 

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -46,7 +46,6 @@ public:
     void setShowSelectionInfo(const bool b) override;
 
 private:
-    void cancelChanges();
     void applyTransformation();
     void updateSettings(const SETTING setting);
 
@@ -60,7 +59,6 @@ private:
 
     Layer* currentPaintableLayer();
 
-    Layer* mCurrentLayer = nullptr;
     qreal mRotatedAngle = 0.0;
     qreal mPreviousAngle = 0.0;
     int mRotationIncrement = 0;

--- a/core_lib/src/tool/penciltool.h
+++ b/core_lib/src/tool/penciltool.h
@@ -51,9 +51,7 @@ public:
     void setUseFillContour(const bool useFillContour) override;
 
 private:
-    QColor mCurrentPressuredColor{ 0, 0, 0, 255 };
     QPointF mLastBrushPoint{ 0, 0 };
-    qreal mOpacity = 1.0f;
     QPointF mMouseDownPoint;
 };
 

--- a/core_lib/src/tool/selecttool.h
+++ b/core_lib/src/tool/selecttool.h
@@ -50,21 +50,20 @@ private:
     void manageSelectionOrigin(QPointF currentPoint, QPointF originPoint);
     void controlOffsetOrigin(QPointF currentPoint, QPointF anchorPoint);
 
-    void beginSelection();
-    void keepSelection();
+    void beginSelection(Layer* currentLayer);
+    void keepSelection(Layer* currentLayer);
 
     QPointF offsetFromPressPos();
 
     inline bool isSelectionPointValid() { return mAnchorOriginPoint != getLastPoint(); }
     bool maybeDeselect();
 
-    // Store selection origin so we can calculate
+    // Store selection origin, so we can calculate
     // the selection rectangle in mousePressEvent.
     QPointF mAnchorOriginPoint;
     MoveMode mMoveMode;
     MoveMode mStartMoveMode = MoveMode::NONE;
     QRectF mSelectionRect;
-    Layer* mCurrentLayer = nullptr;
 
     QPixmap mCursorPixmap = QPixmap(24, 24);
 };


### PR DESCRIPTION
Steps to reproduce:

- Use something like AddressSanitizer which detects heap use after free
- Open Pencil2D
- Switch to move tool
- Move cursor across ScribbleArea
- Ctrl-N to create new project
- heap use after free occurs in MoveTool::leavingThisTool because the move tool keeps an attribute with a pointer to the last used layer which it tries to access after the old project is already unloaded.

Solution: get rid of the pointer.

I also noticed the same kind of layer pointer attribute in SelectTool. Although I don’t think it’s causing any issues right now I removed it anyway because the layer can just as easily passed as a parameter there and storing it as an attribute basically just serves as a booby trap for the next person making changes to that tool.