### PR TITLE
Fix deprecated top-level developer_name in AppData XML

### DIFF
--- a/app/data/org.pencil2d.Pencil2D.metainfo.xml
+++ b/app/data/org.pencil2d.Pencil2D.metainfo.xml
@@ -3,7 +3,9 @@
   <id>org.pencil2d.Pencil2D</id>
   <launchable type="desktop-id">org.pencil2d.Pencil2D.desktop</launchable>
   <name>Pencil2D</name>
-  <developer_name>The Pencil2D Team</developer_name>
+  <developer>
+    <name>The Pencil2D Team</name>
+  </developer>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <summary>2D animation software supporting bitmap and vector graphics</summary>


### PR DESCRIPTION
Use the `name` element in a `developer` block instead, as recommended by `appstreamcli` 1.0.0.

This fixes all warnings when validating the AppData XML file, although there are still informational messages:

```
I: org.pencil2d.Pencil2D:6: developer-id-missing
   The `developer` element is missing an `id` property, containing a unique string ID for the
   developer. Consider adding a unique ID.

✔ Validation was successful: infos: 1, pedantic: 2
```