### PR TITLE
Improve support for animated image importing

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -47,6 +47,8 @@ GNU General Public License for more details.
 #include "soundclip.h"
 #include "camera.h"
 
+#include "importimageseqdialog.h"
+#include "importpositiondialog.h"
 #include "movieimporter.h"
 #include "movieexporter.h"
 #include "filedialog.h"
@@ -64,6 +66,50 @@ ActionCommands::ActionCommands(QWidget* parent) : QObject(parent)
 }
 
 ActionCommands::~ActionCommands() {}
+
+Status ActionCommands::importAnimatedImage(FileType type)
+{
+    ImportImageSeqDialog gifDialog(mParent, ImportExportDialog::Import, type);
+    gifDialog.exec();
+    if (gifDialog.result() != QDialog::Accepted)
+    {
+        return Status::CANCELED;
+    }
+    int frameSpacing = gifDialog.getSpace();
+    QString strImgFileLower = gifDialog.getFilePath();
+
+    ImportPositionDialog positionDialog(mEditor, mParent);
+    positionDialog.exec();
+    if (positionDialog.result() != QDialog::Accepted)
+    {
+        return Status::CANCELED;
+    }
+
+    // Show a progress dialog, as this could take a while if the gif is huge
+    QProgressDialog progressDialog(tr("Importing Animated GIF..."), tr("Abort"), 0, 100, mParent);
+    hideQuestionMark(progressDialog);
+    progressDialog.setWindowModality(Qt::WindowModal);
+    progressDialog.show();
+
+    Status st = mEditor->importAnimatedImage(strImgFileLower, frameSpacing, [&progressDialog](int prog) {
+        progressDialog.setValue(prog);
+        QApplication::processEvents();
+    }, [&progressDialog]() {
+        return progressDialog.wasCanceled();
+    });
+
+    progressDialog.setValue(100);
+    progressDialog.close();
+
+    if (!st.ok())
+    {
+        ErrorDialog errorDialog(st.title(), st.description(), st.details().html());
+        errorDialog.exec();
+        return Status::SAFE;
+    }
+
+    return Status::OK;
+}
 
 Status ActionCommands::importMovieVideo()
 {
@@ -106,6 +152,7 @@ Status ActionCommands::importMovieVideo()
     {
         ErrorDialog errorDialog(st.title(), st.description(), st.details().html(), mParent);
         errorDialog.exec();
+        return Status::SAFE;
     }
 
     mEditor->layers()->notifyAnimationLengthChanged();

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -293,7 +293,7 @@ Status ActionCommands::exportMovie(bool isGif)
     desc.loop = dialog->getLoop();
     desc.alpha = dialog->getTransparency();
 
-    DoubleProgressDialog progressDlg;
+    DoubleProgressDialog progressDlg(mParent);
     progressDlg.setWindowModality(Qt::WindowModal);
     progressDlg.setWindowTitle(tr("Exporting movie"));
     Qt::WindowFlags eFlags = Qt::Dialog | Qt::WindowTitleHint;

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -86,7 +86,7 @@ Status ActionCommands::importAnimatedImage()
     }
 
     // Show a progress dialog, as this could take a while if the gif is huge
-    QProgressDialog progressDialog(tr("Importing Animated GIF..."), tr("Abort"), 0, 100, mParent);
+    QProgressDialog progressDialog(tr("Importing Animated Image..."), tr("Abort"), 0, 100, mParent);
     hideQuestionMark(progressDialog);
     progressDialog.setWindowModality(Qt::WindowModal);
     progressDialog.show();

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -67,16 +67,16 @@ ActionCommands::ActionCommands(QWidget* parent) : QObject(parent)
 
 ActionCommands::~ActionCommands() {}
 
-Status ActionCommands::importAnimatedImage(FileType type)
+Status ActionCommands::importAnimatedImage()
 {
-    ImportImageSeqDialog gifDialog(mParent, ImportExportDialog::Import, type);
-    gifDialog.exec();
-    if (gifDialog.result() != QDialog::Accepted)
+    ImportImageSeqDialog fileDialog(mParent, ImportExportDialog::Import, FileType::ANIMATED_IMAGE);
+    fileDialog.exec();
+    if (fileDialog.result() != QDialog::Accepted)
     {
         return Status::CANCELED;
     }
-    int frameSpacing = gifDialog.getSpace();
-    QString strImgFileLower = gifDialog.getFilePath();
+    int frameSpacing = fileDialog.getSpace();
+    QString strImgFileLower = fileDialog.getFilePath();
 
     ImportPositionDialog positionDialog(mEditor, mParent);
     positionDialog.exec();

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -37,7 +37,7 @@ public:
     void setCore(Editor* e) { mEditor = e; }
 
     // file
-    Status importAnimatedImage(FileType type);
+    Status importAnimatedImage();
     Status importMovieVideo();
     Status importSound(FileType type);
     Status exportMovie(bool isGif = false);

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -37,6 +37,7 @@ public:
     void setCore(Editor* e) { mEditor = e; }
 
     // file
+    Status importAnimatedImage(FileType type);
     Status importMovieVideo();
     Status importSound(FileType type);
     Status exportMovie(bool isGif = false);

--- a/app/src/doubleprogressdialog.cpp
+++ b/app/src/doubleprogressdialog.cpp
@@ -21,7 +21,7 @@ GNU General Public License for more details.
 #include <QtMath>
 
 DoubleProgressDialog::DoubleProgressDialog(QWidget *parent) :
-    QDialog(parent),
+    QProgressDialog(parent),
     ui(new Ui::DoubleProgressDialog)
 {
     ui->setupUi(this);
@@ -29,7 +29,7 @@ DoubleProgressDialog::DoubleProgressDialog(QWidget *parent) :
     major = new ProgressBarControl(ui->majorProgressBar);
     minor = new ProgressBarControl(ui->minorProgressBar);
 
-    connect(ui->cancelButton, &QPushButton::pressed, this, &DoubleProgressDialog::canceled);
+    setCancelButton(ui->cancelButton);
 }
 
 DoubleProgressDialog::~DoubleProgressDialog()

--- a/app/src/doubleprogressdialog.h
+++ b/app/src/doubleprogressdialog.h
@@ -18,14 +18,14 @@ GNU General Public License for more details.
 #ifndef DOUBLEPROGRESSDIALOG_H
 #define DOUBLEPROGRESSDIALOG_H
 
-#include <QDialog>
+#include <QProgressDialog>
 #include <QProgressBar>
 
 namespace Ui {
 class DoubleProgressDialog;
 }
 
-class DoubleProgressDialog : public QDialog
+class DoubleProgressDialog : public QProgressDialog
 {
     Q_OBJECT
 
@@ -63,8 +63,8 @@ public:
 
     ProgressBarControl *major, *minor;
 
-signals:
-    void canceled();
+//signals:
+    //void canceled();
 
 private:
     Ui::DoubleProgressDialog *ui;

--- a/app/src/doubleprogressdialog.h
+++ b/app/src/doubleprogressdialog.h
@@ -63,9 +63,6 @@ public:
 
     ProgressBarControl *major, *minor;
 
-//signals:
-    //void canceled();
-
 private:
     Ui::DoubleProgressDialog *ui;
 };

--- a/app/src/filedialog.cpp
+++ b/app/src/filedialog.cpp
@@ -119,6 +119,7 @@ QString FileDialog::getDefaultExtensionByFileType(const FileType fileType)
     case FileType::IMAGE: return PFF_DEFAULT_IMAGE_EXT;
     case FileType::IMAGE_SEQUENCE: return PFF_DEFAULT_IMAGE_SEQ_EXT;
     case FileType::GIF: return PFF_DEFAULT_ANIMATED_EXT;
+    case FileType::ANIMATED_IMAGE: return PFF_DEFAULT_ANIMATED_EXT;
     case FileType::PALETTE: return PFF_DEFAULT_PALETTE_EXT;
     case FileType::MOVIE: return PFF_DEFAULT_MOVIE_EXT;
     case FileType::SOUND: return PFF_DEFAULT_SOUND_EXT;
@@ -167,6 +168,7 @@ QString FileDialog::openDialogCaption(FileType fileType)
     case FileType::IMAGE: return tr("Import image");
     case FileType::IMAGE_SEQUENCE: return tr("Import image sequence");
     case FileType::GIF: return tr("Import Animated GIF");
+    case FileType::ANIMATED_IMAGE: return tr("Import animated image");
     case FileType::MOVIE: return tr("Import movie");
     case FileType::SOUND: return tr("Import sound");
     case FileType::PALETTE: return tr("Open palette");
@@ -182,6 +184,7 @@ QString FileDialog::saveDialogCaption(FileType fileType)
     case FileType::IMAGE: return tr("Export image");
     case FileType::IMAGE_SEQUENCE: return tr("Export image sequence");
     case FileType::GIF: return tr("Export Animated GIF");
+    case FileType::ANIMATED_IMAGE: return tr("Export animated image");
     case FileType::MOVIE: return tr("Export movie");
     case FileType::SOUND: return tr("Export sound");
     case FileType::PALETTE: return tr("Export palette");
@@ -197,6 +200,7 @@ QString FileDialog::openFileFilters(FileType fileType)
     case FileType::IMAGE: return PFF_IMAGE_FILTER;
     case FileType::IMAGE_SEQUENCE: return PFF_IMAGE_SEQ_FILTER;
     case FileType::GIF: return PFF_GIF_EXT_FILTER;
+    case FileType::ANIMATED_IMAGE: return PFF_ANIMATED_IMAGE_EXT_FILTER;
     case FileType::MOVIE: return PFF_MOVIE_EXT;
     case FileType::SOUND: return PFF_SOUND_EXT_FILTER;
     case FileType::PALETTE: return PFF_PALETTE_EXT_FILTER;
@@ -212,6 +216,7 @@ QString FileDialog::saveFileFilters(FileType fileType)
     case FileType::IMAGE: return "";
     case FileType::IMAGE_SEQUENCE: return "";
     case FileType::GIF: return QString("%1 (*.gif)").arg(tr("Animated GIF"));
+    case FileType::ANIMATED_IMAGE: return "";
     case FileType::MOVIE: return "MP4 (*.mp4);; AVI (*.avi);; WebM (*.webm);; APNG (*.apng)";
     case FileType::SOUND: return "";
     case FileType::PALETTE: return PFF_PALETTE_EXT_FILTER;
@@ -286,6 +291,7 @@ QString FileDialog::toSettingKey(FileType fileType)
     case FileType::IMAGE: return "Image";
     case FileType::IMAGE_SEQUENCE: return "ImageSequence";
     case FileType::GIF: return "Animated GIF";
+    case FileType::ANIMATED_IMAGE: return "Animated Image";
     case FileType::MOVIE: return "Movie";
     case FileType::SOUND: return "Sound";
     case FileType::PALETTE: return "Palette";

--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -64,10 +64,10 @@ void ImportImageSeqDialog::setupLayout()
         setWindowTitle(tr("Import Animated GIF"));
         break;
     case FileType::IMAGE_SEQUENCE:
-        setWindowTitle(tr("Import animated image"));
+        setWindowTitle(tr("Import image sequence"));
         break;
     default:
-        setWindowTitle(tr("Import image sequence"));
+        setWindowTitle(tr("Import animated image"));
     }
 
     connect(uiOptionsBox->spaceSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &ImportImageSeqDialog::setSpace);

--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -58,9 +58,15 @@ void ImportImageSeqDialog::setupLayout()
 
     hideInstructionsLabel(true);
 
-    if (mFileType == FileType::GIF) {
+    switch (mFileType)
+    {
+    case FileType::GIF:
         setWindowTitle(tr("Import Animated GIF"));
-    } else {
+        break;
+    case FileType::IMAGE_SEQUENCE:
+        setWindowTitle(tr("Import animated image"));
+        break;
+    default:
         setWindowTitle(tr("Import image sequence"));
     }
 

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -254,7 +254,7 @@ void MainWindow2::createMenus()
     connect(ui->actionImport_ImageSeqNum, &QAction::triggered, this, &MainWindow2::importPredefinedImageSet);
     connect(ui->actionImportLayers_from_pclx, &QAction::triggered, this, &MainWindow2::importLayers);
     connect(ui->actionImport_MovieVideo, &QAction::triggered, this, &MainWindow2::importMovieVideo);
-    connect(ui->actionImport_Gif, &QAction::triggered, this, &MainWindow2::importGIF);
+    connect(ui->actionImport_AnimatedImage, &QAction::triggered, this, &MainWindow2::importAnimatedImage);
 
     connect(ui->actionImport_Sound, &QAction::triggered, [=] { mCommands->importSound(FileType::SOUND); });
     connect(ui->actionImport_MovieAudio, &QAction::triggered, [=] { mCommands->importSound(FileType::MOVIE); });
@@ -949,12 +949,12 @@ void MainWindow2::importLayers()
     importLayers->open();
 }
 
-void MainWindow2::importGIF()
+void MainWindow2::importAnimatedImage()
 {
     // Flag this so we don't prompt the user about auto-save in the middle of the import.
     mSuppressAutoSaveDialog = true;
 
-    mCommands->importAnimatedImage(FileType::GIF);
+    mCommands->importAnimatedImage();
 
     mSuppressAutoSaveDialog = false;
 }

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -951,55 +951,10 @@ void MainWindow2::importLayers()
 
 void MainWindow2::importGIF()
 {
-    auto gifDialog = new ImportImageSeqDialog(this, ImportExportDialog::Import, FileType::GIF);
-    gifDialog->exec();
-    if (gifDialog->result() == QDialog::Rejected)
-    {
-        return;
-    }
-
     // Flag this so we don't prompt the user about auto-save in the middle of the import.
     mSuppressAutoSaveDialog = true;
 
-    ImportPositionDialog* positionDialog = new  ImportPositionDialog(mEditor, this);
-    OnScopeExit(delete positionDialog)
-
-    positionDialog->exec();
-    if (positionDialog->result() != QDialog::Accepted)
-    {
-        return;
-    }
-
-    int space = gifDialog->getSpace();
-
-    // Show a progress dialog, as this could take a while if the gif is huge
-    QProgressDialog progress(tr("Importing Animated GIF..."), tr("Abort"), 0, 100, this);
-    hideQuestionMark(progress);
-    progress.setWindowModality(Qt::WindowModal);
-    progress.show();
-
-    QString strImgFileLower = gifDialog->getFilePath();
-    if (!strImgFileLower.toLower().endsWith(".gif"))
-    {
-        ErrorDialog errorDialog(tr("Import failed"), tr("You can only import files ending with .gif."));
-        errorDialog.exec();
-    }
-    else
-    {
-        Status st = mEditor->importGIF(strImgFileLower, space);
-
-        progress.setValue(50);
-        QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);  // Required to make progress bar update
-
-        progress.setValue(100);
-        progress.close();
-
-        if (!st.ok())
-        {
-            ErrorDialog errorDialog(st.title(), st.description(), st.details().html());
-            errorDialog.exec();
-        }
-    }
+    mCommands->importAnimatedImage(FileType::GIF);
 
     mSuppressAutoSaveDialog = false;
 }

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -90,7 +90,7 @@ public:
     void importPredefinedImageSet();
     void importLayers();
     void importMovieVideo();
-    void importGIF();
+    void importAnimatedImage();
 
     void lockWidgets(bool shouldLock);
 

--- a/app/ui/exportimageoptions.ui
+++ b/app/ui/exportimageoptions.ui
@@ -98,6 +98,11 @@
           <string>TIFF</string>
          </property>
         </item>
+        <item>
+         <property name="text">
+          <string>WEBP</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item>

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -65,7 +65,7 @@
      <addaction name="actionImport_ImageSeq"/>
      <addaction name="actionImport_ImageSeqNum"/>
      <addaction name="actionImport_MovieVideo"/>
-     <addaction name="actionImport_Gif"/>
+     <addaction name="actionImport_AnimatedImage"/>
      <addaction name="actionImportLayers_from_pclx"/>
      <addaction name="separator"/>
      <addaction name="actionImport_Sound"/>
@@ -912,9 +912,9 @@
     <string>F1</string>
    </property>
   </action>
-  <action name="actionImport_Gif">
+  <action name="actionImport_AnimatedImage">
    <property name="text">
-    <string>Animated GIF...</string>
+    <string>Animated Image...</string>
    </property>
   </action>
   <action name="actionExport_Animated_GIF">

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -230,7 +230,7 @@ public: //slots
     void resetAutoSaveCounter();
 
 private:
-    Status importBitmapImage(const QString&, int space = 0);
+    Status importBitmapImage(const QString&);
     Status importVectorImage(const QString&);
 
     void pasteToCanvas(BitmapImage* bitmapImage, int frameNumber);

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -174,7 +174,7 @@ public: //slots
     void clearCurrentFrame();
 
     Status importImage(const QString& filePath);
-    Status importGIF(const QString& filePath, int numOfImages = 0);
+    Status importAnimatedImage(const QString& filePath, int frameSpacing, const std::function<void (int)>& progressChanged, const std::function<bool ()>& wasCanceled);
     void restoreKey();
 
     void scrubNextKeyFrame();

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -828,6 +828,10 @@ bool Object::exportFrames(int frameStart, int frameEnd,
         extension = ".bmp";
         transparency = false;
     }
+    if (formatStr == "WEBP" || formatStr == "webp") {
+        format = "WEBP";
+        extension = ".webp";
+    }
     if (filePath.endsWith(extension, Qt::CaseInsensitive))
     {
         filePath.chop(extension.size());

--- a/core_lib/src/util/fileformat.cpp
+++ b/core_lib/src/util/fileformat.cpp
@@ -59,6 +59,7 @@ QString detectFormatByFileNameExtension(const QString& fileName)
             { "tif",  "TIF" },
             { "tiff", "TIF" },
             { "bmp",  "BMP" },
+            { "webp", "WEBP" },
             { "mp4",  "MP4" },
             { "avi",  "AVI" },
             { "gif",  "GIF" },

--- a/core_lib/src/util/fileformat.h
+++ b/core_lib/src/util/fileformat.h
@@ -51,6 +51,9 @@ GNU General Public License for more details.
 #define PFF_GIF_EXT_FILTER \
     QCoreApplication::translate("FileFormat", "Animated GIF") + " (*.gif)"
 
+#define PFF_ANIMATED_IMAGE_EXT_FILTER \
+    QCoreApplication::translate("FileFormat", "Animated image formats") + " (*.gif *.webp);;GIF(*.gif);;WEBP(*.webp)"
+
 #define PFF_SOUND_EXT_FILTER \
     QCoreApplication::translate("FileFormat", "Sound formats") + " (*.wav *.mp3 *.wma *.ogg *.flac *.opus *.aiff *.aac *.caf);;WAV (*.wav);;MP3 (*.mp3);;WMA (*.wma);;OGG (*.ogg);;FLAC (*.flac);;Opus (*.opus);;AIFF (*.aiff);;AAC (*.aac);;CAF (*.caf)"
 

--- a/core_lib/src/util/fileformat.h
+++ b/core_lib/src/util/fileformat.h
@@ -40,10 +40,10 @@ GNU General Public License for more details.
         ";;SWF(*.swf);;FLV(*.flv);;WEBM(*.webm);;WMV(*.wmv)"
 
 #define PFF_IMAGE_FILTER \
-   QCoreApplication::translate("FileFormat",  "Image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);;TIFF(*.tif *.tiff)"
+   QCoreApplication::translate("FileFormat",  "Image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff *.webp);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);;TIFF(*.tif *.tiff);;WEBP(*.webp)"
 
 #define PFF_IMAGE_SEQ_FILTER \
-    QCoreApplication::translate("FileFormat",  "Image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);;TIFF(*.tif *.tiff)"
+    QCoreApplication::translate("FileFormat",  "Image formats") + " (*.png *.jpg *.jpeg *.bmp *.tif *.tiff *.webp);;PNG (*.png);;JPG(*.jpg *.jpeg);;BMP(*.bmp);;TIFF(*.tif *.tiff);;WEBP(*.webp)"
 
 #define PFF_PALETTE_EXT_FILTER \
     QCoreApplication::translate("FileFormat", "Palette formats") + " (*.xml *.gpl);;" + QCoreApplication::translate("FileFormat", "Pencil2D Palette") + " (*.xml);;" + QCoreApplication::translate("FileFormat", "GIMP Palette") + " (*.gpl)"

--- a/core_lib/src/util/filetype.h
+++ b/core_lib/src/util/filetype.h
@@ -7,6 +7,7 @@ enum class FileType
     IMAGE,
     IMAGE_SEQUENCE,
     GIF,
+    ANIMATED_IMAGE,
     MOVIE,
     SOUND,
     PALETTE


### PR DESCRIPTION
This PR contains a few loosely related changes to image importing. Specifically:
- Add support for importing animated WebP images (same Qt code that handles animated GIF import)
- Progress dialog for animated image import with abort support
- Separate logic handling single and animated image importing
- Make movie export modal so the user can't perform other operations that might interfere with the export ([report](https://discuss.pencil2d.org/t/accidentally-using-a-drawing-tool-on-a-bitmapped-layer-whilst-pencil2d-is-expecting-an-mp4-video-file/7599?u=j5lx))
- Fix possible issue with error checking during image importing. I did not try to produce the issue, but based on the code it would probably handle some image corruption errors incorrectly.
- Add non-animated WebP image import/export