### PR TITLE
Fix stroke not being shown on a selection while drawing

### DIFF
--- a/core_lib/src/canvaspainter.cpp
+++ b/core_lib/src/canvaspainter.cpp
@@ -315,7 +315,7 @@ void CanvasPainter::paintCurrentBitmapFrame(QPainter& painter, const QRect& blit
     }
 
     // We do not wish to draw selection transformations on anything but the current layer
-    if (isCurrentLayer && mRenderTransform) {
+    if (isCurrentLayer && mRenderTransform && !isDrawing) {
         paintTransformedSelection(currentBitmapPainter, paintedImage, mSelection);
     }
 


### PR DESCRIPTION
How to reproduce:
1. Create a selection
2. Draw a stroke inside it

Expected:
Stroke is drawn

Actual:
Stroke is not drawn until you stop drawing.