### PR TITLE
Fix AppStream developer id

### DIFF
--- a/app/data/org.pencil2d.Pencil2D.metainfo.xml
+++ b/app/data/org.pencil2d.Pencil2D.metainfo.xml
@@ -3,7 +3,7 @@
   <id>org.pencil2d.Pencil2D</id>
   <launchable type="desktop-id">org.pencil2d.Pencil2D.desktop</launchable>
   <name>Pencil2D</name>
-  <developer id="pencil2d.org">
+  <developer id="org.pencil2d">
     <name>The Pencil2D Team</name>
   </developer>
   <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
Per https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer, this should have been `org.pencil2d` instead of `pencil2d.org`. Technically, the ID can be any string, but the FreeDesktop documentation strongly recommends a reverse-DNS string.

This is a follow-up to https://github.com/pencil2d/pencil/pull/1796.