### PR TITLE
Fix delayed vector transformation rendering

### DIFF
--- a/core_lib/src/canvaspainter.cpp
+++ b/core_lib/src/canvaspainter.cpp
@@ -298,20 +298,15 @@ void CanvasPainter::paintCurrentBitmapFrame(QPainter& painter, const QRect& blit
     painter.setOpacity(paintedImage->getOpacity() - (1.0-painter.opacity()));
     painter.setWorldMatrixEnabled(false);
 
+    currentBitmapPainter.drawImage(paintedImage->topLeft(), *paintedImage->image());
+
     if (isCurrentLayer && isDrawing)
     {
-        currentBitmapPainter.drawImage(paintedImage->topLeft(), *paintedImage->image());
-
         currentBitmapPainter.setCompositionMode(mOptions.cmBufferBlendMode);
         const auto tiles = mTiledBuffer->tiles();
         for (const Tile* tile : tiles) {
             currentBitmapPainter.drawPixmap(tile->posF(), tile->pixmap());
         }
-    } else {
-        // When we're drawing using a tool, the surface will be painted by the tiled buffer,
-        // and thus we don't want to paint the current image again
-        // When we're on another layer though, the tiled buffer is not used
-        currentBitmapPainter.drawImage(paintedImage->topLeft(), *paintedImage->image());
     }
 
     // We do not wish to draw selection transformations on anything but the current layer
@@ -344,14 +339,12 @@ void CanvasPainter::paintCurrentVectorFrame(QPainter& painter, const QRect& blit
     // Paint existing vector image to the painter
     vectorImage->paintImage(currentVectorPainter, *mObject, mOptions.bOutlines, mOptions.bThinLines, mOptions.bAntiAlias);
 
-    if (isCurrentLayer) {
-        if (isDrawing) {
-            currentVectorPainter.setCompositionMode(mOptions.cmBufferBlendMode);
+    if (isCurrentLayer && isDrawing) {
+        currentVectorPainter.setCompositionMode(mOptions.cmBufferBlendMode);
 
-            const auto tiles = mTiledBuffer->tiles();
-            for (const Tile* tile : tiles) {
-                currentVectorPainter.drawPixmap(tile->posF(), tile->pixmap());
-            }
+        const auto tiles = mTiledBuffer->tiles();
+        for (const Tile* tile : tiles) {
+            currentVectorPainter.drawPixmap(tile->posF(), tile->pixmap());
         }
     }
 

--- a/core_lib/src/canvaspainter.cpp
+++ b/core_lib/src/canvaspainter.cpp
@@ -337,6 +337,10 @@ void CanvasPainter::paintCurrentVectorFrame(QPainter& painter, const QRect& blit
 
     const bool isDrawing = mTiledBuffer->isValid();
 
+    if (mRenderTransform) {
+        vectorImage->setSelectionTransformation(mSelectionTransform);
+    }
+
     // Paint existing vector image to the painter
     vectorImage->paintImage(currentVectorPainter, *mObject, mOptions.bOutlines, mOptions.bThinLines, mOptions.bAntiAlias);
 
@@ -348,8 +352,6 @@ void CanvasPainter::paintCurrentVectorFrame(QPainter& painter, const QRect& blit
             for (const Tile* tile : tiles) {
                 currentVectorPainter.drawPixmap(tile->posF(), tile->pixmap());
             }
-        } else if (mRenderTransform) {
-            vectorImage->setSelectionTransformation(mSelectionTransform);
         }
     }
 


### PR DESCRIPTION
This PR fixes a small cosmetic bug I stumbled upon while working on the new undo/redo feature.

How to reproduce:
1. Draw a vector stroke
2. Select it using the Select tool
3. Move or transform using the Move tool
4. undo/redo the operation and notice that it might either glitch and show the previous state then the new state, or it might not show the new state until you stop holding down ctrl or cmd on mac.

I also simplified the rendering logic a bit, check the commits for clarification about what does what.