### PR TITLE
Fix rotation would jump when using undo/redo and trying to modify again

### DIFF
--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -193,7 +193,6 @@ void MoveTool::transformSelection(const QPointF& pos, Qt::KeyboardModifiers keyM
         if (selectMan->getMoveMode() == MoveMode::ROTATION) {
             QPointF anchorPoint = selectMan->currentTransformAnchor();
             newAngle = selectMan->angleFromPoint(pos, anchorPoint) - mRotatedAngle;
-            mPreviousAngle = newAngle;
         }
 
         selectMan->adjustSelection(pos, mOffset, newAngle, rotationIncrement);
@@ -240,7 +239,7 @@ void MoveTool::beginInteraction(const QPointF& pos, Qt::KeyboardModifiers keyMod
     mOffset = selectMan->myTranslation();
 
     if(selectMan->getMoveMode() == MoveMode::ROTATION) {
-        mRotatedAngle = selectMan->angleFromPoint(pos, selectMan->currentTransformAnchor()) - mPreviousAngle;
+        mRotatedAngle = selectMan->angleFromPoint(pos, selectMan->currentTransformAnchor()) - selectMan->myRotation();
     }
 }
 
@@ -316,7 +315,6 @@ void MoveTool::applyTransformation()
     // This ensures that if the selection has been rotated, it will still fit the bounds of the image.
     selectMan->setSelection(selectMan->mapToSelection(QPolygonF(selectMan->mySelectionRect())).boundingRect());
     mRotatedAngle = 0;
-    mPreviousAngle = 0;
 }
 
 bool MoveTool::leavingThisTool()

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -62,7 +62,6 @@ private:
 
     QPointF mCurrentPoint;
     qreal mRotatedAngle = 0.0;
-    qreal mPreviousAngle = 0.0;
     int mRotationIncrement = 0;
     MoveMode mPerspMode;
     QPointF mOffset;


### PR DESCRIPTION
Fixes a small bug where if you had rotated an object, then used undo/redo on it, the rotation state would be wrong, so when you try to rotate it again, the object would be rotated too much.

How to reproduce:
1. Draw a stroke
2. Select it using the Select tool
3. Rotate it using the Move tool
4. Move it somewhere else and rotate it 90 deg
5. Now undo until you're back at step 3.
6. Try to rotate the object agian

Expected behavior:
The object is doesn't rotate until you actually move the mouse around

Actual result:
The object jumps to the previous rotated value
