### PR TITLE
Fix polyline buffer not always being cleared

### DIFF
--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -100,7 +100,6 @@ bool PolylineTool::leavingThisTool()
     if (mPoints.size() > 0)
     {
         cancelPolyline();
-        clearToolData();
     }
     return true;
 }
@@ -117,8 +116,16 @@ QCursor PolylineTool::cursor()
 
 void PolylineTool::clearToolData()
 {
+    if (mPoints.empty()) {
+        return;
+    }
+
     mPoints.clear();
     emit isActiveChanged(POLYLINE, false);
+
+    // Clear the in-progress polyline from the bitmap buffer.
+    mScribbleArea->clearDrawingBuffer();
+    mScribbleArea->updateFrame();
 }
 
 void PolylineTool::pointerPressEvent(PointerEvent* event)
@@ -189,7 +196,6 @@ void PolylineTool::pointerDoubleClickEvent(PointerEvent* event)
     mEditor->backup(typeName());
 
     endPolyline(mPoints);
-    clearToolData();
 }
 
 
@@ -201,7 +207,6 @@ bool PolylineTool::keyPressEvent(QKeyEvent* event)
         if (mPoints.size() > 0)
         {
             endPolyline(mPoints);
-            clearToolData();
             return true;
         }
         break;
@@ -210,7 +215,6 @@ bool PolylineTool::keyPressEvent(QKeyEvent* event)
         if (mPoints.size() > 0)
         {
             cancelPolyline();
-            clearToolData();
             return true;
         }
         break;
@@ -269,9 +273,7 @@ void PolylineTool::drawPolyline(QList<QPointF> points, QPointF endPoint)
 
 void PolylineTool::cancelPolyline()
 {
-    // Clear the in-progress polyline from the bitmap buffer.
-    mScribbleArea->clearDrawingBuffer();
-    mScribbleArea->updateFrame();
+    clearToolData();
 }
 
 void PolylineTool::endPolyline(QList<QPointF> points)
@@ -303,4 +305,6 @@ void PolylineTool::endPolyline(QList<QPointF> points)
     }
     mScribbleArea->endStroke();
     mEditor->setModified(mEditor->layers()->currentLayerIndex(), mEditor->currentFrame());
+
+    clearToolData();
 }


### PR DESCRIPTION
First reported here: https://discuss.pencil2d.org/t/problems-with-nightly-build-11-april-2024/8025

On the bitmap layer, applying a polyline path results in ScribbleArea::paintBitmapBuffer being called, which clears the mTiledBuffer. However, this function is never called when using the tool on the vector layer where the the curve is added by the tool. It will also never get cleared if clearToolData is called directly, but it seems that this function isn't currently being called outside the polyline tool. I've refactored it a bit so when clearToolData is called, the buffer is always cleared (and always after deactivating the tool so ScribbleArea::updateFrame works). One slight change is that isActiveChanged will only be triggered if mPoints is not empty, which makes sense because if it is empty, then the tool was not active and the state is not changing.