### PR TITLE
Remove "macdeployqtfix" from our deployment script

### DIFF
--- a/.github/actions/create-package/create-package.sh
+++ b/.github/actions/create-package/create-package.sh
@@ -94,15 +94,7 @@ create_package_macos() {
   echo "::group::Deploy Qt libraries"
   macdeployqt Pencil2D.app
   echo "::endgroup::"
-  echo "::group::Apply macdeployqt fix"
-  curl -fsSLO https://github.com/aurelien-rainone/macdeployqtfix/archive/master.zip
-  bsdtar xf master.zip
-  /Library/Frameworks/Python.framework/Versions/2.7/bin/python macdeployqtfix-master/macdeployqtfix.py \
-    Pencil2D.app/Contents/MacOS/Pencil2D \
-    /usr/local/Cellar/qt/5.9.1/
-  echo "::endgroup::"
-  echo "Remove files"
-  rm -rf macdeployqtfix-master master.zip
+  
   popd >/dev/null
   echo "Create ZIP"
   local qtsuffix="-qt${INPUT_QT}"

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ ipch
 
 # Build directory
 build
+.qtc_clangd


### PR DESCRIPTION
The use of `macdeployqtfix` is no longer needed as the official Qt deployment tool `macdeployqt` works as expected.

I carefully checked the Mac app bundles before and after applying `macdeployqtfix`, and I didn't see any differences between the two. Therefore, it should be safe to remove `macdeployqtfix` from our deployment process.

The only scenario where `macdeployqtfix` may be required is building the legacy Mac version, which is built with Qt 5.6 as far as I know.
