### PR TITLE
Make OnionSkins UI more compact 

### DIFF
--- a/app/ui/onionskin.ui
+++ b/app/ui/onionskin.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>213</width>
-    <height>382</height>
+    <width>219</width>
+    <height>238</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>187</width>
-    <height>122</height>
+    <width>190</width>
+    <height>124</height>
    </size>
   </property>
   <property name="floating">
@@ -30,6 +30,9 @@
     </sizepolicy>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="spacing">
+     <number>0</number>
+    </property>
     <property name="leftMargin">
      <number>0</number>
     </property>
@@ -76,8 +79,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>213</width>
-         <height>360</height>
+         <width>219</width>
+         <height>214</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -87,17 +90,20 @@
         </sizepolicy>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_3">
+        <property name="spacing">
+         <number>3</number>
+        </property>
         <property name="leftMargin">
-         <number>6</number>
+         <number>3</number>
         </property>
         <property name="topMargin">
-         <number>6</number>
+         <number>3</number>
         </property>
         <property name="rightMargin">
-         <number>6</number>
+         <number>3</number>
         </property>
         <property name="bottomMargin">
-         <number>6</number>
+         <number>3</number>
         </property>
         <item>
          <widget class="QGroupBox" name="prevFramesGroup">
@@ -108,6 +114,9 @@
            <bool>true</bool>
           </property>
           <layout class="QHBoxLayout" name="onionPrevLayout">
+           <property name="spacing">
+            <number>3</number>
+           </property>
            <property name="sizeConstraint">
             <enum>QLayout::SetDefaultConstraint</enum>
            </property>
@@ -115,13 +124,13 @@
             <number>0</number>
            </property>
            <property name="topMargin">
-            <number>6</number>
+            <number>3</number>
            </property>
            <property name="rightMargin">
             <number>0</number>
            </property>
            <property name="bottomMargin">
-            <number>6</number>
+            <number>3</number>
            </property>
            <item>
             <widget class="QSpinBox" name="onionPrevFramesNumBox">
@@ -189,6 +198,9 @@
            <bool>true</bool>
           </property>
           <layout class="QHBoxLayout" name="onionNextlLayout">
+           <property name="spacing">
+            <number>3</number>
+           </property>
            <property name="sizeConstraint">
             <enum>QLayout::SetDefaultConstraint</enum>
            </property>
@@ -196,13 +208,13 @@
             <number>0</number>
            </property>
            <property name="topMargin">
-            <number>6</number>
+            <number>3</number>
            </property>
            <property name="rightMargin">
             <number>0</number>
            </property>
            <property name="bottomMargin">
-            <number>6</number>
+            <number>3</number>
            </property>
            <item>
             <widget class="QSpinBox" name="onionNextFramesNumBox">
@@ -278,84 +290,28 @@
           <property name="title">
            <string>Distributed Opacity</string>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_2">
+          <layout class="QHBoxLayout" name="horizontalLayout">
            <property name="spacing">
-            <number>6</number>
+            <number>0</number>
            </property>
            <property name="leftMargin">
             <number>0</number>
            </property>
            <property name="topMargin">
-            <number>6</number>
+            <number>0</number>
            </property>
            <property name="rightMargin">
             <number>0</number>
            </property>
            <property name="bottomMargin">
-            <number>6</number>
+            <number>3</number>
            </property>
-           <item>
-            <widget class="QWidget" name="minOpacityGroup" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout_2">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QLabel" name="minOpacityLabel">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Min</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QSpinBox" name="onionMinOpacityBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>60</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="suffix">
-                 <string> %</string>
-                </property>
-                <property name="prefix">
-                 <string/>
-                </property>
-                <property name="maximum">
-                 <number>100</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
            <item>
             <widget class="QWidget" name="maxOpacityGroup" native="true">
              <layout class="QHBoxLayout" name="horizontalLayout_3">
+              <property name="spacing">
+               <number>3</number>
+              </property>
               <property name="leftMargin">
                <number>0</number>
               </property>
@@ -379,6 +335,9 @@
                 <property name="text">
                  <string>Max</string>
                 </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
                </widget>
               </item>
               <item>
@@ -391,7 +350,72 @@
                 </property>
                 <property name="minimumSize">
                  <size>
-                  <width>60</width>
+                  <width>50</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="suffix">
+                 <string> %</string>
+                </property>
+                <property name="prefix">
+                 <string/>
+                </property>
+                <property name="maximum">
+                 <number>100</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QWidget" name="minOpacityGroup" native="true">
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <property name="spacing">
+               <number>3</number>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="minOpacityLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Min</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="onionMinOpacityBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>50</width>
                   <height>0</height>
                  </size>
                 </property>


### PR DESCRIPTION
Improve the OnionSkins UI by reducing the spacing between UI components.

Currently, on my HiDPI laptop displays (Win11 with 150% scaling), the OnionSkins options are barely visible. We can improve it by minimizing the spacing between UI elements, so more options can be displayed within the limited available space.

Please see the before/after screenshots as follows:

### Before
![onionskins-old](https://github.com/pencil2d/pencil/assets/163800/fb34a822-72e2-4871-9517-513ad9fbfa31)

### After
![onionskins-new](https://github.com/pencil2d/pencil/assets/163800/5f9cb824-009b-45d7-8954-6bc501ceff60)
