### PR TITLE
Enable C++17 by default when building against Qt 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,6 @@ jobs:
       run: mkdir build; ${{runner.os == 'Linux' && matrix.qt == 6 && 'qmake6' || 'qmake'}}
         -o build PREFIX=/usr CONFIG-=debug_and_release CONFIG+=release CONFIG+=GIT
         CONFIG+=PENCIL2D_${{github.ref == 'refs/heads/release' && 'RELEASE' || 'NIGHTLY'}}
-        ${{matrix.qt == 6 && 'CONFIG+=c++17 QMAKE_CXX_FLAGS+=-std=c++17' || ''}}
 
     - name: Build Pencil2D
       working-directory: build

--- a/util/common.pri
+++ b/util/common.pri
@@ -18,32 +18,23 @@ greaterThan(QT_MAJOR_VERSION, 5) {
     CONFIG += c++11
 }
 
-win32-msvc* {
-    QMAKE_CXXFLAGS += /MP /utf-8
-    CONFIG(release,debug|release) {
-        QMAKE_CXXFLAGS += /Gy /GL
-        CONFIG += ltcg
-        CONFIG += force_debug_info
-    }
+# utf8_source is only for Qt 5, it is the default since Qt 6
+CONFIG += msvc_mp utf8_source
+
+win32-msvc*:CONFIG(release,debug|release) {
+    QMAKE_CXXFLAGS += /Gy /GL
+    CONFIG += ltcg
+    CONFIG += force_debug_info
 }
 
 WIN_LEGACY {
-    QMAKE_CXXFLAGS -= /utf-8
     QMAKE_LFLAGS += /SUBSYSTEM:CONSOLE,5.01
     QMAKE_CXX += /D_USING_V110_SDK71_
     DEFINES += _WIN32_WINNT=0x0501
 }
 win32:!WIN_LEGACY: DEFINES += _WIN32_WINNT=0x0601
 
-macx {
-    QMAKE_CXXFLAGS += -stdlib=libc++
-    LIBS += -lobjc -framework Carbon -framework AppKit
-}
-
-unix:!macx {
-    QMAKE_LINK = $$QMAKE_CXX
-    QMAKE_LINK_SHLIB = $$QMAKE_CXX
-}
+macx: LIBS += -lobjc -framework Carbon -framework AppKit
 
 # The following define makes your compiler emit warnings if you use
 # any feature of Qt which as been marked deprecated (the exact warnings

--- a/util/common.pri
+++ b/util/common.pri
@@ -11,10 +11,11 @@ PENCIL2D_RELEASE {
     DEFINES += PENCIL2D_RELEASE_BUILD
 }
 
-CONFIG += c++11
-
-win32-g++ {
-    QMAKE_CXXFLAGS += -std=c++11
+CONFIG += strict_c strict_c++
+greaterThan(QT_MAJOR_VERSION, 5) {
+    CONFIG += c++17
+} else {
+    CONFIG += c++11
 }
 
 win32-msvc* {
@@ -35,12 +36,11 @@ WIN_LEGACY {
 win32:!WIN_LEGACY: DEFINES += _WIN32_WINNT=0x0601
 
 macx {
-    QMAKE_CXXFLAGS += -std=c++11 -stdlib=libc++
+    QMAKE_CXXFLAGS += -stdlib=libc++
     LIBS += -lobjc -framework Carbon -framework AppKit
 }
 
 unix:!macx {
-    QMAKE_CXXFLAGS += -std=c++11
     QMAKE_LINK = $$QMAKE_CXX
     QMAKE_LINK_SHLIB = $$QMAKE_CXX
 }

--- a/util/common.pri
+++ b/util/common.pri
@@ -21,18 +21,13 @@ greaterThan(QT_MAJOR_VERSION, 5) {
 # utf8_source is only for Qt 5, it is the default since Qt 6
 CONFIG += msvc_mp utf8_source
 
-win32-msvc*:CONFIG(release,debug|release) {
-    QMAKE_CXXFLAGS += /Gy /GL
-    CONFIG += ltcg
-    CONFIG += force_debug_info
-}
-
+win32-msvc*:CONFIG(release,debug|release): CONFIG += force_debug_info
+win32:!WIN_LEGACY: DEFINES += _WIN32_WINNT=0x0601
 WIN_LEGACY {
     QMAKE_LFLAGS += /SUBSYSTEM:CONSOLE,5.01
     QMAKE_CXX += /D_USING_V110_SDK71_
     DEFINES += _WIN32_WINNT=0x0501
 }
-win32:!WIN_LEGACY: DEFINES += _WIN32_WINNT=0x0601
 
 macx: LIBS += -lobjc -framework Carbon -framework AppKit
 


### PR DESCRIPTION
Also cleans up other compiler options a bit:

- use strict_c/c++ QMake feature to disable compiler extensions instead of messing directly with compiler flags
- same with msvc_mp and utf8_source. the latter also does compiler detection so there should be no need for special handling of legacy builds
- -stdlib=libc++ for macOS is removed since it appears to be the default since Qt 5.1
- QMAKE_LINK{,_SHLIB} = $$QMAKE_CXX also appears to be the default