### PR TITLE
Update to WiX 5

### DIFF
--- a/.github/actions/create-package/create-package.sh
+++ b/.github/actions/create-package/create-package.sh
@@ -151,7 +151,7 @@ create_package_windows() {
     -out "pencil2d-${platform}-$3.msi" \
     ../util/installer/pencil2d.wxs windeployqt.wxs resources.wxs
   wix build -pdbtype none -arch "x${wordsize/32/86}" -dcl high -sw1133 -b ../util/installer -b Pencil2D \
-    -ext WixToolset.Util.wixext -ext WixToolset.Bal.wixext \
+    -ext WixToolset.Util.wixext -ext WixToolset.BootstrapperApplications.wixext \
     $versiondefines \
     -out "pencil2d-${platform}-$3.exe" \
     ../util/installer/pencil2d.bundle.wxs

--- a/.github/actions/install-dependencies/install-dependencies.sh
+++ b/.github/actions/install-dependencies/install-dependencies.sh
@@ -55,11 +55,11 @@ setup_windows() {
   curl -fsSLO https://okapiframework.org/binaries/main/1.45.0/okapi-apps_win32-x86_64_1.45.0.zip
   mkdir okapi
   "${WINDIR}\\System32\\tar" xfC okapi-apps_win32-x86_64_1.45.0.zip okapi
-  dotnet tool install -g wix --version 4.0.4
-  wix extension add -g WixToolset.Util.wixext/4.0.4 WixToolset.Bal.wixext/4.0.4
-  nuget install -x -OutputDirectory util/installer WixToolset.BootstrapperCore.Native -Version 4.0.4
-  nuget install -x -OutputDirectory util/installer WixToolset.DUtil -Version 4.0.4
-  nuget install -x -OutputDirectory util/installer WixToolset.BalUtil -Version 4.0.4
+  dotnet tool install -g wix --version 5.0.0
+  wix extension add -g WixToolset.Util.wixext/5.0.0 WixToolset.BootstrapperApplications.wixext/5.0.0
+  nuget install -x -OutputDirectory util/installer WixToolset.DUtil -Version 5.0.0
+  nuget install -x -OutputDirectory util/installer WixToolset.BootstrapperApplicationApi -Version 5.0.0
+  nuget install -x -OutputDirectory util/installer WixToolset.WixStandardBootstrapperApplicationFunctionApi -Version 5.0.0
 }
 
 "setup_$(echo "${RUNNER_OS}" | tr '[A-Z]' '[a-z]')"

--- a/docs/installer-development.md
+++ b/docs/installer-development.md
@@ -31,16 +31,16 @@ please first make sure MSVC is available on your system. Additionally, you will 
   make sure there are no warnings concerning po2rc. If qmake cannot find po2rc, you can also manually set the PO2RC
   qmake variable to the path of the po2rc executable.
 - Tikal from the [Okapi Framework](https://okapiframework.org/).
-- The WiX Toolset as well as its Bal and Util extensions. Use the following commands to install these from the command
-  line:
+- The WiX Toolset as well as its BootstrapperApplications and Util extensions. Use the following commands to install
+  these from the command line:
 
       dotnet tool install -g wix
-      wix extension add -g WixToolset.Util.wixext WixToolset.Bal.wixext
+      wix extension add -g WixToolset.Util.wixext WixToolset.BootstrapperApplications.wixext
 
 - WiX utility libraries. The build system expects these in the util/installer directory. Use the following command to
   install them from the command line:
 
-      nuget install -x -OutputDirectory path\to\util\installer WixToolset.BalUtil
+      nuget install -x -OutputDirectory path\to\util\installer WixToolset.WixStandardBootstrapperApplicationFunctionApi
 
 - The WiX theme viewer (optional), which can be useful when making changes to the installer's UI layout. It is available
   from the [WiX Toolset GitHub releases](https://github.com/wixtoolset/wix/releases) through the WixAdditionalTools
@@ -135,7 +135,7 @@ Available LCIDs are listed in the
 Finally, building the bootstrapper requires the same version information as the Windows Installer database. Use the
 following command to build it:
 
-    wix build -arch x64 -sw1133 -b path\to\util\installer -b DISTDIR -ext WixToolset.Util.wixext -ext WixToolset.Bal.wixext -d Edition=Release -d Version=X.X.X -out pencil2d-win64-X.X.X.exe path\to\util\installer\pencil2d.bundle.wxs
+    wix build -arch x64 -sw1133 -b path\to\util\installer -b DISTDIR -ext WixToolset.Util.wixext -ext WixToolset.BootstrapperApplications.wixext -d Edition=Release -d Version=X.X.X -out pencil2d-win64-X.X.X.exe path\to\util\installer\pencil2d.bundle.wxs
 
 Again, in order to build for something other than 64-bit x86, replace x64 and win64 accordingly. It may be necessary to
 add the directories containing the Windows Installer database or pencil2d.dll to WiX’s search path using the `-b` option

--- a/util/installer/pencil2d.bundle.wxs
+++ b/util/installer/pencil2d.bundle.wxs
@@ -44,6 +44,7 @@
       <!-- Translations -->
       <Payload SourceFile="pencil2d_de.wxl" Name="7\thm.wxl" />
       <!-- Assets -->
+      <Payload SourceFile="pencil2d.ico" />
       <Payload SourceFile="pencil2d.png" />
       <Payload SourceFile="pencil2d@2x.png" />
       <Payload SourceFile="cog.png" />

--- a/util/installer/pencil2d.bundle.wxs
+++ b/util/installer/pencil2d.bundle.wxs
@@ -58,8 +58,9 @@
       <Variable Name="NightlyBuildTimestamp" Type="string" Value="$(NightlyBuildTimestamp)" />
     <?endif?>
     <Chain>
+      <!-- Set Cache to remove to work around WiX issue #8063 -->
       <!-- Set InstallSize to 0 to ensure the size in the ARP entry is correct (since the redist entry is separate) -->
-      <BundlePackage SourceFile="vc_redist.$(sys.BUILDARCH).exe" Permanent="yes" InstallSize="0" />
+      <BundlePackage SourceFile="vc_redist.$(sys.BUILDARCH).exe" Cache="remove" Permanent="yes" InstallSize="0" />
       <MsiPackage SourceFile="$(MsiName).msi">
         <MsiProperty Name="INSTALLDIR" Value="[InstallFolder]" />
         <!-- Need an explicit condition here - Windows Installer and the options page cancel button

--- a/util/installer/pencil2d.pro
+++ b/util/installer/pencil2d.pro
@@ -6,16 +6,18 @@ QMAKE_LFLAGS_RELEASE += /GUARD:CF
 DEFINES += _WIN32_MSI=500 _WIN32_WINNT=0x0600
 QT -= core gui
 INCLUDEPATH += WixToolset.DUtil/build/native/include \
-               WixToolset.BALUtil/build/native/include \
-               WixToolset.BootstrapperCore.Native/build/native/include
+               WixToolset.BootstrapperApplicationApi/build/native/include \
+               WixToolset.WixStandardBootstrapperApplicationFunctionApi/lib/native/include
 equals(QMAKE_TARGET.arch, "x86") {
     LIBS += "-L$$PWD/WixToolset.DUtil/build/native/v14/x86" \
-            "-L$$PWD/WixToolset.BALUtil/build/native/v14/x86"
+            "-L$$PWD/WixToolset.BootstrapperApplicationApi/build/native/v14/x86" \
+            "-L$$PWD/WixToolset.WixStandardBootstrapperApplicationFunctionApi/lib/native/v14/x86"
 }
 equals(QMAKE_TARGET.arch, "x86_64") {
     LIBS += "-L$$PWD/WixToolset.DUtil/build/native/v14/x64" \
-            "-L$$PWD/WixToolset.BALUtil/build/native/v14/x64"
+            "-L$$PWD/WixToolset.BootstrapperApplicationApi/build/native/v14/x64" \
+            "-L$$PWD/WixToolset.WixStandardBootstrapperApplicationFunctionApi/lib/native/v14/x64"
 }
-LIBS += User32.lib Advapi32.lib Ole32.lib OleAut32.lib Version.lib balutil.lib dutil.lib
+LIBS += User32.lib Advapi32.lib Ole32.lib OleAut32.lib Version.lib Shell32.lib wixstdfn.lib balutil.lib dutil.lib
 SOURCES += pencil2d.cpp
 DEF_FILE = pencil2d.def

--- a/util/installer/pencil2d.thm
+++ b/util/installer/pencil2d.thm
@@ -11,7 +11,7 @@
       <AlternateResolution ImageFile="cog-hover@2x.png" />
     </Image>
 
-    <Window Width="640" Height="413" HexStyle="100a0000" FontId="Normal" Caption="#(loc.Caption)">
+    <Window Width="640" Height="413" HexStyle="100a0000" FontId="Normal" IconFile="pencil2d.ico" Caption="#(loc.Caption)">
         <ImageControl X="20" Y="20" Width="600" Height="175" ImageId="pencil2d" Visible="yes"/>
         <Label Name="Version" X="20" Y="-22" Width="246" Height="17" FontId="Normal" DisablePrefix="yes" VisibleCondition="WixStdBAShowVersion">
           <Text>#(loc.Version)</Text>


### PR DESCRIPTION
This updates the installer from WiX 4 to WiX 5, which came out earlier this month. WiX 5 moved the bootstrapper application (think of it as the UI) out-of-process, so the changes are a bit more extensive than usual but still pretty straightforward. Some packages and header files got renamed, initialisation moved to OnCreate and localisation loading moved to OnThemeLoaded. The window icon is made explicit since it is now created in a separate process and therefore no longer inherited from the main installer binary.

Additionally, I also added a small workaround for a WiX caching issue, which is unrelated to the version 5 update.

Already tested a bunch of different scenarios and haven’t seen any new issues pop up so far.