### PR TITLE
Fix gaps when drawing with small pen and antialiasing off

### DIFF
--- a/core_lib/src/graphics/bitmap/tiledbuffer.cpp
+++ b/core_lib/src/graphics/bitmap/tiledbuffer.cpp
@@ -48,8 +48,7 @@ Tile* TiledBuffer::getTileFromIndex(const TileIndex& tileIndex)
     return selectedTile;
 }
 
-void TiledBuffer::drawBrush(const QPointF& point, qreal brushWidth, QPen pen, QBrush brush, QPainter::CompositionMode cm, bool antialiasing) {
-    const QRectF brushRect(point.x() - 0.5 * brushWidth, point.y() - 0.5 * brushWidth, brushWidth, brushWidth);
+void TiledBuffer::drawBrush(QPointF point, qreal brushWidth, QPen pen, QBrush brush, QPainter::CompositionMode cm, bool antialiasing) {
     const float tileSize = UNIFORM_TILE_SIZE;
 
     // Gather the number of tiles that fits the size of the brush width
@@ -57,6 +56,21 @@ void TiledBuffer::drawBrush(const QPointF& point, qreal brushWidth, QPen pen, QB
     const int xRight = qFloor((qFloor(point.x() + brushWidth)) / tileSize);
     const int yTop = qFloor(qFloor(point.y() - brushWidth) / tileSize);
     const int yBottom = qFloor(qFloor(point.y() + brushWidth) / tileSize);
+
+    // If we are not using antialiasing, make sure at least one pixel is within the brush's circle
+    bool drawPoint = false;
+    if (!antialiasing && brushWidth < 1.42) { // Overestimated approximation of 2*sqrt(2), which is the maximum distance a point can be from the center of a pixel
+        // Measure the actual distance to the center of the nearest pixel
+        const QPointF nearestPixelCenter(qRound(point.x()+0.5)-0.5, qRound(point.y()+0.5)-0.5);
+        const qreal distanceToNearest = QLineF(point, nearestPixelCenter).length();
+        if (distanceToNearest >= brushWidth/2) {
+            // Nothing will be drawn with drawEllipse, so prepare to draw the nearest pixel with drawPoint
+            drawPoint = true;
+            point = QPointF(nearestPixelCenter.x() - 0.5, nearestPixelCenter.y() - 0.5);
+            pen = QPen(brush, 1);
+        }
+    }
+    const QRectF brushRect(point.x() - 0.5 * brushWidth, point.y() - 0.5 * brushWidth, brushWidth, brushWidth);
 
     for (int tileY = yTop; tileY <= yBottom; tileY++) {
         for (int tileX = xLeft; tileX <= xRight; tileX++) {
@@ -70,7 +84,11 @@ void TiledBuffer::drawBrush(const QPointF& point, qreal brushWidth, QPen pen, QB
             painter.setPen(pen);
             painter.setBrush(brush);
             painter.setCompositionMode(cm);
-            painter.drawEllipse(brushRect);
+            if (drawPoint) {
+                painter.drawPoint(point);
+            } else {
+                painter.drawEllipse(brushRect);
+            }
             painter.end();
 
             mTileBounds.extend(tile->bounds());

--- a/core_lib/src/graphics/bitmap/tiledbuffer.cpp
+++ b/core_lib/src/graphics/bitmap/tiledbuffer.cpp
@@ -128,7 +128,7 @@ void TiledBuffer::drawImage(const QImage& image, const QRect& imageBounds, QPain
 void TiledBuffer::drawPath(QPainterPath path, QPen pen, QBrush brush,
                            QPainter::CompositionMode cm, bool antialiasing)
 {
-    const int width = pen.width();
+    const qreal width = pen.widthF();
     const float tileSize = UNIFORM_TILE_SIZE;
     const QRectF pathRect = path.boundingRect();
 

--- a/core_lib/src/graphics/bitmap/tiledbuffer.h
+++ b/core_lib/src/graphics/bitmap/tiledbuffer.h
@@ -59,7 +59,7 @@ public:
     bool isValid() const { return !mTiles.isEmpty(); }
 
     /** Draws a brush with the specified parameters to the tiled buffer */
-    void drawBrush(const QPointF& point, qreal brushWidth, QPen pen, QBrush brush, QPainter::CompositionMode cm, bool antialiasing);
+    void drawBrush(QPointF point, qreal brushWidth, QPen pen, QBrush brush, QPainter::CompositionMode cm, bool antialiasing);
     /** Draws a path with the specified parameters to the tiled buffer */
     void drawPath(QPainterPath path, QPen pen, QBrush brush,
                   QPainter::CompositionMode cm, bool antialiasing);


### PR DESCRIPTION
When drawing with the Pen tool with the width set to 1.00 (and also at lower and slightly higher sizes) and antialiasing turned off, there would occasionally be gaps in the stroke. I've determined that this is to be expected when the point being drawn with a specific area. Consider this diagram:
![Pixel Grid](https://github.com/pencil2d/pencil/assets/3461051/91002b61-de3b-404d-8ba8-991fd620a3b2)
The black grid represents the edges of four pixels. The light blue represents the center and radius of the circle to be drawn for a tool with a width (ie. diameter) of 1px. The dark blue dots represent the center of the pixels. As best as I can figure, when QPainter::drawEllipse is called without antialiasing, it will only fill in the pixels where the center of those pixels are contained within the ellipse. As you can see in this example, none of the pixels meet this criteria, so nothing would be drawn for this step. With a size of 1, it is quite easy to get into a situation like this for several steps in a row when path travels right along the borders of two pixels.

My solution to this is to check for this particular case, first with a quick check to make sure antialiasing is turned off and that the width is small enough for this to be possible, and then with a longer check actually calculating the Euclidean distance. If this scenario is encountered, the nearest pixel is found and filled. This is done with drawPoint because I couldn't get drawEllipse to work reliably at this scale.

Testing this approach seems to give reasonable results in terms of line quality. Comparing it to GIMP's pencil tool, the diagonal lines seem a little thicker on average, but that probably is a result of differences in the path step size, or perhaps they do some different algorithm entirely.