### PR TITLE
Update AppStream summary and add brand colors

### DIFF
--- a/app/data/org.pencil2d.Pencil2D.metainfo.xml
+++ b/app/data/org.pencil2d.Pencil2D.metainfo.xml
@@ -3,12 +3,16 @@
   <id>org.pencil2d.Pencil2D</id>
   <launchable type="desktop-id">org.pencil2d.Pencil2D.desktop</launchable>
   <name>Pencil2D</name>
+  <branding>
+    <color type="primary" scheme_preference="light">#81bdff</color>
+    <color type="primary" scheme_preference="dark">#003d80</color>
+  </branding>
   <developer id="org.pencil2d">
     <name>The Pencil2D Team</name>
   </developer>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
-  <summary>2D animation software supporting bitmap and vector graphics</summary>
+  <summary>Create 2D animations with ease</summary>
   <description>
     <p>
       Pencil2D is a 2D animation program that lets you easily create
@@ -28,7 +32,9 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="0.6.6" date="2021-02-17"/>
+    <release version="0.6.6" date="2021-02-17">
+      <url type="details">https://www.pencil2d.org/2021/02/pencil2d-0.6.6-release.html</url>
+    </release>
     <release version="0.6.5" date="2020-07-31">
       <url type="details">https://www.pencil2d.org/2020/07/pencil2d-0.6.5-release.html</url>
     </release>


### PR DESCRIPTION
Resolves #1812. Here’s what the brand colours look like in their preview tool (still using the current, outdated screenshot):

![image](https://github.com/pencil2d/pencil/assets/2063777/9fdaf89c-20fc-464c-989f-349e18d27cbf)

For examples of other apps, check out [the Flathub home page](https://flathub.org/).

I’m a bit unsure about the dark brand colour. When you make it too light, the contrast against the circle isn’t that good, but when you make it too dark, the contrast against the tip of the pencil suffers. Would appreciate some feedback there. You can try out the preview tool at https://docs.flathub.org/banner-preview/ if you’d like to experiment some yourself. AppStream does not allow specifying separate icons for light and dark mode.