### PR TITLE
Prevent MP4 export with invalid resolution

### DIFF
--- a/app/src/exportmoviedialog.cpp
+++ b/app/src/exportmoviedialog.cpp
@@ -32,8 +32,8 @@ ExportMovieDialog::ExportMovieDialog(QWidget *parent, Mode mode, FileType fileTy
         setWindowTitle(tr("Export Movie"));
     }
     connect(this, &ExportMovieDialog::filePathsChanged, this, &ExportMovieDialog::onFilePathsChanged);
-    connect(ui->widthSpinBox, &QSpinBox::valueChanged, this, &ExportMovieDialog::validateResolution);
-    connect(ui->heightSpinBox, &QSpinBox::valueChanged, this, &ExportMovieDialog::validateResolution);
+    connect(ui->widthSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &ExportMovieDialog::validateResolution);
+    connect(ui->heightSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &ExportMovieDialog::validateResolution);
 }
 
 ExportMovieDialog::~ExportMovieDialog()

--- a/app/src/exportmoviedialog.cpp
+++ b/app/src/exportmoviedialog.cpp
@@ -31,6 +31,14 @@ ExportMovieDialog::ExportMovieDialog(QWidget *parent, Mode mode, FileType fileTy
     } else {
         setWindowTitle(tr("Export Movie"));
     }
+
+    QSizePolicy policy = ui->unevenWidthLabel->sizePolicy();
+    policy.setRetainSizeWhenHidden(true);
+    ui->unevenWidthLabel->setSizePolicy(policy);
+    policy = ui->unevenHeightLabel->sizePolicy();
+    policy.setRetainSizeWhenHidden(true);
+    ui->unevenHeightLabel->setSizePolicy(policy);
+
     connect(this, &ExportMovieDialog::filePathsChanged, this, &ExportMovieDialog::onFilePathsChanged);
     connect(ui->widthSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &ExportMovieDialog::validateResolution);
     connect(ui->heightSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &ExportMovieDialog::validateResolution);

--- a/app/src/exportmoviedialog.cpp
+++ b/app/src/exportmoviedialog.cpp
@@ -32,6 +32,8 @@ ExportMovieDialog::ExportMovieDialog(QWidget *parent, Mode mode, FileType fileTy
         setWindowTitle(tr("Export Movie"));
     }
     connect(this, &ExportMovieDialog::filePathsChanged, this, &ExportMovieDialog::onFilePathsChanged);
+    connect(ui->widthSpinBox, &QSpinBox::valueChanged, this, &ExportMovieDialog::validateResolution);
+    connect(ui->heightSpinBox, &QSpinBox::valueChanged, this, &ExportMovieDialog::validateResolution);
 }
 
 ExportMovieDialog::~ExportMovieDialog()
@@ -66,6 +68,7 @@ void ExportMovieDialog::updateResolutionCombo( int index )
 
     ui->widthSpinBox->setValue( camSize.width() );
     ui->heightSpinBox->setValue( camSize.height() );
+    validateResolution();
 }
 
 void ExportMovieDialog::setDefaultRange(int startFrame, int endFrame, int endFrameWithSounds)
@@ -128,6 +131,7 @@ void ExportMovieDialog::onFilePathsChanged(QStringList filePaths)
         ui->loopCheckBox->setChecked(false);
     }
     ui->transparencyCheckBox->setEnabled(supportsTransparency(filePath));
+    validateResolution();
 }
 
 bool ExportMovieDialog::supportsLooping(QString filePath) const
@@ -140,4 +144,14 @@ bool ExportMovieDialog::supportsTransparency(QString filePath) const
 {
     return filePath.endsWith(".apng", Qt::CaseInsensitive) ||
            filePath.endsWith(".webm", Qt::CaseInsensitive);
+}
+
+void ExportMovieDialog::validateResolution()
+{
+    const bool isMp4 = getFilePath().endsWith(".mp4", Qt::CaseInsensitive);
+    const bool widthValid = !isMp4 || ui->widthSpinBox->value() % 2 == 0;
+    const bool heightValid = !isMp4 || ui->heightSpinBox->value() % 2 == 0;
+    ui->unevenWidthLabel->setHidden(widthValid);
+    ui->unevenHeightLabel->setHidden(heightValid);
+    setOkButtonEnabled(widthValid && heightValid);
 }

--- a/app/src/exportmoviedialog.h
+++ b/app/src/exportmoviedialog.h
@@ -54,6 +54,7 @@ private:
 
     bool supportsLooping(QString filePath) const;
     bool supportsTransparency(QString filePath) const;
+    void validateResolution();
 
     int mEndFrameWithSounds = 0;
     int mEndFrame = 0;

--- a/app/src/importexportdialog.cpp
+++ b/app/src/importexportdialog.cpp
@@ -71,6 +71,11 @@ void ImportExportDialog::setInstructionsLabel(const QString& text)
     ui->instructionsLabel->setText(text);
 }
 
+void ImportExportDialog::setOkButtonEnabled(const bool enabled)
+{
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(enabled);
+}
+
 void ImportExportDialog::init()
 {
     switch (mMode)

--- a/app/src/importexportdialog.h
+++ b/app/src/importexportdialog.h
@@ -58,6 +58,7 @@ protected:
     void hideInstructionsLabel(bool hide);
 
     void setInstructionsLabel(const QString& text);
+    void setOkButtonEnabled(bool enabled);
 
 private slots:
     void browse();

--- a/app/ui/exportmovieoptions.ui
+++ b/app/ui/exportmovieoptions.ui
@@ -40,7 +40,7 @@
      <property name="title">
       <string>Resolution</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1,1,0,1">
       <item>
        <widget class="QLabel" name="label">
         <property name="sizePolicy">
@@ -57,6 +57,16 @@
         </property>
         <property name="text">
          <string>Width</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="unevenWidthLabel">
+        <property name="toolTip">
+         <string>The MP4 format does not support odd width. Please specify an even width or use a different file format.</string>
+        </property>
+        <property name="text">
+         <string notr="true">⚠</string>
         </property>
        </widget>
       </item>
@@ -86,6 +96,16 @@
         </property>
         <property name="text">
          <string>Height</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="unevenHeightLabel">
+        <property name="toolTip">
+         <string>The MP4 format does not support odd height. Please specify an even height or use a different file format.</string>
+        </property>
+        <property name="text">
+         <string notr="true">⚠</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Fixes #1491. Has some small layout jumps when the warning is shown or hidden that I’m not quite sure how to properly deal with, but that’s still much better than the confusing wall of text that we have now.