### PR TITLE
Fix build server only deploys arm64 macOS binaries

### DIFF
--- a/.github/actions/create-package/create-package.sh
+++ b/.github/actions/create-package/create-package.sh
@@ -99,8 +99,8 @@ create_package_macos() {
   echo "Create ZIP"
   local qtsuffix="-qt${INPUT_QT}"
   local arch=`uname -m`
-  bsdtar caf "pencil2d${qtsuffix/-qt5/}-mac-${arch}.zip" Pencil2D
-  echo "output-basename=pencil2d${qtsuffix/-qt5/}-mac-${arch}" > "${GITHUB_OUTPUT}"
+  bsdtar caf "pencil2d${qtsuffix/-qt5/}-mac-${arch}-$3.zip" Pencil2D
+  echo "output-basename=pencil2d${qtsuffix/-qt5/}-mac-${arch}-$3" > "${GITHUB_OUTPUT}"
 }
 
 create_package_windows() {

--- a/.github/actions/create-package/create-package.sh
+++ b/.github/actions/create-package/create-package.sh
@@ -98,8 +98,9 @@ create_package_macos() {
   popd >/dev/null
   echo "Create ZIP"
   local qtsuffix="-qt${INPUT_QT}"
-  bsdtar caf "pencil2d${qtsuffix/-qt5/}-mac-$3.zip" Pencil2D
-  echo "output-basename=pencil2d${qtsuffix/-qt5/}-mac-$3" > "${GITHUB_OUTPUT}"
+  local arch=`uname -m`
+  bsdtar caf "pencil2d${qtsuffix/-qt5/}-mac-${arch}.zip" Pencil2D
+  echo "output-basename=pencil2d${qtsuffix/-qt5/}-mac-${arch}" > "${GITHUB_OUTPUT}"
 }
 
 create_package_windows() {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
           container: { image: "ubuntu:16.04", options: --privileged }
           qt: 5
         - name: Qt 5 / macOS x86_64
+          os: macos-12
+          container:
+          qt: 5
+        - name: Qt 5 / macOS arm64
           os: macos-latest
           container:
           qt: 5
@@ -53,6 +57,10 @@ jobs:
           container: { image: "ubuntu:22.04", options: --privileged }
           qt: 6
         - name: Qt 6 / macOS x86_64
+          os: macos-12
+          container:
+          qt: 6
+        - name: Qt 6 / macOS arm64
           os: macos-latest
           container:
           qt: 6


### PR DESCRIPTION
We do this for now by introducing more mac os runners. This means that we deploy proper arm64 builds now as well as x86_64.

Ideally we would build universal binaries but Homebrew does not support building cross platform, as such we would have to build Qt ourselves in order to support this.

Note: We have to remember to make changes to the website, so we can see both new build types