### PR TITLE
Warn that translation changes require restart in new language

### DIFF
--- a/app/src/generalpage.cpp
+++ b/app/src/generalpage.cpp
@@ -19,6 +19,7 @@ GNU General Public License for more details.
 
 #include <QMessageBox>
 #include <QSettings>
+#include <QTranslator>
 
 #include "pencildef.h"
 #include "preferencemanager.h"
@@ -197,9 +198,19 @@ void GeneralPage::languageChanged(int i)
     QString strLocale = ui->languageCombo->itemData(i).toString();
     mManager->set(SETTING::LANGUAGE, strLocale);
 
-    QMessageBox::warning(this,
-                         tr("Restart Required"),
-                         tr("The language change will take effect after a restart of Pencil2D"));
+    QLocale locale = strLocale.isEmpty() ? QLocale::system() : QLocale(strLocale);
+    std::unique_ptr<QTranslator> newlangTr(new QTranslator(this));
+    if (newlangTr->load(locale, "pencil", "_", ":/i18n/"))
+    {
+        QMessageBox::warning(this,
+                             newlangTr->translate(staticMetaObject.className(), "Restart Required"),
+                             newlangTr->translate(staticMetaObject.className(), "The language change will take effect after a restart of Pencil2D"));
+    } else {
+        Q_ASSERT(false);
+        QMessageBox::warning(this,
+                             tr("Restart Required"),
+                             tr("The language change will take effect after a restart of Pencil2D"));
+    }
 }
 
 void GeneralPage::backgroundChanged(QAbstractButton* button)


### PR DESCRIPTION
When changing languages in the preferences window, this displays the warning in the target language instead of the current language so that people can actually read and understand it.