### PR TITLE
Prevent Pencil2D projects from referencing external files

### DIFF
--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -24,6 +24,7 @@ GNU General Public License for more details.
 #include "fileformat.h"
 #include "object.h"
 #include "layercamera.h"
+#include "util/util.h"
 
 FileManager::FileManager(QObject* parent) : QObject(parent)
 {
@@ -612,8 +613,8 @@ bool FileManager::loadPalette(Object* obj)
 {
     FILEMANAGER_LOG("Load Palette..");
 
-    QString paletteFilePath = QDir(obj->dataDir()).filePath(PFF_PALETTE_FILE);
-    if (!obj->importPalette(paletteFilePath))
+    QString paletteFilePath = validateDataPath(PFF_PALETTE_FILE, obj->dataDir());
+    if (paletteFilePath.isEmpty() || !obj->importPalette(paletteFilePath))
     {
         obj->loadDefaultPalette();
     }

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -211,7 +211,7 @@ void LayerBitmap::loadDomElement(const QDomElement& element, QString dataDirPath
             QFileInfo fi(dataDirPath, imageElement.attribute("src"));
             // Make sure file is in data directory after resolving relative components and symlinks
             QString canonicalPath = fi.canonicalFilePath();
-            fi = !canonicalPath.isEmpty() ? canonicalPath : fi.absoluteFilePath();
+            fi.setFile(!canonicalPath.isEmpty() ? canonicalPath : fi.absoluteFilePath());
             QDir dataDir(dataDirPath);
             QDir ancestor = fi.dir();
             while (ancestor != dataDir)

--- a/core_lib/src/structure/layersound.cpp
+++ b/core_lib/src/structure/layersound.cpp
@@ -21,6 +21,7 @@ GNU General Public License for more details.
 #include <QFileInfo>
 #include <QDir>
 #include "soundclip.h"
+#include "util/util.h"
 
 
 LayerSound::LayerSound(int id) : Layer(id, Layer::SOUND)
@@ -101,32 +102,11 @@ void LayerSound::loadDomElement(const QDomElement& element, QString dataDirPath,
 
             if (!soundFile.isEmpty())
             {
-                bool shouldLoad = true;
-
-                // Make sure src path is relative
-                shouldLoad &= QFileInfo(soundFile).isRelative();
-                // Make sure file is in data directory after resolving relative components and symlinks
-                QFileInfo fi(dataDirPath, soundFile);
-                QString canonicalPath = fi.canonicalFilePath();
-                fi.setFile(!canonicalPath.isEmpty() ? canonicalPath : fi.absoluteFilePath());
-                QDir dataDir(dataDirPath);
-                QDir ancestor = fi.dir();
-                while (ancestor != dataDir)
-                {
-                    QDir newAncestor = QFileInfo(ancestor.absolutePath()).dir();
-                    if (ancestor == newAncestor)
-                    {
-                        // Data dir was not found in ancestors of the src path
-                        shouldLoad = false;
-                        break;
-                    }
-                    ancestor = newAncestor;
-                }
-
-                if (shouldLoad)
+                QString path = validateDataPath(soundFile, dataDirPath);
+                if (!path.isEmpty())
                 {
                     int position = soundElement.attribute("frame").toInt();
-                    Status st = loadSoundClipAtFrame(sSoundClipName, fi.absoluteFilePath(), position);
+                    Status st = loadSoundClipAtFrame(sSoundClipName, path, position);
                     Q_ASSERT(st.ok());
                 }
             }

--- a/core_lib/src/structure/layersound.cpp
+++ b/core_lib/src/structure/layersound.cpp
@@ -108,7 +108,7 @@ void LayerSound::loadDomElement(const QDomElement& element, QString dataDirPath,
                 // Make sure file is in data directory after resolving relative components and symlinks
                 QFileInfo fi(dataDirPath, soundFile);
                 QString canonicalPath = fi.canonicalFilePath();
-                fi = !canonicalPath.isEmpty() ? canonicalPath : fi.absoluteFilePath();
+                fi.setFile(!canonicalPath.isEmpty() ? canonicalPath : fi.absoluteFilePath());
                 QDir dataDir(dataDirPath);
                 QDir ancestor = fi.dir();
                 while (ancestor != dataDir)

--- a/core_lib/src/structure/layervector.cpp
+++ b/core_lib/src/structure/layervector.cpp
@@ -168,7 +168,7 @@ void LayerVector::loadDomElement(const QDomElement& element, QString dataDirPath
                 QFileInfo fi(dataDirPath, rawPath);
                 // Make sure file is in data directory after resolving relative components and symlinks
                 QString canonicalPath = fi.canonicalFilePath();
-                fi = !canonicalPath.isEmpty() ? canonicalPath : fi.absoluteFilePath();
+                fi.setFile(!canonicalPath.isEmpty() ? canonicalPath : fi.absoluteFilePath());
                 QDir dataDir(dataDirPath);
                 QDir ancestor = fi.dir();
                 while (ancestor != dataDir)

--- a/core_lib/src/util/util.cpp
+++ b/core_lib/src/util/util.cpp
@@ -138,25 +138,29 @@ QString validateDataPath(QString filePath, QString dataDirPath)
     // Recursively resolve symlinks
     QString canonicalPath = fi.canonicalFilePath();
 
-    // Iterate over parent directories of the file path to see if one of them equals the data directory
     QDir dataDir(dataDirPath);
-    if (dataDir.exists()) dataDir.setPath(dataDir.canonicalPath());
+    // Resolve symlinks in data dir path so it can be compared against file paths with resolved symlinks
+    if (dataDir.exists())
+    {
+        dataDir.setPath(dataDir.canonicalPath());
+    }
+    // Iterate over parent directories of the file path to see if one of them equals the data directory
     if (canonicalPath.isEmpty())
     {
         // File does not exist, use absolute path and attempt to resolve symlinks again for each parent directory
         fi.setFile(fi.absoluteFilePath());
         QDir ancestor(fi.absoluteFilePath());
         while (true) {
+            if (ancestor == dataDir)
+            {
+                // Found data dir in parents
+                return fi.absoluteFilePath();
+            }
             QDir newAncestor = QFileInfo(ancestor.absolutePath()).dir();
             if (newAncestor.exists())
             {
                 // Resolve directory symlinks
                 newAncestor.setPath(newAncestor.canonicalPath());
-            }
-            if (ancestor == dataDir)
-            {
-                // Found data dir in parents
-                return fi.absoluteFilePath();
             }
             if (ancestor == newAncestor)
             {

--- a/core_lib/src/util/util.h
+++ b/core_lib/src/util/util.h
@@ -68,4 +68,26 @@ QString ffmpegLocation();
 quint64 imageSize(const QImage&);
 QString uniqueString(int len);
 
+/**
+ * Performs safety checks for paths to data directory assets.
+ *
+ * Validates that the given file path is contained within the given
+ * data directory after resolving symlinks. Also requires paths to
+ * be relative to prevent project portability issues or intentional
+ * platform-dependent behavior.
+ *
+ * This function does not verify if the path actually exists.
+ *
+ * This function should be called for every file being read from the data directory.
+ * For writing files to the data directory, it is only necessary to call this
+ * function if:
+ * - An existing file is being modified/appended in-place (not overwritten) in the data directory.
+ * - The data directory is not guaranteed to be the immediate parent directory of the file being written.
+ *
+ * @param filePath A path to a data file.
+ * @param dataDir The path to the data directory.
+ * @return The valid resolved path, or empty if the path is not valid.
+ */
+QString validateDataPath(QString filePath, QString dataDirPath);
+
 #endif // UTIL_H

--- a/tests/src/test_layerbitmap.cpp
+++ b/tests/src/test_layerbitmap.cpp
@@ -18,13 +18,14 @@ GNU General Public License for more details.
 #include "layerbitmap.h"
 #include "bitmapimage.h"
 
+#include <memory>
 #include <QDir>
 #include <QDomElement>
 #include <QTemporaryDir>
 
 TEST_CASE("Load bitmap layer from XML")
 {
-    Layer* bitmapLayer = new LayerBitmap(1);
+    std::unique_ptr<Layer> bitmapLayer(new LayerBitmap(1));
     QTemporaryDir dataDir;
     REQUIRE(dataDir.isValid());
     QDomDocument doc;

--- a/tests/src/test_layerbitmap.cpp
+++ b/tests/src/test_layerbitmap.cpp
@@ -1,0 +1,116 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+#include "catch.hpp"
+
+#include "layerbitmap.h"
+#include "bitmapimage.h"
+
+#include <QDir>
+#include <QDomElement>
+#include <QTemporaryDir>
+
+TEST_CASE("Load bitmap layer from XML")
+{
+    Layer* bitmapLayer = new LayerBitmap(1);
+    QTemporaryDir dataDir;
+    REQUIRE(dataDir.isValid());
+    QDomDocument doc;
+    doc.setContent(QString("<layer id='1' name='Bitmap Layer' visibility='1'></layer>"));
+    QDomElement layerElem = doc.documentElement();
+    ProgressCallback nullCallback = []() {};
+
+    auto createFrame = [&layerElem, &doc](QString src = "001.001.png", int frame = 1, int topLeftX = 0, int topLeftY = 0)
+    {
+        QDomElement frameElem = doc.createElement("image");
+        frameElem.setAttribute("src", src);
+        frameElem.setAttribute("frame", frame);
+        frameElem.setAttribute("topLeftX", topLeftX);
+        frameElem.setAttribute("topLeftY", topLeftY);
+        layerElem.appendChild(frameElem);
+    };
+
+    SECTION("No frames")
+    {
+        bitmapLayer->loadDomElement(layerElem, dataDir.path(), []() {});
+
+        REQUIRE(bitmapLayer->keyFrameCount() == 0);
+    }
+
+    SECTION("Single frame")
+    {
+        createFrame("001.001.png", 1, 0, 0);
+
+        bitmapLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(bitmapLayer->keyFrameCount() == 1);
+        BitmapImage* frame = static_cast<BitmapImage*>(bitmapLayer->getKeyFrameAt(1));
+        REQUIRE(frame != nullptr);
+        REQUIRE(frame->top() == 0);
+        REQUIRE(frame->left() == 0);
+        REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath("001.001.png")));
+    }
+
+    SECTION("Multiple frames")
+    {
+        createFrame("001.001.png", 1);
+        createFrame("001.002.png", 2);
+
+        bitmapLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(bitmapLayer->keyFrameCount() == 2);
+        for (int i = 1; i <= 2; i++)
+        {
+            BitmapImage* frame = static_cast<BitmapImage*>(bitmapLayer->getKeyFrameAt(i));
+            REQUIRE(frame != nullptr);
+            REQUIRE(frame->top() == 0);
+            REQUIRE(frame->left() == 0);
+            REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath(QString("001.%1.png").arg(QString::number(i), 3, QChar('0')))));
+        }
+    }
+
+    SECTION("Frame with absolute src")
+    {
+        createFrame(QDir(dataDir.filePath("001.001.png")).absolutePath());
+
+        bitmapLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(bitmapLayer->keyFrameCount() == 0);
+    }
+
+    SECTION("Frame src outside of data dir")
+    {
+        QTemporaryDir otherDir;
+        createFrame(QDir(dataDir.path()).relativeFilePath(QDir(otherDir.filePath("001.001.png")).absolutePath()));
+
+        bitmapLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(bitmapLayer->keyFrameCount() == 0);
+    }
+
+    SECTION("Frame src nested in data dir")
+    {
+        createFrame("subdir/001.001.png");
+
+        bitmapLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(bitmapLayer->keyFrameCount() == 1);
+        BitmapImage* frame = static_cast<BitmapImage*>(bitmapLayer->getKeyFrameAt(1));
+        REQUIRE(frame != nullptr);
+        REQUIRE(frame->top() == 0);
+        REQUIRE(frame->left() == 0);
+        REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath("subdir/001.001.png")));
+    }
+}

--- a/tests/src/test_layersound.cpp
+++ b/tests/src/test_layersound.cpp
@@ -18,13 +18,14 @@ GNU General Public License for more details.
 #include "layersound.h"
 #include "soundclip.h"
 
+#include <memory>
 #include <QDir>
 #include <QDomElement>
 #include <QTemporaryDir>
 
 TEST_CASE("Load sound layer from XML")
 {
-    Layer* soundLayer = new LayerSound(1);
+    std::unique_ptr<Layer> soundLayer(new LayerSound(1));
     QTemporaryDir dataDir;
     REQUIRE(dataDir.isValid());
     QDomDocument doc;

--- a/tests/src/test_layersound.cpp
+++ b/tests/src/test_layersound.cpp
@@ -1,0 +1,115 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+#include "catch.hpp"
+
+#include "layersound.h"
+#include "soundclip.h"
+
+#include <QDir>
+#include <QDomElement>
+#include <QTemporaryDir>
+
+TEST_CASE("Load sound layer from XML")
+{
+    Layer* soundLayer = new LayerSound(1);
+    QTemporaryDir dataDir;
+    REQUIRE(dataDir.isValid());
+    QDomDocument doc;
+    doc.setContent(QString("<layer id='1' name='Sound Layer' visibility='1'></layer>"));
+    QDomElement layerElem = doc.documentElement();
+    ProgressCallback nullCallback = []() {};
+
+    auto createFrame = [&layerElem, &doc, &dataDir](QString src = "sound_001.wav", int frame = 1)
+    {
+        QDomElement clipElem = doc.createElement("sound");
+        clipElem.setAttribute("src", src);
+        clipElem.setAttribute("frame", frame);
+        layerElem.appendChild(clipElem);
+        if (QDir(src).isAbsolute()) {
+            src = QDir(dataDir.path()).relativeFilePath(src);
+        }
+        QFile soundFile(dataDir.filePath(src));
+        soundFile.open(QIODevice::WriteOnly);
+        soundFile.close();
+    };
+
+    SECTION("No clips")
+    {
+        soundLayer->loadDomElement(layerElem, dataDir.path(), []() {});
+
+        REQUIRE(soundLayer->keyFrameCount() == 0);
+    }
+
+    SECTION("Single clip")
+    {
+        createFrame("sound_001.wav", 1);
+
+        soundLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(soundLayer->keyFrameCount() == 1);
+        SoundClip* frame = static_cast<SoundClip*>(soundLayer->getKeyFrameAt(1));
+        REQUIRE(frame != nullptr);
+        REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath("sound_001.wav")));
+    }
+
+    SECTION("Multiple clips")
+    {
+        createFrame("sound_001.wav", 1);
+        createFrame("sound_002.wav", 2);
+
+        soundLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(soundLayer->keyFrameCount() == 2);
+        for (int i = 1; i <= 2; i++)
+        {
+            SoundClip* frame = static_cast<SoundClip*>(soundLayer->getKeyFrameAt(i));
+            REQUIRE(frame != nullptr);
+            REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath(QString("sound_%1.wav").arg(QString::number(i), 3, QChar('0')))));
+        }
+    }
+
+    SECTION("Clip with absolute src")
+    {
+        createFrame(QDir(dataDir.filePath("sound_001.wav")).absolutePath());
+
+        soundLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(soundLayer->keyFrameCount() == 0);
+    }
+
+    SECTION("Clip src outside of data dir")
+    {
+        QTemporaryDir otherDir;
+        createFrame(QDir(dataDir.path()).relativeFilePath(QDir(otherDir.filePath("sound_001.wav")).absolutePath()));
+
+        soundLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(soundLayer->keyFrameCount() == 0);
+    }
+
+    SECTION("Clip src nested in data dir")
+    {
+        REQUIRE(QDir(dataDir.path()).mkdir("subdir"));
+        createFrame("subdir/sound_001.wav");
+
+        soundLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(soundLayer->keyFrameCount() == 1);
+        SoundClip* frame = static_cast<SoundClip*>(soundLayer->getKeyFrameAt(1));
+        REQUIRE(frame != nullptr);
+        REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath("subdir/sound_001.wav")));
+    }
+}

--- a/tests/src/test_layervector.cpp
+++ b/tests/src/test_layervector.cpp
@@ -18,6 +18,8 @@ GNU General Public License for more details.
 #include "layervector.h"
 #include "vectorimage.h"
 
+
+#include <memory>
 #include <QDir>
 #include <QDomElement>
 #include <QTemporaryDir>
@@ -25,7 +27,7 @@ GNU General Public License for more details.
 
 TEST_CASE("Load vector layer from XML")
 {
-    Layer* vectorLayer = new LayerVector(1);
+    std::unique_ptr<Layer> vectorLayer(new LayerVector(1));
     QTemporaryDir dataDir;
     REQUIRE(dataDir.isValid());
     QDomDocument doc;

--- a/tests/src/test_layervector.cpp
+++ b/tests/src/test_layervector.cpp
@@ -1,0 +1,122 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+#include "catch.hpp"
+
+#include "layervector.h"
+#include "vectorimage.h"
+
+#include <QDir>
+#include <QDomElement>
+#include <QTemporaryDir>
+#include <QTextStream>
+
+TEST_CASE("Load vector layer from XML")
+{
+    Layer* vectorLayer = new LayerVector(1);
+    QTemporaryDir dataDir;
+    REQUIRE(dataDir.isValid());
+    QDomDocument doc;
+    doc.setContent(QString("<layer id='1' name='Vector Layer' visibility='1'></layer>"));
+    QDomElement layerElem = doc.documentElement();
+    ProgressCallback nullCallback = []() {};
+
+    QFile vecFile(dataDir.filePath("temp.vec"));
+    vecFile.open(QIODevice::WriteOnly);
+
+    QTextStream fout(&vecFile);
+    fout << "<!DOCTYPE PencilVectorImage>";
+    fout << "<image type='vector'/>";
+    vecFile.close();
+
+    auto createFrame = [&layerElem, &doc, &dataDir, &vecFile](QString src = "001.001.vec", int frame = 1)
+    {
+        QDomElement frameElem = doc.createElement("image");
+        frameElem.setAttribute("src", src);
+        frameElem.setAttribute("frame", frame);
+        layerElem.appendChild(frameElem);
+        if (QDir(src).isAbsolute()) {
+            src = QDir(dataDir.path()).relativeFilePath(src);
+        }
+        vecFile.copy(dataDir.filePath(src));
+    };
+
+    SECTION("No frames")
+    {
+        vectorLayer->loadDomElement(layerElem, dataDir.path(), []() {});
+
+        REQUIRE(vectorLayer->keyFrameCount() == 0);
+    }
+
+    SECTION("Single frame")
+    {
+        createFrame("001.001.vec", 1);
+
+        vectorLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(vectorLayer->keyFrameCount() == 1);
+        VectorImage* frame = static_cast<VectorImage*>(vectorLayer->getKeyFrameAt(1));
+        REQUIRE(frame != nullptr);
+        REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath("001.001.vec")));
+    }
+
+    SECTION("Multiple frames")
+    {
+        createFrame("001.001.vec", 1);
+        createFrame("001.002.vec", 2);
+
+        vectorLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(vectorLayer->keyFrameCount() == 2);
+        for (int i = 1; i <= 2; i++)
+        {
+            VectorImage* frame = static_cast<VectorImage*>(vectorLayer->getKeyFrameAt(i));
+            REQUIRE(frame != nullptr);
+            REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath(QString("001.%1.vec").arg(QString::number(i), 3, QChar('0')))));
+        }
+    }
+
+    SECTION("Frame with absolute src")
+    {
+        createFrame(QDir(dataDir.filePath("001.001.vec")).absolutePath());
+
+        vectorLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(vectorLayer->keyFrameCount() == 0);
+    }
+
+    SECTION("Frame src outside of data dir")
+    {
+        QTemporaryDir otherDir;
+        createFrame(QDir(dataDir.path()).relativeFilePath(QDir(otherDir.filePath("001.001.vec")).absolutePath()));
+
+        vectorLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(vectorLayer->keyFrameCount() == 0);
+    }
+
+    SECTION("Frame src nested in data dir")
+    {
+        REQUIRE(QDir(dataDir.path()).mkdir("subdir"));
+        createFrame("subdir/001.001.vec");
+
+        vectorLayer->loadDomElement(layerElem, dataDir.path(), nullCallback);
+
+        REQUIRE(vectorLayer->keyFrameCount() == 1);
+        VectorImage* frame = static_cast<VectorImage*>(vectorLayer->getKeyFrameAt(1));
+        REQUIRE(frame != nullptr);
+        REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath("subdir/001.001.vec")));
+    }
+}

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -33,8 +33,11 @@ SOURCES += \
     src/main.cpp \
     src/test_colormanager.cpp \
     src/test_layer.cpp \
+    src/test_layerbitmap.cpp \
     src/test_layercamera.cpp \
     src/test_layermanager.cpp \
+    src/test_layersound.cpp \
+    src/test_layervector.cpp \
     src/test_object.cpp \
     src/test_filemanager.cpp \
     src/test_bitmapimage.cpp \


### PR DESCRIPTION
This PR adds additional checks to the loading of bitmap/vector/sound layers so that they will not be loaded if they are outside of the data directory. This can occur with specially crafted main.xml files, or with symlinks. This closes multiple admittedly unlikely security threats in the program that can result in exfiltrating images from arbitrary locations though animations, and even duplicating arbitrary files under some circumstances. Tests have also been written for the scenarios this PR covers with the exception of symlinks (and possibly Windows shortcuts) because Qt has very bad support for symlink creation.

This also incidentally fixes an issue where an infinite loop will occur when loading a main.xml file that contains a non-element node (ex. an xml comment) in the sound layer.