### PR TITLE
Do not make a new keyframe if double clicking on an existing keyframe

### DIFF
--- a/app/src/timelinecells.cpp
+++ b/app/src/timelinecells.cpp
@@ -1130,7 +1130,10 @@ void TimeLineCells::mouseDoubleClickEvent(QMouseEvent* event)
         if (mType == TIMELINE_CELL_TYPE::Tracks && (layerNumber != -1) && (frameNumber > 0) && layerNumber < mEditor->object()->getLayerCount())
         {
             mEditor->scrubTo(frameNumber);
-            emit insertNewKeyFrame();
+            if (!layer->getKeyFrameAt(frameNumber))
+            {
+                emit insertNewKeyFrame();
+            }
 
             // The release event will toggle the frame on again, so we make sure it gets
             // deselected now instead.

--- a/app/src/timelinecells.cpp
+++ b/app/src/timelinecells.cpp
@@ -1129,9 +1129,9 @@ void TimeLineCells::mouseDoubleClickEvent(QMouseEvent* event)
     {
         if (mType == TIMELINE_CELL_TYPE::Tracks && (layerNumber != -1) && (frameNumber > 0) && layerNumber < mEditor->object()->getLayerCount())
         {
-            mEditor->scrubTo(frameNumber);
-            if (!layer->getKeyFrameAt(frameNumber))
+            if (!layer->keyExistsWhichCovers(frameNumber))
             {
+                mEditor->scrubTo(frameNumber);
                 emit insertNewKeyFrame();
             }
 


### PR DESCRIPTION
Based on the message from the Software's discord server, quoted:

> Not sure if it's been discussed here but:
First, double clicking in anywhere in the timeline gives you a new keyframe. Double clicking on a keyframe appends one after it.
When you need to move a keyframe, you need to click on it first before you can drag it around. If I happen to do this too fast, pencil2d registers this as a double click and does the keyframe appending. This can be annoying 

> I think it'll help a lot if pencil2d distinguishes between double clicking on an empty space and on a keyframe


This PR does exactly what the message above wants to. When double clicking on an existing keyframe, the program won't make a new keyframe, instead only selects it. Beneficial for those who want to drag the keyframe around in a quick way.