### PR TITLE
Temporarily modify width and feather during Quick Sizing

### DIFF
--- a/core_lib/src/managers/toolmanager.cpp
+++ b/core_lib/src/managers/toolmanager.cpp
@@ -153,7 +153,6 @@ void ToolManager::setWidth(float newWidth)
     }
 
     currentTool()->setWidth(static_cast<qreal>(newWidth));
-    emit penWidthValueChanged(newWidth);
     emit toolPropertyChanged(currentTool()->type(), WIDTH);
 }
 
@@ -165,32 +164,6 @@ void ToolManager::setFeather(float newFeather)
     }
 
     currentTool()->setFeather(static_cast<qreal>(newFeather));
-    emit penFeatherValueChanged(newFeather);
-    emit toolPropertyChanged(currentTool()->type(), FEATHER);
-}
-
-// Temporarily sets the width and feather of tool during Quick Sizing.
-void ToolManager::setTmpWidth(float newWidth)
-{
-    if (std::isnan(newWidth) || newWidth < 0)
-    {
-        newWidth = 1.f;
-    }
-
-    currentTool()->setTmpWidth(static_cast<qreal>(newWidth));
-    emit penWidthValueChanged(newWidth);
-    emit toolPropertyChanged(currentTool()->type(), WIDTH);
-}
-
-void ToolManager::setTmpFeather(float newFeather)
-{
-    if (std::isnan(newFeather) || newFeather < 0)
-    {
-        newFeather = 0.f;
-    }
-
-    currentTool()->setTmpFeather(static_cast<qreal>(newFeather));
-    emit penFeatherValueChanged(newFeather);
     emit toolPropertyChanged(currentTool()->type(), FEATHER);
 }
 
@@ -258,7 +231,6 @@ void ToolManager::setTolerance(int newTolerance)
     newTolerance = qMax(0, newTolerance);
 
     currentTool()->setTolerance(newTolerance);
-    emit toleranceValueChanged(newTolerance);
     emit toolPropertyChanged(currentTool()->type(), TOLERANCE);
 }
 

--- a/core_lib/src/managers/toolmanager.cpp
+++ b/core_lib/src/managers/toolmanager.cpp
@@ -169,6 +169,31 @@ void ToolManager::setFeather(float newFeather)
     emit toolPropertyChanged(currentTool()->type(), FEATHER);
 }
 
+// Temporarily sets the width and feather of tool during Quick Sizing.
+void ToolManager::setTmpWidth(float newWidth)
+{
+    if (std::isnan(newWidth) || newWidth < 0)
+    {
+        newWidth = 1.f;
+    }
+
+    currentTool()->setTmpWidth(static_cast<qreal>(newWidth));
+    emit penWidthValueChanged(newWidth);
+    emit toolPropertyChanged(currentTool()->type(), WIDTH);
+}
+
+void ToolManager::setTmpFeather(float newFeather)
+{
+    if (std::isnan(newFeather) || newFeather < 0)
+    {
+        newFeather = 0.f;
+    }
+
+    currentTool()->setTmpFeather(static_cast<qreal>(newFeather));
+    emit penFeatherValueChanged(newFeather);
+    emit toolPropertyChanged(currentTool()->type(), FEATHER);
+}
+
 void ToolManager::setUseFeather(bool usingFeather)
 {
     int usingAA = currentTool()->properties.useAA;

--- a/core_lib/src/managers/toolmanager.h
+++ b/core_lib/src/managers/toolmanager.h
@@ -53,10 +53,6 @@ public:
     int propertySwitch(bool condition, int property);
 
 signals:
-    void penWidthValueChanged(float);
-    void penFeatherValueChanged(float);
-    void toleranceValueChanged(qreal);
-
     void toolChanged(ToolType);
     void toolPropertyChanged(ToolType, ToolPropertyType);
 
@@ -65,9 +61,6 @@ public slots:
 
     void setWidth(float);
     void setFeather(float);
-
-    void setTmpWidth(float);
-    void setTmpFeather(float);
 
     void setUseFeather(bool);
     void setInvisibility(bool);

--- a/core_lib/src/managers/toolmanager.h
+++ b/core_lib/src/managers/toolmanager.h
@@ -65,6 +65,10 @@ public slots:
 
     void setWidth(float);
     void setFeather(float);
+
+    void setTmpWidth(float);
+    void setTmpFeather(float);
+
     void setUseFeather(bool);
     void setInvisibility(bool);
     void setPreserveAlpha(bool);

--- a/core_lib/src/tool/basetool.cpp
+++ b/core_lib/src/tool/basetool.cpp
@@ -133,17 +133,6 @@ void BaseTool::setFeather(const qreal feather)
     properties.feather = feather;
 }
 
-// Temporarily set the Width and Feather of the tool during Quick Sizing.
-void BaseTool::setTmpWidth(const qreal width)
-{
-    properties.width = width;
-}
-
-void BaseTool::setTmpFeather(const qreal feather)
-{
-    properties.feather = feather;
-}
-
 void BaseTool::setUseFeather(const bool usingFeather)
 {
     properties.useFeather = usingFeather;

--- a/core_lib/src/tool/basetool.cpp
+++ b/core_lib/src/tool/basetool.cpp
@@ -133,6 +133,17 @@ void BaseTool::setFeather(const qreal feather)
     properties.feather = feather;
 }
 
+// Temporarily set the Width and Feather of the tool during Quick Sizing.
+void BaseTool::setTmpWidth(const qreal width)
+{
+    properties.width = width;
+}
+
+void BaseTool::setTmpFeather(const qreal feather)
+{
+    properties.feather = feather;
+}
+
 void BaseTool::setUseFeather(const bool usingFeather)
 {
     properties.useFeather = usingFeather;

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -108,9 +108,6 @@ public:
     virtual void setWidth(const qreal width);
     virtual void setFeather(const qreal feather);
 
-    void setTmpWidth(const qreal width);
-    void setTmpFeather(const qreal feather);
-
     virtual void setInvisibility(const bool invisibility);
     virtual void setBezier(const bool bezier_state);
     virtual void setPressure(const bool pressure);

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -107,6 +107,10 @@ public:
 
     virtual void setWidth(const qreal width);
     virtual void setFeather(const qreal feather);
+
+    void setTmpWidth(const qreal width);
+    void setTmpFeather(const qreal feather);
+
     virtual void setInvisibility(const bool invisibility);
     virtual void setBezier(const bool bezier_state);
     virtual void setPressure(const bool pressure);

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -347,7 +347,7 @@ void StrokeTool::adjustCursor(Qt::KeyboardModifiers modifiers)
         // map it back to its original value, we can multiply by the factor we divided with
         const qreal newValue = QLineF(mAdjustPosition, getCurrentPoint()).length() * 2.0;
 
-        mEditor->tools()->setTmpWidth(qBound(WIDTH_MIN, newValue, WIDTH_MAX));
+        setTemporaryWidth(qBound(WIDTH_MIN, newValue, WIDTH_MAX));
         break;
     }
     case FEATHER: {
@@ -361,7 +361,7 @@ void StrokeTool::adjustCursor(Qt::KeyboardModifiers modifiers)
         // We flip min and max here in order to get the inverted value for the UI
         const qreal mappedValue = MathUtils::map(distance, inputMin, inputMax, outputMax, outputMin);
 
-        mEditor->tools()->setTmpFeather(qBound(FEATHER_MIN, mappedValue, FEATHER_MAX));
+        setTemporaryFeather(qBound(FEATHER_MIN, mappedValue, FEATHER_MAX));
         break;
     }
     default:
@@ -374,4 +374,26 @@ void StrokeTool::adjustCursor(Qt::KeyboardModifiers modifiers)
 void StrokeTool::paint(QPainter& painter, const QRect& blitRect)
 {
     mCanvasCursorPainter.paint(painter, blitRect);
+}
+
+void StrokeTool::setTemporaryWidth(qreal width)
+{
+    if (std::isnan(width) || width < 0)
+    {
+        width = 1.f;
+    }
+
+    properties.width = width;
+    emit mEditor->tools()->toolPropertyChanged(this->type(), WIDTH);
+}
+
+void StrokeTool::setTemporaryFeather(qreal feather)
+{
+    if (std::isnan(feather) || feather < 0)
+    {
+        feather = 0.f;
+    }
+
+    properties.feather = feather;
+    emit mEditor->tools()->toolPropertyChanged(this->type(), FEATHER);
 }

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -331,6 +331,10 @@ void StrokeTool::stopAdjusting()
 {
     msIsAdjusting = false;
     mAdjustPosition = QPointF();
+
+    mEditor->tools()->setWidth(properties.width);
+    mEditor->tools()->setFeather(properties.feather);
+
     updateCanvasCursor();
 }
 
@@ -343,7 +347,7 @@ void StrokeTool::adjustCursor(Qt::KeyboardModifiers modifiers)
         // map it back to its original value, we can multiply by the factor we divided with
         const qreal newValue = QLineF(mAdjustPosition, getCurrentPoint()).length() * 2.0;
 
-        mEditor->tools()->setWidth(qBound(WIDTH_MIN, newValue, WIDTH_MAX));
+        mEditor->tools()->setTmpWidth(qBound(WIDTH_MIN, newValue, WIDTH_MAX));
         break;
     }
     case FEATHER: {
@@ -357,7 +361,7 @@ void StrokeTool::adjustCursor(Qt::KeyboardModifiers modifiers)
         // We flip min and max here in order to get the inverted value for the UI
         const qreal mappedValue = MathUtils::map(distance, inputMin, inputMax, outputMax, outputMin);
 
-        mEditor->tools()->setFeather(qBound(FEATHER_MIN, mappedValue, FEATHER_MAX));
+        mEditor->tools()->setTmpFeather(qBound(FEATHER_MIN, mappedValue, FEATHER_MAX));
         break;
     }
     default:

--- a/core_lib/src/tool/stroketool.h
+++ b/core_lib/src/tool/stroketool.h
@@ -110,6 +110,12 @@ protected:
     CanvasCursorPainter mCanvasCursorPainter;
 
     StrokeInterpolator mInterpolator;
+
+private:
+    /// Sets the width value without calling settings to store the state
+    void setTemporaryWidth(qreal width);
+    /// Sets the feather value, without calling settings to store the state
+    void setTemporaryFeather(qreal feather);
 };
 
 #endif // STROKETOOL_H


### PR DESCRIPTION
During Quick Sizing, Pencil2d tries to write changes to disk every time the width/feather changes. Some devices, particularly drawing tablets, send events at a high rate, causing Pencil2d to fail to keep up with with the events and hang for a moment.

This PR temporarily fixes the issue by introducing new methods that only changes the properties, then calling the original methods (which includes writing to disk) once we're done doing Quick Sizing.