### PR TITLE
Improve preferences layout for long translations

### DIFF
--- a/app/src/preferencesdialog.cpp
+++ b/app/src/preferencesdialog.cpp
@@ -23,6 +23,13 @@ PreferencesDialog::PreferencesDialog(QWidget* parent) :
     ui(new Ui::PreferencesDialog)
 {
     ui->setupUi(this);
+
+    for (int i = 0; i < 0 + 1 * ui->contentsWidget->count(); i++) {
+        QListWidgetItem* item = ui->contentsWidget->item(i);
+        // Fill entire width
+        item->setSizeHint({std::numeric_limits<int>::max(),
+                           ui->contentsWidget->visualItemRect(item).height()});
+    }
 }
 
 PreferencesDialog::~PreferencesDialog()

--- a/app/ui/generalpage.ui
+++ b/app/ui/generalpage.ui
@@ -13,18 +13,6 @@
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
     <widget class="QScrollArea" name="scrollArea">
-     <property name="minimumSize">
-      <size>
-       <width>128</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>400</width>
-       <height>16777215</height>
-      </size>
-     </property>
      <property name="verticalScrollBarPolicy">
       <enum>Qt::ScrollBarAlwaysOn</enum>
      </property>

--- a/app/ui/preferencesdialog.ui
+++ b/app/ui/preferencesdialog.ui
@@ -6,15 +6,9 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>534</width>
-    <height>445</height>
+    <width>800</width>
+    <height>600</height>
    </rect>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>600</width>
-    <height>680</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string>Preferences</string>
@@ -32,15 +26,21 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>120</width>
+         <width>175</width>
          <height>0</height>
         </size>
        </property>
        <property name="maximumSize">
         <size>
-         <width>128</width>
+         <width>175</width>
          <height>16777215</height>
         </size>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
        </property>
        <property name="iconSize">
         <size>
@@ -51,8 +51,11 @@
        <property name="movement">
         <enum>QListView::Static</enum>
        </property>
-       <property name="spacing">
-        <number>20</number>
+       <property name="flow">
+        <enum>QListView::TopToBottom</enum>
+       </property>
+       <property name="isWrapping" stdset="0">
+        <bool>false</bool>
        </property>
        <property name="viewMode">
         <enum>QListView::IconMode</enum>
@@ -60,8 +63,11 @@
        <property name="uniformItemSizes">
         <bool>false</bool>
        </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
        <property name="currentRow">
-        <number>-1</number>
+        <number>0</number>
        </property>
        <item>
         <property name="text">


### PR DESCRIPTION
Fixes #1850 by simply removing the size restriction altogether. I couldn’t think of a good reason to keep it. I also made the dialog a little bigger by default and made some changes to the “tab bar” to avoid cutting off long translations.

Before:

![image](https://github.com/pencil2d/pencil/assets/2063777/511511c2-b02d-4e1f-a0a2-44833894951e)

After:

![image](https://github.com/pencil2d/pencil/assets/2063777/7d578da2-cc0c-42b9-9019-36ef87ae51c5)
