### PR TITLE
Fixed a few warnings

### DIFF
--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -272,7 +272,7 @@ const PredefinedKeySetParams ImportImageSeqDialog::predefinedKeySetParams() cons
     dot = finalList[0].lastIndexOf(".");
 
     QStringList absolutePaths;
-    for (const QString& fileName : qAsConst(finalList)) {
+    for (const QString& fileName : finalList) {
         absolutePaths << path + fileName;
     }
 

--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -272,7 +272,7 @@ const PredefinedKeySetParams ImportImageSeqDialog::predefinedKeySetParams() cons
     dot = finalList[0].lastIndexOf(".");
 
     QStringList absolutePaths;
-    for (const QString &fileName : finalList) {
+    for (const QString& fileName : qAsConst(finalList)) {
         absolutePaths << path + fileName;
     }
 

--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -137,7 +137,7 @@ const PredefinedKeySet ImportImageSeqDialog::generatePredefinedKeySet() const
 
     for (int i = 0; i < filenames.size(); i++)
     {
-        const int& frameIndex = filenames[i].mid(setParams.dot - digits, digits).toInt();
+        const int& frameIndex = filenames[i].midRef(setParams.dot - digits, digits).toInt();
         const QString& absolutePath = folderPath + filenames[i];
 
         keySet.insert(frameIndex, absolutePath);
@@ -263,7 +263,7 @@ const PredefinedKeySetParams ImportImageSeqDialog::predefinedKeySetParams() cons
     {
         if (sList[i].startsWith(prefix) &&
                 sList[i].length() == validLength &&
-                sList[i].mid(sList[i].lastIndexOf(".") - digits, digits).toInt() > 0 &&
+                sList[i].midRef(sList[i].lastIndexOf(".") - digits, digits).toInt() > 0 &&
                 sList[i].endsWith(suffix))
         {
             finalList.append(sList[i]);

--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -137,7 +137,7 @@ const PredefinedKeySet ImportImageSeqDialog::generatePredefinedKeySet() const
 
     for (int i = 0; i < filenames.size(); i++)
     {
-        const int& frameIndex = filenames[i].midRef(setParams.dot - digits, digits).toInt();
+        const int& frameIndex = filenames[i].mid(setParams.dot - digits, digits).toInt();
         const QString& absolutePath = folderPath + filenames[i];
 
         keySet.insert(frameIndex, absolutePath);
@@ -260,7 +260,7 @@ const PredefinedKeySetParams ImportImageSeqDialog::predefinedKeySetParams() cons
     {
         if (sList[i].startsWith(prefix) &&
                 sList[i].length() == validLength &&
-                sList[i].midRef(sList[i].lastIndexOf(".") - digits, digits).toInt() > 0 &&
+                sList[i].mid(sList[i].lastIndexOf(".") - digits, digits).toInt() > 0 &&
                 sList[i].endsWith(suffix))
         {
             finalList.append(sList[i]);

--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -275,7 +275,7 @@ const PredefinedKeySetParams ImportImageSeqDialog::predefinedKeySetParams() cons
     dot = finalList[0].lastIndexOf(".");
 
     QStringList absolutePaths;
-    for (QString fileName : finalList) {
+    for (const QString &fileName : finalList) {
         absolutePaths << path + fileName;
     }
 

--- a/app/src/importimageseqdialog.cpp
+++ b/app/src/importimageseqdialog.cpp
@@ -187,8 +187,6 @@ void ImportImageSeqDialog::importArbitrarySequence()
 
     for (const QString& strImgFile : files)
     {
-        QString strImgFileLower = strImgFile.toLower();
-
         Status st = mEditor->importImage(strImgFile);
         if (!st.ok())
         {
@@ -225,7 +223,6 @@ const PredefinedKeySetParams ImportImageSeqDialog::predefinedKeySetParams() cons
     // local vars for testing file validity
     int dot = strFilePath.lastIndexOf(".");
     int slash = strFilePath.lastIndexOf("/");
-    QString fName = strFilePath.mid(slash + 1);
     QString path = strFilePath.left(slash + 1);
     QString digit = strFilePath.mid(slash + 1, dot - slash - 1);
 
@@ -338,7 +335,6 @@ QStringList ImportImageSeqDialog::getFilePaths()
 
 Status ImportImageSeqDialog::validateKeySet(const PredefinedKeySet& keySet, const QStringList& filepaths)
 {
-    QString msg = "";
     QString failedPathsString;
 
     Status status = Status::OK;

--- a/app/src/repositionframesdialog.cpp
+++ b/app/src/repositionframesdialog.cpp
@@ -190,7 +190,7 @@ void RepositionFramesDialog::updateLayersBox()
 
 void RepositionFramesDialog::closeClicked()
 {
-    rejected();
+    emit rejected();
 }
 
 void RepositionFramesDialog::updateLayersToSelect()

--- a/core_lib/src/interface/backupelement.cpp
+++ b/core_lib/src/interface/backupelement.cpp
@@ -60,7 +60,7 @@ void BackupBitmapElement::restore(Editor* editor)
 
     selectMan->calculateSelectionTransformation();
 
-    editor->frameModified(this->frame);
+    emit editor->frameModified(this->frame);
 }
 
 void BackupVectorElement::restore(Editor* editor)
@@ -109,7 +109,7 @@ void BackupVectorElement::restore(Editor* editor)
     selectMan->setTranslation(translation);
     selectMan->calculateSelectionTransformation();
 
-    editor->frameModified(this->frame);
+    emit editor->frameModified(this->frame);
 
 }
 
@@ -122,7 +122,7 @@ void BackupSoundElement::restore(Editor* editor)
     if (editor->currentFrame() != this->frame) {
         editor->scrubTo(this->frame);
     }
-    editor->frameModified(this->frame);
+    emit editor->frameModified(this->frame);
 
     // TODO: soundclip won't restore if overlapping on first frame
     if (this->frame > 0 && layer->getKeyFrameAt(this->frame) == nullptr)

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -549,7 +549,7 @@ void Editor::copyAndCut()
         for (int pos : currentLayer->selectedKeyFramesPositions()) {
             currentLayer->removeKeyFrame(pos);
         }
-        layers()->currentLayerChanged(currentLayerIndex());
+        emit layers()->currentLayerChanged(currentLayerIndex());
         emit updateTimeLine();
         return;
     }

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -442,22 +442,22 @@ void ScribbleArea::keyEventForSelection(QKeyEvent* event)
     case Qt::Key_Right:
         selectMan->translate(QPointF(1, 0));
         selectMan->calculateSelectionTransformation();
-        mEditor->frameModified(mEditor->currentFrame());
+        emit mEditor->frameModified(mEditor->currentFrame());
         return;
     case Qt::Key_Left:
         selectMan->translate(QPointF(-1, 0));
         selectMan->calculateSelectionTransformation();
-        mEditor->frameModified(mEditor->currentFrame());
+        emit mEditor->frameModified(mEditor->currentFrame());
         return;
     case Qt::Key_Up:
         selectMan->translate(QPointF(0, -1));
         selectMan->calculateSelectionTransformation();
-        mEditor->frameModified(mEditor->currentFrame());
+        emit mEditor->frameModified(mEditor->currentFrame());
         return;
     case Qt::Key_Down:
         selectMan->translate(QPointF(0, 1));
         selectMan->calculateSelectionTransformation();
-        mEditor->frameModified(mEditor->currentFrame());
+        emit mEditor->frameModified(mEditor->currentFrame());
         return;
     case Qt::Key_Return:
         applyTransformedSelection();

--- a/core_lib/src/managers/layermanager.cpp
+++ b/core_lib/src/managers/layermanager.cpp
@@ -348,7 +348,7 @@ Status LayerManager::renameLayer(Layer* layer, const QString& newName)
     if (newName.isEmpty()) return Status::FAIL;
 
     layer->setName(newName);
-    currentLayerChanged(getIndex(layer));
+    emit currentLayerChanged(getIndex(layer));
     return Status::OK;
 }
 

--- a/core_lib/src/movieexporter.cpp
+++ b/core_lib/src/movieexporter.cpp
@@ -696,7 +696,7 @@ Status MovieExporter::executeFFMpegPipe(const QString& cmd, const QStringList& a
                 }
                 if(output.startsWith("frame="))
                 {
-                    lastFrameProcessed = framesProcessed = output.mid(6, output.indexOf(' ')).toInt();
+                    lastFrameProcessed = framesProcessed = output.midRef(6, output.indexOf(' ')).toInt();
                 }
             }
 

--- a/core_lib/src/movieexporter.cpp
+++ b/core_lib/src/movieexporter.cpp
@@ -696,7 +696,7 @@ Status MovieExporter::executeFFMpegPipe(const QString& cmd, const QStringList& a
                 }
                 if(output.startsWith("frame="))
                 {
-                    lastFrameProcessed = framesProcessed = output.midRef(6, output.indexOf(' ')).toInt();
+                    lastFrameProcessed = framesProcessed = output.mid(6, output.indexOf(' ')).toInt();
                 }
             }
 

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -562,7 +562,7 @@ int FileManager::countExistingBackups(const QString& fileName) const
     const QString& baseName = fileInfo.completeBaseName();
 
     int backupCount = 0;
-    for (QFileInfo dirFileInfo : directory.entryInfoList(QDir::Filter::Files)) {
+    for (const QFileInfo &dirFileInfo : directory.entryInfoList(QDir::Filter::Files)) {
         QString searchFileBaseName = dirFileInfo.completeBaseName();
         if (baseName.compare(searchFileBaseName) == 0 && searchFileBaseName.contains(PFF_BACKUP_IDENTIFIER)) {
             backupCount++;

--- a/core_lib/src/structure/pegbaraligner.cpp
+++ b/core_lib/src/structure/pegbaraligner.cpp
@@ -67,7 +67,7 @@ Status PegBarAligner::align(const QStringList& layers)
             }
             img->moveTopLeft(QPoint(img->left() + (pegX - result.point.x()), img->top() + (pegY - result.point.y())));
 
-            mEditor->frameModified(img->pos());
+            emit mEditor->frameModified(img->pos());
         }
     }
 

--- a/core_lib/src/tool/cameratool.cpp
+++ b/core_lib/src/tool/cameratool.cpp
@@ -438,7 +438,7 @@ void CameraTool::transformView(LayerCamera* layerCamera, CameraMoveType mode, co
     curCam->modification();
 }
 
-void CameraTool::paint(QPainter& painter, const QRect& blitRect)
+void CameraTool::paint(QPainter& painter, const QRect&)
 {
     int frameIndex = mEditor->currentFrame();
     LayerCamera* cameraLayerBelow = static_cast<LayerCamera*>(mEditor->object()->getLayerBelow(mEditor->currentLayerIndex(), Layer::CAMERA));

--- a/core_lib/src/tool/cameratool.h
+++ b/core_lib/src/tool/cameratool.h
@@ -51,7 +51,7 @@ public:
     QCursor cursor() override;
     ToolType type() override { return ToolType::CAMERA; }
 
-    void paint(QPainter& painter, const QRect& blitRect) override;
+    void paint(QPainter& painter, const QRect&) override;
 
     void loadSettings() override;
 

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -172,7 +172,7 @@ void MoveTool::pointerReleaseEvent(PointerEvent*)
         return;
 
     mScribbleArea->updateToolCursor();
-    mEditor->frameModified(mEditor->currentFrame());
+    emit mEditor->frameModified(mEditor->currentFrame());
 }
 
 void MoveTool::transformSelection(const QPointF& pos, Qt::KeyboardModifiers keyMod)

--- a/core_lib/src/tool/smudgetool.cpp
+++ b/core_lib/src/tool/smudgetool.cpp
@@ -182,7 +182,7 @@ void SmudgeTool::pointerPressEvent(PointerEvent* event)
                 selectMan->vectorSelection.add(selectMan->closestCurves());
                 selectMan->vectorSelection.add(selectMan->closestVertices());
 
-                mEditor->frameModified(mEditor->currentFrame());
+                emit mEditor->frameModified(mEditor->currentFrame());
             }
             else
             {


### PR DESCRIPTION
This PR fixes a handful of simple warnings, mostly missing `emit` keywords and unused QStrings.

There were a lot more warnings but unfortunately my Qt and C++ knowledge isn't good enough to handle those so I decided not to risk breaking something. At least I fixed more than just the missing `emit`s.