### PR TITLE
iss: 1873 - Fix frame not being drawn on the timeline

### DIFF
--- a/app/src/timelinecells.cpp
+++ b/app/src/timelinecells.cpp
@@ -444,11 +444,18 @@ void TimeLineCells::paintFrames(QPainter& painter, QColor trackCol, const Layer*
 
     int recHeight = height - 4;
 
-    layer->foreachKeyFrame([&](KeyFrame* key)
+    const QList<int> selectedFrames = layer->getSelectedFramesByPos();
+    for (auto pair : layer->keyframes())
     {
+        const KeyFrame* key = pair.second;
         int framePos = key->pos();
         int recWidth = standardWidth;
         int recLeft = getFrameX(framePos) - recWidth;
+
+        // Selected frames are painted separately
+        if (selectedFrames.contains(framePos)) {
+            continue;
+        }
 
         if (key->length() > 1)
         {
@@ -463,19 +470,11 @@ void TimeLineCells::paintFrames(QPainter& painter, QColor trackCol, const Layer*
         // Paint the frame contents
         if (selected)
         {
-            if (key->isSelected()) {
-                painter.setBrush(QColor(60, 60, 60));
-            }
-            else
-            {
-                painter.setBrush(QColor(trackCol.red(), trackCol.green(), trackCol.blue(), 150));
-            }
+            painter.setBrush(QColor(trackCol.red(), trackCol.green(), trackCol.blue(), 150));
         }
 
-        if (!key->isSelected()) {
-            painter.drawRect(recLeft, recTop, recWidth, recHeight);
-        }
-    });
+        painter.drawRect(recLeft, recTop, recWidth, recHeight);
+    }
 }
 
 void TimeLineCells::paintCurrentFrameBorder(QPainter &painter, int recLeft, int recTop, int recWidth, int recHeight) const
@@ -729,7 +728,7 @@ void TimeLineCells::paintEvent(QPaintEvent*)
         int currentFrame = mEditor->currentFrame();
         Layer* currentLayer = mEditor->layers()->currentLayer();
         KeyFrame* keyFrame = currentLayer->getKeyFrameWhichCovers(currentFrame);
-        if (keyFrame != nullptr && !keyFrame->isSelected())
+        if (keyFrame != nullptr)
         {
             int recWidth = keyFrame->length() == 1 ? mFrameSize - 2 : mFrameSize * keyFrame->length();
             int recLeft = getFrameX(keyFrame->pos()) - (mFrameSize - 2);

--- a/core_lib/src/managers/layermanager.cpp
+++ b/core_lib/src/managers/layermanager.cpp
@@ -112,7 +112,9 @@ void LayerManager::setCurrentLayer(int layerIndex)
 
     // Deselect frames of previous layer.
     Layer* previousLayer = currentLayer();
-    previousLayer->deselectAll();
+    if (previousLayer != object()->getLayer(layerIndex)) {
+        previousLayer->deselectAll();
+    }
 
     emit currentLayerWillChange(layerIndex);
 

--- a/core_lib/src/structure/keyframe.cpp
+++ b/core_lib/src/structure/keyframe.cpp
@@ -27,7 +27,6 @@ KeyFrame::KeyFrame(const KeyFrame& k2)
     mFrame = k2.mFrame;
     mLength = k2.mLength;
     mIsModified = k2.mIsModified;
-    mIsSelected = k2.mIsSelected;
     mAttachedFileName = k2.mAttachedFileName;
     // intentionally not copying event listeners
 }
@@ -50,7 +49,6 @@ KeyFrame& KeyFrame::operator=(const KeyFrame& k2)
 	mFrame = k2.mFrame;
 	mLength = k2.mLength;
 	mIsModified = k2.mIsModified;
-	mIsSelected = k2.mIsSelected;
 	mAttachedFileName = k2.mAttachedFileName;
     // intentionally not copying event listeners
     return *this;

--- a/core_lib/src/structure/keyframe.h
+++ b/core_lib/src/structure/keyframe.h
@@ -45,9 +45,6 @@ public:
     void setModified(bool b) { mIsModified = b; }
     bool isModified() const { return mIsModified; }
 
-    void setSelected(bool b) { mIsSelected = b; }
-    bool isSelected() const { return mIsSelected; }
-
     QString fileName() const { return mAttachedFileName; }
     void    setFileName(QString strFileName) { mAttachedFileName = strFileName; }
 
@@ -65,7 +62,6 @@ private:
     int mFrame = -1;
     int mLength = 1;
     bool mIsModified = true;
-    bool mIsSelected = false;
     QString mAttachedFileName;
 
     std::vector<KeyFrameEventListener*> mEventListeners;

--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -222,9 +222,7 @@ bool Layer::removeKeyFrame(int position)
 
     if (frame)
     {
-        if (frame->isSelected()) {
-            removeFromSelectionList(frame->pos());
-        }
+        removeFromSelectionList(frame->pos());
         mKeyFrames.erase(frame->pos());
         markFrameAsDirty(frame->pos());
         delete frame;
@@ -383,9 +381,7 @@ bool Layer::isFrameSelected(int position) const
     KeyFrame* keyFrame = getKeyFrameWhichCovers(position);
     if (keyFrame == nullptr) { return false; }
 
-    int frameFound = mSelectedFrames_byLast.contains(keyFrame->pos());
-    Q_ASSERT(!frameFound || keyFrame->isSelected());
-    return frameFound;
+    return mSelectedFrames_byLast.contains(keyFrame->pos());
 }
 
 void Layer::setFrameSelected(int position, bool isSelected)
@@ -410,7 +406,6 @@ void Layer::setFrameSelected(int position, bool isSelected)
             mSelectedFrames_byLast.removeOne(startPosition);
             mSelectedFrames_byPosition.removeOne(startPosition);
         }
-        keyFrame->setSelected(isSelected);
     }
 }
 
@@ -496,11 +491,6 @@ void Layer::deselectAll()
 {
     mSelectedFrames_byLast.clear();
     mSelectedFrames_byPosition.clear();
-
-    for (auto pair : mKeyFrames)
-    {
-        pair.second->setSelected(false);
-    }
 }
 
 bool Layer::canMoveSelectedFramesToOffset(int offset) const

--- a/core_lib/src/structure/layer.h
+++ b/core_lib/src/structure/layer.h
@@ -170,6 +170,8 @@ public:
     /** Clear the list of dirty keyframes */
     void clearDirtyFrames() { mDirtyFrames.clear(); }
 
+    std::map<int, KeyFrame*, std::greater<int>> keyframes() const { return mKeyFrames; }
+
 protected:
     virtual KeyFrame* createKeyFrame(int position) = 0;
     bool loadKey(KeyFrame*);

--- a/tests/src/test_layer.cpp
+++ b/tests/src/test_layer.cpp
@@ -355,8 +355,8 @@ TEST_CASE("Layer::moveKeyFrame(int position, int offset)")
         layer->moveKeyFrame(2, 1);
 
         // Confirm that both frames are still selected.
-        REQUIRE(layer->getKeyFrameAt(2)->isSelected());
-        REQUIRE(layer->getKeyFrameAt(3)->isSelected());
+        REQUIRE(layer->isFrameSelected(2));
+        REQUIRE(layer->isFrameSelected(3));
 
         // Verify that poiners has been swapped
         REQUIRE(frame1 == layer->getKeyFrameAt(3));
@@ -376,8 +376,8 @@ TEST_CASE("Layer::moveKeyFrame(int position, int offset)")
         layer->moveKeyFrame(2, 1);
 
         // Confirm that both frames are still selected.
-        REQUIRE(layer->getKeyFrameAt(2)->isSelected());
-        REQUIRE_FALSE(layer->getKeyFrameAt(3)->isSelected());
+        REQUIRE(layer->isFrameSelected(2));
+        REQUIRE_FALSE(layer->isFrameSelected(3));
     }
 
     SECTION("move non selected frame across multiple selected frames")
@@ -402,11 +402,11 @@ TEST_CASE("Layer::moveKeyFrame(int position, int offset)")
         layer->moveKeyFrame(8, 1);
 
         // Confirm that both frames are still selected.
-        REQUIRE(layer->getKeyFrameAt(4)->isSelected());
-        REQUIRE(layer->getKeyFrameAt(5)->isSelected());
-        REQUIRE(layer->getKeyFrameAt(6)->isSelected());
-        REQUIRE(layer->getKeyFrameAt(7)->isSelected());
-        REQUIRE_FALSE(layer->getKeyFrameAt(9)->isSelected());
+        REQUIRE(layer->isFrameSelected(4));
+        REQUIRE(layer->isFrameSelected(5));
+        REQUIRE(layer->isFrameSelected(6));
+        REQUIRE(layer->isFrameSelected(7));
+        REQUIRE_FALSE(layer->isFrameSelected(9));
     }
 
     SECTION("move selected frame across multiple not selected frames")
@@ -433,11 +433,11 @@ TEST_CASE("Layer::moveKeyFrame(int position, int offset)")
         layer->moveKeyFrame(4, -1);
 
         // Confirm that both frames are still selected.
-        REQUIRE(layer->getKeyFrameAt(3)->isSelected());
-        REQUIRE_FALSE(layer->getKeyFrameAt(5)->isSelected());
-        REQUIRE_FALSE(layer->getKeyFrameAt(6)->isSelected());
-        REQUIRE_FALSE(layer->getKeyFrameAt(7)->isSelected());
-        REQUIRE_FALSE(layer->getKeyFrameAt(8)->isSelected());
+        REQUIRE(layer->isFrameSelected(3));
+        REQUIRE_FALSE(layer->isFrameSelected(5));
+        REQUIRE_FALSE(layer->isFrameSelected(6));
+        REQUIRE_FALSE(layer->isFrameSelected(7));
+        REQUIRE_FALSE(layer->isFrameSelected(8));
     }
 
     delete obj;


### PR DESCRIPTION
The reason for this is that while we keep a list of selected keyframes to move and paint on the timeline, a keyframe also has its own "isSelected" state. This state is backed up through undo/redo operations while the layer::getSelectedFrames is not.
We use the isSelected state to ignore selected frames in the TimeLineCells::paintFrames while we use Layer::getSelectedFrames() to paint the selected frames. 

This means that we can get into a situation where the frame is neither painted as selected nor non selected because of the two different sources of truth.

The solution is to remove one of the sources. As such, I went ahead and removed isSelected from Keyframe, so there's only one truth. By doing so, said frames can no longer be put in a selected state through undo/redo operations, which I personally think is good. I've inspected a few other applications which does also not keep selections as undo/redo'able state.

There's also the benefit that we don't have to iterate through all frames to know which is selected.

To that end my conclusion is that we shouldn't have to do that either.

fixes #1873 