### PR TITLE
iss-1881: Move frames as far as possible

### DIFF
--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -503,14 +503,25 @@ void Layer::deselectAll()
     }
 }
 
-bool Layer::canMoveSelectedFramesToOffset(int offset) const
+bool Layer::canMoveSelectedFramesToOffset(int fromIndex, int offset) const
 {
     QList<int> newByPositions = mSelectedFrames_byPosition;
 
-    for (int pos : newByPositions)
+    int step = -1;
+
+    if (fromIndex < 0 || fromIndex > newByPositions.count() - 1) {
+        return false;
+    }
+
+    if (offset < 0) {
+        step = 1;
+    }
+
+    for (; fromIndex> -1 && fromIndex < newByPositions.count(); fromIndex += step)
     {
-        pos += offset;
-        if (keyExists(pos) && !newByPositions.contains(pos)) {
+        int newPos = newByPositions[fromIndex] + offset;
+
+        if (keyExists(newPos) && !newByPositions.contains(newPos)) {
             return false;
         }
     }
@@ -629,7 +640,6 @@ bool Layer::moveSelectedFrames(int offset)
         return false;
     }
 
-    // If we are moving to the right we start moving selected frames from the highest (right) to the lowest (left)
     int indexInSelection = mSelectedFrames_byPosition.count() - 1;
     int step = -1;
 
@@ -638,12 +648,8 @@ bool Layer::moveSelectedFrames(int offset)
         // If we are moving to the left we start moving selected frames from the lowest (left) to the highest (right)
         indexInSelection = 0;
         step = 1;
-
-        // Check if we are not moving out of the timeline
-        if (mSelectedFrames_byPosition[0] + offset < 1) return false;
     }
 
-    if (!canMoveSelectedFramesToOffset(offset)) { return false; }
 
     for (; indexInSelection > -1 && indexInSelection < mSelectedFrames_byPosition.count(); indexInSelection += step)
     {
@@ -653,7 +659,19 @@ bool Layer::moveSelectedFrames(int offset)
         // Get the frame to move
         KeyFrame* selectedFrame = getKeyFrameAt(fromPos);
 
-        Q_ASSERT(!keyExists(toPos));
+        if (toPos < 1) {
+            toPos = 1;
+            offset = toPos - fromPos;
+        }
+
+        while (!canMoveSelectedFramesToOffset(indexInSelection, offset)) {
+            toPos += 1;
+            offset += 1;
+        }
+
+        if (fromPos == toPos) {
+            continue;
+        }
 
         mKeyFrames.erase(fromPos);
         markFrameAsDirty(fromPos);

--- a/core_lib/src/structure/layer.h
+++ b/core_lib/src/structure/layer.h
@@ -152,10 +152,11 @@ public:
 
     /** Predetermines whether the frames can be moved to a new position depending on the offset
      *
+     * @param fromIndex changes the start index to this, otherwise it's zero
      * @param offset Should be start press position - current position
      * @return true if selected frames can be moved otherwise false
      */
-    bool canMoveSelectedFramesToOffset(int offset) const;
+    bool canMoveSelectedFramesToOffset(int fromIndex, int offset) const;
 
     Status save(const QString& sDataFolder, QStringList& attachedFiles, ProgressCallback progressStep);
     virtual Status presave(const QString& sDataFolder) { Q_UNUSED(sDataFolder); return Status::SAFE; }


### PR DESCRIPTION
This fixes #1881 

Instead of moving keyframes back to where they were, the frames will now be shifted to the right until there's room for all selected frames.

![issue-1881](https://github.com/user-attachments/assets/0757cd6c-01da-47a2-b3ac-afe099e6cef1)
