### PR TITLE
Feature/iss 748 - undo redo keyframes

### DIFF
--- a/app/src/timelinecells.cpp
+++ b/app/src/timelinecells.cpp
@@ -32,6 +32,7 @@ GNU General Public License for more details.
 #include "object.h"
 #include "playbackmanager.h"
 #include "preferencemanager.h"
+#include "undoredomanager.h"
 #include "timeline.h"
 
 #include "cameracontextmenu.h"
@@ -1066,8 +1067,13 @@ void TimeLineCells::mouseReleaseEvent(QMouseEvent* event)
             int posUnderCursor = getFrameNumber(mMousePressX);
             int offset = frameNumber - posUnderCursor;
 
-            currentLayer->moveSelectedFrames(offset);
+            if (currentLayer->canMoveSelectedFramesToOffset(offset)) {
+                UndoSaveState* state = mEditor->undoRedo()->createState(UndoRedoRecordType::KEYFRAME_MOVE);
+                state->moveFramesState = MoveFramesSaveState(offset, currentLayer->selectedKeyFramesPositions());
 
+                currentLayer->moveSelectedFrames(offset);
+                mEditor->undoRedo()->record(state, tr("Move Frames"));
+            }
             mEditor->layers()->notifyAnimationLengthChanged();
             emit mEditor->framesModified();
             updateContent();

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -936,12 +936,15 @@ void Editor::removeKey()
         return;
     }
 
+    const UndoSaveState* state =  undoRedo()->state(UndoRedoRecordType::KEYFRAME_REMOVE);
     backup(tr("Remove frame"));
 
     deselectAll();
     layer->removeKeyFrame(currentFrame());
     layers()->notifyAnimationLengthChanged();
     emit layers()->currentLayerChanged(layers()->currentLayerIndex()); // trigger timeline repaint.
+
+    undoRedo()->record(state, tr("Remove frame"));
 }
 
 void Editor::scrubNextKeyFrame()

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -915,7 +915,7 @@ KeyFrame* Editor::addKeyFrame(const int layerNumber, int frameIndex)
     Q_ASSERT(ok); // We already ensured that there is no keyframe at frameIndex, so this should always succeed
     scrubTo(frameIndex); // currentFrameChanged() emit inside.
 
-    const UndoSaveState* state = undoRedo()->state(UndoRedoRecordType::KEYFRAME_ADD);
+    UndoSaveState* state = undoRedo()->createState(UndoRedoRecordType::KEYFRAME_ADD);
     emit frameModified(frameIndex);
     layers()->notifyAnimationLengthChanged();
     KeyFrame* newFrame = layer->getKeyFrameAt(frameIndex);
@@ -942,7 +942,7 @@ void Editor::removeKey()
         return;
     }
 
-    const UndoSaveState* state =  undoRedo()->state(UndoRedoRecordType::KEYFRAME_REMOVE);
+    UndoSaveState* state =  undoRedo()->createState(UndoRedoRecordType::KEYFRAME_REMOVE);
     backup(tr("Remove frame"));
 
     deselectAll();

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -914,9 +914,15 @@ KeyFrame* Editor::addKeyFrame(const int layerNumber, int frameIndex)
     const bool ok = layer->addNewKeyFrameAt(frameIndex);
     Q_ASSERT(ok); // We already ensured that there is no keyframe at frameIndex, so this should always succeed
     scrubTo(frameIndex); // currentFrameChanged() emit inside.
+
+    const UndoSaveState* state = undoRedo()->state(UndoRedoRecordType::KEYFRAME_ADD);
     emit frameModified(frameIndex);
     layers()->notifyAnimationLengthChanged();
-    return layer->getKeyFrameAt(frameIndex);
+    KeyFrame* newFrame = layer->getKeyFrameAt(frameIndex);
+
+    undoRedo()->record(state, tr("Add frame"));
+
+    return newFrame;
 }
 
 void Editor::removeKey()

--- a/core_lib/src/interface/undoredocommand.cpp
+++ b/core_lib/src/interface/undoredocommand.cpp
@@ -116,9 +116,7 @@ void KeyFrameAddCommand::undo()
     UndoRedoCommand::undo();
 
     Layer* layer = editor()->layers()->findLayerById(undoLayerId);
-    if (layer == nullptr) {
-        // Until we support layer deletion recovery, we mark the command as
-        // obsolete as soon as it's been
+    if (!layer) {
         return setObsolete(true);
     }
 
@@ -138,6 +136,10 @@ void KeyFrameAddCommand::redo()
     if (isFirstRedo()) { setFirstRedo(false); return; }
 
     Layer* layer = editor()->layers()->findLayerById(redoLayerId);
+    if (!layer) {
+        return setObsolete(true);
+    }
+
     layer->addNewKeyFrameAt(redoPosition);
 
     emit editor()->frameModified(redoPosition);
@@ -169,7 +171,9 @@ void MoveKeyFramesCommand::undo()
 
     Layer* undoLayer = editor()->layers()->findLayerById(undoLayerId);
 
-    if (!undoLayer) { return; }
+    if (!undoLayer) {
+        return setObsolete(true);
+    }
 
     for (int position : qAsConst(positions)) {
         undoLayer->moveKeyFrame(position + frameOffset, -frameOffset);
@@ -186,6 +190,10 @@ void MoveKeyFramesCommand::redo()
     if (isFirstRedo()) { setFirstRedo(false); return; }
 
     Layer* redoLayer = editor()->layers()->findLayerById(redoLayerId);
+
+    if (!redoLayer) {
+        return setObsolete(true);
+    }
 
     for (int position : qAsConst(positions)) {
         redoLayer->moveKeyFrame(position, frameOffset);
@@ -216,9 +224,7 @@ void BitmapReplaceCommand::undo()
     UndoRedoCommand::undo();
 
     Layer* layer = editor()->layers()->findLayerById(undoLayerId);
-    if (layer == nullptr) {
-        // Until we support layer deletion recovery, we mark the command as
-        // obsolete as soon as it's been
+    if (!layer) {
         return setObsolete(true);
     }
 
@@ -235,6 +241,10 @@ void BitmapReplaceCommand::redo()
     if (isFirstRedo()) { setFirstRedo(false); return; }
 
     Layer* layer = editor()->layers()->findLayerById(redoLayerId);
+    if (!layer) {
+        return setObsolete(true);
+    }
+
     static_cast<LayerBitmap*>(layer)->replaceKeyFrame(&redoBitmap);
 
     editor()->scrubTo(redoBitmap.pos());
@@ -262,9 +272,7 @@ void VectorReplaceCommand::undo()
     UndoRedoCommand::undo();
 
     Layer* layer = editor()->layers()->findLayerById(undoLayerId);
-    if (layer == nullptr) {
-        // Until we support layer deletion recovery, we mark the command as
-        // obsolete as soon as it's been
+    if (!layer) {
         return setObsolete(true);
     }
 
@@ -281,6 +289,9 @@ void VectorReplaceCommand::redo()
     if (isFirstRedo()) { setFirstRedo(false); return; }
 
     Layer* layer = editor()->layers()->findLayerById(redoLayerId);
+    if (!layer) {
+        return setObsolete(true);
+    }
 
     static_cast<LayerVector*>(layer)->replaceKeyFrame(&redoVector);
 

--- a/core_lib/src/interface/undoredocommand.h
+++ b/core_lib/src/interface/undoredocommand.h
@@ -24,13 +24,15 @@ GNU General Public License for more details.
 
 #include "bitmapimage.h"
 #include "vectorimage.h"
+#include "soundclip.h"
+#include "camera.h"
+#include "layer.h"
 
 class Editor;
 class UndoRedoManager;
 class PreferenceManager;
 class SoundClip;
 class Camera;
-class Layer;
 class KeyFrame;
 class TransformCommand;
 
@@ -49,6 +51,29 @@ protected:
 private:
     Editor* mEditor = nullptr;
     bool mIsFirstRedo = true;
+};
+
+class KeyFrameRemoveCommand : public UndoRedoCommand
+{
+public:
+    KeyFrameRemoveCommand(const KeyFrame* undoKeyFrame,
+                        int undoLayerId,
+                        const QString& description,
+                        Editor* editor,
+                        QUndoCommand* parent = nullptr
+                                               );
+    ~KeyFrameRemoveCommand();
+
+    void undo() override;
+    void redo() override;
+
+private:
+
+    int undoLayerId = 0;
+    int redoLayerId = 0;
+
+    KeyFrame* undoKeyFrame = nullptr;
+    int redoPosition;
 };
 
 class BitmapReplaceCommand : public UndoRedoCommand

--- a/core_lib/src/interface/undoredocommand.h
+++ b/core_lib/src/interface/undoredocommand.h
@@ -43,7 +43,7 @@ public:
     ~UndoRedoCommand() override;
 
 protected:
-    Editor* editor() { return mEditor; }
+    Editor* editor() const { return mEditor; }
 
     bool isFirstRedo() const { return mIsFirstRedo; }
     void setFirstRedo(const bool state) { mIsFirstRedo = state; }
@@ -73,7 +73,30 @@ private:
     int redoLayerId = 0;
 
     KeyFrame* undoKeyFrame = nullptr;
-    int redoPosition;
+    int redoPosition = 0;
+};
+
+class KeyFrameAddCommand : public UndoRedoCommand
+{
+public:
+    KeyFrameAddCommand(int undoPosition,
+                        int undoLayerId,
+                        const QString& description,
+                        Editor* editor,
+                        QUndoCommand* parent = nullptr
+                                               );
+    ~KeyFrameAddCommand();
+
+    void undo() override;
+    void redo() override;
+
+private:
+
+    int undoLayerId = 0;
+    int redoLayerId = 0;
+
+    int undoPosition = 0;
+    int redoPosition = 0;
 };
 
 class BitmapReplaceCommand : public UndoRedoCommand

--- a/core_lib/src/interface/undoredocommand.h
+++ b/core_lib/src/interface/undoredocommand.h
@@ -83,8 +83,7 @@ public:
                         int undoLayerId,
                         const QString& description,
                         Editor* editor,
-                        QUndoCommand* parent = nullptr
-                                               );
+                        QUndoCommand* parent = nullptr);
     ~KeyFrameAddCommand();
 
     void undo() override;
@@ -97,6 +96,27 @@ private:
 
     int undoPosition = 0;
     int redoPosition = 0;
+};
+
+class MoveKeyFramesCommand : public UndoRedoCommand
+{
+public:
+    MoveKeyFramesCommand(int offset,
+                         QList<int> listOfPositions,
+                         int undoLayerId,
+                         const QString& description,
+                         Editor* editor,
+                         QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    int undoLayerId = 0;
+    int redoLayerId = 0;
+
+    int frameOffset = 0;
+    QList<int> positions;
 };
 
 class BitmapReplaceCommand : public UndoRedoCommand

--- a/core_lib/src/managers/layermanager.cpp
+++ b/core_lib/src/managers/layermanager.cpp
@@ -100,7 +100,7 @@ Layer* LayerManager::findLayerByName(QString sName, Layer::LAYER_TYPE type)
     return object()->findLayerByName(sName, type);
 }
 
-Layer* LayerManager::findLayerById(int layerId)
+Layer* LayerManager::findLayerById(int layerId) const
 {
     return object()->findLayerById(layerId);
 }

--- a/core_lib/src/managers/layermanager.h
+++ b/core_lib/src/managers/layermanager.h
@@ -44,7 +44,7 @@ public:
     Layer* getLayer(int index);
     LayerCamera* getCameraLayerBelow(int layerIndex) const;
     Layer* findLayerByName(QString sName, Layer::LAYER_TYPE type = Layer::UNDEFINED);
-    Layer* findLayerById(int layerId);
+    Layer* findLayerById(int layerId) const;
     Layer* getLastCameraLayer();
     int    currentLayerIndex();
     void   setCurrentLayer(int nIndex);

--- a/core_lib/src/managers/undoredomanager.h
+++ b/core_lib/src/managers/undoredomanager.h
@@ -41,9 +41,7 @@ class UndoRedoCommand;
 /// The undo/redo type which correspond to what is being recorded
 enum class UndoRedoRecordType {
     KEYFRAME_MODIFY, // Any modification that involve a keyframe
-
-    // Possible future actions
-    // KEYFRAME_REMOVE, // Removing a keyframe
+    KEYFRAME_REMOVE, // Removing a keyframe
     // KEYFRAME_ADD, // Adding a keyframe
     // SCRUB_LAYER, // Scrubbing layer
     // SCRUB_KEYFRAME, // Scrubbing keyframe
@@ -156,7 +154,9 @@ private:
     void replaceBitmap(const UndoSaveState& undoState, const QString& description);
     void replaceVector(const UndoSaveState& undoState, const QString& description);
 
-    const UndoSaveState* savedKeyFrameState() const;
+    void removeKeyFrame(const UndoSaveState& undoState, const QString& description);
+
+    const UndoSaveState* savedKeyFrameState(const UndoRedoRecordType& type) const;
 
     void pushCommand(QUndoCommand* command);
 

--- a/core_lib/src/managers/undoredomanager.h
+++ b/core_lib/src/managers/undoredomanager.h
@@ -128,7 +128,7 @@ public:
     * @param undoState The state to record.
     * @param description The description that will bound to the undo/redo action.
     */
-    void record(UndoSaveState*& undoState, const QString& description);
+    void record(const UndoSaveState* undoState, const QString& description);
 
 
     /** Checks whether there are unsaved changes.
@@ -137,7 +137,7 @@ public:
 
     /** Prepares and returns an save state with common data
      * @return A UndoSaveState struct with common keyframe data */
-    UndoSaveState* createState(UndoRedoRecordType recordType) const;
+    UndoSaveState* createState(UndoRedoRecordType recordType);
 
     QAction* createUndoAction(QObject* parent, const QIcon& icon);
     QAction* createRedoAction(QObject* parent, const QIcon& icon);
@@ -188,9 +188,12 @@ private:
 
     void pushCommand(QUndoCommand* command);
 
+    void clearCurrentState();
+
     void legacyUndo();
     void legacyRedo();
 
+    UndoSaveState* mCurrentState = nullptr;
     QUndoStack mUndoStack;
 
     // Legacy system

--- a/core_lib/src/managers/undoredomanager.h
+++ b/core_lib/src/managers/undoredomanager.h
@@ -42,7 +42,7 @@ class UndoRedoCommand;
 enum class UndoRedoRecordType {
     KEYFRAME_MODIFY, // Any modification that involve a keyframe
     KEYFRAME_REMOVE, // Removing a keyframe
-    // KEYFRAME_ADD, // Adding a keyframe
+    KEYFRAME_ADD, // Adding a keyframe
     // SCRUB_LAYER, // Scrubbing layer
     // SCRUB_KEYFRAME, // Scrubbing keyframe
     INVALID
@@ -77,6 +77,7 @@ struct SelectionSaveState {
 /// whatever states that needs to be stored temporarily.
 struct UndoSaveState {
     int layerId = 0;
+    int currentFrameIndex = 0;
     Layer::LAYER_TYPE layerType = Layer::UNDEFINED;
 
     std::unique_ptr<KeyFrame> keyframe = nullptr;
@@ -154,6 +155,7 @@ private:
     void replaceBitmap(const UndoSaveState& undoState, const QString& description);
     void replaceVector(const UndoSaveState& undoState, const QString& description);
 
+    void addKeyFrame(const UndoSaveState& undoState, const QString& description);
     void removeKeyFrame(const UndoSaveState& undoState, const QString& description);
 
     const UndoSaveState* savedKeyFrameState(const UndoRedoRecordType& type) const;

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -212,7 +212,7 @@ void MoveTool::beginInteraction(const QPointF& pos, Qt::KeyboardModifiers keyMod
     QRectF selectionRect = selectMan->mySelectionRect();
     if (!selectionRect.isNull())
     {
-        mUndoSaveState = mEditor->undoRedo()->state(UndoRedoRecordType::KEYFRAME_MODIFY);
+        mUndoSaveState = mEditor->undoRedo()->createState(UndoRedoRecordType::KEYFRAME_MODIFY);
         mEditor->backup(typeName());
     }
 

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -67,7 +67,7 @@ private:
     MoveMode mPerspMode;
     QPointF mOffset;
 
-    const UndoSaveState* mUndoSaveState = nullptr;
+    UndoSaveState* mUndoSaveState = nullptr;
 };
 
 #endif

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -207,7 +207,7 @@ void PolylineTool::pointerDoubleClickEvent(PointerEvent* event)
     // include the current point before ending the line.
     mPoints << getCurrentPoint();
 
-    const UndoSaveState* saveState = mEditor->undoRedo()->state(UndoRedoRecordType::KEYFRAME_MODIFY);
+    UndoSaveState* saveState = mEditor->undoRedo()->createState(UndoRedoRecordType::KEYFRAME_MODIFY);
     mEditor->backup(typeName());
 
     endPolyline(mPoints);
@@ -243,7 +243,7 @@ bool PolylineTool::keyPressEvent(QKeyEvent* event)
     case Qt::Key_Return:
         if (mPoints.size() > 0)
         {
-            const UndoSaveState* saveState = mEditor->undoRedo()->state(UndoRedoRecordType::KEYFRAME_MODIFY);
+            UndoSaveState* saveState = mEditor->undoRedo()->createState(UndoRedoRecordType::KEYFRAME_MODIFY);
             endPolyline(mPoints);
             mEditor->undoRedo()->record(saveState, typeName());
             return true;

--- a/core_lib/src/tool/selecttool.cpp
+++ b/core_lib/src/tool/selecttool.cpp
@@ -126,7 +126,7 @@ void SelectTool::pointerPressEvent(PointerEvent* event)
     if (event->button() != Qt::LeftButton) { return; }
     auto selectMan = mEditor->select();
 
-    mUndoState = mEditor->undoRedo()->state(UndoRedoRecordType::KEYFRAME_MODIFY);
+    mUndoState = mEditor->undoRedo()->createState(UndoRedoRecordType::KEYFRAME_MODIFY);
 
     mPressPoint = event->canvasPos();
     selectMan->setMoveModeForAnchorInRange(mPressPoint);

--- a/core_lib/src/tool/selecttool.h
+++ b/core_lib/src/tool/selecttool.h
@@ -69,7 +69,7 @@ private:
 
     QPixmap mCursorPixmap = QPixmap(24, 24);
 
-    const UndoSaveState* mUndoState = nullptr;
+    UndoSaveState* mUndoState = nullptr;
 };
 
 #endif

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -140,7 +140,7 @@ void StrokeTool::startStroke(PointerEvent::InputType inputType)
     mStrokePressures << mInterpolator.getPressure();
 
     mCurrentInputType = inputType;
-    mUndoSaveState = mEditor->undoRedo()->state(UndoRedoRecordType::KEYFRAME_MODIFY);
+    mUndoSaveState = mEditor->undoRedo()->createState(UndoRedoRecordType::KEYFRAME_MODIFY);
 
     disableCoalescing();
 }

--- a/core_lib/src/tool/stroketool.h
+++ b/core_lib/src/tool/stroketool.h
@@ -112,7 +112,7 @@ protected:
 
     StrokeInterpolator mInterpolator;
 
-    const UndoSaveState* mUndoSaveState = nullptr;
+    UndoSaveState* mUndoSaveState = nullptr;
 
 private:
     /// Sets the width value without calling settings to store the state


### PR DESCRIPTION
This PR adds the following to the undo/redo system:

- Adding keyframes
- Deleting keyframes
- Moving keyframes

In addition I had to make some changes to the structure of the undoredomanager, as it wasn't as flexible as I needed it to be. The change is for the better though.

I've also introduced a set of guards to avoid dealing with an undo/redo stack that is potentially useless, for example when you delete the layer where there were once keyframes.
Since we don't support that yet, we have to guard against it to avoid crashing.

partially fixes #748 