### PR TITLE
Acting on KeyFrame create/destroy and modify

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -754,14 +754,7 @@ void ActionCommands::duplicateLayer()
     fromLayer->foreachKeyFrame([&] (KeyFrame* key) {
         key = key->clone();
         toLayer->addOrReplaceKeyFrame(key->pos(), key);
-        if (toLayer->type() == Layer::SOUND)
-        {
-            mEditor->sound()->processSound(static_cast<SoundClip*>(key));
-        }
-        else
-        {
-            key->modification();
-        }
+        key->modification();
     });
     if (!fromLayer->keyExists(1)) {
         toLayer->removeKeyFrame(1);
@@ -800,7 +793,6 @@ void ActionCommands::duplicateKey()
 
     if (layer->type() == Layer::SOUND)
     {
-        mEditor->sound()->processSound(dynamic_cast<SoundClip*>(dupKey));
         showSoundClipWarningIfNeeded();
     }
     else

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1047,14 +1047,6 @@ void MainWindow2::newObject()
     auto object = new Object();
     object->init();
 
-    // default layers
-    object->addNewCameraLayer();
-    object->addNewBitmapLayer();
-    // Layers are counted bottom up
-    // 0 - Camera Layer
-    // 1 - Bitmap Layer
-    object->data()->setCurrentLayer(1);
-
     mEditor->setObject(object);
 
     closeDialogs();

--- a/app/src/timelinecells.cpp
+++ b/app/src/timelinecells.cpp
@@ -196,11 +196,6 @@ void TimeLineCells::showCameraMenu(QPoint pos)
         mHighlightFrameEnabled = false;
         mHighlightedFrame = -1;
         update();
-
-        KeyFrame* key = curLayer->getKeyFrameAt(frameNumber);
-        if (key->isModified()) {
-            emit mEditor->frameModified(frameNumber);
-        }
     });
 
     // Update needs to happen before executing menu, otherwise paint event might be postponed

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -351,12 +351,6 @@ void Editor::pasteToFrames()
         // TODO: undo/redo implementation
         KeyFrame* keyClone = it->second->clone();
         currentLayer->addKeyFrame(newPosition, keyClone);
-        if (currentLayer->type() == Layer::SOUND)
-        {
-            auto soundClip = static_cast<SoundClip*>(keyClone);
-            sound()->loadSound(soundClip, soundClip->fileName());
-        }
-
         currentLayer->setFrameSelected(keyClone->pos(), true);
     }
 }

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -128,16 +128,19 @@ void Editor::makeConnections()
 
 void Editor::onLayerEvent(Layer* layer, KeyFrameEvent event, KeyFrame* keyframe)
 {
+    if (event == KeyFrameEvent::CREATE) {
+        setupKeyframeDependencies(layer, keyframe);
+    }
+
+    // Currently all frame events will trigger a frame modified event, if this is excessive, we can
+    // always move in into a MODIFY block only.
+    emit frameModified(keyframe->pos());
+}
+
+void Editor::setupKeyframeDependencies(Layer* layer, KeyFrame* keyframe)
+{
     if (layer->type() == Layer::SOUND) {
-        if (event == KeyFrameEvent::CREATE) {
-            sound()->processSound(static_cast<SoundClip*>(keyframe));
-        }
-    } else if (layer->type() == Layer::BITMAP) {
-        qDebug() << "OnKeyFrameevent: Bitmap";
-        if (event == KeyFrameEvent::CREATE) {
-            select()->createEditor(static_cast<BitmapImage*>(keyframe));
-            qDebug() << "onKeyFrameEvent: creating bitmap editor";
-        }
+        sound()->processSound(static_cast<SoundClip*>(keyframe));
     }
 }
 
@@ -416,8 +419,6 @@ void Editor::setModified(int layerNumber, int frameNumber)
 
     layer->setModified(frameNumber, true);
     undoRedo()->rememberLastModifiedFrame(layerNumber, frameNumber);
-
-    emit frameModified(frameNumber);
 }
 
 void Editor::clipboardChanged()

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -230,6 +230,7 @@ public: //slots
     void resetAutoSaveCounter();
 
 private:
+    void setupKeyframeDependencies(Layer* layer, KeyFrame* keyframe);
     void onLayerEvent(Layer* layer, KeyFrameEvent event, KeyFrame* keyframe);
 
     Status importBitmapImage(const QString&);

--- a/core_lib/src/interface/editor.h
+++ b/core_lib/src/interface/editor.h
@@ -148,7 +148,6 @@ signals:
 
     void updateTimeLine() const;
     void updateTimeLineCached();
-    void updateLayerCount();
 
     void objectLoaded();
 
@@ -231,6 +230,8 @@ public: //slots
     void resetAutoSaveCounter();
 
 private:
+    void onLayerEvent(Layer* layer, KeyFrameEvent event, KeyFrame* keyframe);
+
     Status importBitmapImage(const QString&);
     Status importVectorImage(const QString&);
 

--- a/core_lib/src/managers/layermanager.cpp
+++ b/core_lib/src/managers/layermanager.cpp
@@ -231,7 +231,7 @@ LayerBitmap* LayerManager::createBitmapLayer(const QString& strLayerName)
 {
     LayerBitmap* layer = object()->addNewBitmapLayer();
 
-    layer->setLayerEventCallback([this] (KeyFrameEvent event, KeyFrame* keyframe, Layer* layer) {
+    layer->setupLayerEventCallback([this] (KeyFrameEvent event, KeyFrame* keyframe, Layer* layer) {
         emit layerEventFired(layer, event, keyframe);
     });
     layer->addNewKeyFrameAt(1);
@@ -246,6 +246,10 @@ LayerBitmap* LayerManager::createBitmapLayer(const QString& strLayerName)
 LayerVector* LayerManager::createVectorLayer(const QString& strLayerName)
 {
     LayerVector* layer = object()->addNewVectorLayer();
+    layer->setupLayerEventCallback([this] (KeyFrameEvent event, KeyFrame* keyframe, Layer* layer) {
+        emit layerEventFired(layer, event, keyframe);
+    });
+
     layer->setName(strLayerName);
     layer->addNewKeyFrameAt(1);
 
@@ -258,6 +262,9 @@ LayerVector* LayerManager::createVectorLayer(const QString& strLayerName)
 LayerCamera* LayerManager::createCameraLayer(const QString& strLayerName)
 {
     LayerCamera* layer = object()->addNewCameraLayer();
+    layer->setupLayerEventCallback([this] (KeyFrameEvent event, KeyFrame* keyframe, Layer* layer) {
+        emit layerEventFired(layer, event, keyframe);
+    });
     layer->setName(strLayerName);
     layer->addNewKeyFrameAt(1);
 
@@ -270,6 +277,9 @@ LayerCamera* LayerManager::createCameraLayer(const QString& strLayerName)
 LayerSound* LayerManager::createSoundLayer(const QString& strLayerName)
 {
     LayerSound* layer = object()->addNewSoundLayer();
+    layer->setupLayerEventCallback([this] (KeyFrameEvent event, KeyFrame* keyframe, Layer* layer) {
+        emit layerEventFired(layer, event, keyframe);
+    });
     layer->setName(strLayerName);
     // No default keyFrame at position 1 for Sound layer.
 

--- a/core_lib/src/managers/layermanager.h
+++ b/core_lib/src/managers/layermanager.h
@@ -86,7 +86,10 @@ signals:
     void animationLengthChanged(int length);
     void layerDeleted(int index);
 
+    void layerEventFired(Layer* layer, KeyFrameEvent event, KeyFrame* KeyFrame);
+
 private:
+    void createDefaultLayers();
     int getIndex(Layer*) const;
 
     int mLastCameraLayerIdx = 0;

--- a/core_lib/src/managers/soundmanager.cpp
+++ b/core_lib/src/managers/soundmanager.cpp
@@ -39,27 +39,8 @@ bool SoundManager::init()
     return true;
 }
 
-Status SoundManager::load(Object* obj)
+Status SoundManager::load(Object*)
 {
-    int count = obj->getLayerCount();
-    for (int i = 0; i < count; ++i)
-    {
-        Layer* layer = obj->getLayer(i);
-        if (layer->type() != Layer::SOUND)
-        {
-            continue;
-        }
-
-        LayerSound* soundLayer = static_cast<LayerSound*>(layer);
-
-        soundLayer->foreachKeyFrame([this](KeyFrame* key)
-        {
-            SoundClip* clip = dynamic_cast<SoundClip*>(key);
-            Q_ASSERT(clip);
-
-            createMediaPlayer(clip);
-        });
-    }
     return Status::OK;
 }
 

--- a/core_lib/src/structure/keyframe.cpp
+++ b/core_lib/src/structure/keyframe.cpp
@@ -56,6 +56,28 @@ KeyFrame& KeyFrame::operator=(const KeyFrame& k2)
     return *this;
 }
 
+void KeyFrame::modification() {
+    mIsModified = true;
+
+    if (eventCallback) {
+        eventCallback(KeyFrameEvent::MODIFY, this);
+    }
+}
+
+void KeyFrame::setModified(bool b)
+{
+    mIsModified = b;
+
+    if (b && eventCallback) {
+        eventCallback(KeyFrameEvent::MODIFY, this);
+    }
+}
+
+void KeyFrame::setupEventCallback(KeyFrameEventCallback eventCallback)
+{
+    this->eventCallback = eventCallback;
+}
+
 void KeyFrame::addEventListener(KeyFrameEventListener* listener)
 {
     auto it = std::find(mEventListeners.begin(), mEventListeners.end(), listener);

--- a/core_lib/src/structure/keyframe.cpp
+++ b/core_lib/src/structure/keyframe.cpp
@@ -38,6 +38,9 @@ KeyFrame::~KeyFrame()
     {
         listener->onKeyFrameDestroy(this);
     }
+    if (eventCallback) {
+        eventCallback(KeyFrameEvent::DESTROY, this);
+    }
 }
 
 KeyFrame& KeyFrame::operator=(const KeyFrame& k2)
@@ -76,6 +79,7 @@ void KeyFrame::setModified(bool b)
 void KeyFrame::setupEventCallback(KeyFrameEventCallback eventCallback)
 {
     this->eventCallback = eventCallback;
+    eventCallback(KeyFrameEvent::CREATE, this);
 }
 
 void KeyFrame::addEventListener(KeyFrameEventListener* listener)

--- a/core_lib/src/structure/keyframe.h
+++ b/core_lib/src/structure/keyframe.h
@@ -23,6 +23,8 @@ GNU General Public License for more details.
 #include <memory>
 #include <QString>
 #include "pencilerror.h"
+#include "pencildef.h"
+
 class KeyFrameEventListener;
 
 
@@ -30,6 +32,8 @@ class KeyFrame
 {
 public:
     explicit KeyFrame();
+
+    typedef std::function<void(KeyFrameEvent event, KeyFrame*)> KeyFrameEventCallback;
     explicit KeyFrame(const KeyFrame& k2);
     virtual ~KeyFrame();
 
@@ -41,8 +45,8 @@ public:
     int length() const { return mLength; }
     void setLength(int len) { mLength = len; }
 
-    void modification() { mIsModified = true; }
-    void setModified(bool b) { mIsModified = b; }
+    void modification();
+    void setModified(bool b);
     bool isModified() const { return mIsModified; }
 
     void setSelected(bool b) { mIsSelected = b; }
@@ -50,6 +54,8 @@ public:
 
     QString fileName() const { return mAttachedFileName; }
     void    setFileName(QString strFileName) { mAttachedFileName = strFileName; }
+
+    void setupEventCallback(KeyFrameEventCallback eventCallback);
 
     void addEventListener(KeyFrameEventListener*);
     void removeEventListner(KeyFrameEventListener*);
@@ -60,6 +66,8 @@ public:
     virtual bool isLoaded() const { return true; }
 
     virtual quint64 memoryUsage() { return 0; }
+
+    KeyFrameEventCallback eventCallback;
 
 private:
     int mFrame = -1;

--- a/core_lib/src/structure/keyframe.h
+++ b/core_lib/src/structure/keyframe.h
@@ -67,14 +67,16 @@ public:
 
     virtual quint64 memoryUsage() { return 0; }
 
-    KeyFrameEventCallback eventCallback;
-
 private:
     int mFrame = -1;
     int mLength = 1;
     bool mIsModified = true;
     bool mIsSelected = false;
     QString mAttachedFileName;
+
+    // Contrary to KeyFrameEventListener, this callback is meant to be
+    // setup and triggered for all keyframe types
+    KeyFrameEventCallback eventCallback;
 
     std::vector<KeyFrameEventListener*> mEventListeners;
 };

--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -195,9 +195,22 @@ bool Layer::addKeyFrame(int position, KeyFrame* pKeyFrame)
         return false;
     }
 
+    qDebug() << "adding new keyframe";
+
     pKeyFrame->setPos(position);
     mKeyFrames.emplace(position, pKeyFrame);
     markFrameAsDirty(position);
+
+    pKeyFrame->setupEventCallback([this](KeyFrameEvent event, KeyFrame* keyframe) {
+
+        // switch (event) {
+        if (mLayerEventCallback) {
+            mLayerEventCallback(event, keyframe, this);
+        }
+        // }
+    });
+
+    pKeyFrame->eventCallback(KeyFrameEvent::CREATE, pKeyFrame);
     return true;
 }
 
@@ -225,6 +238,8 @@ bool Layer::removeKeyFrame(int position)
         if (frame->isSelected()) {
             removeFromSelectionList(frame->pos());
         }
+
+        frame->eventCallback(KeyFrameEvent::DESTROY, frame);
         mKeyFrames.erase(frame->pos());
         markFrameAsDirty(frame->pos());
         delete frame;

--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -195,22 +195,15 @@ bool Layer::addKeyFrame(int position, KeyFrame* pKeyFrame)
         return false;
     }
 
-    qDebug() << "adding new keyframe";
-
     pKeyFrame->setPos(position);
     mKeyFrames.emplace(position, pKeyFrame);
     markFrameAsDirty(position);
 
     pKeyFrame->setupEventCallback([this](KeyFrameEvent event, KeyFrame* keyframe) {
-
-        // switch (event) {
         if (mLayerEventCallback) {
             mLayerEventCallback(event, keyframe, this);
         }
-        // }
     });
-
-    pKeyFrame->eventCallback(KeyFrameEvent::CREATE, pKeyFrame);
     return true;
 }
 
@@ -239,7 +232,6 @@ bool Layer::removeKeyFrame(int position)
             removeFromSelectionList(frame->pos());
         }
 
-        frame->eventCallback(KeyFrameEvent::DESTROY, frame);
         mKeyFrames.erase(frame->pos());
         markFrameAsDirty(frame->pos());
         delete frame;

--- a/core_lib/src/structure/layer.h
+++ b/core_lib/src/structure/layer.h
@@ -73,7 +73,7 @@ public:
     QDomElement createBaseDomElement(QDomDocument& doc) const;
     void loadBaseDomElement(const QDomElement& elem);
 
-    void setLayerEventCallback(LayerEventCallback eventCallback) { mLayerEventCallback = eventCallback; }
+    void setupLayerEventCallback(LayerEventCallback eventCallback) { mLayerEventCallback = eventCallback; }
 
     // KeyFrame interface
     int getMaxKeyFramePosition() const;
@@ -182,10 +182,6 @@ protected:
     bool loadKey(KeyFrame*);
 
 private:
-
-    LayerEventCallback mLayerEventCallback;
-    void keyFrameCreated(KeyFrame*);
-
     void removeFromSelectionList(int position);
 
     LAYER_TYPE meType = UNDEFINED;
@@ -193,6 +189,7 @@ private:
     bool       mVisible = true;
     QString    mName;
 
+    LayerEventCallback mLayerEventCallback;
     std::map<int, KeyFrame*, std::greater<int>> mKeyFrames;
 
     // We need to keep track of selected frames ordered by last selected

--- a/core_lib/src/structure/layer.h
+++ b/core_lib/src/structure/layer.h
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 #include <QString>
 #include <QDomElement>
 #include "pencilerror.h"
+#include "pencildef.h"
 
 class KeyFrame;
 class Status;
@@ -33,6 +34,8 @@ class Layer
 {
     Q_DECLARE_TR_FUNCTIONS(Layer)
 public:
+    typedef std::function<void(KeyFrameEvent, KeyFrame*, Layer*)> LayerEventCallback;
+
     enum LAYER_TYPE
     {
         UNDEFINED = 0,
@@ -69,6 +72,8 @@ public:
     virtual QDomElement createDomElement(QDomDocument& doc) const = 0;
     QDomElement createBaseDomElement(QDomDocument& doc) const;
     void loadBaseDomElement(const QDomElement& elem);
+
+    void setLayerEventCallback(LayerEventCallback eventCallback) { mLayerEventCallback = eventCallback; }
 
     // KeyFrame interface
     int getMaxKeyFramePosition() const;
@@ -177,6 +182,10 @@ protected:
     bool loadKey(KeyFrame*);
 
 private:
+
+    LayerEventCallback mLayerEventCallback;
+    void keyFrameCreated(KeyFrame*);
+
     void removeFromSelectionList(int position);
 
     LAYER_TYPE meType = UNDEFINED;

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -23,8 +23,6 @@ GNU General Public License for more details.
 #include "bitmapimage.h"
 #include "util/util.h"
 
-#include "selectionbitmapeditor.h"
-
 LayerBitmap::LayerBitmap(int id) : Layer(id, Layer::BITMAP)
 {
     setName(tr("Bitmap Layer"));

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -23,6 +23,8 @@ GNU General Public License for more details.
 #include "bitmapimage.h"
 #include "util/util.h"
 
+#include "selectionbitmapeditor.h"
+
 LayerBitmap::LayerBitmap(int id) : Layer(id, Layer::BITMAP)
 {
     setName(tr("Bitmap Layer"));
@@ -109,6 +111,7 @@ KeyFrame* LayerBitmap::createKeyFrame(int position)
     BitmapImage* b = new BitmapImage;
     b->setPos(position);
     b->enableAutoCrop(true);
+    // b->attachSelectionEditor(new SelectionBitmapEditor);
     return b;
 }
 

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -121,9 +121,6 @@ LayerBitmap* Object::addNewBitmapLayer()
 {
     LayerBitmap* layerBitmap = new LayerBitmap(getUniqueLayerID());
     mLayers.append(layerBitmap);
-
-    layerBitmap->addNewKeyFrameAt(1);
-
     return layerBitmap;
 }
 
@@ -132,8 +129,6 @@ LayerVector* Object::addNewVectorLayer()
     LayerVector* layerVector = new LayerVector(getUniqueLayerID());
     mLayers.append(layerVector);
 
-    layerVector->addNewKeyFrameAt(1);
-
     return layerVector;
 }
 
@@ -141,9 +136,6 @@ LayerSound* Object::addNewSoundLayer()
 {
     LayerSound* layerSound = new LayerSound(getUniqueLayerID());
     mLayers.append(layerSound);
-
-    // No default keyFrame at position 1 for Sound layer.
-
     return layerSound;
 }
 
@@ -151,9 +143,6 @@ LayerCamera* Object::addNewCameraLayer()
 {
     LayerCamera* layerCamera = new LayerCamera(getUniqueLayerID());
     mLayers.append(layerCamera);
-
-    layerCamera->addNewKeyFrameAt(1);
-
     return layerCamera;
 }
 

--- a/core_lib/src/structure/pegbaraligner.cpp
+++ b/core_lib/src/structure/pegbaraligner.cpp
@@ -66,8 +66,6 @@ Status PegBarAligner::align(const QStringList& layers)
                 return Status(result.code(), errorDescription);
             }
             img->moveTopLeft(QPoint(img->left() + (pegX - result.point.x()), img->top() + (pegY - result.point.y())));
-
-            emit mEditor->frameModified(img->pos());
         }
     }
 

--- a/core_lib/src/tool/cameratool.cpp
+++ b/core_lib/src/tool/cameratool.cpp
@@ -239,7 +239,6 @@ void CameraTool::resetTransform(CameraFieldOption option)
     }
 
     layer->resetCameraAtFrame(option, mEditor->currentFrame());
-    emit mEditor->frameModified(mEditor->currentFrame());
 }
 
 void CameraTool::transformCamera(const QPointF& pos, Qt::KeyboardModifiers keyMod)
@@ -320,7 +319,6 @@ void CameraTool::pointerReleaseEvent(PointerEvent* event)
         transformCameraPath(event->canvasPos());
         mEditor->view()->forceUpdateViewTransform();
     }
-    emit mEditor->frameModified(frame);
 }
 
 qreal CameraTool::getAngleBetween(const QPointF& pos1, const QPointF& pos2) const

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -105,6 +105,13 @@ enum class LayerVisibility
     // If you are adding new enum values here, be sure to update the ++/-- operators below
 };
 
+enum class KeyFrameEvent {
+    INVALID = 0,
+    CREATE,
+    DESTROY,
+    MODIFY
+};
+
 inline LayerVisibility& operator++(LayerVisibility& vis)
 {
     return vis = (vis == LayerVisibility::ALL) ? LayerVisibility::CURRENTONLY : static_cast<LayerVisibility>(static_cast<int>(vis)+1);

--- a/tests/src/test_layer.cpp
+++ b/tests/src/test_layer.cpp
@@ -135,12 +135,6 @@ TEST_CASE("Test Layer::keyExists()", "[Layer]")
 {
     Object* obj = new Object;
 
-    SECTION("Fresh new Layer")
-    {
-        Layer* layer = obj->addNewBitmapLayer();
-        REQUIRE(layer->keyExists(1) == true); // there is a frame at 1 in default.
-
-    }
     SECTION("Key exists at 15")
     {
         Layer* layer = obj->addNewBitmapLayer();
@@ -182,6 +176,7 @@ TEST_CASE("Layer::firstKeyFramePosition()")
     SECTION("At least one key")
     {
         Layer* layer = obj->addNewBitmapLayer();
+        layer->addNewKeyFrameAt(1);
         REQUIRE(layer->firstKeyFramePosition() == 1);
 
         layer->addNewKeyFrameAt(99);
@@ -201,6 +196,7 @@ TEST_CASE("Layer::getMaxKeyFramePosition()")
     SECTION("Bitmap")
     {
         Layer* layer = obj->addNewBitmapLayer();
+        layer->addNewKeyFrameAt(1);
 
         // 1 at beginning.
         REQUIRE(layer->getMaxKeyFramePosition() == 1);
@@ -228,6 +224,7 @@ TEST_CASE("Layer::removeKeyFrame()")
     SECTION("Bitmap")
     {
         Layer* layer = obj->addNewBitmapLayer();
+        layer->addNewKeyFrameAt(1);
 
         // there is always a key at position 1 at beginning
         // and we prevent deletion of it unless the layer is SOUND!
@@ -264,6 +261,7 @@ TEST_CASE("Layer::getPreviousKeyFramePosition()")
     SECTION("KeyFrame 1")
     {
         Layer* layer = obj->addNewBitmapLayer();
+        layer->addNewKeyFrameAt(1);
         CHECK(layer->keyFrameCount() == 1);
 
         REQUIRE(layer->getPreviousKeyFramePosition(1) == 1);
@@ -275,6 +273,7 @@ TEST_CASE("Layer::getPreviousKeyFramePosition()")
     SECTION("KeyFrame 1, 2, 8")
     {
         Layer* layer = obj->addNewBitmapLayer();
+        layer->addNewKeyFrameAt(1);
         layer->addNewKeyFrameAt(2);
         layer->addNewKeyFrameAt(8);
         REQUIRE(layer->getPreviousKeyFramePosition(2) == 1);
@@ -284,6 +283,7 @@ TEST_CASE("Layer::getPreviousKeyFramePosition()")
     SECTION("KeyFrame 1, 15")
     {
         Layer* layer = obj->addNewBitmapLayer();
+        layer->addNewKeyFrameAt(1);
         REQUIRE(layer->getPreviousKeyFramePosition(-5) == 1);
 
         layer->addNewKeyFrameAt(15);
@@ -310,6 +310,7 @@ TEST_CASE("Layer::getNextKeyFramePosition()")
     SECTION("KeyFrame 1, 5")
     {
         Layer* layer = obj->addNewBitmapLayer();
+        layer->addNewKeyFrameAt(1);
 
         REQUIRE(layer->getNextKeyFramePosition(1) == 1);
         REQUIRE(layer->getNextKeyFramePosition(10) == 1);
@@ -328,6 +329,7 @@ TEST_CASE("Layer::getPreviousFrameNumber()")
     SECTION("KeyFrame 1")
     {
         Layer* layer = obj->addNewVectorLayer();
+        layer->addNewKeyFrameAt(1);
         REQUIRE(layer->getPreviousFrameNumber(1, true) == -1); // couldn't find previous frame
 
         REQUIRE(layer->getPreviousFrameNumber(3, true) == 1);


### PR DESCRIPTION
This PR introduces callbacks to Layer and KeyFrame, in order to be able to notify when a keyframe has been created, destroyed and modified.

For Keyframe creations: One benefit here is for example to be able to setup a SoundClip and not having to worry whether the SoundPlayer gets created or not because it's handled universally in Editor. In addition it also opens up for a more general handling of adding dependencies to Layer or KeyFrame without creating tight coupling.

For keyframe modifications: All modification() calls on KeyFrame will automatically now trigger a frameModified event. In practice this means that we might see more frameModified and potentially double updates to scribblearea because this has until now been handled with manual frameModified calls. As such I've removed `frameModified` emits where I could see a KeyFrame::modification() call was also made.

For KeyFrame destructions: Currently unused but could be used for cleanup tasks. 

It's important to note that to get callbacks working properly, I had to make some changes to when we create a keyframe on Layer and move the entire default layer setup from Object to LayerManager.