### PR TITLE
Use keyPressEvent rather than shortcut for polyline delete segment

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@
 + Fix hanging when adjusting cursor because of too many writes to disk [#1853](https://github.com/pencil2d/pencil/pull/1853)
 + Avoid updating width/feather sliders for tools that don’t use them [cce3107](https://github.com/pencil2d/pencil/commit/cce31079c871fcc04e957c44d5c6e65990f635f1)
 + Fix fill misbehaving when drawing was partly outside border [#1865](https://github.com/pencil2d/pencil/pull/1865)
++ Fix clearing selection with the delete shortcut [#1892](https://github.com/pencil2d/pencil/pull/1892)
 
 ## Pencil2D v0.7.0 - 12 July 2024
 

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -40,7 +40,6 @@ GNU General Public License for more details.
 #include "pencilsettings.h"
 #include "object.h"
 #include "editor.h"
-#include "polylinetool.h"
 
 #include "filemanager.h"
 #include "colormanager.h"
@@ -265,7 +264,6 @@ void MainWindow2::createMenus()
 
     //--- Edit Menu ---
     replaceUndoRedoActions();
-    connect(ui->actionRemoveLastPolylineSegment, &QAction::triggered, static_cast<PolylineTool*>(mEditor->tools()->getTool(POLYLINE)), &PolylineTool::removeLastPolylineSegment);
     connect(ui->actionCut, &QAction::triggered, mEditor, &Editor::copyAndCut);
     connect(ui->actionCopy, &QAction::triggered, mEditor, &Editor::copy);
     connect(ui->actionPaste_Previous, &QAction::triggered, mEditor, &Editor::pasteFromPreviousFrame);
@@ -1207,7 +1205,6 @@ void MainWindow2::setupKeyboardShortcuts()
     // edit menu
     ui->actionUndo->setShortcut(cmdKeySeq(CMD_UNDO));
     ui->actionRedo->setShortcut(cmdKeySeq(CMD_REDO));
-    ui->actionRemoveLastPolylineSegment->setShortcut(cmdKeySeq(CMD_REMOVE_LAST_POLYLINE_SEGMENT));
     ui->actionCut->setShortcut(cmdKeySeq(CMD_CUT));
     ui->actionCopy->setShortcut(cmdKeySeq(CMD_COPY));
     ui->actionPaste_Previous->setShortcut(cmdKeySeq(CMD_PASTE_FROM_PREVIOUS));
@@ -1323,9 +1320,6 @@ void MainWindow2::setupKeyboardShortcuts()
 
     ui->actionHelp->setShortcut(cmdKeySeq(CMD_HELP));
     ui->actionExit->setShortcut(cmdKeySeq(CMD_EXIT));
-
-    // Actions not in a menu won't work unless added to a widget
-    addAction(ui->actionRemoveLastPolylineSegment);
 }
 
 void MainWindow2::clearKeyboardShortcuts()

--- a/app/src/shortcutspage.cpp
+++ b/app/src/shortcutspage.cpp
@@ -400,7 +400,6 @@ static QString getHumanReadableShortcutName(const QString& cmdName)
         {CMD_CHANGE_LINE_COLOR_LAYER, ShortcutsPage::tr("Change Line Color (All keyframes on layer)", "Shortcut")},
         {CMD_CHANGE_LAYER_OPACITY, ShortcutsPage::tr("Change Layer / Keyframe Opacity", "Shortcut")},
         {CMD_UNDO, ShortcutsPage::tr("Undo", "Shortcut")},
-        {CMD_REMOVE_LAST_POLYLINE_SEGMENT, ShortcutsPage::tr("Remove Last Polyline Segment", "Shortcut")},
         {CMD_ZOOM_100, ShortcutsPage::tr("Set Zoom to 100%", "Shortcut")},
         {CMD_ZOOM_200, ShortcutsPage::tr("Set Zoom to 200%", "Shortcut")},
         {CMD_ZOOM_25, ShortcutsPage::tr("Set Zoom to 25%", "Shortcut")},

--- a/app/ui/mainwindow2.ui
+++ b/app/ui/mainwindow2.ui
@@ -1273,14 +1273,6 @@
     <string>30°</string>
    </property>
   </action>
-  <action name="actionRemoveLastPolylineSegment">
-   <property name="text">
-    <string>Remove Last Polyline Segment</string>
-   </property>
-   <property name="toolTip">
-    <string>Removes the lastest Polyline segment</string>
-   </property>
-  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/core_lib/data/resources/kb.ini
+++ b/core_lib/data/resources/kb.ini
@@ -20,7 +20,6 @@ CmdExportMovie=
 CmdExportGIF=Ctrl+G
 CmdExportPalette=
 CmdUndo=Ctrl+Z
-CmdRemoveLastPolylineSegment=Backspace
 CmdRedo=Ctrl+Shift+Z
 CmdCut=Ctrl+X
 CmdCopy=Ctrl+C

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -216,8 +216,6 @@ void PolylineTool::pointerDoubleClickEvent(PointerEvent* event)
 
 void PolylineTool::removeLastPolylineSegment()
 {
-    if (!isActive()) return;
-
     if (mPoints.size() > 1)
     {
         mPoints.removeLast();
@@ -249,7 +247,12 @@ bool PolylineTool::keyPressEvent(QKeyEvent* event)
             return true;
         }
         break;
-
+    case Qt::Key_Backspace:
+        if (mPoints.size() > 0)
+        {
+            removeLastPolylineSegment();
+            return true;
+        }
     case Qt::Key_Escape:
         if (mPoints.size() > 0)
         {

--- a/core_lib/src/tool/polylinetool.h
+++ b/core_lib/src/tool/polylinetool.h
@@ -47,8 +47,6 @@ public:
     void setAA(const int AA) override;
     void setClosedPath(const bool closed) override;
 
-    void removeLastPolylineSegment();
-
     bool leavingThisTool() override;
 
     bool isActive() const override;
@@ -58,6 +56,7 @@ private:
     bool mClosedPathOverrideEnabled = false;
 
     void drawPolyline(QList<QPointF> points, QPointF endPoint);
+    void removeLastPolylineSegment();
     void cancelPolyline();
     void endPolyline(QList<QPointF> points);
 };

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -139,7 +139,6 @@ const static int MaxFramesBound = 9999;
 #define CMD_EXPORT_GIF "CmdExportGIF"
 #define CMD_EXPORT_PALETTE "CmdExportPalette"
 #define CMD_UNDO "CmdUndo"
-#define CMD_REMOVE_LAST_POLYLINE_SEGMENT "CmdRemoveLastPolylineSegment"
 #define CMD_REDO "CmdRedo"
 #define CMD_CUT "CmdCut"
 #define CMD_COPY "CmdCopy"


### PR DESCRIPTION
#1861 Introduced the ability to delete segments of an active polyline with a shortcut (the backspace key by default). This prevented the keypress event from being received by ScribbleArea::keyPressEvent, which in turn broke the delete selection action. This PR reverts the creation of the new shortcut, and uses PolylineTool::keyPressEvent instead to trigger this behavior. This allows for both the polyline tool and selection to use the backspace shortcuts. I also think this is a better way to do things code-wise.

However, it does mean that the polyline delete segment action is another one of shortcuts which is currently hardcoded. I do think it was a nice idea to have this as a customizable shortcut, but I think window-level shortcuts were the wrong way to go about this, or at the very least, *all* shortcuts would have to be handled this way to prevent some from getting overridden the delete selection action was.