### PR TITLE
Add more details to FileManager error report

### DIFF
--- a/app/src/errordialog.cpp
+++ b/app/src/errordialog.cpp
@@ -17,6 +17,9 @@ GNU General Public License for more details.
 #include "errordialog.h"
 #include "ui_errordialog.h"
 
+#include <QPushButton>
+#include <QClipboard>
+
 ErrorDialog::ErrorDialog( QString title, QString description, QString details, QWidget *parent ) :
     QDialog( parent ),
     ui(new Ui::ErrorDialog)
@@ -34,9 +37,18 @@ ErrorDialog::ErrorDialog( QString title, QString description, QString details, Q
     {
         ui->details->setText( QString( "<pre>%1</pre>" ).arg( details ) );
     }
+
+    QPushButton* copyToClipboard = new QPushButton(tr("Copy to Clipboard"));
+    ui->buttonBox->addButton(copyToClipboard, QDialogButtonBox::ActionRole);
+
+    connect(copyToClipboard, &QPushButton::clicked, this, &ErrorDialog::onCopyToClipboard);
 }
 
 ErrorDialog::~ErrorDialog()
 {
     delete ui;
+}
+
+void ErrorDialog::onCopyToClipboard() {
+    QGuiApplication::clipboard()->setText(ui->details->toPlainText());
 }

--- a/app/src/errordialog.h
+++ b/app/src/errordialog.h
@@ -32,6 +32,9 @@ public:
     explicit ErrorDialog(QString title, QString description, QString details = QString(), QWidget *parent = nullptr);
     ~ErrorDialog();
 
+public slots:
+    void onCopyToClipboard();
+
 private:
     Ui::ErrorDialog *ui;
 };

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -773,7 +773,7 @@ bool MainWindow2::saveObject(QString strSavedFileName)
 
         ErrorDialog errorDialog(st.title(),
                                 st.description().append(tr("<br><br>An error has occurred and your file may not have saved successfully."
-                                                           "If you believe that this error is an issue with Pencil2D, please create a new issue at:"
+                                                           "\nIf you believe that this error is an issue with Pencil2D, please create a new issue at:"
                                                            "<br><a href='https://github.com/pencil2d/pencil/issues'>https://github.com/pencil2d/pencil/issues</a><br>"
                                                            "Please be sure to include the following details in your issue:")), st.details().html());
         errorDialog.exec();

--- a/app/ui/errordialog.ui
+++ b/app/ui/errordialog.ui
@@ -83,6 +83,16 @@
     </layout>
    </item>
    <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>The following report contains vital information to figure out the cause of the error. Make sure to copy all of it, if you intend to report the bug.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QTextEdit" name="details">
      <property name="readOnly">
       <bool>true</bool>

--- a/app/ui/errordialog.ui
+++ b/app/ui/errordialog.ui
@@ -85,7 +85,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>The following report contains vital information to figure out the cause of the error. Make sure to copy all of it, if you intend to report the bug.</string>
+      <string>This report contains vital information. Copy all of it when submitting a bug.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -742,9 +742,14 @@ Status BitmapImage::writeFile(const QString& filename)
         if(f.exists())
         {
             bool b = f.remove();
-            return (b) ? Status::OK : Status::FAIL;
+            if (!b) {
+                return Status::FAIL;
+            }
         }
-        return Status::SAFE;
+
+        // The frame is likely empty, act like there's no file name
+        // so we don't end up writing to it later.
+        setFileName("");
     }
     return Status::SAFE;
 }

--- a/core_lib/src/graphics/vector/vectorimage.cpp
+++ b/core_lib/src/graphics/vector/vectorimage.cpp
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 #include <QDebug>
 #include <QXmlStreamWriter>
 #include "object.h"
+#include "util.h"
 
 
 VectorImage::VectorImage()
@@ -82,6 +83,9 @@ bool VectorImage::read(QString filePath)
     {
         return false;
     }
+    ScopeGuard fileScope([&] {
+        file.close();
+    });
 
     QDomDocument doc;
     if (!doc.setContent(&file)) return false; // this is not a XML file
@@ -123,6 +127,9 @@ Status VectorImage::write(QString filePath, QString format)
         debugInfo << ("file.error() = " + file.errorString());
         return Status(Status::FAIL, debugInfo);
     }
+    ScopeGuard fileScope([&] {
+        file.close();
+    });
 
     if (format != "VEC")
     {

--- a/core_lib/src/graphics/vector/vectorimage.cpp
+++ b/core_lib/src/graphics/vector/vectorimage.cpp
@@ -83,9 +83,6 @@ bool VectorImage::read(QString filePath)
     {
         return false;
     }
-    ScopeGuard fileScope([&] {
-        file.close();
-    });
 
     QDomDocument doc;
     if (!doc.setContent(&file)) return false; // this is not a XML file
@@ -127,9 +124,6 @@ Status VectorImage::write(QString filePath, QString format)
         debugInfo << ("file.error() = " + file.errorString());
         return Status(Status::FAIL, debugInfo);
     }
-    ScopeGuard fileScope([&] {
-        file.close();
-    });
 
     if (format != "VEC")
     {

--- a/core_lib/src/managers/undoredomanager.cpp
+++ b/core_lib/src/managers/undoredomanager.cpp
@@ -86,7 +86,7 @@ Status UndoRedoManager::save(Object* /*o*/)
 {
     if (mNewBackupSystemEnabled) {
         mUndoStack.setClean();
-    } else {
+    } else if (!mLegacyBackupList.isEmpty() && mLegacyBackupIndex < mLegacyBackupList.count()) {
         mLegacyBackupAtSave = mLegacyBackupList[mLegacyBackupIndex];
     }
     return Status::OK;

--- a/core_lib/src/qminiz.cpp
+++ b/core_lib/src/qminiz.cpp
@@ -83,6 +83,9 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
     mz_zip_zero_struct(mz);
 
     mz_bool ok = mz_zip_writer_init_file(mz, zipFilePath.toUtf8().data(), 0);
+    ScopeGuard mzScopeGuard2([&] {
+        mz_zip_reader_end(mz);
+    });
 
     if (!ok)
     {
@@ -132,15 +135,6 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
         return Status(Status::FAIL, dd);
     }
 
-    ok &= mz_zip_writer_end(mz);
-
-    if (!ok)
-    {
-        mz_zip_error err = mz_zip_get_last_error(mz);
-        dd << QString("Miniz writer end failed: error %1, %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
-        return Status(Status::FAIL, dd);
-    }
-
     return Status::OK;
 }
 
@@ -173,6 +167,9 @@ Status MiniZ::uncompressFolder(QString zipFilePath, QString destPath)
     mz_zip_zero_struct(mz);
 
     mz_bool ok = mz_zip_reader_init_file(mz, zipFilePath.toUtf8().data(), 0);
+    ScopeGuard mzScopeGuard2([&] {
+        mz_zip_reader_end(mz);
+    });
 
     if (!ok) {
         mz_zip_error err = mz_zip_get_last_error(mz);
@@ -223,12 +220,8 @@ Status MiniZ::uncompressFolder(QString zipFilePath, QString destPath)
         }
     }
 
-    ok &= mz_zip_reader_end(mz);
-
     if (!ok)
     {
-        mz_zip_error err = mz_zip_get_last_error(mz);
-        dd << QString("Error: Failed to end zip reader, Error code: %1, reason: %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));;
         return Status(Status::FAIL, dd);
     }
     return Status::OK;

--- a/core_lib/src/qminiz.cpp
+++ b/core_lib/src/qminiz.cpp
@@ -86,7 +86,7 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
 
     mz_bool ok = mz_zip_writer_init_file(mz, zipFilePath.toUtf8().data(), 0);
     ScopeGuard mzScopeGuard2([&] {
-        mz_zip_reader_end(mz);
+        mz_zip_writer_end(mz);
     });
 
     if (!ok)

--- a/core_lib/src/qminiz.cpp
+++ b/core_lib/src/qminiz.cpp
@@ -68,10 +68,12 @@ size_t MiniZ::istreamReadCallback(void *pOpaque, mz_uint64 file_ofs, void * pBuf
 Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const QStringList& fileList, QString mimetype)
 {
     DebugDetails dd;
+    dd << "\n[Miniz COMPRESSION diagnostics]\n";
     dd << QString("Creating Zip %1 from folder %2").arg(zipFilePath, srcFolderPath);
 
     if (!srcFolderPath.endsWith("/"))
     {
+        dd << "Adding / to path";
         srcFolderPath.append("/");
     }
 
@@ -90,7 +92,8 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
     if (!ok)
     {
         mz_zip_error err = mz_zip_get_last_error(mz);
-        dd << QString("Miniz writer init failed. Error code: %1, reason: %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
+        dd << QString("Error: Failed to init writer. Error code: %1, reason: %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
+        return Status(Status::FAIL, dd);
     }
 
     // Add special uncompressed mimetype file to help with the identification of projects
@@ -103,7 +106,8 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
         if (!ok)
         {
             mz_zip_error err = mz_zip_get_last_error(mz);
-            dd << QString("Cannot add mimetype. Error code: %1, reason: %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
+            dd << QString("ERROR: Unable to add mimetype. Error code: %1, reason: %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
+            return Status(Status::FAIL, dd);
         }
     }
 
@@ -123,7 +127,7 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
         if (!ok)
         {
             mz_zip_error err = mz_zip_get_last_error(mz);
-            dd << QString("Cannot add %3. Error code: %1, reason: %2 - Aborting!").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err), sRelativePath);
+            dd << QString("Error: Unable to add file: %3. Error code: %1, reason: %2 - Aborting!").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err), sRelativePath);
             return Status(Status::FAIL, dd);
         }
     }
@@ -131,7 +135,7 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
     if (!ok)
     {
         mz_zip_error err = mz_zip_get_last_error(mz);
-        dd << QString("Miniz finalize archive failed. Error code %1, reason: %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
+        dd << QString("Error: Failed to finalize archive. Error code %1, reason: %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
         return Status(Status::FAIL, dd);
     }
 
@@ -141,6 +145,7 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
 Status MiniZ::uncompressFolder(QString zipFilePath, QString destPath)
 {
     DebugDetails dd;
+    dd << "\n[Miniz EXTRACTION diagnostics]\n";
     dd << QString("Unzip file %1 to folder %2").arg(zipFilePath, destPath);
 
     if (!QFile::exists(zipFilePath))
@@ -173,7 +178,7 @@ Status MiniZ::uncompressFolder(QString zipFilePath, QString destPath)
 
     if (!ok) {
         mz_zip_error err = mz_zip_get_last_error(mz);
-        dd << QString("Error: Failed to init the zip reader. Error code: %1, reason: %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
+        dd << QString("Error: Failed to init reader. Error code: %1, reason: %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
         return Status(Status::FAIL, dd);
     }
 
@@ -215,7 +220,7 @@ Status MiniZ::uncompressFolder(QString zipFilePath, QString destPath)
             {
                 ok = false;
                 mz_zip_error err = mz_zip_get_last_error(mz);
-                dd << QString("File extraction failed. Error code: %1, reason: %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
+                dd << QString("WARNING: Unable to extract file. Error code: %1, reason: %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
             }
         }
     }

--- a/core_lib/src/qminiz.cpp
+++ b/core_lib/src/qminiz.cpp
@@ -40,7 +40,7 @@ Status MiniZ::sanityCheck(const QString& sZipFilePath)
     if (!readOk || !closeOk) {
         DebugDetails dd;
 
-        dd << "\n  [Miniz sanity check]\n";
+        dd << "\n[Miniz sanity check]\n";
         if (read_err != MZ_ZIP_NO_ERROR) {
             dd << QString("Found an error while reading the file. Error code: %2, reason: %3").arg(static_cast<int>(read_err)).arg(mz_zip_get_error_string(read_err));
         }

--- a/core_lib/src/qminiz.cpp
+++ b/core_lib/src/qminiz.cpp
@@ -74,14 +74,13 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
     }
 
     mz_zip_archive* mz = new mz_zip_archive;
+    ScopeGuard mzScopeGuard([&] {
+        delete mz;
+    });
+
     mz_zip_zero_struct(mz);
 
     mz_bool ok = mz_zip_writer_init_file(mz, zipFilePath.toUtf8().data(), 0);
-
-    ScopeGuard mzScopeGuard([&] {
-        mz_zip_writer_end(mz);
-        delete mz;
-    });
 
     if (!ok)
     {
@@ -131,9 +130,6 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
     }
 
     ok &= mz_zip_writer_end(mz);
-
-    mzScopeGuard.dismiss();
-    ScopeGuard mzScopeGuard2([&] { delete mz; });
 
     if (!ok)
     {

--- a/core_lib/src/qminiz.cpp
+++ b/core_lib/src/qminiz.cpp
@@ -85,9 +85,6 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
     mz_zip_zero_struct(mz);
 
     mz_bool ok = mz_zip_writer_init_file(mz, zipFilePath.toUtf8().data(), 0);
-    ScopeGuard mzScopeGuard2([&] {
-        mz_zip_writer_end(mz);
-    });
 
     if (!ok)
     {
@@ -95,6 +92,9 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
         dd << QString("Error: Failed to init writer. Error code: %1, reason: %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
         return Status(Status::FAIL, dd);
     }
+    ScopeGuard mzScopeGuard2([&] {
+        mz_zip_writer_end(mz);
+    });
 
     // Add special uncompressed mimetype file to help with the identification of projects
     {
@@ -172,15 +172,14 @@ Status MiniZ::uncompressFolder(QString zipFilePath, QString destPath)
     mz_zip_zero_struct(mz);
 
     mz_bool ok = mz_zip_reader_init_file(mz, zipFilePath.toUtf8().data(), 0);
-    ScopeGuard mzScopeGuard2([&] {
-        mz_zip_reader_end(mz);
-    });
-
     if (!ok) {
         mz_zip_error err = mz_zip_get_last_error(mz);
         dd << QString("Error: Failed to init reader. Error code: %1, reason: %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err));
         return Status(Status::FAIL, dd);
     }
+    ScopeGuard mzScopeGuard2([&] {
+        mz_zip_reader_end(mz);
+    });
 
     int num = mz_zip_reader_get_num_files(mz);
 

--- a/core_lib/src/qminiz.cpp
+++ b/core_lib/src/qminiz.cpp
@@ -118,7 +118,8 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
         if (!ok)
         {
             mz_zip_error err = mz_zip_get_last_error(mz);
-            dd << QString("Cannot add %3: error %1, %2").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err), sRelativePath);
+            dd << QString("Cannot add %3: error %1, %2 - Aborting!").arg(static_cast<int>(err)).arg(mz_zip_get_error_string(err), sRelativePath);
+            return Status(Status::FAIL, dd);
         }
     }
     ok &= mz_zip_writer_finalize_archive(mz);

--- a/core_lib/src/qminiz.cpp
+++ b/core_lib/src/qminiz.cpp
@@ -39,11 +39,13 @@ Status MiniZ::sanityCheck(const QString& sZipFilePath)
 
     if (!readOk || !closeOk) {
         DebugDetails dd;
+
+        dd << "\n  [Miniz sanity check]\n";
         if (read_err != MZ_ZIP_NO_ERROR) {
-            dd << QString("Miniz found an error while reading the file. - %1, %2").arg(static_cast<int>(read_err)).arg(mz_zip_get_error_string(read_err));
+            dd << QString("Found an error while reading the file. Error code: %2, reason: %3").arg(static_cast<int>(read_err)).arg(mz_zip_get_error_string(read_err));
         }
         if (close_err != MZ_ZIP_NO_ERROR) {
-            dd << QString("Miniz found an error while closing file file. - %1, %2").arg(static_cast<int>(close_err)).arg(mz_zip_get_error_string(close_err));
+            dd << QString("Found an error while closing the file. Error code: %2, reason: %3").arg(static_cast<int>(close_err)).arg(mz_zip_get_error_string(close_err));
         }
         return Status(Status::ERROR_MINIZ_FAIL, dd);
     }

--- a/core_lib/src/soundplayer.cpp
+++ b/core_lib/src/soundplayer.cpp
@@ -19,6 +19,7 @@ GNU General Public License for more details.
 #include <QMediaPlayer>
 #include <QFile>
 #include "soundclip.h"
+#include "util.h"
 
 SoundPlayer::SoundPlayer()
 {
@@ -41,6 +42,10 @@ void SoundPlayer::init(SoundClip* clip)
 
     QFile file(clip->fileName());
     file.open(QIODevice::ReadOnly);
+    ScopeGuard fileScope([&] {
+        file.close();
+    });
+
 
     mBuffer.setData(file.readAll());
     mBuffer.open(QBuffer::ReadOnly);

--- a/core_lib/src/soundplayer.cpp
+++ b/core_lib/src/soundplayer.cpp
@@ -42,10 +42,6 @@ void SoundPlayer::init(SoundClip* clip)
 
     QFile file(clip->fileName());
     file.open(QIODevice::ReadOnly);
-    ScopeGuard fileScope([&] {
-        file.close();
-    });
-
 
     mBuffer.setData(file.readAll());
     mBuffer.open(QBuffer::ReadOnly);

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -639,9 +639,10 @@ bool FileManager::loadPalette(Object* obj)
 Status FileManager::writeKeyFrameFiles(const Object* object, const QString& dataFolder, QStringList& filesFlushed)
 {
     DebugDetails dd;
+    dd << "\n[Keyframes WRITE diagnostics]\n";
 
     const int numLayers = object->getLayerCount();
-    dd << QString("Total %1 layers").arg(numLayers);
+    dd << QString("Total layer count: %1").arg(numLayers);
 
     for (int i = 0; i < numLayers; ++i)
     {
@@ -661,25 +662,32 @@ Status FileManager::writeKeyFrameFiles(const Object* object, const QString& data
         {
             saveLayersOK = false;
             dd.collect(st.details());
-            dd << QString("  !! Failed to save Layer[%1] %2").arg(i).arg(layer->name());
+            dd << QString("\n  Error: Failed to save Layer[%1] %2").arg(i).arg(layer->name());
         }
     }
-    dd << "All Layers saved";
 
     progressForward();
 
     auto errorCode = (saveLayersOK) ? Status::OK : Status::FAIL;
+
+    if (saveLayersOK) {
+        dd << "\n  All Layers saved";
+    } else {
+        dd << "\n  Error: Unable to save all layers";
+    }
+
     return Status(errorCode, dd);
 }
 
 Status FileManager::writeMainXml(const Object* object, const QString& mainXmlPath, QStringList& filesWritten)
 {
     DebugDetails dd;
+    dd << "\n[XML WRITE diagnostics]\n";
 
     QFile file(mainXmlPath);
     if (!file.open(QFile::WriteOnly | QFile::Text))
     {
-        dd << "Failed to open Main XML" << mainXmlPath;
+        dd << QString("Error: Failed to open Main XML at: %1, \n  Reason: %2").arg(mainXmlPath).arg(file.errorString());
         return Status(Status::ERROR_FILE_CANNOT_OPEN, dd);
     }
 

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -332,6 +332,7 @@ Status FileManager::save(const Object* object, const QString& sFileName)
 
     if (isArchive)
     {
+        dd << "\n[Archiving diagnostics]\n";
         QString sBackupFile = backupPreviousFile(sFileName);
 
         if (!sBackupFile.isEmpty()) {
@@ -341,23 +342,26 @@ Status FileManager::save(const Object* object, const QString& sFileName)
         if (!saveOk) {
             return Status(Status::FAIL, dd,
                           tr("Internal Error"),
-                          tr("An internal error occurred. Your file may not be saved successfully."));
+                          tr("An internal error occurred. The project could not be saved."));
         }
 
-        dd << "Miniz";
+        dd << "Miniz: Zipping...";
         Status stMiniz = MiniZ::compressFolder(sFileName, sTempWorkingFolder, filesToZip, "application/x-pencil2d-pclx");
         if (!stMiniz.ok())
         {
             dd.collect(stMiniz.details());
+            dd << "\nError: Miniz failed to zip project";
             return Status(Status::ERROR_MINIZ_FAIL, dd,
                           tr("Miniz Error"),
-                          tr("An internal error occurred. Your file may not be saved successfully."));
+                          tr("An internal error occurred. The project may not have been saved successfully."));
         }
-        dd << "Zip file saved successfully";
+        dd << "Miniz: Zip file saved successfully";
         Q_ASSERT(stMiniz.ok());
 
-        if (saveOk)
+        if (saveOk) {
+            dd << "Project saved successfully, deleting backup";
             deleteBackupFile(sBackupFile);
+        }
     }
 
     progressForward();
@@ -366,7 +370,7 @@ Status FileManager::save(const Object* object, const QString& sFileName)
     {
         return Status(Status::FAIL, dd,
                       tr("Internal Error"),
-                      tr("An internal error occurred. Your file may not be saved successfully."));
+                      tr("An internal error occurred. The project may not have been saved successfully."));
     }
 
     return Status::OK;

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -694,6 +694,9 @@ Status FileManager::writeMainXml(const Object* object, const QString& mainXmlPat
         dd << QString("Error: Failed to open Main XML at: %1, \n  Reason: %2").arg(mainXmlPath).arg(file.errorString());
         return Status(Status::ERROR_FILE_CANNOT_OPEN, dd);
     }
+    ScopeGuard fileScopeGuard([&] {
+        file.close();
+    });
 
     QDomDocument xmlDoc("PencilDocument");
     QDomElement root = xmlDoc.createElement("document");
@@ -723,7 +726,6 @@ Status FileManager::writeMainXml(const Object* object, const QString& mainXmlPat
     QTextStream out(&file);
     xmlDoc.save(out, indentSize);
     out.flush();
-    file.close();
 
     dd << "Done writing main xml file: " << mainXmlPath;
 

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -888,6 +888,7 @@ Status FileManager::recoverObject(Object* object)
         xmlDoc.setContent(&file);
         root = xmlDoc.documentElement();
         objectTag = root.firstChildElement("object");
+        file.close();
     }
     loadPalette(object);
 

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -114,6 +114,10 @@ Object* FileManager::load(const QString& sFileName)
         handleOpenProjectError(Status::ERROR_FILE_CANNOT_OPEN, dd);
         return nullptr;
     }
+    ScopeGuard fileScope([&] {
+        file.close();
+    });
+
     dd << "Main XML exists: Yes";
 
     QDomDocument xmlDoc;
@@ -933,6 +937,9 @@ Status FileManager::rebuildMainXML(Object* object)
     {
         return Status::ERROR_FILE_CANNOT_OPEN;
     }
+    ScopeGuard fileScope([&] {
+        file.close();
+    });
 
     QDomDocument xmlDoc("PencilDocument");
     QDomElement root = xmlDoc.createElement("document");
@@ -957,7 +964,6 @@ Status FileManager::rebuildMainXML(Object* object)
     QTextStream fout(&file);
     xmlDoc.save(fout, 2);
     fout.flush();
-    file.close();
 
     return Status::OK;
 }

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -334,6 +334,10 @@ Status FileManager::save(const Object* object, const QString& sFileName)
     {
         QString sBackupFile = backupPreviousFile(sFileName);
 
+        if (!sBackupFile.isEmpty()) {
+            dd << QString("\nNote: A backup has been made here: %1").arg(sBackupFile);
+        }
+
         if (!saveOk) {
             return Status(Status::FAIL, dd,
                           tr("Internal Error"),

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -73,7 +73,7 @@ Object* FileManager::load(const QString& sFileName)
         // Let's check if we can read the file before we try to unzip.
         if (!sanityCheck.ok()) {
             dd.collect(sanityCheck.details());
-            dd << "\n  Error: Unable to extract project, miniz sanity check failed.";
+            dd << "\nError: Unable to extract project, miniz sanity check failed.";
             handleOpenProjectError(Status::ERROR_INVALID_XML_FILE, dd);
             return nullptr;
         } else {
@@ -666,7 +666,7 @@ Status FileManager::writeKeyFrameFiles(const Object* object, const QString& data
         {
             saveLayersOK = false;
             dd.collect(st.details());
-            dd << QString("\n  Error: Failed to save Layer[%1] %2").arg(i).arg(layer->name());
+            dd << QString("\nError: Failed to save Layer[%1] %2").arg(i).arg(layer->name());
         }
     }
 
@@ -675,9 +675,9 @@ Status FileManager::writeKeyFrameFiles(const Object* object, const QString& data
     auto errorCode = (saveLayersOK) ? Status::OK : Status::FAIL;
 
     if (saveLayersOK) {
-        dd << "\n  All Layers saved";
+        dd << "\nAll Layers saved";
     } else {
-        dd << "\n  Error: Unable to save all layers";
+        dd << "\nError: Unable to save all layers";
     }
 
     return Status(errorCode, dd);
@@ -691,7 +691,7 @@ Status FileManager::writeMainXml(const Object* object, const QString& mainXmlPat
     QFile file(mainXmlPath);
     if (!file.open(QFile::WriteOnly | QFile::Text))
     {
-        dd << QString("Error: Failed to open Main XML at: %1, \n  Reason: %2").arg(mainXmlPath).arg(file.errorString());
+        dd << QString("Error: Failed to open Main XML at: %1, \nReason: %2").arg(mainXmlPath).arg(file.errorString());
         return Status(Status::ERROR_FILE_CANNOT_OPEN, dd);
     }
     ScopeGuard fileScopeGuard([&] {

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -739,7 +739,7 @@ Status FileManager::writePalette(const Object* object, const QString& dataFolder
     if (paletteFile.isEmpty())
     {
         DebugDetails dd;
-        dd << "Failed to save palette";
+        dd << "\nError: Failed to save palette";
         return Status(Status::FAIL, dd);
     }
     filesWritten.append(paletteFile);

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -114,9 +114,6 @@ Object* FileManager::load(const QString& sFileName)
         handleOpenProjectError(Status::ERROR_FILE_CANNOT_OPEN, dd);
         return nullptr;
     }
-    ScopeGuard fileScope([&] {
-        file.close();
-    });
 
     dd << "Main XML exists: Yes";
 
@@ -899,7 +896,6 @@ Status FileManager::recoverObject(Object* object)
         xmlDoc.setContent(&file);
         root = xmlDoc.documentElement();
         objectTag = root.firstChildElement("object");
-        file.close();
     }
     loadPalette(object);
 
@@ -937,9 +933,6 @@ Status FileManager::rebuildMainXML(Object* object)
     {
         return Status::ERROR_FILE_CANNOT_OPEN;
     }
-    ScopeGuard fileScope([&] {
-        file.close();
-    });
 
     QDomDocument xmlDoc("PencilDocument");
     QDomElement root = xmlDoc.createElement("document");

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -66,6 +66,7 @@ Object* FileManager::load(const QString& sFileName)
     {
         QString workingDirPath = obj->workingDir();
 
+        dd << QString("Working dir: %1").arg(workingDirPath);
         dd << fileFormat.arg(".pclx");
 
         Status sanityCheck = MiniZ::sanityCheck(sFileName);
@@ -79,9 +80,15 @@ Object* FileManager::load(const QString& sFileName)
         } else {
             Status unzipStatus = unzip(sFileName, workingDirPath);
             dd.collect(unzipStatus.details());
-        }
 
-        dd << QString("Project extracted to: %1 ").arg(workingDirPath);
+            if(unzipStatus.ok()) {
+                dd << QString("Unzipped at: %1 ").arg(workingDirPath);
+            } else {
+                dd << QString("Error: Unzipping failed: %1 ").arg(workingDirPath);
+                handleOpenProjectError(Status::ERROR_INVALID_XML_FILE, dd);
+                return nullptr;
+            }
+        }
 
         strMainXMLFile = QDir(workingDirPath).filePath(PFF_XML_FILE_NAME);
         strDataFolder = QDir(workingDirPath).filePath(PFF_DATA_DIR);
@@ -285,8 +292,8 @@ Status FileManager::save(const Object* object, const QString& sFileName)
     {
         sTempWorkingFolder = object->workingDir();
 
+        dd << QString("Working dir: %1").arg(sTempWorkingFolder);
         dd << fileFormat.arg(".pclx");
-        dd << QString("Project TEMP location: %1").arg(sTempWorkingFolder);
 
         Q_ASSERT(QDir(sTempWorkingFolder).exists());
 

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -24,7 +24,7 @@ GNU General Public License for more details.
 #include "fileformat.h"
 #include "object.h"
 #include "layercamera.h"
-#include "util/util.h"
+#include "util.h"
 
 FileManager::FileManager(QObject* parent) : QObject(parent)
 {

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -74,6 +74,9 @@ Object* FileManager::load(const QString& sFileName)
         // Let's check if we can read the file before we try to unzip.
         if (!sanityCheck.ok()) {
             dd.collect(sanityCheck.details());
+            dd << "\n  Error: Miniz sanity check failed!";
+            handleOpenProjectError(Status::ERROR_INVALID_XML_FILE, dd);
+            return nullptr;
         } else {
             Status unzipStatus = unzip(sFileName, workingDirPath);
             dd.collect(unzipStatus.details());
@@ -93,7 +96,7 @@ Object* FileManager::load(const QString& sFileName)
     QFile file(strMainXMLFile);
     if (!file.exists())
     {
-        dd << "Error: Main XML exists: No";
+        dd << "Error: No main XML exists!";
         handleOpenProjectError(Status::ERROR_INVALID_XML_FILE, dd);
         return nullptr;
     }
@@ -109,7 +112,7 @@ Object* FileManager::load(const QString& sFileName)
     if (!xmlDoc.setContent(&file))
     {
         FILEMANAGER_LOG("Couldn't open the main XML file");
-        dd << "Error parsing or opening the main XML file";
+        dd << "Error: Unable to parse or open the main XML file";
         handleOpenProjectError(Status::ERROR_INVALID_XML_FILE, dd);
         return nullptr;
     }
@@ -118,7 +121,7 @@ Object* FileManager::load(const QString& sFileName)
     if (!(type.name() == "PencilDocument" || type.name() == "MyObject"))
     {
         FILEMANAGER_LOG("Invalid main XML doctype");
-        dd << QString("Invalid main XML doctype: ").append(type.name());
+        dd << QString("Error: Invalid main XML doctype: ").append(type.name());
         handleOpenProjectError(Status::ERROR_INVALID_PENCIL_FILE, dd);
         return nullptr;
     }
@@ -126,7 +129,7 @@ Object* FileManager::load(const QString& sFileName)
     QDomElement root = xmlDoc.documentElement();
     if (root.isNull())
     {
-        dd << "Main XML root node is null";
+        dd << "Error: Main XML root node is null";
         handleOpenProjectError(Status::ERROR_INVALID_PENCIL_FILE, dd);
         return nullptr;
     }
@@ -147,7 +150,7 @@ Object* FileManager::load(const QString& sFileName)
     if (!ok)
     {
         obj.reset();
-        dd << "Issue occurred during object loading";
+        dd << "Error: Issue occurred during object loading";
         handleOpenProjectError(Status::ERROR_INVALID_PENCIL_FILE, dd);
         return nullptr;
     }

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -571,12 +571,15 @@ int FileManager::countExistingBackups(const QString& fileName) const
 {
     QFileInfo fileInfo(fileName);
     QDir directory(fileInfo.absoluteDir());
-    const QString& baseName = fileInfo.completeBaseName();
+    const QString& baseFileName = fileInfo.completeBaseName();
 
     int backupCount = 0;
     for (const QFileInfo &dirFileInfo : directory.entryInfoList(QDir::Filter::Files)) {
-        QString searchFileBaseName = dirFileInfo.completeBaseName();
-        if (baseName.compare(searchFileBaseName) == 0 && searchFileBaseName.contains(PFF_BACKUP_IDENTIFIER)) {
+        QString searchFileAbsPath = dirFileInfo.absoluteFilePath();
+        QString searchFileName = dirFileInfo.baseName();
+
+        bool sameBaseName = baseFileName.compare(searchFileName) == 0;
+        if (sameBaseName && searchFileAbsPath.contains(PFF_BACKUP_IDENTIFIER)) {
             backupCount++;
         }
     }

--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -340,7 +340,7 @@ bool Layer::loadKey(KeyFrame* pKey)
 Status Layer::save(const QString& sDataFolder, QStringList& attachedFiles, ProgressCallback progressStep)
 {
     DebugDetails dd;
-    dd << __FUNCTION__;
+    dd << "\n[Layer SAVE diagnostics]\n";
 
     bool ok = true;
 

--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -364,6 +364,7 @@ Status Layer::save(const QString& sDataFolder, QStringList& attachedFiles, Progr
     }
     if (!ok)
     {
+        dd << "\nError: Failed to save one or more files";
         return Status(Status::FAIL, dd);
     }
     return Status::OK;

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -193,7 +193,9 @@ QDomElement LayerBitmap::createDomElement(QDomDocument& doc) const
         imageTag.setAttribute("opacity", pImg->getOpacity());
         layerElem.appendChild(imageTag);
 
-        Q_ASSERT(QFileInfo(pKeyFrame->fileName()).fileName() == fileName(pKeyFrame));
+        if (!pKeyFrame->fileName().isEmpty()) {
+            Q_ASSERT(QFileInfo(pKeyFrame->fileName()).fileName() == fileName(pKeyFrame));
+        }
     });
 
     return layerElem;

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -95,7 +95,7 @@ Status LayerBitmap::saveKeyFrameFile(KeyFrame* keyframe, QString path)
         dd << "LayerBitmap::saveKeyFrame";
         dd << QString("  KeyFrame.pos() = %1").arg(keyframe->pos());
         dd << QString("  strFilePath = %1").arg(strFilePath);
-        dd << QString("BitmapImage could not be saved");
+        dd << QString("Error: Failed to save BitmapImage");
         dd.collect(st.details());
         return Status(Status::FAIL, dd);
     }

--- a/core_lib/src/structure/layersound.cpp
+++ b/core_lib/src/structure/layersound.cpp
@@ -145,11 +145,11 @@ Status LayerSound::saveKeyFrameFile(KeyFrame* key, QString path)
             key->setFileName("");
 
             DebugDetails dd;
-            dd << __FUNCTION__;
+            dd << "LayerSound::saveKeyFrameFile";
             dd << QString("  KeyFrame.pos() = %1").arg(key->pos());
             dd << QString("  Key->fileName() = %1").arg(key->fileName());
             dd << QString("  FilePath = %1").arg(sDestFileLocation);
-            dd << QString("Couldn't save the sound clip");
+            dd << QString("Error: Failed to save SoundClip");
             return Status(Status::FAIL, dd);
         }
         key->setFileName(sDestFileLocation);

--- a/core_lib/src/structure/layervector.cpp
+++ b/core_lib/src/structure/layervector.cpp
@@ -92,10 +92,10 @@ Status LayerVector::saveKeyFrameFile(KeyFrame* keyFrame, QString path)
         vecImage->setFileName("");
 
         DebugDetails dd;
-        dd << __FUNCTION__;
-        dd << QString("KeyFrame.pos() = %1").arg(keyFrame->pos());
-        dd << QString("FilePath = ").append(strFilePath);
-        dd << "- VectorImage failed to write";
+        dd << "LayerVector::saveKeyFrameFile";
+        dd << QString("  KeyFrame.pos() = %1").arg(keyFrame->pos());
+        dd << QString("  strFilePath = ").append(strFilePath);
+        dd << "Error: Failed to save VectorImage";
         dd.collect(st.details());
         return Status(Status::FAIL, dd);
     }

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -519,13 +519,15 @@ bool Object::exportPalette(const QString& filePath) const
         qDebug("Error: cannot export palette");
         return false;
     }
+    ScopeGuard fileScope([&] {
+        file.close();
+    });
 
     if (file.fileName().endsWith(".gpl", Qt::CaseInsensitive))
         exportPaletteGPL(file);
     else
         exportPalettePencil(file);
 
-    file.close();
     return true;
 }
 
@@ -665,6 +667,9 @@ bool Object::importPalette(const QString& filePath)
     {
         return false;
     }
+    ScopeGuard fileScope([&] {
+        file.close();
+    });
 
     if (file.fileName().endsWith(".gpl", Qt::CaseInsensitive))
     {
@@ -672,7 +677,6 @@ bool Object::importPalette(const QString& filePath)
     } else {
         importPalettePencil(file);
     }
-    file.close();
     return true;
 }
 

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -519,9 +519,6 @@ bool Object::exportPalette(const QString& filePath) const
         qDebug("Error: cannot export palette");
         return false;
     }
-    ScopeGuard fileScope([&] {
-        file.close();
-    });
 
     if (file.fileName().endsWith(".gpl", Qt::CaseInsensitive))
         exportPaletteGPL(file);
@@ -667,9 +664,6 @@ bool Object::importPalette(const QString& filePath)
     {
         return false;
     }
-    ScopeGuard fileScope([&] {
-        file.close();
-    });
 
     if (file.fileName().endsWith(".gpl", Qt::CaseInsensitive))
     {

--- a/core_lib/src/util/pencilerror.cpp
+++ b/core_lib/src/util/pencilerror.cpp
@@ -18,6 +18,7 @@ GNU General Public License for more details.
 #include "pencilerror.h"
 #include <map>
 #include <QSysInfo>
+#include <QLocale>
 
 DebugDetails::DebugDetails()
 {
@@ -55,22 +56,22 @@ void DebugDetails::appendSystemInfo()
         return;
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
-    mDetails << "System Info";
+    mDetails << "\n[System Info]\n";
 #if defined(PENCIL2D_RELEASE_BUILD)
-    mDetails << "Pencil2D version: " APP_VERSION " (stable)";
+    mDetails << "&nbsp;&nbsp;Pencil2D version: " APP_VERSION " (stable)";
 #elif defined(PENCIL2D_NIGHTLY_BUILD)
-    mDetails << "Pencil2D version: " APP_VERSION " (nightly)";
+    mDetails << "&nbsp;&nbsp;Pencil2D version: " APP_VERSION " (nightly)";
 #else
-    mDetails << "Pencil2D version: " APP_VERSION " (dev)";
+    mDetails << "&nbsp;&nbsp;Pencil2D version: " APP_VERSION " (dev)";
 #endif
 
 #if defined(GIT_EXISTS)
-    mDetails << "Commit: " S__GIT_COMMIT_HASH;
+    mDetails << "&nbsp;&nbsp;Commit: " S__GIT_COMMIT_HASH;
 #endif
-    mDetails << "Build ABI: " + QSysInfo::buildAbi();
-    mDetails << "Kernel: " + QSysInfo::kernelType() + ", " + QSysInfo::kernelVersion();
-    mDetails << "Operating System: " + QSysInfo::prettyProductName();
-    mDetails << "end";
+    mDetails << "&nbsp;&nbsp;Build ABI: " + QSysInfo::buildAbi();
+    mDetails << "&nbsp;&nbsp;Kernel: " + QSysInfo::kernelType() + ", " + QSysInfo::kernelVersion();
+    mDetails << "&nbsp;&nbsp;Operating System: " + QSysInfo::prettyProductName();
+    mDetails << "&nbsp;&nbsp;Language: " + QLocale::system().name();
 #endif
 }
 


### PR DESCRIPTION
The purpose of this PR has been to make the error report cover more steps, introduce "Error" to make it more explicit what's a information, a warning and an error.

I've also tried to make it fail faster rather than spitting out all kinds of irrelevant information when the actual error happened 4 lines above.

Here's an example of what our current report looks like:
```
Raw file path: /Users/mrstevns/Desktop/p2d testing/test-save-corruption.pclx
Resolved file path: /Users/mrstevns/Desktop/p2d testing/test-save-corruption.pclx
  File name: /Users/mrstevns/Desktop/p2d testing/test-save-corruption.pclx
  Recognized New zipped Pencil2D File Format (*.pclx) !
    Miniz found an error while reading the file. - 7, failed finding central directory
    Miniz found an error while closing file file. - 24, invalid parameter
  XML file: /private/var/folders/5c/2bmlz9fx2kzbd56j81ktpghr0000gn/T/Pencil2D/test-save-corruption_Y2xD_cplu6r9q/main.xml
  Data folder: /private/var/folders/5c/2bmlz9fx2kzbd56j81ktpghr0000gn/T/Pencil2D/test-save-corruption_Y2xD_cplu6r9q/data
  Working folder: /private/var/folders/5c/2bmlz9fx2kzbd56j81ktpghr0000gn/T/Pencil2D/test-save-corruption_Y2xD_cplu6r9q/
  Main XML file does not exist
System Info
Pencil2D version: 0.7.0.911 (stable)
Build ABI: x86_64-little_endian-lp64
Kernel: darwin, 21.6.0
Operating System: macOS 12.7
end
```

And here's the new one:
```
Raw file path: /Users/mrstevns/Desktop/p2d testing/test-save-corruption.pclx
Resolved file path: /Users/mrstevns/Desktop/p2d testing/test-save-corruption.pclx
  
[Project LOAD diagnostics]

  File name: /Users/mrstevns/Desktop/p2d testing/test-save-corruption.pclx
  Working dir: /private/var/folders/5c/2bmlz9fx2kzbd56j81ktpghr0000gn/T/Pencil2D/test-save-corruption_Y2xD_719f2v7t/
  Project format: .pclx
    
[Miniz sanity check]

    Found an error while reading the file. Error code: 7, reason: failed finding central directory
    Found an error while closing the file. Error code: 24, reason: invalid parameter
  
Error: Unable to extract project, miniz sanity check failed.

[System Info]

  Pencil2D version: 0.0.0.0 (dev)
  Build ABI: x86_64-little_endian-lp64
  Kernel: darwin, 21.6.0
  Operating System: macOS 12.7
  Language: en_GB
```

In addition the error dialog now also has a "Copy to clipboard" button, so the user can more easily paste the error report.

<img width="907" alt="image" src="https://github.com/user-attachments/assets/5360f79a-5e65-41b7-b3fb-7fde4fd785a5">