### PR TITLE
Fix some issues related to frame copying & change pcl working directory

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,12 +3,13 @@
 ### Features
 + Introduce new Undo/Redo system [#1817](https://github.com/pencil2d/pencil/pull/1817)
 
-### Enhancements
+### Enhancements/Changes
 + Add checkbox to allow polyline to close automatically [#1863](https://github.com/pencil2d/pencil/pull/1863)
 + Maintain active layer track in view - [#1867](https://github.com/pencil2d/pencil/pull/1867)
 + Update shortcuts [#1866](https://github.com/pencil2d/pencil/pull/1866)
 + Improve dock layout for lower resolutions [#1840](https://github.com/pencil2d/pencil/pull/1840)
 + Add ability to remove Last Polyline Segment using backspace [#1861](https://github.com/pencil2d/pencil/pull/1861)
++ Changed handling of pcl projects - [#1896](https://github.com/pencil2d/pencil/pull/1896)
 
 ### Bugfixes:
 + Do not make a new keyframe if double clicking on an existing keyframe - [#1851](https://github.com/pencil2d/pencil/pull/1851)
@@ -18,6 +19,9 @@
 + Avoid updating width/feather sliders for tools that don’t use them [cce3107](https://github.com/pencil2d/pencil/commit/cce31079c871fcc04e957c44d5c6e65990f635f1)
 + Fix fill misbehaving when drawing was partly outside border [#1865](https://github.com/pencil2d/pencil/pull/1865)
 + Fix clearing selection with the delete shortcut [#1892](https://github.com/pencil2d/pencil/pull/1892)
++ Fixed memory leak when copying bitmap keyframes - [#1896](https://github.com/pencil2d/pencil/pull/1896)
++ Fixed potential issue on some systems when repeatedly copying bitmap frames - [#1896](https://github.com/pencil2d/pencil/pull/1896)
++ Fixed bitmap frame wipe that can occur under specific situations when using keyframe copy & paste - [#1896](https://github.com/pencil2d/pencil/pull/1896)
 
 ## Pencil2D v0.7.0 - 12 July 2024
 

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -758,10 +758,6 @@ void ActionCommands::duplicateLayer()
         {
             mEditor->sound()->processSound(static_cast<SoundClip*>(key));
         }
-        else
-        {
-            key->modification();
-        }
     });
     if (!fromLayer->keyExists(1)) {
         toLayer->removeKeyFrame(1);
@@ -802,11 +798,6 @@ void ActionCommands::duplicateKey()
     {
         mEditor->sound()->processSound(dynamic_cast<SoundClip*>(dupKey));
         showSoundClipWarningIfNeeded();
-    }
-    else
-    {
-        dupKey->setFileName(""); // don't share filename
-        dupKey->modification();
     }
 
     mEditor->layers()->notifyAnimationLengthChanged();

--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -101,7 +101,7 @@ BitmapImage* BitmapImage::clone() const
     b->setFileName(""); // don't link to the file of the source bitmap image
 
     const bool validKeyFrame = !fileName().isEmpty();
-    if (validKeyFrame && !isLoaded())
+    if (validKeyFrame && !isModified())
     {
         // This bitmapImage is temporarily unloaded.
         // since it's not in the memory, we need to copy the linked png file to prevent data loss.
@@ -109,21 +109,15 @@ BitmapImage* BitmapImage::clone() const
         Q_ASSERT(finfo.isAbsolute());
         Q_ASSERT(QFile::exists(fileName()));
 
-        QDir tempDir = finfo.canonicalPath();
-        tempDir.cd("temp");
-        tempDir.mkpath(".");
-
         QString newFilePath;
-        QFileInfo newFileInfo;
         do
         {
-            newFilePath = QString("%1/%2.%3")
-                .arg(tempDir.canonicalPath())
+            newFilePath = QString("%1/temp-%2.%3")
+                .arg(finfo.canonicalPath())
                 .arg(uniqueString(12))
                 .arg(finfo.suffix());
-            newFileInfo.setFile(newFilePath);
         }
-        while (newFileInfo.exists());
+        while (QFile::exists(newFilePath));
 
         b->setFileName(newFilePath);
         bool ok = QFile::copy(fileName(), newFilePath);

--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -18,6 +18,7 @@ GNU General Public License for more details.
 
 #include <cmath>
 #include <QDebug>
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QPainterPath>
@@ -108,14 +109,24 @@ BitmapImage* BitmapImage::clone() const
         Q_ASSERT(finfo.isAbsolute());
         Q_ASSERT(QFile::exists(fileName()));
 
-        QString newFileName = QString("%1/%2-%3.%4")
-            .arg(finfo.canonicalPath())
-            .arg(finfo.completeBaseName())
-            .arg(uniqueString(12))
-            .arg(finfo.suffix());
-        b->setFileName(newFileName);
+        QDir tempDir = finfo.canonicalPath();
+        tempDir.cd("temp");
+        tempDir.mkpath(".");
 
-        bool ok = QFile::copy(fileName(), newFileName);
+        QString newFilePath;
+        QFileInfo newFileInfo;
+        do
+        {
+            newFilePath = QString("%1/%2.%3")
+                .arg(tempDir.canonicalPath())
+                .arg(uniqueString(12))
+                .arg(finfo.suffix());
+            newFileInfo.setFile(newFilePath);
+        }
+        while (newFileInfo.exists());
+
+        b->setFileName(newFilePath);
+        bool ok = QFile::copy(fileName(), newFilePath);
         Q_ASSERT(ok);
         qDebug() << "COPY>" << fileName();
     }

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -330,19 +330,19 @@ void Editor::pasteToFrames()
             currentLayer->moveSelectedFrames(1);
         }
 
+        KeyFrame* key = it->second;
         // It's a bug if the keyframe is nullptr at this point...
-        Q_ASSERT(it->second != nullptr);
+        Q_ASSERT(key != nullptr);
 
         // TODO: undo/redo implementation
-        KeyFrame* keyClone = it->second->clone();
-        currentLayer->addKeyFrame(newPosition, keyClone);
+        currentLayer->addKeyFrame(newPosition, key);
         if (currentLayer->type() == Layer::SOUND)
         {
-            auto soundClip = static_cast<SoundClip*>(keyClone);
+            auto soundClip = static_cast<SoundClip*>(key);
             sound()->loadSound(soundClip, soundClip->fileName());
         }
 
-        currentLayer->setFrameSelected(keyClone->pos(), true);
+        currentLayer->setFrameSelected(key->pos(), true);
     }
 }
 
@@ -354,7 +354,7 @@ void Editor::paste()
 
     if (!canPaste()) { return; }
 
-    if (clipboards()->getClipboardFrames().empty()) {
+    if (clipboards()->framesIsEmpty()) {
 
         backup(tr("Paste"));
 

--- a/core_lib/src/managers/clipboardmanager.cpp
+++ b/core_lib/src/managers/clipboardmanager.cpp
@@ -79,17 +79,20 @@ void ClipboardManager::copyVectorImage(const VectorImage* vectorImage)
     mVectorImage = *vectorImage->clone();
 }
 
-void ClipboardManager::copySelectedFrames(const Layer* currentLayer) {
+void ClipboardManager::copySelectedFrames(const Layer* currentLayer)
+{
     resetStates();
 
     for (int pos : currentLayer->selectedKeyFramesPositions()) {
         KeyFrame* keyframe = currentLayer->getKeyFrameAt(pos);
-
         Q_ASSERT(keyframe != nullptr);
 
-        keyframe->loadFile();
+        KeyFrame* newKeyframe = keyframe->clone();
+        // Unload unmodified keyframes now as they won't ever get unloaded
+        // by activeframepool while in clipboard manager.
+        newKeyframe->unloadFile();
 
-        mFrames.insert(std::make_pair(keyframe->pos(), keyframe->clone()));
+        mFrames.insert(std::make_pair(keyframe->pos(), newKeyframe));
     }
     mFramesType = currentLayer->type();
 }

--- a/core_lib/src/managers/clipboardmanager.cpp
+++ b/core_lib/src/managers/clipboardmanager.cpp
@@ -28,7 +28,11 @@ ClipboardManager::ClipboardManager(Editor* editor) : BaseManager(editor, "Clipbo
 
 ClipboardManager::~ClipboardManager()
 {
-
+    for (auto it : mFrames)
+    {
+        KeyFrame* frame = it.second;
+        delete frame;
+    }
 }
 
 void ClipboardManager::setFromSystemClipboard(const QPointF& pos, const Layer* layer)
@@ -90,9 +94,25 @@ void ClipboardManager::copySelectedFrames(const Layer* currentLayer) {
     mFramesType = currentLayer->type();
 }
 
+std::map<int, KeyFrame*> ClipboardManager::getClipboardFrames()
+{
+    std::map<int, KeyFrame*> resultMap;
+    for (auto it : mFrames)
+    {
+        resultMap.insert(std::make_pair(it.first, it.second->clone()));
+    }
+    return resultMap;
+}
+
 void ClipboardManager::resetStates()
 {
+    for (auto it : mFrames)
+    {
+        KeyFrame* frame = it.second;
+        delete frame;
+    }
     mFrames.clear();
+
     mBitmapImage = BitmapImage();
     mVectorImage = VectorImage();
     mFramesType = Layer::LAYER_TYPE::UNDEFINED;

--- a/core_lib/src/managers/clipboardmanager.h
+++ b/core_lib/src/managers/clipboardmanager.h
@@ -61,7 +61,13 @@ public:
 
     const BitmapImage& getBitmapClipboard() const { return mBitmapImage; }
     const VectorImage& getVectorClipboard() const { return mVectorImage; }
-    std::map<int, KeyFrame*> getClipboardFrames() { return mFrames; }
+
+    /** Return a copy of all clipboard frames keyed by their position.
+     *
+     *  The caller takes ownership of the returned keyframe objects and is
+     *  responsible for deleting them when no longer in use.
+     */
+    std::map<int, KeyFrame*> getClipboardFrames();
 
     Layer::LAYER_TYPE framesLayerType() const { return mFramesType; }
     bool framesIsEmpty() const { return mFrames.empty(); }

--- a/core_lib/src/structure/filemanager.h
+++ b/core_lib/src/structure/filemanager.h
@@ -30,6 +30,7 @@ GNU General Public License for more details.
 
 class Object;
 class ObjectData;
+class QDir;
 
 
 class FileManager : public QObject
@@ -55,6 +56,7 @@ signals:
     void progressRangeChanged(int maxValue);
 
 private:
+    Status copyDir(const QDir src, const QDir dst);
     Status unzip(const QString& strZipFile, const QString& strUnzipTarget);
 
     bool loadObject(Object*, const QDomElement& root);


### PR DESCRIPTION
Upon reviewing the code used to copy keyframes, multiple issues were found. These issues are:

### Memory leak in ClipboardManager

A memory leak in ClipboardManager where cloned frames are not deleted. Normally KeyFrame deletion is handled by Layer, but since the KeyFrames held in the clipboard are not part of a layer, deleting them must be handled separately.

### Filename exceeds the path length limit

Suffixes are always added to BitmapImages. This works as expected when cloning regular images, however when cloned images are cloned, the resulting image's filename has two suffixes. Repeat this, adding 13 characters each time, and the filename can quickly exceed the maximum length of a filename on some systems. This issue exists for various methods for copying bitmap images, but it is most obvious with copy and pasted keyframes because they are cloned twice (once to the clipboard, and once when pasting).

### Frame being wiped

Pasted BitmapImages using the keyframe copy/paste can sometimes be in a state vulnerable to being wiped. What was happening here is that the clone function only copied the backing file (the .png file in the working directory corresponding to the KeyFrame) for a BitmapImage if the key is not loaded. But we force every key to be loaded when copying, so the backing files are never copied. This has been not an issue with other frame copying actions because we set the modification state of all duplicated frames to true, forcing them to stay in memory until saving.

However, the recently added copy selected frames feature forgot to set them to modified, so if the pasted frames were subsequently attempted to be unloaded by ActiveFramePool, then they would be deleted from memory because they were not marked as modified. However recall that the backing file was never copied, so the frame ends up in a state where the image data is no longer in memory and has not been saved to the disk :scream: . 

A simple solution would have been to set keys to modified when pasting, just as we have done for duplicating keys or layers. However, the better solution, implemented here, is to copy the files if they have not been modified, then we don't even need to load frames to copy them, let alone keep them all in memory until saving.

This last fix raised a new problem: where to put the files for cloned frames before saving. When faced with a similar problem for movie importing, we created a new temporary directory for each import. I didn't think this would be a good solution for duplicating frames given that copying frames could happen quite often.

So I wanted to simply write the files with a temporary name to the working directory. This raised a new issue: for pcl projects, the working directory is the data directory of the save (ie. the .pcl.data directory). So by writing these temporary files, we are effectively partially saving the project. If the users decide later they do not want to save the project, these temporary files remain in the data directory indefinitely.

So, I've also added another significant change to this PR to address this. Now, when loading a pcl project, **the data directory will be copied to the temporary working directory, and when saving, the files will be written back to the data directory**. This fixes the aforementioned issue with the temporary files, and opens up opportunities for many new features to use the data directory (lazy-loading resources, proxy files, unloading dirty frames, improving data recovery, versioning, ...I have many ideas for this).

Right now I have opted for the simplest possible implementation so that it can be merged easier, but there is lots of room to improve how pcl projects are loaded/saved. Considering it's a legacy format, I think this functional implementation is sufficient for now.