### PR TITLE
Write tool properties to disk when calling leavingThisTool() or ~ToolManager()

### DIFF
--- a/core_lib/src/managers/toolmanager.cpp
+++ b/core_lib/src/managers/toolmanager.cpp
@@ -36,6 +36,14 @@ ToolManager::ToolManager(Editor* editor) : BaseManager(editor, __FUNCTION__)
 {
 }
 
+ToolManager::~ToolManager()
+{
+    foreach(BaseTool* tool, mToolSetHash)
+    {
+        tool->saveSettings();
+    }
+}
+
 bool ToolManager::init()
 {
     mToolSetHash.insert(PEN, new PenTool(this));

--- a/core_lib/src/managers/toolmanager.h
+++ b/core_lib/src/managers/toolmanager.h
@@ -31,6 +31,7 @@ class ToolManager : public BaseManager
     Q_OBJECT
 public:
     explicit ToolManager(Editor* editor);
+    ~ToolManager() override;
 
     bool init() override;
     Status load(Object*) override;

--- a/core_lib/src/tool/basetool.cpp
+++ b/core_lib/src/tool/basetool.cpp
@@ -72,6 +72,9 @@ bool BaseTool::leavingThisTool()
        disconnect(connection);
        mActiveConnections.removeOne(connection);
    }
+
+   saveSettings();
+
    return true;
 }
 

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -71,7 +71,6 @@ class BaseTool : public QObject
     Q_OBJECT
 protected:
     explicit BaseTool(QObject* parent);
-
 public:
     static QString TypeName(ToolType);
     QString typeName() { return TypeName(type()); }
@@ -80,6 +79,7 @@ public:
 
     virtual ToolType type() = 0;
     virtual void loadSettings() = 0;
+    virtual void saveSettings() = 0;
     virtual QCursor cursor();
 
     virtual void pointerPressEvent(PointerEvent*) = 0;

--- a/core_lib/src/tool/brushtool.cpp
+++ b/core_lib/src/tool/brushtool.cpp
@@ -71,6 +71,19 @@ void BrushTool::loadSettings()
     mQuickSizingProperties.insert(Qt::ControlModifier, FEATHER);
 }
 
+void BrushTool::saveSettings()
+{
+    QSettings settings(PENCIL2D, PENCIL2D);
+
+    settings.setValue("brushWidth", properties.width);
+    settings.setValue("brushFeather", properties.feather);
+    settings.setValue("brushPressure", properties.pressure);
+    settings.setValue("brushInvisibility", properties.invisibility);
+    settings.setValue("brushLineStabilization", properties.stabilizerLevel);
+
+    settings.sync();
+}
+
 void BrushTool::resetToDefault()
 {
     setWidth(24.0);
@@ -82,52 +95,29 @@ void BrushTool::setWidth(const qreal width)
 {
     // Set current property
     properties.width = width;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("brushWidth", width);
-    settings.sync();
 }
 
 void BrushTool::setFeather(const qreal feather)
 {
     // Set current property
     properties.feather = feather;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("brushFeather", feather);
-    settings.sync();
 }
 
 void BrushTool::setInvisibility(const bool invisibility)
 {
     // force value
     properties.invisibility = invisibility;
-
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("brushInvisibility", invisibility);
-    settings.sync();
 }
 
 void BrushTool::setPressure(const bool pressure)
 {
     // Set current property
     properties.pressure = pressure;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("brushPressure", pressure);
-    settings.sync();
 }
 
 void BrushTool::setStabilizerLevel(const int level)
 {
     properties.stabilizerLevel = level;
-
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("brushLineStabilization", level);
-    settings.sync();
 }
 
 QCursor BrushTool::cursor()

--- a/core_lib/src/tool/brushtool.h
+++ b/core_lib/src/tool/brushtool.h
@@ -31,6 +31,7 @@ public:
     explicit BrushTool(QObject* parent = 0);
     ToolType type() override;
     void loadSettings() override;
+    void saveSettings() override;
     void resetToDefault() override;
     QCursor cursor() override;
 

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -63,6 +63,21 @@ void BucketTool::loadSettings()
     properties.fillMode = settings.value(SETTING_FILL_MODE, 0).toInt();
 }
 
+void BucketTool::saveSettings()
+{
+    QSettings settings(PENCIL2D, PENCIL2D);
+
+    settings.setValue("fillThickness", properties.width);
+    settings.setValue(SETTING_BUCKET_TOLERANCE, properties.tolerance);
+    settings.setValue(SETTING_BUCKET_TOLERANCE_ON, properties.toleranceEnabled);
+    settings.setValue(SETTING_BUCKET_FILL_EXPAND, properties.bucketFillExpand);
+    settings.setValue(SETTING_BUCKET_FILL_EXPAND_ON, properties.bucketFillExpandEnabled);
+    settings.setValue(SETTING_BUCKET_FILL_REFERENCE_MODE, properties.bucketFillReferenceMode);
+    settings.setValue(SETTING_FILL_MODE, properties.fillMode);
+
+    settings.sync();
+}
+
 void BucketTool::resetToDefault()
 {
     setWidth(4.0);
@@ -90,11 +105,6 @@ void BucketTool::setTolerance(const int tolerance)
 {
     // Set current property
     properties.tolerance = tolerance;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue(SETTING_BUCKET_TOLERANCE, tolerance);
-    settings.sync();
 }
 
 /**
@@ -106,62 +116,34 @@ void BucketTool::setWidth(const qreal width)
 {
     // Set current property
     properties.width = width;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("fillThickness", width);
-    settings.sync();
 }
 
 void BucketTool::setFillMode(int mode)
 {
     // Set current property
     properties.fillMode = mode;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue(SETTING_FILL_MODE, mode);
-    settings.sync();
 }
 
 void BucketTool::setToleranceEnabled(const bool enabled)
 {
     properties.toleranceEnabled = enabled;
 
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue(SETTING_BUCKET_TOLERANCE_ON, enabled);
-    settings.sync();
 }
 
 void BucketTool::setFillExpandEnabled(const bool enabled)
 {
     properties.bucketFillExpandEnabled = enabled;
 
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue(SETTING_BUCKET_FILL_EXPAND_ON, enabled);
-    settings.sync();
 }
 
 void BucketTool::setFillExpand(const int fillExpandValue)
 {
     properties.bucketFillExpand = fillExpandValue;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue(SETTING_BUCKET_FILL_EXPAND, fillExpandValue);
-    settings.sync();
 }
 
 void BucketTool::setFillReferenceMode(int referenceMode)
 {
     properties.bucketFillReferenceMode = referenceMode;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue(SETTING_BUCKET_FILL_REFERENCE_MODE, referenceMode);
-    settings.sync();
 }
 
 void BucketTool::pointerPressEvent(PointerEvent* event)

--- a/core_lib/src/tool/buckettool.h
+++ b/core_lib/src/tool/buckettool.h
@@ -33,6 +33,7 @@ public:
     explicit BucketTool(QObject* parent = nullptr);
     ToolType type() override;
     void loadSettings() override;
+    void saveSettings() override;
     void resetToDefault() override;
     QCursor cursor() override;
 

--- a/core_lib/src/tool/cameratool.cpp
+++ b/core_lib/src/tool/cameratool.cpp
@@ -43,6 +43,7 @@ CameraTool::CameraTool(QObject* object) : BaseTool(object)
 
 CameraTool::~CameraTool()
 {
+    saveSettings();
 }
 
 void CameraTool::loadSettings()
@@ -62,6 +63,10 @@ void CameraTool::loadSettings()
     mHandlePen = QPen();
     mHandlePen.setColor(QColor(0, 0, 0, 255));
     mHandlePen.setWidth(2);
+}
+
+void CameraTool::saveSettings()
+{
 }
 
 void CameraTool::updateUIAssists(const Layer* layer)

--- a/core_lib/src/tool/cameratool.h
+++ b/core_lib/src/tool/cameratool.h
@@ -54,6 +54,7 @@ public:
     void paint(QPainter& painter, const QRect&) override;
 
     void loadSettings() override;
+    void saveSettings() override;
 
     void pointerPressEvent(PointerEvent* event) override;
     void pointerReleaseEvent(PointerEvent* event) override;

--- a/core_lib/src/tool/erasertool.cpp
+++ b/core_lib/src/tool/erasertool.cpp
@@ -69,6 +69,20 @@ void EraserTool::loadSettings()
     mQuickSizingProperties.insert(Qt::ControlModifier, FEATHER);
 }
 
+void EraserTool::saveSettings()
+{
+    QSettings settings(PENCIL2D, PENCIL2D);
+
+    settings.setValue("eraserWidth", properties.width);
+    settings.setValue("eraserFeather", properties.feather);
+    settings.setValue("eraserUseFeather", properties.useFeather);
+    settings.setValue("eraserPressure", properties.pressure);
+    settings.setValue("eraserAA", properties.useAA);
+    settings.setValue("stabilizerLevel", properties.stabilizerLevel);
+
+    settings.sync();
+}
+
 void EraserTool::resetToDefault()
 {
     setWidth(24.0);
@@ -83,64 +97,35 @@ void EraserTool::setWidth(const qreal width)
 {
     // Set current property
     properties.width = width;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("eraserWidth", width);
-    settings.sync();
 }
 
 void EraserTool::setUseFeather(const bool usingFeather)
 {
     // Set current property
     properties.useFeather = usingFeather;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("eraserUseFeather", usingFeather);
-    settings.sync();
 }
 
 void EraserTool::setFeather(const qreal feather)
 {
     // Set current property
     properties.feather = feather;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("eraserFeather", feather);
-    settings.sync();
 }
 
 void EraserTool::setPressure(const bool pressure)
 {
     // Set current property
     properties.pressure = pressure;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("eraserPressure", pressure);
-    settings.sync();
 }
 
 void EraserTool::setAA(const int AA)
 {
     // Set current property
     properties.useAA = AA;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("eraserAA", AA);
-    settings.sync();
 }
 
 void EraserTool::setStabilizerLevel(const int level)
 {
     properties.stabilizerLevel = level;
-
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("stabilizerLevel", level);
-    settings.sync();
 }
 
 

--- a/core_lib/src/tool/erasertool.h
+++ b/core_lib/src/tool/erasertool.h
@@ -28,6 +28,7 @@ public:
     explicit EraserTool(QObject* parent = nullptr);
     ToolType type() override;
     void loadSettings() override;
+    void saveSettings() override;
     void resetToDefault() override;
     QCursor cursor() override;
 

--- a/core_lib/src/tool/eyedroppertool.cpp
+++ b/core_lib/src/tool/eyedroppertool.cpp
@@ -45,6 +45,10 @@ void EyedropperTool::loadSettings()
     properties.useAA = -1;
 }
 
+void EyedropperTool::saveSettings()
+{
+}
+
 QCursor EyedropperTool::cursor()
 {
     if (mEditor->preference()->isOn(SETTING::TOOL_CURSOR))

--- a/core_lib/src/tool/eyedroppertool.h
+++ b/core_lib/src/tool/eyedroppertool.h
@@ -30,6 +30,7 @@ public:
     explicit EyedropperTool( QObject* parent = 0 );
     ToolType type() override { return EYEDROPPER; }
     void loadSettings() override;
+    void saveSettings() override;
     QCursor cursor() override;
     QCursor cursor( const QColor color );
 

--- a/core_lib/src/tool/handtool.cpp
+++ b/core_lib/src/tool/handtool.cpp
@@ -45,6 +45,10 @@ void HandTool::loadSettings()
     connect(mEditor->preference(), &PreferenceManager::optionChanged, this, &HandTool::updateSettings);
 }
 
+void HandTool::saveSettings()
+{
+}
+
 void HandTool::updateSettings(const SETTING setting)
 {
     switch (setting)

--- a/core_lib/src/tool/handtool.h
+++ b/core_lib/src/tool/handtool.h
@@ -29,6 +29,7 @@ public:
     explicit HandTool( QObject* parent = 0 );
     ToolType type() override { return HAND; }
     void loadSettings() override;
+    void saveSettings() override;
     QCursor cursor() override;
 
     void pointerPressEvent(PointerEvent *) override;

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -59,6 +59,15 @@ void MoveTool::loadSettings()
     connect(mEditor->preference(), &PreferenceManager::optionChanged, this, &MoveTool::updateSettings);
 }
 
+void MoveTool::saveSettings()
+{
+    QSettings settings(PENCIL2D, PENCIL2D);
+
+    settings.setValue("ShowSelectionInfo", properties.showSelectionInfo);
+
+    settings.sync();
+}
+
 QCursor MoveTool::cursor()
 {
     MoveMode mode = MoveMode::NONE;

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -34,6 +34,7 @@ public:
     explicit MoveTool(QObject* parent);
     ToolType type() override;
     void loadSettings() override;
+    void saveSettings() override;
     QCursor cursor() override;
     QCursor cursor(MoveMode mode) const;
 

--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -58,6 +58,19 @@ void PencilTool::loadSettings()
     mQuickSizingProperties.insert(Qt::ShiftModifier, WIDTH);
 }
 
+void PencilTool::saveSettings()
+{
+    QSettings settings(PENCIL2D, PENCIL2D);
+
+    settings.setValue("pencilWidth", properties.width);
+    settings.setValue("pencilPressure", properties.pressure);
+    settings.setValue("brushUseFeather", properties.useFeather);
+    settings.setValue("pencilLineStabilization", properties.stabilizerLevel);
+    settings.setValue("FillContour", properties.useFillContour);
+
+    settings.sync();
+}
+
 void PencilTool::resetToDefault()
 {
     setWidth(4.0);
@@ -70,11 +83,6 @@ void PencilTool::setWidth(const qreal width)
 {
     // Set current property
     properties.width = width;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("pencilWidth", width);
-    settings.sync();
 }
 
 void PencilTool::setFeather(const qreal feather)
@@ -87,10 +95,6 @@ void PencilTool::setUseFeather(const bool usingFeather)
     // Set current property
     properties.useFeather = usingFeather;
 
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("brushUseFeather", usingFeather);
-    settings.sync();
 }
 
 void PencilTool::setInvisibility(const bool)
@@ -103,11 +107,6 @@ void PencilTool::setPressure(const bool pressure)
 {
     // Set current property
     properties.pressure = pressure;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("pencilPressure", pressure);
-    settings.sync();
 }
 
 void PencilTool::setPreserveAlpha(const bool preserveAlpha)
@@ -120,19 +119,11 @@ void PencilTool::setPreserveAlpha(const bool preserveAlpha)
 void PencilTool::setStabilizerLevel(const int level)
 {
     properties.stabilizerLevel = level;
-
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("pencilLineStabilization", level);
-    settings.sync();
 }
 
 void PencilTool::setUseFillContour(const bool useFillContour)
 {
     properties.useFillContour = useFillContour;
-
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("FillContour", useFillContour);
-    settings.sync();
 }
 
 QCursor PencilTool::cursor()

--- a/core_lib/src/tool/penciltool.h
+++ b/core_lib/src/tool/penciltool.h
@@ -30,6 +30,7 @@ public:
     explicit PencilTool(QObject* parent);
     ToolType type() override { return PENCIL; }
     void loadSettings() override;
+    void saveSettings() override;
     QCursor cursor() override;
     void resetToDefault() override;
 

--- a/core_lib/src/tool/pentool.cpp
+++ b/core_lib/src/tool/pentool.cpp
@@ -58,6 +58,18 @@ void PenTool::loadSettings()
     mQuickSizingProperties.insert(Qt::ShiftModifier, WIDTH);
 }
 
+void PenTool::saveSettings()
+{
+    QSettings settings(PENCIL2D, PENCIL2D);
+
+    settings.setValue("penWidth", properties.width);
+    settings.setValue("penPressure", properties.pressure);
+    settings.setValue("penAA", properties.useAA);
+    settings.setValue("penLineStabilization", properties.stabilizerLevel);
+
+    settings.sync();
+}
+
 void PenTool::resetToDefault()
 {
     setWidth(12.0);
@@ -71,22 +83,12 @@ void PenTool::setWidth(const qreal width)
 {
     // Set current property
     properties.width = width;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("penWidth", width);
-    settings.sync();
 }
 
 void PenTool::setPressure(const bool pressure)
 {
     // Set current property
     properties.pressure = pressure;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("penPressure", pressure);
-    settings.sync();
 }
 
 void PenTool::setAA(const int AA)
@@ -94,19 +96,11 @@ void PenTool::setAA(const int AA)
     // Set current property
     properties.useAA = AA;
 
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("penAA", AA);
-    settings.sync();
 }
 
 void PenTool::setStabilizerLevel(const int level)
 {
     properties.stabilizerLevel = level;
-
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("penLineStabilization", level);
-    settings.sync();
 }
 
 QCursor PenTool::cursor()

--- a/core_lib/src/tool/pentool.h
+++ b/core_lib/src/tool/pentool.h
@@ -29,6 +29,7 @@ public:
     PenTool(QObject* parent = 0);
     ToolType type() override { return PEN; }
     void loadSettings() override;
+    void saveSettings() override;
     QCursor cursor() override;
     void resetToDefault() override;
 

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -63,6 +63,17 @@ void PolylineTool::loadSettings()
     mQuickSizingProperties.insert(Qt::ShiftModifier, WIDTH);
 }
 
+void PolylineTool::saveSettings()
+{
+    QSettings settings(PENCIL2D, PENCIL2D);
+
+    settings.setValue("polyLineWidth", properties.width);
+    settings.setValue("brushAA", properties.useAA);
+    settings.setValue("closedPolylinePath", properties.closedPolylinePath);
+
+    settings.sync();
+}
+
 void PolylineTool::resetToDefault()
 {
     setWidth(8.0);
@@ -74,11 +85,6 @@ void PolylineTool::setWidth(const qreal width)
 {
     // Set current property
     properties.width = width;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("polyLineWidth", width);
-    settings.sync();
 }
 
 void PolylineTool::setFeather(const qreal feather)
@@ -91,21 +97,11 @@ void PolylineTool::setAA(const int AA)
 {
     // Set current property
     properties.useAA = AA;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("brushAA", AA);
-    settings.sync();
 }
 
 void PolylineTool::setClosedPath(const bool closed)
 {
     BaseTool::setClosedPath(closed);
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("closedPolylinePath", closed);
-    settings.sync();
 }
 
 bool PolylineTool::leavingThisTool()

--- a/core_lib/src/tool/polylinetool.h
+++ b/core_lib/src/tool/polylinetool.h
@@ -29,6 +29,7 @@ public:
     explicit PolylineTool(QObject* parent = 0);
     ToolType type() override;
     void loadSettings() override;
+    void saveSettings() override;
     QCursor cursor() override;
     void resetToDefault() override;
 

--- a/core_lib/src/tool/selecttool.cpp
+++ b/core_lib/src/tool/selecttool.cpp
@@ -41,6 +41,15 @@ void SelectTool::loadSettings()
     mPropertyEnabled[SHOWSELECTIONINFO] = true;
 }
 
+void SelectTool::saveSettings()
+{
+    QSettings settings(PENCIL2D, PENCIL2D);
+
+    settings.setValue("ShowSelectionInfo", properties.showSelectionInfo);
+
+    settings.sync();
+}
+
 QCursor SelectTool::cursor()
 {
     // Don't update cursor while we're moving the selection
@@ -89,9 +98,6 @@ void SelectTool::resetToDefault()
 void SelectTool::setShowSelectionInfo(const bool b)
 {
     properties.showSelectionInfo = b;
-
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("ShowSelectionInfo", b);
 }
 
 void SelectTool::beginSelection(Layer* currentLayer, const QPointF& pos)

--- a/core_lib/src/tool/selecttool.h
+++ b/core_lib/src/tool/selecttool.h
@@ -35,6 +35,7 @@ public:
     explicit SelectTool(QObject* parent = nullptr);
     ToolType type() override { return SELECT; }
     void loadSettings() override;
+    void saveSettings() override;
     QCursor cursor() override;
 
     void resetToDefault() override;

--- a/core_lib/src/tool/smudgetool.cpp
+++ b/core_lib/src/tool/smudgetool.cpp
@@ -59,6 +59,17 @@ void SmudgeTool::loadSettings()
     mQuickSizingProperties.insert(Qt::ControlModifier, FEATHER);
 }
 
+void SmudgeTool::saveSettings()
+{
+    QSettings settings(PENCIL2D, PENCIL2D);
+
+    settings.setValue("smudgeWidth", properties.width);
+    settings.setValue("smudgeFeather", properties.feather);
+    settings.setValue("smudgePressure", properties.pressure);
+
+    settings.sync();
+}
+
 void SmudgeTool::resetToDefault()
 {
     setWidth(24.0);
@@ -69,33 +80,18 @@ void SmudgeTool::setWidth(const qreal width)
 {
     // Set current property
     properties.width = width;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("smudgeWidth", width);
-    settings.sync();
 }
 
 void SmudgeTool::setFeather(const qreal feather)
 {
     // Set current property
     properties.feather = feather;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("smudgeFeather", feather);
-    settings.sync();
 }
 
 void SmudgeTool::setPressure(const bool pressure)
 {
     // Set current property
     properties.pressure = pressure;
-
-    // Update settings
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("smudgePressure", pressure);
-    settings.sync();
 }
 
 bool SmudgeTool::emptyFrameActionEnabled()

--- a/core_lib/src/tool/smudgetool.h
+++ b/core_lib/src/tool/smudgetool.h
@@ -28,6 +28,7 @@ public:
     ToolType type() override;
     uint toolMode;  // 0=normal/smooth 1=smudge - todo: move to basetool? could be useful
     void loadSettings() override;
+    void saveSettings() override;
     void resetToDefault() override;
     QCursor cursor() override;
 

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -335,9 +335,6 @@ void StrokeTool::stopAdjusting()
     msIsAdjusting = false;
     mAdjustPosition = QPointF();
 
-    mEditor->tools()->setWidth(properties.width);
-    mEditor->tools()->setFeather(properties.feather);
-
     updateCanvasCursor();
 }
 
@@ -350,7 +347,7 @@ void StrokeTool::adjustCursor(Qt::KeyboardModifiers modifiers)
         // map it back to its original value, we can multiply by the factor we divided with
         const qreal newValue = QLineF(mAdjustPosition, getCurrentPoint()).length() * 2.0;
 
-        setTemporaryWidth(qBound(WIDTH_MIN, newValue, WIDTH_MAX));
+        mEditor->tools()->setWidth(qBound(WIDTH_MIN, newValue, WIDTH_MAX));
         break;
     }
     case FEATHER: {
@@ -364,7 +361,7 @@ void StrokeTool::adjustCursor(Qt::KeyboardModifiers modifiers)
         // We flip min and max here in order to get the inverted value for the UI
         const qreal mappedValue = MathUtils::map(distance, inputMin, inputMax, outputMax, outputMin);
 
-        setTemporaryFeather(qBound(FEATHER_MIN, mappedValue, FEATHER_MAX));
+        mEditor->tools()->setFeather(qBound(FEATHER_MIN, mappedValue, FEATHER_MAX));
         break;
     }
     default:
@@ -377,26 +374,4 @@ void StrokeTool::adjustCursor(Qt::KeyboardModifiers modifiers)
 void StrokeTool::paint(QPainter& painter, const QRect& blitRect)
 {
     mCanvasCursorPainter.paint(painter, blitRect);
-}
-
-void StrokeTool::setTemporaryWidth(qreal width)
-{
-    if (std::isnan(width) || width < 0)
-    {
-        width = 1.f;
-    }
-
-    properties.width = width;
-    emit mEditor->tools()->toolPropertyChanged(this->type(), WIDTH);
-}
-
-void StrokeTool::setTemporaryFeather(qreal feather)
-{
-    if (std::isnan(feather) || feather < 0)
-    {
-        feather = 0.f;
-    }
-
-    properties.feather = feather;
-    emit mEditor->tools()->toolPropertyChanged(this->type(), FEATHER);
 }

--- a/core_lib/src/tool/stroketool.h
+++ b/core_lib/src/tool/stroketool.h
@@ -113,12 +113,6 @@ protected:
     StrokeInterpolator mInterpolator;
 
     const UndoSaveState* mUndoSaveState = nullptr;
-
-private:
-    /// Sets the width value without calling settings to store the state
-    void setTemporaryWidth(qreal width);
-    /// Sets the feather value, without calling settings to store the state
-    void setTemporaryFeather(qreal feather);
 };
 
 #endif // STROKETOOL_H


### PR DESCRIPTION
Tool properties are written to disk immediately when changed. If you try to slide a scalar value with a high temporal resolution device like a tablet or a high end mouse, the flooding events will cause the program to freeze/lag as it struggles to write every value to the QSettings object.

Previously #1853 was merged to mitigate this problem with quick sizing, but if you change the properties on the tool options panel, the lag is still there.

This PR makes the change so that the program will wait until you switch to another tool, or close the program, to write everything onto the disk.