### PR TITLE
Enable antialiasing option for move tool

### DIFF
--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1346,6 +1346,9 @@ void ScribbleArea::applyTransformedSelection()
     mCanvasPainter.ignoreTransformedSelection();
 
     Layer* layer = mEditor->layers()->currentLayer();
+
+    bool useAA = mEditor->tools()->currentTool()->properties.useAA;
+
     if (layer == nullptr) { return; }
 
     auto selectMan = mEditor->select();
@@ -1358,7 +1361,7 @@ void ScribbleArea::applyTransformedSelection()
             handleDrawingOnEmptyFrame();
             BitmapImage* bitmapImage = currentBitmapImage(layer);
             if (bitmapImage == nullptr) { return; }
-            BitmapImage transformedImage = bitmapImage->transformed(selectMan->mySelectionRect().toRect(), selectMan->selectionTransform(), true);
+            BitmapImage transformedImage = bitmapImage->transformed(selectMan->mySelectionRect().toRect(), selectMan->selectionTransform(), useAA);
 
 
             bitmapImage->clear(selectMan->mySelectionRect());

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -46,15 +46,17 @@ ToolType MoveTool::type()
 
 void MoveTool::loadSettings()
 {
+    QSettings settings(PENCIL2D, PENCIL2D);
+
     properties.width = -1;
     properties.feather = -1;
     properties.useFeather = false;
     properties.stabilizerLevel = -1;
-    properties.useAA = -1;
+    properties.useAA = settings.value("moveAA").toBool();
     mRotationIncrement = mEditor->preference()->getInt(SETTING::ROTATION_INCREMENT);
-    QSettings settings(PENCIL2D, PENCIL2D);
     properties.showSelectionInfo = settings.value("ShowSelectionInfo").toBool();
     mPropertyEnabled[SHOWSELECTIONINFO] = true;
+    mPropertyEnabled[ANTI_ALIASING] = true;
 
     connect(mEditor->preference(), &PreferenceManager::optionChanged, this, &MoveTool::updateSettings);
 }
@@ -64,6 +66,7 @@ void MoveTool::saveSettings()
     QSettings settings(PENCIL2D, PENCIL2D);
 
     settings.setValue("ShowSelectionInfo", properties.showSelectionInfo);
+    settings.setValue("moveAA", properties.useAA);
 
     settings.sync();
 }
@@ -338,6 +341,9 @@ bool MoveTool::leavingThisTool()
     {
         applyTransformation();
     }
+
+    saveSettings();
+
     return true;
 }
 
@@ -349,6 +355,7 @@ bool MoveTool::isActive() const {
 void MoveTool::resetToDefault()
 {
     setShowSelectionInfo(false);
+    setAA(true);
 }
 
 void MoveTool::setShowSelectionInfo(const bool b)


### PR DESCRIPTION
Gives an option for the artist to transform without smoothing. Useful for pixel art.