### PR TITLE
Rework Tool properties architecture

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -89,6 +89,7 @@ HEADERS += \
     src/filespage.h \
     src/generalpage.h \
     src/shortcutspage.h \
+    src/strokeoptionswidget.h \
     src/timelinepage.h \
     src/toolspage.h \
     src/basedockwidget.h \
@@ -141,6 +142,7 @@ SOURCES += \
     src/filespage.cpp \
     src/generalpage.cpp \
     src/shortcutspage.cpp \
+    src/strokeoptionswidget.cpp \
     src/timelinepage.cpp \
     src/toolspage.cpp \
     src/basedockwidget.cpp \
@@ -178,6 +180,7 @@ SOURCES += \
     src/cameraoptionswidget.cpp
 
 FORMS += \
+    ui/strokeoptionswidget.ui \
     ui/addtransparencytopaperdialog.ui \
     ui/cameraoptionswidget.ui \
     ui/camerapropertiesdialog.ui \

--- a/app/src/bucketoptionswidget.cpp
+++ b/app/src/bucketoptionswidget.cpp
@@ -105,7 +105,7 @@ BucketOptionsWidget::BucketOptionsWidget(Editor* editor, QWidget* parent) :
     connect(mEditor->tools(), &ToolManager::toolPropertyChanged, this, &BucketOptionsWidget::onPropertyChanged);
     connect(mEditor->layers(), &LayerManager::currentLayerChanged, this, &BucketOptionsWidget::onLayerChanged);
 
-    const BucketSettings* properties = static_cast<const BucketSettings*>(mEditor->tools()->getTool(BUCKET)->getProperties());
+    const BucketSettings* properties = static_cast<const BucketSettings*>(mEditor->tools()->getTool(BUCKET)->getSettings());
 
     ui->expandSlider->setValue(properties->fillExpandAmount());
     ui->expandSpinBox->setValue(properties->fillExpandAmount());
@@ -151,7 +151,7 @@ void BucketOptionsWidget::updatePropertyVisibility()
 
 void BucketOptionsWidget::onPropertyChanged(ToolType, ToolPropertyType propertyType)
 {
-    const BucketSettings* p = static_cast<const BucketSettings*>(mEditor->tools()->getTool(BUCKET)->getProperties());
+    const BucketSettings* p = static_cast<const BucketSettings*>(mEditor->tools()->getTool(BUCKET)->getSettings());
     switch (propertyType)
     {
     case ToolPropertyType::TOLERANCE:

--- a/app/src/bucketoptionswidget.cpp
+++ b/app/src/bucketoptionswidget.cpp
@@ -95,11 +95,11 @@ BucketOptionsWidget::BucketOptionsWidget(Editor* editor, QWidget* parent) :
     });
 
     connect(ui->strokeThicknessSlider, &SpinSlider::valueChanged, mEditor->tools(), [=](qreal value) {
-        mBucketTool->setWidth(value);
+        mBucketTool->setStrokeThickness(value);
     });
 
     connect(ui->strokeThicknessSpinBox, static_cast<void (QDoubleSpinBox::*)(qreal)>(&QDoubleSpinBox::valueChanged), mEditor->tools(), [=](qreal value) {
-        mBucketTool->setWidth(value);
+        mBucketTool->setStrokeThickness(value);
     });
 
     connect(mEditor->tools(), &ToolManager::toolPropertyChanged, this, &BucketOptionsWidget::onPropertyChanged);

--- a/app/src/bucketoptionswidget.cpp
+++ b/app/src/bucketoptionswidget.cpp
@@ -189,7 +189,7 @@ void BucketOptionsWidget::onPropertyChanged(ToolType, ToolPropertyType propertyT
     case ToolPropertyType::USETOLERANCE:
          setColorToleranceEnabled(p->useTolerance()); break;
     case ToolPropertyType::WIDTH:
-         setStrokeWidth(p->thickness()); break;
+         setStrokeWidth(p->fillThickness()); break;
     case ToolPropertyType::BUCKETFILLEXPAND:
          setFillExpand(p->fillExpandAmount()); break;
     case ToolPropertyType::USEBUCKETFILLEXPAND:

--- a/app/src/bucketoptionswidget.cpp
+++ b/app/src/bucketoptionswidget.cpp
@@ -120,6 +120,14 @@ BucketOptionsWidget::BucketOptionsWidget(Editor* editor, QWidget* parent) :
     updatePropertyVisibility();
 }
 
+void BucketOptionsWidget::updateUI()
+{
+    if (isVisible()) {
+        qDebug() << "update property visibilities";
+        updatePropertyVisibility();
+    }
+}
+
 BucketOptionsWidget::~BucketOptionsWidget()
 {
     delete ui;
@@ -127,56 +135,18 @@ BucketOptionsWidget::~BucketOptionsWidget()
 
 void BucketOptionsWidget::updatePropertyVisibility()
 {
-    Layer* layer = mEditor->layers()->currentLayer();
-
-    Q_ASSERT(layer != nullptr);
-
-    switch (layer->type()) {
-    case Layer::VECTOR:
-        ui->strokeThicknessSlider->show();
-        ui->strokeThicknessSpinBox->show();
-
-        ui->colorToleranceCheckbox->hide();
-        ui->colorToleranceSlider->hide();
-        ui->colorToleranceSpinbox->hide();
-        ui->expandCheckbox->hide();
-        ui->expandSlider->hide();
-        ui->expandSpinBox->hide();
-        ui->referenceLayerComboBox->hide();
-        ui->referenceLayerDescLabel->hide();
-        ui->blendModeComboBox->hide();
-        ui->blendModeLabel->hide();
-        break;
-    case Layer::BITMAP: {
-        ui->strokeThicknessSlider->hide();
-        ui->strokeThicknessSpinBox->hide();
-
-        ui->referenceLayerComboBox->show();
-        ui->referenceLayerDescLabel->show();
-        ui->colorToleranceCheckbox->show();
-        ui->colorToleranceSlider->show();
-        ui->colorToleranceSpinbox->show();
-        ui->expandCheckbox->show();
-        ui->expandSlider->show();
-        ui->expandSpinBox->show();
-        ui->blendModeComboBox->show();
-        ui->blendModeLabel->show();
-        break;
-    }
-    default:
-        ui->strokeThicknessSlider->hide();
-        ui->strokeThicknessSpinBox->hide();
-        ui->colorToleranceCheckbox->hide();
-        ui->colorToleranceSlider->hide();
-        ui->colorToleranceSpinbox->hide();
-        ui->expandCheckbox->hide();
-        ui->expandSlider->hide();
-        ui->expandSpinBox->hide();
-        ui->referenceLayerComboBox->hide();
-        ui->referenceLayerDescLabel->hide();
-        ui->blendModeComboBox->hide();
-        ui->blendModeLabel->hide();
-    }
+    ui->strokeThicknessSlider->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLTHICKNESS_VALUE));
+    ui->strokeThicknessSpinBox->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLTHICKNESS_VALUE));
+    ui->colorToleranceCheckbox->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::TOLERANCE_ON));
+    ui->colorToleranceSlider->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::TOLERANCE_VALUE));
+    ui->colorToleranceSpinbox->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::TOLERANCE_VALUE));
+    ui->expandCheckbox->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLEXPAND_ON));
+    ui->expandSlider->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLEXPAND_VALUE));
+    ui->expandSpinBox->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLEXPAND_VALUE));
+    ui->referenceLayerComboBox->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLLAYERREFERENCEMODE_VALUE));
+    ui->referenceLayerDescLabel->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLLAYERREFERENCEMODE_VALUE));
+    ui->blendModeComboBox->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLMODE_VALUE));
+    ui->blendModeLabel->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLMODE_VALUE));
 }
 
 void BucketOptionsWidget::onPropertyChanged(ToolType, ToolPropertyType propertyType)

--- a/app/src/bucketoptionswidget.cpp
+++ b/app/src/bucketoptionswidget.cpp
@@ -66,9 +66,6 @@ BucketOptionsWidget::BucketOptionsWidget(Editor* editor, QWidget* parent) :
     makeConnectionsFromUIToModel();
     makeConnectionsFromModelToUI();
 
-    // connect(mEditor->tools(), &ToolManager::toolPropertyChanged, this, &BucketOptionsWidget::onPropertyChanged);
-    // connect(mEditor->layers(), &LayerManager::currentLayerChanged, this, &BucketOptionsWidget::onLayerChanged);
-
     clearFocusOnFinished(ui->colorToleranceSpinbox);
     clearFocusOnFinished(ui->expandSpinBox);
 

--- a/app/src/bucketoptionswidget.cpp
+++ b/app/src/bucketoptionswidget.cpp
@@ -44,9 +44,6 @@ BucketOptionsWidget::BucketOptionsWidget(Editor* editor, QWidget* parent) :
 
     QSettings settings(PENCIL2D, PENCIL2D);
 
-    ui->colorToleranceCheckbox->setChecked(settings.value(SETTING_BUCKET_TOLERANCE_ON, true).toBool());
-    ui->expandCheckbox->setChecked(settings.value(SETTING_BUCKET_FILL_EXPAND_ON, true).toBool());
-
     ui->expandSpinBox->setMaximum(MAX_EXPAND);
     ui->strokeThicknessSpinBox->setMaximum(MAX_STROKE_THICKNESS);
     ui->colorToleranceSpinbox->setMaximum(MAX_COLOR_TOLERANCE);
@@ -63,56 +60,12 @@ BucketOptionsWidget::BucketOptionsWidget(Editor* editor, QWidget* parent) :
 
     mBucketTool = static_cast<BucketTool*>(mEditor->tools()->getTool(BUCKET));
 
-    connect(ui->colorToleranceSlider, &SpinSlider::valueChanged, mEditor->tools(), [=](int value) {
-        mBucketTool->setTolerance(value);
-    });
-    connect(ui->colorToleranceSpinbox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), mEditor->tools(), [=](int value) {
-        mBucketTool->setTolerance(value);
-    });
+    makeConnectionsFromUIToModel();
+    makeConnectionsFromModelToUI();
 
-    connect(ui->colorToleranceCheckbox, &QCheckBox::toggled, mEditor->tools(), [=](bool enabled) {
-        mBucketTool->setToleranceON(enabled);
-    });
 
-    connect(ui->expandSlider, &SpinSlider::valueChanged, mEditor->tools(), [=](int value) {
-        mBucketTool->setFillExpand(value);
-    });
-
-    connect(ui->expandSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), mEditor->tools(), [=](int value) {
-        mBucketTool->setFillExpand(value);
-    });
-
-    connect(ui->expandCheckbox, &QCheckBox::toggled, mEditor->tools(), [=](bool enabled) {
-        mBucketTool->setFillExpandON(enabled);
-    });
-
-    connect(ui->referenceLayerComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), mEditor->tools(), [=](int value) {
-        mBucketTool->setFillReferenceMode(value);
-    });
-
-    connect(ui->blendModeComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), mEditor->tools(), [=](int value) {
-        mBucketTool->setFillMode(value);
-    });
-
-    connect(ui->strokeThicknessSlider, &SpinSlider::valueChanged, mEditor->tools(), [=](qreal value) {
-        mBucketTool->setStrokeThickness(value);
-    });
-
-    connect(ui->strokeThicknessSpinBox, static_cast<void (QDoubleSpinBox::*)(qreal)>(&QDoubleSpinBox::valueChanged), mEditor->tools(), [=](qreal value) {
-        mBucketTool->setStrokeThickness(value);
-    });
-
-    connect(mEditor->tools(), &ToolManager::toolPropertyChanged, this, &BucketOptionsWidget::onPropertyChanged);
-    connect(mEditor->layers(), &LayerManager::currentLayerChanged, this, &BucketOptionsWidget::onLayerChanged);
-
-    const BucketSettings* properties = static_cast<const BucketSettings*>(mEditor->tools()->getTool(BUCKET)->settings());
-
-    ui->expandSlider->setValue(properties->fillExpandAmount());
-    ui->expandSpinBox->setValue(properties->fillExpandAmount());
-    ui->colorToleranceSlider->setValue(properties->tolerance());
-    ui->colorToleranceSpinbox->setValue(properties->tolerance());
-    ui->referenceLayerComboBox->setCurrentIndex(properties->fillReferenceMode());
-    ui->blendModeComboBox->setCurrentIndex(properties->fillMode());
+    // connect(mEditor->tools(), &ToolManager::toolPropertyChanged, this, &BucketOptionsWidget::onPropertyChanged);
+    // connect(mEditor->layers(), &LayerManager::currentLayerChanged, this, &BucketOptionsWidget::onLayerChanged);
 
     clearFocusOnFinished(ui->colorToleranceSpinbox);
     clearFocusOnFinished(ui->expandSpinBox);
@@ -120,11 +73,115 @@ BucketOptionsWidget::BucketOptionsWidget(Editor* editor, QWidget* parent) :
     updatePropertyVisibility();
 }
 
+void BucketOptionsWidget::makeConnectionsFromModelToUI()
+{
+    connect(mBucketTool, &BucketTool::toleranceChanged, this, [=](int value) {
+       setColorTolerance(value);
+    });
+
+    connect(mBucketTool, &BucketTool::toleranceONChanged, this, [=](bool enabled) {
+       setColorToleranceEnabled(enabled);
+    });
+
+    connect(mBucketTool, &BucketTool::fillExpandChanged, this, [=](int value) {
+       setFillExpand(value);
+    });
+
+    connect(mBucketTool, &BucketTool::fillExpandONChanged, this, [=](bool enabled) {
+       setFillExpandEnabled(enabled);
+    });
+
+    connect(mBucketTool, &BucketTool::fillReferenceModeChanged, this, [=](int value) {
+       setFillReferenceMode(value);
+    });
+
+    connect(mBucketTool, &BucketTool::fillModeChanged, this, [=](int value) {
+       setFillMode(value);
+    });
+
+    connect(mBucketTool, &BucketTool::strokeThicknessChanged, this, [=](qreal value) {
+       setStrokeWidth(value);
+    });
+}
+
+void BucketOptionsWidget::makeConnectionsFromUIToModel()
+{
+    connect(ui->colorToleranceSlider, &SpinSlider::valueChanged, [=](int value) {
+        mBucketTool->setTolerance(value);
+    });
+    connect(ui->colorToleranceSpinbox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), [=](int value) {
+        mBucketTool->setTolerance(value);
+    });
+
+    connect(ui->colorToleranceCheckbox, &QCheckBox::toggled, [=](bool enabled) {
+        mBucketTool->setToleranceON(enabled);
+    });
+
+    connect(ui->expandSlider, &SpinSlider::valueChanged, [=](int value) {
+        mBucketTool->setFillExpand(value);
+    });
+
+    connect(ui->expandSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), [=](int value) {
+        mBucketTool->setFillExpand(value);
+    });
+
+    connect(ui->expandCheckbox, &QCheckBox::toggled, [=](bool enabled) {
+        mBucketTool->setFillExpandON(enabled);
+    });
+
+    connect(ui->referenceLayerComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), [=](int value) {
+        mBucketTool->setFillReferenceMode(value);
+    });
+
+    connect(ui->blendModeComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), [=](int value) {
+        mBucketTool->setFillMode(value);
+    });
+
+    connect(ui->strokeThicknessSlider, &SpinSlider::valueChanged, [=](qreal value) {
+        mBucketTool->setStrokeThickness(value);
+    });
+
+    connect(ui->strokeThicknessSpinBox, static_cast<void (QDoubleSpinBox::*)(qreal)>(&QDoubleSpinBox::valueChanged), [=](qreal value) {
+        mBucketTool->setStrokeThickness(value);
+    });
+}
+
 void BucketOptionsWidget::updateUI()
 {
-    if (isVisible()) {
-        qDebug() << "update property visibilities";
-        updatePropertyVisibility();
+    if (!isVisible()) {
+        return;
+    }
+
+    updatePropertyVisibility();
+
+    const BucketSettings* p = static_cast<const BucketSettings*>(mBucketTool->settings());
+
+    if (mBucketTool->isPropertyEnabled(BucketSettings::FILLTHICKNESS_VALUE)) {
+        mBucketTool->setStrokeThickness(p->fillThickness());
+    }
+
+    if (mBucketTool->isPropertyEnabled(BucketSettings::FILLEXPAND_ON)) {
+        mBucketTool->setFillExpandON(p->useFillExpand());
+    }
+
+    if (mBucketTool->isPropertyEnabled(BucketSettings::FILLEXPAND_VALUE)) {
+        mBucketTool->setFillExpand(p->fillExpandAmount());
+    }
+
+    if (mBucketTool->isPropertyEnabled(BucketSettings::FILLLAYERREFERENCEMODE_VALUE)) {
+        mBucketTool->setFillReferenceMode(p->fillReferenceMode());
+    }
+
+    if (mBucketTool->isPropertyEnabled(BucketSettings::FILLMODE_VALUE)) {
+        mBucketTool->setFillMode(p->fillMode());
+    }
+
+    if (mBucketTool->isPropertyEnabled(BucketSettings::TOLERANCE_VALUE)) {
+        mBucketTool->setTolerance(p->tolerance());
+    }
+
+    if (mBucketTool->isPropertyEnabled(BucketSettings::TOLERANCE_ON)) {
+        mBucketTool->setToleranceON(p->useTolerance());
     }
 }
 
@@ -147,30 +204,6 @@ void BucketOptionsWidget::updatePropertyVisibility()
     ui->referenceLayerDescLabel->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLLAYERREFERENCEMODE_VALUE));
     ui->blendModeComboBox->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLMODE_VALUE));
     ui->blendModeLabel->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLMODE_VALUE));
-}
-
-void BucketOptionsWidget::onPropertyChanged(ToolType, ToolPropertyType propertyType)
-{
-    // const BucketSettings* p = static_cast<const BucketSettings*>(mEditor->tools()->getTool(BUCKET)->getSettings());
-    // switch (propertyType)
-    // {
-    // case ToolPropertyType::TOLERANCE:
-    //      setColorTolerance(p->tolerance()); break;
-    // case ToolPropertyType::USETOLERANCE:
-    //      setColorToleranceEnabled(p->useTolerance()); break;
-    // case ToolPropertyType::WIDTH:
-    //      setStrokeWidth(p->fillThickness()); break;
-    // case ToolPropertyType::BUCKETFILLEXPAND:
-    //      setFillExpand(p->fillExpandAmount()); break;
-    // case ToolPropertyType::USEBUCKETFILLEXPAND:
-    //     setFillExpandEnabled(p->useFillExpand()); break;
-    // case ToolPropertyType::BUCKETFILLLAYERREFERENCEMODE:
-    //     setFillReferenceMode(p->fillReferenceMode()); break;
-    // case ToolPropertyType::FILL_MODE:
-    //     setFillMode(p->fillMode()); break;
-    // default:
-    //     break;
-    // }
 }
 
 void BucketOptionsWidget::onLayerChanged(int)

--- a/app/src/bucketoptionswidget.cpp
+++ b/app/src/bucketoptionswidget.cpp
@@ -105,7 +105,7 @@ BucketOptionsWidget::BucketOptionsWidget(Editor* editor, QWidget* parent) :
     connect(mEditor->tools(), &ToolManager::toolPropertyChanged, this, &BucketOptionsWidget::onPropertyChanged);
     connect(mEditor->layers(), &LayerManager::currentLayerChanged, this, &BucketOptionsWidget::onLayerChanged);
 
-    const BucketSettings* properties = static_cast<const BucketSettings*>(mEditor->tools()->getTool(BUCKET)->getSettings());
+    const BucketSettings* properties = static_cast<const BucketSettings*>(mEditor->tools()->getTool(BUCKET)->settings());
 
     ui->expandSlider->setValue(properties->fillExpandAmount());
     ui->expandSpinBox->setValue(properties->fillExpandAmount());
@@ -151,26 +151,26 @@ void BucketOptionsWidget::updatePropertyVisibility()
 
 void BucketOptionsWidget::onPropertyChanged(ToolType, ToolPropertyType propertyType)
 {
-    const BucketSettings* p = static_cast<const BucketSettings*>(mEditor->tools()->getTool(BUCKET)->getSettings());
-    switch (propertyType)
-    {
-    case ToolPropertyType::TOLERANCE:
-         setColorTolerance(p->tolerance()); break;
-    case ToolPropertyType::USETOLERANCE:
-         setColorToleranceEnabled(p->useTolerance()); break;
-    case ToolPropertyType::WIDTH:
-         setStrokeWidth(p->fillThickness()); break;
-    case ToolPropertyType::BUCKETFILLEXPAND:
-         setFillExpand(p->fillExpandAmount()); break;
-    case ToolPropertyType::USEBUCKETFILLEXPAND:
-        setFillExpandEnabled(p->useFillExpand()); break;
-    case ToolPropertyType::BUCKETFILLLAYERREFERENCEMODE:
-        setFillReferenceMode(p->fillReferenceMode()); break;
-    case ToolPropertyType::FILL_MODE:
-        setFillMode(p->fillMode()); break;
-    default:
-        break;
-    }
+    // const BucketSettings* p = static_cast<const BucketSettings*>(mEditor->tools()->getTool(BUCKET)->getSettings());
+    // switch (propertyType)
+    // {
+    // case ToolPropertyType::TOLERANCE:
+    //      setColorTolerance(p->tolerance()); break;
+    // case ToolPropertyType::USETOLERANCE:
+    //      setColorToleranceEnabled(p->useTolerance()); break;
+    // case ToolPropertyType::WIDTH:
+    //      setStrokeWidth(p->fillThickness()); break;
+    // case ToolPropertyType::BUCKETFILLEXPAND:
+    //      setFillExpand(p->fillExpandAmount()); break;
+    // case ToolPropertyType::USEBUCKETFILLEXPAND:
+    //     setFillExpandEnabled(p->useFillExpand()); break;
+    // case ToolPropertyType::BUCKETFILLLAYERREFERENCEMODE:
+    //     setFillReferenceMode(p->fillReferenceMode()); break;
+    // case ToolPropertyType::FILL_MODE:
+    //     setFillMode(p->fillMode()); break;
+    // default:
+    //     break;
+    // }
 }
 
 void BucketOptionsWidget::onLayerChanged(int)

--- a/app/src/bucketoptionswidget.h
+++ b/app/src/bucketoptionswidget.h
@@ -45,8 +45,6 @@ public:
     void setColorTolerance(int tolerance);
     void setFillReferenceMode(int referenceMode);
     void setFillMode(int mode);
-
-    void onPropertyChanged(ToolType, const ToolPropertyType propertyType);
     void onLayerChanged(int);
 
 private:

--- a/app/src/bucketoptionswidget.h
+++ b/app/src/bucketoptionswidget.h
@@ -36,6 +36,8 @@ public:
     explicit BucketOptionsWidget(Editor* editor, QWidget* parent);
     ~BucketOptionsWidget();
 
+    void updateUI();
+
     void setStrokeWidth(qreal value);
     void setColorToleranceEnabled(bool enabled);
     void setFillExpandEnabled(bool enabled);

--- a/app/src/bucketoptionswidget.h
+++ b/app/src/bucketoptionswidget.h
@@ -48,6 +48,8 @@ public:
     void onLayerChanged(int);
 
 private:
+    void makeConnectionsFromUIToModel();
+    void makeConnectionsFromModelToUI();
     void updatePropertyVisibility();
 
     BucketTool* mBucketTool;

--- a/app/src/bucketoptionswidget.h
+++ b/app/src/bucketoptionswidget.h
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 class Editor;
 class Layer;
 class BucketTool;
+struct BucketSettings;
 
 namespace Ui {
 class BucketOptionsWidget;
@@ -52,13 +53,10 @@ private:
     void makeConnectionsFromModelToUI();
     void updatePropertyVisibility();
 
-    BucketTool* mBucketTool;
+    BucketTool* mBucketTool = nullptr;
+    const BucketSettings* mSettings = nullptr;
     Ui::BucketOptionsWidget *ui;
     Editor* mEditor = nullptr;
-
-    const static int MAX_EXPAND = 25;
-    const static int MAX_COLOR_TOLERANCE = 100;
-    const static int MAX_STROKE_THICKNESS = 200;
 };
 
 #endif // BUCKETOPTIONSWIDGET_H

--- a/app/src/bucketoptionswidget.h
+++ b/app/src/bucketoptionswidget.h
@@ -22,6 +22,7 @@ GNU General Public License for more details.
 
 class Editor;
 class Layer;
+class BucketTool;
 
 namespace Ui {
 class BucketOptionsWidget;
@@ -49,6 +50,7 @@ public:
 private:
     void updatePropertyVisibility();
 
+    BucketTool* mBucketTool;
     Ui::BucketOptionsWidget *ui;
     Editor* mEditor = nullptr;
 

--- a/app/src/cameraoptionswidget.cpp
+++ b/app/src/cameraoptionswidget.cpp
@@ -74,7 +74,7 @@ void CameraOptionsWidget::updateUI()
 
     Q_ASSERT(mCameraTool->type() == CAMERA);
 
-    const CameraSettings* p = static_cast<const CameraSettings*>(mCameraTool->getProperties());
+    const CameraSettings* p = static_cast<const CameraSettings*>(mCameraTool->getSettings());
 
     setShowCameraPath(p->showPath());
     setPathDotColorType(p->dotColorType());
@@ -82,7 +82,7 @@ void CameraOptionsWidget::updateUI()
 
 void CameraOptionsWidget::onToolPropertyChanged(ToolType, ToolPropertyType ePropertyType)
 {
-    const CameraSettings* p = static_cast<const CameraSettings*>(mCameraTool->getProperties());
+    const CameraSettings* p = static_cast<const CameraSettings*>(mCameraTool->getSettings());
 
     switch (ePropertyType)
     {

--- a/app/src/cameraoptionswidget.cpp
+++ b/app/src/cameraoptionswidget.cpp
@@ -74,7 +74,7 @@ void CameraOptionsWidget::updateUI()
 
     Q_ASSERT(mCameraTool->type() == CAMERA);
 
-    const CameraSettings* p = static_cast<const CameraSettings*>(mCameraTool->getSettings());
+    const CameraSettings* p = static_cast<const CameraSettings*>(mCameraTool->settings());
 
     setShowCameraPath(p->showPath());
     setPathDotColorType(p->dotColorType());
@@ -82,7 +82,7 @@ void CameraOptionsWidget::updateUI()
 
 void CameraOptionsWidget::onToolPropertyChanged(ToolType, ToolPropertyType ePropertyType)
 {
-    const CameraSettings* p = static_cast<const CameraSettings*>(mCameraTool->getSettings());
+    const CameraSettings* p = static_cast<const CameraSettings*>(mCameraTool->settings());
 
     switch (ePropertyType)
     {

--- a/app/src/cameraoptionswidget.cpp
+++ b/app/src/cameraoptionswidget.cpp
@@ -32,36 +32,50 @@ CameraOptionsWidget::CameraOptionsWidget(Editor* editor, QWidget *parent) :
     auto toolMan = mEditor->tools();
     mCameraTool = static_cast<CameraTool*>(toolMan->getTool(CAMERA));
 
-    connect(ui->showCameraPathCheckBox, &QCheckBox::clicked, toolMan, [=](bool enabled) {
+    makeConnectionsFromUIToModel();
+    makeConnectionsFromModelToUI();
+
+    // connect(mEditor->layers(), &LayerManager::currentLayerChanged, this, &CameraOptionsWidget::updateUI);
+    // connect(mEditor->tools(), &ToolManager::toolChanged, this, &CameraOptionsWidget::updateUI);
+}
+
+void CameraOptionsWidget::makeConnectionsFromModelToUI()
+{
+    connect(mCameraTool, &CameraTool::cameraPathONChanged, this, [=](bool enabled) {
+       setShowCameraPath(enabled);
+    });
+
+    connect(mCameraTool, &CameraTool::pathColorChanged, this, [=](DotColorType type) {
+       setPathDotColorType(type);
+    });
+}
+
+void CameraOptionsWidget::makeConnectionsFromUIToModel()
+{
+    connect(ui->showCameraPathCheckBox, &QCheckBox::clicked, [=](bool enabled) {
         mCameraTool->setCameraPathON(enabled);
     });
 
-    // TODO: should this be a tool property or an action with data?
-    connect(ui->pathColorComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), toolMan, [=](int value) {
+    connect(ui->pathColorComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), [=](int value) {
         mCameraTool->setPathDotColorType(static_cast<DotColorType>(value));
     });
 
-    connect(ui->btnResetPath, &QPushButton::clicked, toolMan, [=]() {
-        mCameraTool->performAction(CAMERA_PATH_RESET);
+    connect(ui->btnResetPath, &QPushButton::clicked, [=]() {
+        mCameraTool->performAction(CameraTool::RESET_PATH);
     });
 
-    connect(ui->resetAllButton, &QPushButton::clicked, toolMan, [=] {
-        mCameraTool->performAction(CAMERA_RESET_FIELD);
+    connect(ui->resetAllButton, &QPushButton::clicked, [=] {
+        mCameraTool->performAction(CameraTool::RESET_FIELD);
     });
-    connect(ui->resetTranslationButton, &QPushButton::clicked, toolMan, [=] {
-        mCameraTool->performAction(CAMERA_RESET_TRANSLATION);
+    connect(ui->resetTranslationButton, &QPushButton::clicked, [=] {
+        mCameraTool->performAction(CameraTool::RESET_TRANSLATION);
     });
-    connect(ui->resetRotationButton, &QPushButton::clicked, toolMan, [=] {
-        mCameraTool->performAction(CAMERA_RESET_ROTATION);
+    connect(ui->resetRotationButton, &QPushButton::clicked, [=] {
+        mCameraTool->performAction(CameraTool::RESET_ROTATION);
     });
-    connect(ui->resetScaleButton, &QPushButton::clicked, toolMan, [=] {
-        mCameraTool->performAction(CAMERA_RESET_SCALING);
+    connect(ui->resetScaleButton, &QPushButton::clicked, [=] {
+        mCameraTool->performAction(CameraTool::RESET_SCALING);
     });
-
-    connect(toolMan, &ToolManager::toolPropertyChanged, this, &CameraOptionsWidget::onToolPropertyChanged);
-
-    connect(mEditor->layers(), &LayerManager::currentLayerChanged, this, &CameraOptionsWidget::updateUI);
-    connect(mEditor->tools(), &ToolManager::toolChanged, this, &CameraOptionsWidget::updateUI);
 }
 
 CameraOptionsWidget::~CameraOptionsWidget()
@@ -78,18 +92,6 @@ void CameraOptionsWidget::updateUI()
 
     setShowCameraPath(p->showPath());
     setPathDotColorType(p->dotColorType());
-}
-
-void CameraOptionsWidget::onToolPropertyChanged(ToolType, ToolPropertyType ePropertyType)
-{
-    const CameraSettings* p = static_cast<const CameraSettings*>(mCameraTool->settings());
-
-    switch (ePropertyType)
-    {
-    case CAMERA_SHOWPATH_CHECKED: { setShowCameraPath(p->showPath()); break; }
-    default:
-        break;
-    }
 }
 
 void CameraOptionsWidget::setShowCameraPath(bool showCameraPath)

--- a/app/src/cameraoptionswidget.h
+++ b/app/src/cameraoptionswidget.h
@@ -40,7 +40,9 @@ public:
 
     void setShowCameraPath(bool showCameraPath);
     void setPathDotColorType(DotColorType index);
-    void onToolPropertyChanged(ToolType, ToolPropertyType ePropertyType);
+
+    void makeConnectionsFromModelToUI();
+    void makeConnectionsFromUIToModel();
 
 private:
     Ui::CameraOptionsWidget *ui;

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1495,7 +1495,6 @@ void MainWindow2::makeConnections(Editor* pEditor, TimeLine* pTimeline)
     connect(pEditor, &Editor::updateTimeLineCached, pTimeline, &TimeLine::updateUICached);
 
     connect(pEditor->layers(), &LayerManager::currentLayerChanged, this, &MainWindow2::updateLayerMenu);
-    connect(pEditor->layers(), &LayerManager::currentLayerChanged, mToolOptions, &ToolOptionWidget::updateUI);
 }
 
 void MainWindow2::makeConnections(Editor*, OnionSkinWidget*)

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -1445,8 +1445,6 @@ void MainWindow2::makeConnections(Editor* editor, ScribbleArea* scribbleArea)
 {
     connect(editor->tools(), &ToolManager::toolChanged, scribbleArea, &ScribbleArea::updateToolCursor);
     connect(editor->tools(), &ToolManager::toolChanged, mToolBox, &ToolBoxWidget::onToolSetActive);
-    connect(editor->tools(), &ToolManager::toolPropertyChanged, scribbleArea, &ScribbleArea::updateToolCursor);
-
 
     connect(editor->layers(), &LayerManager::currentLayerChanged, scribbleArea, &ScribbleArea::onLayerChanged);
     connect(editor->layers(), &LayerManager::layerDeleted, scribbleArea, &ScribbleArea::onLayerChanged);

--- a/app/src/strokeoptionswidget.cpp
+++ b/app/src/strokeoptionswidget.cpp
@@ -1,0 +1,435 @@
+#include "strokeoptionswidget.h"
+#include "ui_strokeoptionswidget.h"
+
+#include "editor.h"
+#include "pencilsettings.h"
+#include "basetool.h"
+#include "stroketool.h"
+#include "util.h"
+
+#include "toolmanager.h"
+#include "layermanager.h"
+
+StrokeOptionsWidget::StrokeOptionsWidget(Editor* editor, QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::StrokeOptionsWidget)
+{
+    ui->setupUi(this);
+
+    mEditor = editor;
+
+    initUI();
+
+    setContentsMargins(0,0,0,0);
+}
+
+StrokeOptionsWidget::~StrokeOptionsWidget()
+{
+    delete ui;
+}
+
+void StrokeOptionsWidget::initUI()
+{
+    QSettings settings(PENCIL2D, PENCIL2D);
+
+    ui->sizeSlider->init(tr("Width"), SpinSlider::EXPONENT, SpinSlider::INTEGER, StrokeTool::WIDTH_MIN, StrokeTool::WIDTH_MAX);
+    // ui->sizeSlider->setValue(settings.value("brushWidth", "3").toDouble());
+    // ui->sizeSpinBox->setValue(settings.value("brushWidth", "3").toDouble());
+
+    ui->featherSlider->init(tr("Feather"), SpinSlider::LOG, SpinSlider::INTEGER, StrokeTool::FEATHER_MIN, StrokeTool::FEATHER_MAX);
+    // ui->featherSlider->setValue(settings.value("brushFeather", "5").toDouble());
+    // ui->featherSpinBox->setValue(settings.value("brushFeather", "5").toDouble());
+}
+
+void StrokeOptionsWidget::updateUI()
+{
+    BaseTool* currentTool = mEditor->tools()->currentTool();
+    Q_ASSERT(currentTool);
+
+    setVisibility(currentTool);
+
+    const StrokeSettings* p = static_cast<const StrokeSettings*>(currentTool->getProperties());
+
+    if (currentTool->isPropertyEnabled(WIDTH))
+    {
+        setPenWidth(p->width());
+    }
+    if (currentTool->isPropertyEnabled(FEATHER))
+    {
+        setPenFeather(p->feather());
+    }
+
+    if (currentTool->isPropertyEnabled(USEFEATHER)) {
+        setUseFeather(p->useFeather());
+    }
+
+    if (currentTool->isPropertyEnabled(PRESSURE)) {
+        setPressure(p->usePressure());
+    }
+
+    if (currentTool->isPropertyEnabled(INVISIBILITY)) {
+        setPenInvisibility(p->invisibility());
+    }
+
+    if (currentTool->isPropertyEnabled(ANTI_ALIASING)) {
+        setAA(p->useAntiAliasing());
+    }
+
+    if (currentTool->isPropertyEnabled(STABILIZATION)) {
+        setStabilizerLevel(p->stabilizerLevel());
+    }
+
+    if (currentTool->isPropertyEnabled(FILLCONTOUR)) {
+        setFillContour(p->useFillContour());
+    }
+
+    // if (currentTool->isPropertyEnabled(SHOWSELECTIONINFO) && currentTool->type() == SELECT) {
+    //     const SelectionProperties* selectP = static_cast<const SelectionProperties*>(currentTool->getProperties());
+    //     setShowSelectionInfo(selectP->showSelectionInfo());
+    // }
+
+    if (currentTool->isPropertyEnabled(CLOSEDPATH) && currentTool->type() == POLYLINE) {
+        const PolyLineSettings* polyP = static_cast<const PolyLineSettings*>(currentTool->getProperties());
+        setClosedPath(polyP->closedPath());
+    }
+}
+
+void StrokeOptionsWidget::makeConnectionToEditor(Editor* editor)
+{
+    auto toolManager = editor->tools();
+    // StrokeProperties* properties = static_cast<StrokeProperties*>(toolManager->getTool(STROKETOOL)->getProperties());
+
+    // connect(ui->useBezierBox, &QCheckBox::clicked, toolManager, [=](bool enabled) {
+
+    //     // if (properties) {
+    //     //     properties->
+    //     // }
+    // });
+
+    // connect(ui->useClosedPathBox, &QCheckBox::clicked, toolManager, &ToolManager::setClosedPath);
+    connect(ui->usePressureBox, &QCheckBox::clicked, toolManager, [=](bool enabled) {
+        auto tool = strokeTool();
+        if (tool) {
+            tool->setPressureON(enabled);
+        }
+    });
+
+    connect(ui->makeInvisibleBox, &QCheckBox::clicked, toolManager, [=](bool enabled) {
+        // toolManager->setToolProperty(toolManager->currentTool()->type(), ToolPropertyType::INVISIBILITY, enabled);
+        auto tool = strokeTool();
+        if (tool) {
+            tool->setInvisibilityON(enabled);
+        }
+    });
+
+    connect(ui->useFeatherBox, &QCheckBox::clicked, toolManager, [=](bool enabled) {
+        auto tool = strokeTool();
+        if (tool) {
+            tool->setFeatherON(enabled);
+        }
+    });
+
+    connect(ui->useAABox, &QCheckBox::clicked, toolManager, [=](bool enabled) {
+        auto tool = strokeTool();
+        if (tool) {
+            tool->setAntiAliasingON(enabled);
+        }
+    });
+
+    connect(ui->fillContourBox, &QCheckBox::clicked, toolManager, [=](bool enabled) {
+        auto tool = strokeTool();
+        if (tool) {
+            tool->setFillContourON(enabled);
+        }
+    });
+
+    connect(ui->sizeSlider, &SpinSlider::valueChanged, toolManager, [=](qreal value) {
+        // toolManager->setToolProperty(toolManager->currentTool()->type(), ToolPropertyType::WIDTH, value);
+        auto tool = strokeTool();
+        if (tool) {
+            tool->setWidth(value);
+        }
+    });
+
+    connect(ui->featherSlider, &SpinSlider::valueChanged, toolManager, [=](qreal value) {
+        auto tool = strokeTool();
+        if (tool) {
+            tool->setFeather(value);
+        }
+    });
+
+    auto spinboxValueChanged = static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged);
+    connect(ui->sizeSpinBox, spinboxValueChanged, toolManager, [=](qreal value) {
+        // toolManager->setToolProperty(toolManager->currentTool()->type(), ToolPropertyType::WIDTH, value);
+        auto tool = strokeTool();
+        if (tool) {
+            tool->setWidth(value);
+        }
+    });
+
+    connect(ui->featherSpinBox, spinboxValueChanged, toolManager, [=](qreal value) {
+        // toolManager->setToolProperty(toolManager->currentTool()->type(), ToolPropertyType::FEATHER, value);
+        auto tool = strokeTool();
+        if (tool) {
+            tool->setFeather(value);
+        }
+    });
+
+    clearFocusOnFinished(ui->sizeSpinBox);
+    clearFocusOnFinished(ui->featherSpinBox);
+
+    connect(ui->inpolLevelsCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), toolManager, [=](int value) {
+        // toolManager->setToolProperty(toolManager->currentTool()->type(), ToolPropertyType::STABILIZATION, value);
+        auto tool = strokeTool();
+        if (tool) {
+            tool->setStablizationLevel(value);
+        }
+    });
+
+    connect(toolManager, &ToolManager::toolChanged, this, &StrokeOptionsWidget::onToolChanged);
+    connect(toolManager, &ToolManager::toolPropertyChanged, this, &StrokeOptionsWidget::onToolPropertyChanged);
+}
+
+void StrokeOptionsWidget::onToolPropertyChanged(ToolType, ToolPropertyType ePropertyType)
+{
+    if (mEditor->tools()->currentTool()->category() != STROKETOOL) {
+        return;
+    }
+
+    // const Properties& p = editor()->tools()->currentTool()->properties;
+
+    // switch (ePropertyType)
+    // {
+    // case WIDTH: setPenWidth(p.width()); break;
+    // case FEATHER: setPenFeather(p.feather); break;
+    // case USEFEATHER: setUseFeather(p.useFeather); break;
+    // case PRESSURE: setPressure(p.pressure); break;
+    // case INVISIBILITY: setPenInvisibility(p.invisibility); break;
+    // case PRESERVEALPHA: setPreserveAlpha(p.preserveAlpha); break;
+    // case VECTORMERGE: setVectorMergeEnabled(p.vectorMergeEnabled); break;
+    // case ANTI_ALIASING: setAA(p.useAA); break;
+    // case STABILIZATION: setStabilizerLevel(p.stabilizerLevel); break;
+    // case FILLCONTOUR: setFillContour(p.useFillContour); break;
+    // case SHOWSELECTIONINFO: setShowSelectionInfo(p.showSelectionInfo); break;
+    // case BEZIER: setBezier(p.bezier_state); break;
+    // case CLOSEDPATH: setClosedPath(p.closedPolylinePath); break;
+    // case CAMERAPATH: { break; }
+    // case TOLERANCE: break;
+    // case USETOLERANCE: break;
+    // case BUCKETFILLEXPAND: break;
+    // case USEBUCKETFILLEXPAND: break;
+    // case BUCKETFILLLAYERREFERENCEMODE: break;
+    // case FILL_MODE: break;
+    // default:
+    //     Q_ASSERT(false);
+    //     break;
+    // }
+}
+
+void StrokeOptionsWidget::setVisibility(BaseTool* tool)
+{
+    ui->sizeSlider->setVisible(tool->isPropertyEnabled(WIDTH));
+    ui->sizeSpinBox->setVisible(tool->isPropertyEnabled(WIDTH));
+    ui->featherSlider->setVisible(tool->isPropertyEnabled(FEATHER));
+    ui->featherSpinBox->setVisible(tool->isPropertyEnabled(FEATHER));
+    ui->useFeatherBox->setVisible(tool->isPropertyEnabled(USEFEATHER));
+    ui->useBezierBox->setVisible(tool->isPropertyEnabled(BEZIER));
+    ui->useClosedPathBox->setVisible(tool->isPropertyEnabled(CLOSEDPATH));
+    ui->usePressureBox->setVisible(tool->isPropertyEnabled(PRESSURE));
+    ui->makeInvisibleBox->setVisible(tool->isPropertyEnabled(INVISIBILITY));
+    // ui->preserveAlphaBox->setVisible(tool->isPropertyEnabled(PRESERVEALPHA));
+    ui->useAABox->setVisible(tool->isPropertyEnabled(ANTI_ALIASING));
+    ui->stabilizerLabel->setVisible(tool->isPropertyEnabled(STABILIZATION));
+    ui->inpolLevelsCombo->setVisible(tool->isPropertyEnabled(STABILIZATION));
+    ui->fillContourBox->setVisible(tool->isPropertyEnabled(FILLCONTOUR));
+    // ui->showInfoBox->setVisible(tool->isPropertyEnabled(SHOWSELECTIONINFO));
+
+    auto currentLayerType = mEditor->layers()->currentLayer()->type();
+    auto propertyType = mEditor->tools()->currentTool()->type();
+
+    if (currentLayerType == Layer::VECTOR)
+    {
+        switch (propertyType)
+        {
+        case SMUDGE:
+            ui->sizeSlider->setVisible(false);
+            ui->sizeSpinBox->setVisible(false);
+            ui->usePressureBox->setVisible(false);
+            ui->featherSlider->setVisible(false);
+            ui->featherSpinBox->setVisible(false);
+            ui->useFeatherBox->setVisible(false);
+            break;
+        case PENCIL:
+            ui->sizeSlider->setVisible(false);
+            ui->sizeSpinBox->setVisible(false);
+            ui->usePressureBox->setVisible(false);
+            break;
+        default:
+            ui->sizeSlider->setLabel(tr("Width"));
+            ui->useAABox->setVisible(false);
+            break;
+        }
+    }
+    else
+    {
+        switch (propertyType)
+        {
+        case PENCIL:
+            ui->fillContourBox->setVisible(false);
+            break;
+        case BUCKET:
+            ui->sizeSpinBox->setVisible(false);
+            ui->sizeSlider->setVisible(false);
+            break;
+        case SELECT:
+        case MOVE:
+            ui->sizeSlider->setVisible(false);
+            ui->sizeSpinBox->setVisible(false);
+            ui->usePressureBox->setVisible(false);
+            ui->featherSlider->setVisible(false);
+            ui->featherSpinBox->setVisible(false);
+            ui->useFeatherBox->setVisible(false);
+            break;
+        default:
+            ui->makeInvisibleBox->setVisible(false);
+            break;
+        }
+    }
+}
+
+void StrokeOptionsWidget::onToolChanged(ToolType)
+{
+    updateUI();
+}
+
+void StrokeOptionsWidget::setPenWidth(qreal width)
+{
+    QSignalBlocker b(ui->sizeSlider);
+    ui->sizeSlider->setEnabled(true);
+    ui->sizeSlider->setValue(width);
+
+    QSignalBlocker b2(ui->sizeSpinBox);
+    ui->sizeSpinBox->setEnabled(true);
+    ui->sizeSpinBox->setValue(width);
+}
+
+void StrokeOptionsWidget::setPenFeather(qreal featherValue)
+{
+    QSignalBlocker b(ui->featherSlider);
+    ui->featherSlider->setEnabled(true);
+    ui->featherSlider->setValue(featherValue);
+
+    QSignalBlocker b2(ui->featherSpinBox);
+    ui->featherSpinBox->setEnabled(true);
+    ui->featherSpinBox->setValue(featherValue);
+}
+
+void StrokeOptionsWidget::setUseFeather(bool useFeather)
+{
+    QSignalBlocker b(ui->useFeatherBox);
+    ui->useFeatherBox->setEnabled(true);
+    ui->useFeatherBox->setChecked(useFeather);
+}
+
+void StrokeOptionsWidget::setPenInvisibility(int x)
+{
+    QSignalBlocker b(ui->makeInvisibleBox);
+    ui->makeInvisibleBox->setEnabled(true);
+    ui->makeInvisibleBox->setChecked(x > 0);
+}
+
+void StrokeOptionsWidget::setPressure(int x)
+{
+    QSignalBlocker b(ui->usePressureBox);
+    ui->usePressureBox->setEnabled(true);
+    ui->usePressureBox->setChecked(x > 0);
+}
+
+// void StrokeOptionsWidget::setPreserveAlpha(int x)
+// {
+//     QSignalBlocker b(ui->preserveAlphaBox);
+//     ui->preserveAlphaBox->setEnabled(true);
+//     ui->preserveAlphaBox->setChecked(x > 0);
+// }
+
+// void StrokeOptionsWidget::setVectorMergeEnabled(int x)
+// {
+//     QSignalBlocker b(ui->vectorMergeBox);
+//     ui->vectorMergeBox->setEnabled(true);
+//     ui->vectorMergeBox->setChecked(x > 0);
+// }
+
+void StrokeOptionsWidget::setAA(int x)
+{
+    QSignalBlocker b(ui->useAABox);
+    ui->useAABox->setEnabled(true);
+    ui->useAABox->setVisible(false);
+
+    auto layerType = mEditor->layers()->currentLayer()->type();
+
+    if (layerType == Layer::BITMAP)
+    {
+        if (x == -1)
+        {
+            ui->useAABox->setEnabled(false);
+            ui->useAABox->setVisible(false);
+        }
+        else
+        {
+            ui->useAABox->setVisible(true);
+        }
+        ui->useAABox->setChecked(x > 0);
+    }
+}
+
+void StrokeOptionsWidget::setStabilizerLevel(int x)
+{
+    ui->inpolLevelsCombo->setCurrentIndex(qBound(0, x, ui->inpolLevelsCombo->count() - 1));
+}
+
+void StrokeOptionsWidget::setFillContour(int useFill)
+{
+    QSignalBlocker b(ui->fillContourBox);
+    ui->fillContourBox->setEnabled(true);
+    ui->fillContourBox->setChecked(useFill > 0);
+}
+
+void StrokeOptionsWidget::setBezier(bool useBezier)
+{
+    QSignalBlocker b(ui->useBezierBox);
+    ui->useBezierBox->setChecked(useBezier);
+}
+
+void StrokeOptionsWidget::setClosedPath(bool useClosedPath)
+{
+    QSignalBlocker b(ui->useClosedPathBox);
+    ui->useClosedPathBox->setChecked(useClosedPath);
+}
+
+// void StrokeOptionsWidget::setShowSelectionInfo(bool showSelectionInfo)
+// {
+    // QSignalBlocker b(ui->showInfoBox);
+    // ui->showInfoBox->setChecked(showSelectionInfo);
+// }
+
+void StrokeOptionsWidget::disableAllOptions()
+{
+    ui->sizeSlider->hide();
+    ui->sizeSpinBox->hide();
+    ui->featherSlider->hide();
+    ui->featherSpinBox->hide();
+    ui->useFeatherBox->hide();
+    ui->useBezierBox->hide();
+    ui->useClosedPathBox->hide();
+    ui->usePressureBox->hide();
+    ui->makeInvisibleBox->hide();
+    ui->useAABox->hide();
+    ui->inpolLevelsCombo->hide();
+    ui->fillContourBox->hide();
+    ui->stabilizerLabel->hide();
+}
+
+StrokeTool* StrokeOptionsWidget::strokeTool()
+{
+    return static_cast<StrokeTool*>(mEditor->tools()->getTool(STROKETOOL));
+}

--- a/app/src/strokeoptionswidget.cpp
+++ b/app/src/strokeoptionswidget.cpp
@@ -34,14 +34,9 @@ void StrokeOptionsWidget::initUI()
     QSettings settings(PENCIL2D, PENCIL2D);
 
     ui->sizeSlider->init(tr("Width"), SpinSlider::EXPONENT, SpinSlider::INTEGER, StrokeTool::WIDTH_MIN, StrokeTool::WIDTH_MAX);
-    // ui->sizeSlider->setValue(settings.value("brushWidth", "3").toDouble());
-    // ui->sizeSpinBox->setValue(settings.value("brushWidth", "3").toDouble());
-
     ui->featherSlider->init(tr("Feather"), SpinSlider::LOG, SpinSlider::INTEGER, StrokeTool::FEATHER_MIN, StrokeTool::FEATHER_MAX);
-    // ui->featherSlider->setValue(settings.value("brushFeather", "5").toDouble());
-    // ui->featherSpinBox->setValue(settings.value("brushFeather", "5").toDouble());
 
-    makeConnectionToEditor(mEditor);
+    makeConnectionFromUIToModel();
 }
 
 void StrokeOptionsWidget::updateUI()
@@ -51,9 +46,9 @@ void StrokeOptionsWidget::updateUI()
 
     Q_ASSERT(currentTool);
 
-    if (isVisible()) {
-        setVisibility(currentTool);
-    }
+    updateToolConnections(currentTool);
+
+    setVisibility(currentTool);
 
     const StrokeSettings* p = static_cast<const StrokeSettings*>(currentTool->getSettings());
 
@@ -102,131 +97,91 @@ void StrokeOptionsWidget::updateUI()
     }
 }
 
-void StrokeOptionsWidget::makeConnectionToEditor(Editor* editor)
+void StrokeOptionsWidget::updateToolConnections(BaseTool* tool)
 {
-    auto toolManager = editor->tools();
-    // StrokeProperties* properties = static_cast<StrokeProperties*>(toolManager->getTool(STROKETOOL)->getProperties());
+    if (mCurrentTool) {
+        disconnect(mCurrentTool, nullptr, this, nullptr);
+    }
 
-    connect(ui->useBezierBox, &QCheckBox::clicked, toolManager, [=](bool enabled) {
-        auto tool = static_cast<PolylineTool*>(strokeTool());
-        if (tool) {
-            tool->setUseBezier(enabled);
-        }
-    });
+    StrokeTool* strokeTool = static_cast<StrokeTool*>(tool);
+    mCurrentTool = strokeTool;
 
-    // connect(ui->useClosedPathBox, &QCheckBox::clicked, toolManager, &ToolManager::setClosedPath);
-    connect(ui->usePressureBox, &QCheckBox::clicked, toolManager, [=](bool enabled) {
-        auto tool = strokeTool();
-        if (tool) {
-            tool->setPressureON(enabled);
-        }
-    });
+    makeConnectionFromModelToUI(strokeTool);
+}
 
-    connect(ui->makeInvisibleBox, &QCheckBox::clicked, toolManager, [=](bool enabled) {
-        auto tool = strokeTool();
-        if (tool) {
-            tool->setInvisibilityON(enabled);
-        }
-    });
+void StrokeOptionsWidget::makeConnectionFromModelToUI(StrokeTool* strokeTool)
+{
+    connect(strokeTool, &StrokeTool::widthChanged, this, &StrokeOptionsWidget::setPenWidth);
+    connect(strokeTool, &StrokeTool::featherChanged, this, &StrokeOptionsWidget::setPenFeather);
+    connect(strokeTool, &StrokeTool::featherONChanged, this, &StrokeOptionsWidget::setUseFeather);
+    connect(strokeTool, &StrokeTool::pressureONChanged, this, &StrokeOptionsWidget::setPressure);
+    connect(strokeTool, &StrokeTool::stabilizationLevelChanged, this, &StrokeOptionsWidget::setStabilizerLevel);
+    connect(strokeTool, &StrokeTool::antiAliasingONChanged, this, &StrokeOptionsWidget::setAA);
+    connect(strokeTool, &StrokeTool::fillContourONChanged, this, &StrokeOptionsWidget::setFillContour);
+    connect(strokeTool, &StrokeTool::invisibilityONChanged, this, &StrokeOptionsWidget::setPenInvisibility);
 
-    connect(ui->useFeatherBox, &QCheckBox::clicked, toolManager, [=](bool enabled) {
-        auto tool = strokeTool();
-        if (tool) {
-            tool->setFeatherON(enabled);
-        }
-    });
+    if (strokeTool->type() == POLYLINE) {
+        PolylineTool* polyline = static_cast<PolylineTool*>(strokeTool);
+        connect(polyline, &PolylineTool::useBezierChanged, this, &StrokeOptionsWidget::setBezier);
+        connect(polyline, &PolylineTool::closePathChanged, this, &StrokeOptionsWidget::setClosedPath);
+    }
+}
 
-    connect(ui->useAABox, &QCheckBox::clicked, toolManager, [=](bool enabled) {
-        auto tool = strokeTool();
-        if (tool) {
-            tool->setAntiAliasingON(enabled);
-        }
-    });
-
-    connect(ui->fillContourBox, &QCheckBox::clicked, toolManager, [=](bool enabled) {
-        auto tool = strokeTool();
-        if (tool) {
-            tool->setFillContourON(enabled);
-        }
-    });
-
-    connect(ui->sizeSlider, &SpinSlider::valueChanged, toolManager, [=](qreal value) {
-        auto tool = strokeTool();
-        if (tool) {
-            tool->setWidth(value);
-        }
-    });
-
-    connect(ui->featherSlider, &SpinSlider::valueChanged, toolManager, [=](qreal value) {
-        auto tool = strokeTool();
-        if (tool) {
-            tool->setFeather(value);
-        }
-    });
-
+void StrokeOptionsWidget::makeConnectionFromUIToModel()
+{
     auto spinboxValueChanged = static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged);
-    connect(ui->sizeSpinBox, spinboxValueChanged, toolManager, [=](qreal value) {
-        auto tool = strokeTool();
-        if (tool) {
-            tool->setWidth(value);
-        }
+
+    connect(ui->useBezierBox, &QCheckBox::clicked, [=](bool enabled) {
+        PolylineTool* tool = static_cast<PolylineTool*>(mCurrentTool);
+        tool->setUseBezier(enabled);
     });
 
-    connect(ui->featherSpinBox, spinboxValueChanged, toolManager, [=](qreal value) {
-        auto tool = strokeTool();
-        if (tool) {
-            tool->setFeather(value);
-        }
+    connect(ui->useClosedPathBox, &QCheckBox::clicked, [=](bool enabled) {
+        PolylineTool* tool = static_cast<PolylineTool*>(mCurrentTool);
+        tool->setClosePath(enabled);
+    });
+    connect(ui->usePressureBox, &QCheckBox::clicked, [=](bool enabled) {
+        mCurrentTool->setPressureON(enabled);
+    });
+
+    connect(ui->makeInvisibleBox, &QCheckBox::clicked, [=](bool enabled) {
+        mCurrentTool->setInvisibilityON(enabled);
+    });
+
+    connect(ui->useFeatherBox, &QCheckBox::clicked, [=](bool enabled) {
+        mCurrentTool->setFeatherON(enabled);
+    });
+
+    connect(ui->useAABox, &QCheckBox::clicked, [=](bool enabled) {
+        mCurrentTool->setAntiAliasingON(enabled);
+    });
+
+    connect(ui->fillContourBox, &QCheckBox::clicked, [=](bool enabled) {
+        mCurrentTool->setFillContourON(enabled);
+    });
+
+    connect(ui->sizeSlider, &SpinSlider::valueChanged, [=](qreal value) {
+        mCurrentTool->setWidth(value);
+    });
+
+    connect(ui->sizeSpinBox, spinboxValueChanged, [=](qreal value) {
+        mCurrentTool->setWidth(value);
+    });
+
+    connect(ui->featherSlider, &SpinSlider::valueChanged, [=](qreal value) {
+        mCurrentTool->setFeather(value);
+    });
+
+    connect(ui->featherSpinBox, spinboxValueChanged, [=](qreal value) {
+        mCurrentTool->setFeather(value);
     });
 
     clearFocusOnFinished(ui->sizeSpinBox);
     clearFocusOnFinished(ui->featherSpinBox);
 
-    connect(ui->inpolLevelsCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), toolManager, [=](int value) {
-        auto tool = strokeTool();
-        if (tool) {
-            tool->setStablizationLevel(value);
-        }
+    connect(ui->inpolLevelsCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), [=](int value) {
+        mCurrentTool->setStablizationLevel(value);
     });
-
-    connect(toolManager, &ToolManager::toolChanged, this, &StrokeOptionsWidget::onToolChanged);
-    connect(toolManager, &ToolManager::toolPropertyChanged, this, &StrokeOptionsWidget::onToolPropertyChanged);
-}
-
-void StrokeOptionsWidget::onToolPropertyChanged(ToolType, ToolPropertyType ePropertyType)
-{
-    if (mEditor->tools()->currentTool()->category() != STROKETOOL) {
-        return;
-    }
-
-    // const Properties& p = editor()->tools()->currentTool()->properties;
-
-    // switch (ePropertyType)
-    // {
-    // case WIDTH: setPenWidth(p.width()); break;
-    // case FEATHER: setPenFeather(p.feather); break;
-    // case USEFEATHER: setUseFeather(p.useFeather); break;
-    // case PRESSURE: setPressure(p.pressure); break;
-    // case INVISIBILITY: setPenInvisibility(p.invisibility); break;
-    // case PRESERVEALPHA: setPreserveAlpha(p.preserveAlpha); break;
-    // case VECTORMERGE: setVectorMergeEnabled(p.vectorMergeEnabled); break;
-    // case ANTI_ALIASING: setAA(p.useAA); break;
-    // case STABILIZATION: setStabilizerLevel(p.stabilizerLevel); break;
-    // case FILLCONTOUR: setFillContour(p.useFillContour); break;
-    // case SHOWSELECTIONINFO: setShowSelectionInfo(p.showSelectionInfo); break;
-    // case BEZIER: setBezier(p.bezier_state); break;
-    // case CLOSEDPATH: setClosedPath(p.closedPolylinePath); break;
-    // case CAMERAPATH: { break; }
-    // case TOLERANCE: break;
-    // case USETOLERANCE: break;
-    // case BUCKETFILLEXPAND: break;
-    // case USEBUCKETFILLEXPAND: break;
-    // case BUCKETFILLLAYERREFERENCEMODE: break;
-    // case FILL_MODE: break;
-    // default:
-    //     Q_ASSERT(false);
-    //     break;
-    // }
 }
 
 void StrokeOptionsWidget::setVisibility(BaseTool* tool)
@@ -246,19 +201,17 @@ void StrokeOptionsWidget::setVisibility(BaseTool* tool)
     ui->useClosedPathBox->setVisible(tool->isPropertyEnabled(PolyLineSettings::CLOSEDPATH_ON));
 }
 
-void StrokeOptionsWidget::onToolChanged(ToolType)
-{
-    updateUI();
-}
+// void StrokeOptionsWidget::onToolChanged(ToolType)
+// {
+//     updateUI();
+// }
 
 void StrokeOptionsWidget::setPenWidth(qreal width)
 {
     QSignalBlocker b(ui->sizeSlider);
-    ui->sizeSlider->setEnabled(true);
     ui->sizeSlider->setValue(width);
 
     QSignalBlocker b2(ui->sizeSpinBox);
-    ui->sizeSpinBox->setEnabled(true);
     ui->sizeSpinBox->setValue(width);
 }
 
@@ -357,8 +310,8 @@ void StrokeOptionsWidget::setClosedPath(bool useClosedPath)
 
 // void StrokeOptionsWidget::setShowSelectionInfo(bool showSelectionInfo)
 // {
-    // QSignalBlocker b(ui->showInfoBox);
-    // ui->showInfoBox->setChecked(showSelectionInfo);
+//     QSignalBlocker b(ui->showInfoBox);
+//     ui->showInfoBox->setChecked(showSelectionInfo);
 // }
 
 void StrokeOptionsWidget::disableAllOptions()
@@ -368,8 +321,8 @@ void StrokeOptionsWidget::disableAllOptions()
     ui->featherSlider->hide();
     ui->featherSpinBox->hide();
     ui->useFeatherBox->hide();
-    ui->useBezierBox->hide();
-    ui->useClosedPathBox->hide();
+    // ui->useBezierBox->hide();
+    // ui->useClosedPathBox->hide();
     ui->usePressureBox->hide();
     ui->makeInvisibleBox->hide();
     ui->useAABox->hide();

--- a/app/src/strokeoptionswidget.cpp
+++ b/app/src/strokeoptionswidget.cpp
@@ -50,7 +50,7 @@ void StrokeOptionsWidget::updateUI()
 
     setVisibility(currentTool);
 
-    const StrokeSettings* p = static_cast<const StrokeSettings*>(currentTool->getSettings());
+    const StrokeSettings* p = static_cast<const StrokeSettings*>(currentTool->settings());
 
     if (currentTool->isPropertyEnabled(StrokeSettings::WIDTH_VALUE))
     {
@@ -91,7 +91,7 @@ void StrokeOptionsWidget::updateUI()
     // }
 
     if (currentTool->type() == POLYLINE) {
-        const PolyLineSettings* polyP = static_cast<const PolyLineSettings*>(currentTool->getSettings());
+        const PolylineSettings* polyP = static_cast<const PolylineSettings*>(currentTool->settings());
         setClosedPath(polyP->closedPath());
         setBezier(polyP->useBezier());
     }
@@ -197,8 +197,8 @@ void StrokeOptionsWidget::setVisibility(BaseTool* tool)
     ui->stabilizerLabel->setVisible(tool->isPropertyEnabled(StrokeSettings::STABILIZATION_VALUE));
     ui->inpolLevelsCombo->setVisible(tool->isPropertyEnabled(StrokeSettings::STABILIZATION_VALUE));
     ui->fillContourBox->setVisible(tool->isPropertyEnabled(StrokeSettings::FILLCONTOUR_ON));
-    ui->useBezierBox->setVisible(tool->isPropertyEnabled(PolyLineSettings::BEZIER_ON));
-    ui->useClosedPathBox->setVisible(tool->isPropertyEnabled(PolyLineSettings::CLOSEDPATH_ON));
+    ui->useBezierBox->setVisible(tool->isPropertyEnabled(PolylineSettings::BEZIER_ON));
+    ui->useClosedPathBox->setVisible(tool->isPropertyEnabled(PolylineSettings::CLOSEDPATH_ON));
 }
 
 // void StrokeOptionsWidget::onToolChanged(ToolType)

--- a/app/src/strokeoptionswidget.h
+++ b/app/src/strokeoptionswidget.h
@@ -29,13 +29,11 @@ public:
     void updateUI();
     void initUI();
 
-    void makeConnectionToEditor(Editor* editor);
-
-public slots:
-    void onToolPropertyChanged(ToolType, ToolPropertyType);
-    void onToolChanged(ToolType);
-
 private:
+    void makeConnectionFromModelToUI(StrokeTool* strokeTool);
+    void makeConnectionFromUIToModel();
+    void updateToolConnections(BaseTool* tool);
+
     void setPenWidth(qreal);
     void setPenFeather(qreal);
     void setUseFeather(bool);
@@ -54,6 +52,8 @@ private:
 
 private:
     Ui::StrokeOptionsWidget *ui;
+
+    StrokeTool* mCurrentTool = nullptr;
 
     Editor* mEditor = nullptr;
 

--- a/app/src/strokeoptionswidget.h
+++ b/app/src/strokeoptionswidget.h
@@ -1,0 +1,62 @@
+#ifndef STROKEOPTIONSWIDGET_H
+#define STROKEOPTIONSWIDGET_H
+
+#include <QWidget>
+
+#include "pencildef.h"
+
+class Editor;
+class BaseTool;
+class QCheckBox;
+class SpinSlider;
+class QSpinBox;
+// class QComboBox;
+
+class StrokeTool;
+
+namespace Ui {
+class StrokeOptionsWidget;
+}
+
+class StrokeOptionsWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit StrokeOptionsWidget(Editor* editor, QWidget *parent = nullptr);
+    ~StrokeOptionsWidget();
+
+    void updateUI();
+    void initUI();
+
+    void makeConnectionToEditor(Editor* editor);
+
+public slots:
+    void onToolPropertyChanged(ToolType, ToolPropertyType);
+    void onToolChanged(ToolType);
+
+private:
+    void setPenWidth(qreal);
+    void setPenFeather(qreal);
+    void setUseFeather(bool);
+    void setPenInvisibility(int);
+    void setPressure(int);
+    void setAA(int);
+    void setStabilizerLevel(int);
+    void setFillContour(int);
+    void setBezier(bool);
+    void setClosedPath(bool);
+
+    void disableAllOptions();
+    void setVisibility(BaseTool*);
+
+    StrokeTool* strokeTool();
+
+private:
+    Ui::StrokeOptionsWidget *ui;
+
+    Editor* mEditor = nullptr;
+
+};
+
+#endif // STROKEOPTIONSWIDGET_H

--- a/app/src/toolbox.cpp
+++ b/app/src/toolbox.cpp
@@ -25,6 +25,7 @@ GNU General Public License for more details.
 #include <QKeySequence>
 #include <QResizeEvent>
 
+#include "basetool.h"
 #include "flowlayout.h"
 #include "spinslider.h"
 #include "editor.h"

--- a/app/src/tooloptionwidget.cpp
+++ b/app/src/tooloptionwidget.cpp
@@ -174,11 +174,9 @@ void ToolOptionWidget::setVisibility(BaseTool* tool)
     disableAllOptions();
 
     mBucketOptionsWidget->setVisible(tool->type() == BUCKET);
+    mBucketOptionsWidget->updateUI();
     mCameraOptionsWidget->setVisible(tool->type() == CAMERA);
-
-    // if (tool->type() == BUCKET) {
-        mStrokeOptionsWidget->setVisible(tool->category() == STROKETOOL && tool->type() != BUCKET);
-    // }
+    mStrokeOptionsWidget->setVisible(tool->category() == STROKETOOL && tool->type() != BUCKET);
 
     // ui->sizeSlider->setVisible(tool->isPropertyEnabled(WIDTH));
     // ui->brushSpinBox->setVisible(tool->isPropertyEnabled(WIDTH));

--- a/app/src/tooloptionwidget.cpp
+++ b/app/src/tooloptionwidget.cpp
@@ -66,7 +66,7 @@ void ToolOptionWidget::updateUI()
     BaseTool* currentTool = editor()->tools()->currentTool();
     Q_ASSERT(currentTool);
 
-    setVisibility(currentTool);
+    setWidgetVisibility(currentTool);
 }
 
 void ToolOptionWidget::makeConnectionToEditor(Editor* editor)
@@ -75,7 +75,7 @@ void ToolOptionWidget::makeConnectionToEditor(Editor* editor)
     connect(editor->layers(), &LayerManager::currentLayerChanged, this, &ToolOptionWidget::onLayerChanged);
 }
 
-void ToolOptionWidget::setVisibility(BaseTool* tool)
+void ToolOptionWidget::setWidgetVisibility(BaseTool* tool)
 {
     Q_ASSERT(mBucketOptionsWidget);
     Q_ASSERT(mCameraOptionsWidget);
@@ -96,121 +96,11 @@ void ToolOptionWidget::onLayerChanged(int layerIndex)
         return;
     }
 
-    setVisibility(editor()->tools()->currentTool());
+    setWidgetVisibility(editor()->tools()->currentTool());
 }
 
 void ToolOptionWidget::onToolChanged(ToolType toolType)
 {
     BaseTool* tool = editor()->tools()->getTool(toolType);
-    setVisibility(tool);
+    setWidgetVisibility(tool);
 }
-
-// void ToolOptionWidget::setPenWidth(qreal width)
-// {
-//     QSignalBlocker b(ui->sizeSlider);
-//     ui->sizeSlider->setEnabled(true);
-//     ui->sizeSlider->setValue(width);
-
-//     QSignalBlocker b2(ui->brushSpinBox);
-//     ui->brushSpinBox->setEnabled(true);
-//     ui->brushSpinBox->setValue(width);
-// }
-
-// void ToolOptionWidget::setPenFeather(qreal featherValue)
-// {
-//     QSignalBlocker b(ui->featherSlider);
-//     ui->featherSlider->setEnabled(true);
-//     ui->featherSlider->setValue(featherValue);
-
-//     QSignalBlocker b2(ui->featherSpinBox);
-//     ui->featherSpinBox->setEnabled(true);
-//     ui->featherSpinBox->setValue(featherValue);
-// }
-
-// void ToolOptionWidget::setUseFeather(bool useFeather)
-// {
-//     QSignalBlocker b(ui->useFeatherBox);
-//     ui->useFeatherBox->setEnabled(true);
-//     ui->useFeatherBox->setChecked(useFeather);
-// }
-
-// void ToolOptionWidget::setPenInvisibility(int x)
-// {
-//     QSignalBlocker b(ui->makeInvisibleBox);
-//     ui->makeInvisibleBox->setEnabled(true);
-//     ui->makeInvisibleBox->setChecked(x > 0);
-// }
-
-// void ToolOptionWidget::setPressure(int x)
-// {
-//     QSignalBlocker b(ui->usePressureBox);
-//     ui->usePressureBox->setEnabled(true);
-//     ui->usePressureBox->setChecked(x > 0);
-// }
-
-// void ToolOptionWidget::setPreserveAlpha(int x)
-// {
-//     QSignalBlocker b(ui->preserveAlphaBox);
-//     ui->preserveAlphaBox->setEnabled(true);
-//     ui->preserveAlphaBox->setChecked(x > 0);
-// }
-
-// void ToolOptionWidget::setVectorMergeEnabled(int x)
-// {
-//     QSignalBlocker b(ui->vectorMergeBox);
-//     ui->vectorMergeBox->setEnabled(true);
-//     ui->vectorMergeBox->setChecked(x > 0);
-// }
-
-// void ToolOptionWidget::setAA(int x)
-// {
-//     QSignalBlocker b(ui->useAABox);
-//     ui->useAABox->setEnabled(true);
-//     ui->useAABox->setVisible(false);
-
-//     auto layerType = editor()->layers()->currentLayer()->type();
-
-//     if (layerType == Layer::BITMAP)
-//     {
-//         if (x == -1)
-//         {
-//             ui->useAABox->setEnabled(false);
-//             ui->useAABox->setVisible(false);
-//         }
-//         else
-//         {
-//             ui->useAABox->setVisible(true);
-//         }
-//         ui->useAABox->setChecked(x > 0);
-//     }
-// }
-
-// void ToolOptionWidget::setStabilizerLevel(int x)
-// {
-//     ui->inpolLevelsCombo->setCurrentIndex(qBound(0, x, ui->inpolLevelsCombo->count() - 1));
-// }
-
-// void ToolOptionWidget::setFillContour(int useFill)
-// {
-//     QSignalBlocker b(ui->fillContourBox);
-//     ui->fillContourBox->setEnabled(true);
-//     ui->fillContourBox->setChecked(useFill > 0);
-// }
-
-// void ToolOptionWidget::setBezier(bool useBezier)
-// {
-//     QSignalBlocker b(ui->useBezierBox);
-//     ui->useBezierBox->setChecked(useBezier);
-// }
-
-// void ToolOptionWidget::setClosedPath(bool useClosedPath)
-// {
-//     QSignalBlocker b(ui->useClosedPathBox);
-//     ui->useClosedPathBox->setChecked(useClosedPath);
-// }
-
-// void ToolOptionWidget::setShowSelectionInfo(bool showSelectionInfo)
-// {
-//     QSignalBlocker b(ui->showInfoBox);
-//     ui->showInfoBox->setChecked(showSelectionInfo);
-// }

--- a/app/src/tooloptionwidget.cpp
+++ b/app/src/tooloptionwidget.cpp
@@ -22,6 +22,7 @@ GNU General Public License for more details.
 
 #include "cameraoptionswidget.h"
 #include "bucketoptionswidget.h"
+#include "strokeoptionswidget.h"
 #include "spinslider.h"
 #include "editor.h"
 #include "util.h"
@@ -49,18 +50,20 @@ void ToolOptionWidget::initUI()
 {
     mBucketOptionsWidget = new BucketOptionsWidget(editor(), this);
     mCameraOptionsWidget = new CameraOptionsWidget(editor(), this);
-    ui->horizontalLayout_2->addWidget(mBucketOptionsWidget);
-    ui->horizontalLayout_2->addWidget(mCameraOptionsWidget);
+    mStrokeOptionsWidget = new StrokeOptionsWidget(editor(), this);
+    ui->scrollAreaWidgetContents->layout()->addWidget(mBucketOptionsWidget);
+    ui->scrollAreaWidgetContents->layout()->addWidget(mCameraOptionsWidget);
+    ui->scrollAreaWidgetContents->layout()->addWidget(mStrokeOptionsWidget);
 
-    QSettings settings(PENCIL2D, PENCIL2D);
+    // QSettings settings(PENCIL2D, PENCIL2D);
 
-    ui->sizeSlider->init(tr("Width"), SpinSlider::EXPONENT, SpinSlider::INTEGER, StrokeTool::WIDTH_MIN, StrokeTool::WIDTH_MAX);
-    ui->sizeSlider->setValue(settings.value("brushWidth", "3").toDouble());
-    ui->brushSpinBox->setValue(settings.value("brushWidth", "3").toDouble());
+    // ui->sizeSlider->init(tr("Width"), SpinSlider::EXPONENT, SpinSlider::INTEGER, StrokeTool::WIDTH_MIN, StrokeTool::WIDTH_MAX);
+    // ui->sizeSlider->setValue(settings.value("brushWidth", "3").toDouble());
+    // ui->brushSpinBox->setValue(settings.value("brushWidth", "3").toDouble());
 
-    ui->featherSlider->init(tr("Feather"), SpinSlider::LOG, SpinSlider::INTEGER, StrokeTool::FEATHER_MIN, StrokeTool::FEATHER_MAX);
-    ui->featherSlider->setValue(settings.value("brushFeather", "5").toDouble());
-    ui->featherSpinBox->setValue(settings.value("brushFeather", "5").toDouble());
+    // ui->featherSlider->init(tr("Feather"), SpinSlider::LOG, SpinSlider::INTEGER, StrokeTool::FEATHER_MIN, StrokeTool::FEATHER_MAX);
+    // ui->featherSlider->setValue(settings.value("brushFeather", "5").toDouble());
+    // ui->featherSpinBox->setValue(settings.value("brushFeather", "5").toDouble());
 }
 
 void ToolOptionWidget::updateUI()
@@ -70,26 +73,26 @@ void ToolOptionWidget::updateUI()
 
     setVisibility(currentTool);
 
-    const Properties& p = currentTool->properties;
+    // TODO: should we cast to tool type here and get the specific properties object?
+    // or is there a smarter way?
+    // const Properties* p = currentTool->getProperties();
 
-    if (currentTool->isPropertyEnabled(WIDTH))
-    {
-        setPenWidth(p.width);
-    }
-    if (currentTool->isPropertyEnabled(FEATHER))
-    {
-        setPenFeather(p.feather);
-    }
-    setUseFeather(p.useFeather);
-    setPressure(p.pressure);
-    setPenInvisibility(p.invisibility);
-    setPreserveAlpha(p.preserveAlpha);
-    setVectorMergeEnabled(p.vectorMergeEnabled);
-    setAA(p.useAA);
-    setStabilizerLevel(p.stabilizerLevel);
-    setFillContour(p.useFillContour);
-    setShowSelectionInfo(p.showSelectionInfo);
-    setClosedPath(p.closedPolylinePath);
+    // if (currentTool->isPropertyEnabled(WIDTH))
+    // {
+    //     setPenWidth(p.width());
+    // }
+    // if (currentTool->isPropertyEnabled(FEATHER))
+    // {
+    //     setPenFeather(p.feather());
+    // }
+    // setUseFeather(p.useFeather());
+    // setPressure(p.usePressure());
+    // setPenInvisibility(p.invisibility());
+    // setAA(p.useAntiAliasing());
+    // setStabilizerLevel(p.stabilizerLevel());
+    // setFillContour(p.useFillContour());
+    // setShowSelectionInfo(p.showSelectionInfo());
+    // setClosedPath(p.closedPath());
 }
 
 void ToolOptionWidget::createUI()
@@ -99,66 +102,68 @@ void ToolOptionWidget::makeConnectionToEditor(Editor* editor)
 {
     auto toolManager = editor->tools();
 
-    connect(ui->useBezierBox, &QCheckBox::clicked, toolManager, &ToolManager::setBezier);
-    connect(ui->useClosedPathBox, &QCheckBox::clicked, toolManager, &ToolManager::setClosedPath);
-    connect(ui->usePressureBox, &QCheckBox::clicked, toolManager, &ToolManager::setPressure);
-    connect(ui->makeInvisibleBox, &QCheckBox::clicked, toolManager, &ToolManager::setInvisibility);
-    connect(ui->preserveAlphaBox, &QCheckBox::clicked, toolManager, &ToolManager::setPreserveAlpha);
+    // connect(ui->useBezierBox, &QCheckBox::clicked, toolManager, &ToolManager::setBezier);
+    // connect(ui->useClosedPathBox, &QCheckBox::clicked, toolManager, &ToolManager::setClosedPath);
+    // connect(ui->usePressureBox, &QCheckBox::clicked, toolManager, &ToolManager::setPressure);
+    // connect(ui->makeInvisibleBox, &QCheckBox::clicked, toolManager, &ToolManager::setInvisibility);
+    // connect(ui->preserveAlphaBox, &QCheckBox::clicked, toolManager, &ToolManager::setPreserveAlpha);
 
-    connect(ui->sizeSlider, &SpinSlider::valueChanged, toolManager, &ToolManager::setWidth);
-    connect(ui->featherSlider, &SpinSlider::valueChanged, toolManager, &ToolManager::setFeather);
+    // connect(ui->sizeSlider, &SpinSlider::valueChanged, toolManager, [=](qreal value) {
+    //     toolManager->setToolProperty(toolManager->currentTool()->type(), ToolPropertyType::WIDTH, value);
+    // });
+    // connect(ui->featherSlider, &SpinSlider::valueChanged, toolManager, &ToolManager::setFeather);
 
-    auto spinboxValueChanged = static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged);
-    connect(ui->brushSpinBox, spinboxValueChanged, toolManager, &ToolManager::setWidth);
-    clearFocusOnFinished(ui->brushSpinBox);
-    connect(ui->featherSpinBox, spinboxValueChanged, toolManager, &ToolManager::setFeather);
-    clearFocusOnFinished(ui->featherSpinBox);
+    // auto spinboxValueChanged = static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged);
+    // connect(ui->brushSpinBox, spinboxValueChanged, toolManager, &ToolManager::setWidth);
+    // clearFocusOnFinished(ui->brushSpinBox);
+    // connect(ui->featherSpinBox, spinboxValueChanged, toolManager, &ToolManager::setFeather);
+    // clearFocusOnFinished(ui->featherSpinBox);
 
-    connect(ui->useFeatherBox, &QCheckBox::clicked, toolManager, &ToolManager::setUseFeather);
+    // connect(ui->useFeatherBox, &QCheckBox::clicked, toolManager, &ToolManager::setUseFeather);
 
-    connect(ui->vectorMergeBox, &QCheckBox::clicked, toolManager, &ToolManager::setVectorMergeEnabled);
-    connect(ui->useAABox, &QCheckBox::clicked, toolManager, &ToolManager::setAA);
+    // connect(ui->vectorMergeBox, &QCheckBox::clicked, toolManager, &ToolManager::setVectorMergeEnabled);
+    // connect(ui->useAABox, &QCheckBox::clicked, toolManager, &ToolManager::setAA);
 
-    connect(ui->inpolLevelsCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), toolManager, &ToolManager::setStabilizerLevel);
+    // connect(ui->inpolLevelsCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), toolManager, &ToolManager::setStabilizerLevel);
 
-    connect(ui->fillContourBox, &QCheckBox::clicked, toolManager, &ToolManager::setUseFillContour);
+    // connect(ui->fillContourBox, &QCheckBox::clicked, toolManager, &ToolManager::setUseFillContour);
 
-    connect(ui->showInfoBox, &QCheckBox::clicked, toolManager, &ToolManager::setShowSelectionInfo);
+    // connect(ui->showInfoBox, &QCheckBox::clicked, toolManager, &ToolManager::setShowSelectionInfo);
 
     connect(toolManager, &ToolManager::toolChanged, this, &ToolOptionWidget::onToolChanged);
-    connect(toolManager, &ToolManager::toolPropertyChanged, this, &ToolOptionWidget::onToolPropertyChanged);
+    // connect(toolManager, &ToolManager::toolPropertyChanged, this, &ToolOptionWidget::onToolPropertyChanged);
 }
 
 void ToolOptionWidget::onToolPropertyChanged(ToolType, ToolPropertyType ePropertyType)
 {
-    const Properties& p = editor()->tools()->currentTool()->properties;
+    // const Properties& p = editor()->tools()->currentTool()->properties;
 
-    switch (ePropertyType)
-    {
-    case WIDTH: setPenWidth(p.width); break;
-    case FEATHER: setPenFeather(p.feather); break;
-    case USEFEATHER: setUseFeather(p.useFeather); break;
-    case PRESSURE: setPressure(p.pressure); break;
-    case INVISIBILITY: setPenInvisibility(p.invisibility); break;
-    case PRESERVEALPHA: setPreserveAlpha(p.preserveAlpha); break;
-    case VECTORMERGE: setVectorMergeEnabled(p.vectorMergeEnabled); break;
-    case ANTI_ALIASING: setAA(p.useAA); break;
-    case STABILIZATION: setStabilizerLevel(p.stabilizerLevel); break;
-    case FILLCONTOUR: setFillContour(p.useFillContour); break;
-    case SHOWSELECTIONINFO: setShowSelectionInfo(p.showSelectionInfo); break;
-    case BEZIER: setBezier(p.bezier_state); break;
-    case CLOSEDPATH: setClosedPath(p.closedPolylinePath); break;
-    case CAMERAPATH: { break; }
-    case TOLERANCE: break;
-    case USETOLERANCE: break;
-    case BUCKETFILLEXPAND: break;
-    case USEBUCKETFILLEXPAND: break;
-    case BUCKETFILLLAYERREFERENCEMODE: break;
-    case FILL_MODE: break;
-    default:
-        Q_ASSERT(false);
-        break;
-    }
+    // switch (ePropertyType)
+    // {
+    // case WIDTH: setPenWidth(p.width()); break;
+    // case FEATHER: setPenFeather(p.feather); break;
+    // case USEFEATHER: setUseFeather(p.useFeather); break;
+    // case PRESSURE: setPressure(p.pressure); break;
+    // case INVISIBILITY: setPenInvisibility(p.invisibility); break;
+    // case PRESERVEALPHA: setPreserveAlpha(p.preserveAlpha); break;
+    // case VECTORMERGE: setVectorMergeEnabled(p.vectorMergeEnabled); break;
+    // case ANTI_ALIASING: setAA(p.useAA); break;
+    // case STABILIZATION: setStabilizerLevel(p.stabilizerLevel); break;
+    // case FILLCONTOUR: setFillContour(p.useFillContour); break;
+    // case SHOWSELECTIONINFO: setShowSelectionInfo(p.showSelectionInfo); break;
+    // case BEZIER: setBezier(p.bezier_state); break;
+    // case CLOSEDPATH: setClosedPath(p.closedPolylinePath); break;
+    // case CAMERAPATH: { break; }
+    // case TOLERANCE: break;
+    // case USETOLERANCE: break;
+    // case BUCKETFILLEXPAND: break;
+    // case USEBUCKETFILLEXPAND: break;
+    // case BUCKETFILLLAYERREFERENCEMODE: break;
+    // case FILL_MODE: break;
+    // default:
+    //     Q_ASSERT(false);
+    //     break;
+    // }
 }
 
 void ToolOptionWidget::setVisibility(BaseTool* tool)
@@ -168,88 +173,80 @@ void ToolOptionWidget::setVisibility(BaseTool* tool)
 
     disableAllOptions();
 
-    if (tool->type() == BUCKET)
-    {
-        mBucketOptionsWidget->setHidden(false);
-        return;
-    }
-    else if (tool->type() == CAMERA)
-    {
-        mCameraOptionsWidget->setHidden(false);
-    }
-    else
-    {
-        mCameraOptionsWidget->setHidden(true);
-        mBucketOptionsWidget->setHidden(true);
-    }
+    mBucketOptionsWidget->setVisible(tool->type() == BUCKET);
+    mCameraOptionsWidget->setVisible(tool->type() == CAMERA);
 
-    ui->sizeSlider->setVisible(tool->isPropertyEnabled(WIDTH));
-    ui->brushSpinBox->setVisible(tool->isPropertyEnabled(WIDTH));
-    ui->featherSlider->setVisible(tool->isPropertyEnabled(FEATHER));
-    ui->featherSpinBox->setVisible(tool->isPropertyEnabled(FEATHER));
-    ui->useFeatherBox->setVisible(tool->isPropertyEnabled(USEFEATHER));
-    ui->useBezierBox->setVisible(tool->isPropertyEnabled(BEZIER));
-    ui->useClosedPathBox->setVisible(tool->isPropertyEnabled(CLOSEDPATH));
-    ui->usePressureBox->setVisible(tool->isPropertyEnabled(PRESSURE));
-    ui->makeInvisibleBox->setVisible(tool->isPropertyEnabled(INVISIBILITY));
-    ui->preserveAlphaBox->setVisible(tool->isPropertyEnabled(PRESERVEALPHA));
-    ui->useAABox->setVisible(tool->isPropertyEnabled(ANTI_ALIASING));
-    ui->stabilizerLabel->setVisible(tool->isPropertyEnabled(STABILIZATION));
-    ui->inpolLevelsCombo->setVisible(tool->isPropertyEnabled(STABILIZATION));
-    ui->fillContourBox->setVisible(tool->isPropertyEnabled(FILLCONTOUR));
-    ui->showInfoBox->setVisible(tool->isPropertyEnabled(SHOWSELECTIONINFO));
+    // if (tool->type() == BUCKET) {
+        mStrokeOptionsWidget->setVisible(tool->category() == STROKETOOL && tool->type() != BUCKET);
+    // }
 
-    auto currentLayerType = editor()->layers()->currentLayer()->type();
-    auto propertyType = editor()->tools()->currentTool()->type();
+    // ui->sizeSlider->setVisible(tool->isPropertyEnabled(WIDTH));
+    // ui->brushSpinBox->setVisible(tool->isPropertyEnabled(WIDTH));
+    // ui->featherSlider->setVisible(tool->isPropertyEnabled(FEATHER));
+    // ui->featherSpinBox->setVisible(tool->isPropertyEnabled(FEATHER));
+    // ui->useFeatherBox->setVisible(tool->isPropertyEnabled(USEFEATHER));
+    // ui->useBezierBox->setVisible(tool->isPropertyEnabled(BEZIER));
+    // ui->useClosedPathBox->setVisible(tool->isPropertyEnabled(CLOSEDPATH));
+    // ui->usePressureBox->setVisible(tool->isPropertyEnabled(PRESSURE));
+    // ui->makeInvisibleBox->setVisible(tool->isPropertyEnabled(INVISIBILITY));
+    // ui->preserveAlphaBox->setVisible(tool->isPropertyEnabled(PRESERVEALPHA));
+    // ui->useAABox->setVisible(tool->isPropertyEnabled(ANTI_ALIASING));
+    // ui->stabilizerLabel->setVisible(tool->isPropertyEnabled(STABILIZATION));
+    // ui->inpolLevelsCombo->setVisible(tool->isPropertyEnabled(STABILIZATION));
+    // ui->fillContourBox->setVisible(tool->isPropertyEnabled(FILLCONTOUR));
+    // ui->showInfoBox->setVisible(tool->isPropertyEnabled(SHOWSELECTIONINFO));
 
-    if (currentLayerType == Layer::VECTOR)
-    {
-        switch (propertyType)
-        {
-        case SMUDGE:
-            ui->sizeSlider->setVisible(false);
-            ui->brushSpinBox->setVisible(false);
-            ui->usePressureBox->setVisible(false);
-            ui->featherSlider->setVisible(false);
-            ui->featherSpinBox->setVisible(false);
-            ui->useFeatherBox->setVisible(false);
-            break;
-        case PENCIL:
-            ui->sizeSlider->setVisible(false);
-            ui->brushSpinBox->setVisible(false);
-            ui->usePressureBox->setVisible(false);
-            break;
-        default:
-            ui->sizeSlider->setLabel(tr("Width"));
-            ui->useAABox->setVisible(false);
-            break;
-        }
-    }
-    else
-    {
-        switch (propertyType)
-        {
-        case PENCIL:
-            ui->fillContourBox->setVisible(false);
-            break;
-        case BUCKET:
-            ui->brushSpinBox->setVisible(false);
-            ui->sizeSlider->setVisible(false);
-            break;
-        case SELECT:
-        case MOVE:
-            ui->sizeSlider->setVisible(false);
-            ui->brushSpinBox->setVisible(false);
-            ui->usePressureBox->setVisible(false);
-            ui->featherSlider->setVisible(false);
-            ui->featherSpinBox->setVisible(false);
-            ui->useFeatherBox->setVisible(false);
-            break;
-        default:
-            ui->makeInvisibleBox->setVisible(false);
-            break;
-        }
-    }
+    // auto currentLayerType = editor()->layers()->currentLayer()->type();
+    // auto propertyType = editor()->tools()->currentTool()->type();
+
+    // if (currentLayerType == Layer::VECTOR)
+    // {
+    //     switch (propertyType)
+    //     {
+    //     case SMUDGE:
+    //         ui->sizeSlider->setVisible(false);
+    //         ui->brushSpinBox->setVisible(false);
+    //         ui->usePressureBox->setVisible(false);
+    //         ui->featherSlider->setVisible(false);
+    //         ui->featherSpinBox->setVisible(false);
+    //         ui->useFeatherBox->setVisible(false);
+    //         break;
+    //     case PENCIL:
+    //         ui->sizeSlider->setVisible(false);
+    //         ui->brushSpinBox->setVisible(false);
+    //         ui->usePressureBox->setVisible(false);
+    //         break;
+    //     default:
+    //         ui->sizeSlider->setLabel(tr("Width"));
+    //         ui->useAABox->setVisible(false);
+    //         break;
+    //     }
+    // }
+    // else
+    // {
+    //     switch (propertyType)
+    //     {
+    //     case PENCIL:
+    //         ui->fillContourBox->setVisible(false);
+    //         break;
+    //     case BUCKET:
+    //         ui->brushSpinBox->setVisible(false);
+    //         ui->sizeSlider->setVisible(false);
+    //         break;
+    //     case SELECT:
+    //     case MOVE:
+    //         ui->sizeSlider->setVisible(false);
+    //         ui->brushSpinBox->setVisible(false);
+    //         ui->usePressureBox->setVisible(false);
+    //         ui->featherSlider->setVisible(false);
+    //         ui->featherSpinBox->setVisible(false);
+    //         ui->useFeatherBox->setVisible(false);
+    //         break;
+    //     default:
+    //         ui->makeInvisibleBox->setVisible(false);
+    //         break;
+    //     }
+    // }
 }
 
 void ToolOptionWidget::onToolChanged(ToolType)
@@ -257,132 +254,132 @@ void ToolOptionWidget::onToolChanged(ToolType)
     updateUI();
 }
 
-void ToolOptionWidget::setPenWidth(qreal width)
-{
-    QSignalBlocker b(ui->sizeSlider);
-    ui->sizeSlider->setEnabled(true);
-    ui->sizeSlider->setValue(width);
+// void ToolOptionWidget::setPenWidth(qreal width)
+// {
+//     QSignalBlocker b(ui->sizeSlider);
+//     ui->sizeSlider->setEnabled(true);
+//     ui->sizeSlider->setValue(width);
 
-    QSignalBlocker b2(ui->brushSpinBox);
-    ui->brushSpinBox->setEnabled(true);
-    ui->brushSpinBox->setValue(width);
-}
+//     QSignalBlocker b2(ui->brushSpinBox);
+//     ui->brushSpinBox->setEnabled(true);
+//     ui->brushSpinBox->setValue(width);
+// }
 
-void ToolOptionWidget::setPenFeather(qreal featherValue)
-{
-    QSignalBlocker b(ui->featherSlider);
-    ui->featherSlider->setEnabled(true);
-    ui->featherSlider->setValue(featherValue);
+// void ToolOptionWidget::setPenFeather(qreal featherValue)
+// {
+//     QSignalBlocker b(ui->featherSlider);
+//     ui->featherSlider->setEnabled(true);
+//     ui->featherSlider->setValue(featherValue);
 
-    QSignalBlocker b2(ui->featherSpinBox);
-    ui->featherSpinBox->setEnabled(true);
-    ui->featherSpinBox->setValue(featherValue);
-}
+//     QSignalBlocker b2(ui->featherSpinBox);
+//     ui->featherSpinBox->setEnabled(true);
+//     ui->featherSpinBox->setValue(featherValue);
+// }
 
-void ToolOptionWidget::setUseFeather(bool useFeather)
-{
-    QSignalBlocker b(ui->useFeatherBox);
-    ui->useFeatherBox->setEnabled(true);
-    ui->useFeatherBox->setChecked(useFeather);
-}
+// void ToolOptionWidget::setUseFeather(bool useFeather)
+// {
+//     QSignalBlocker b(ui->useFeatherBox);
+//     ui->useFeatherBox->setEnabled(true);
+//     ui->useFeatherBox->setChecked(useFeather);
+// }
 
-void ToolOptionWidget::setPenInvisibility(int x)
-{
-    QSignalBlocker b(ui->makeInvisibleBox);
-    ui->makeInvisibleBox->setEnabled(true);
-    ui->makeInvisibleBox->setChecked(x > 0);
-}
+// void ToolOptionWidget::setPenInvisibility(int x)
+// {
+//     QSignalBlocker b(ui->makeInvisibleBox);
+//     ui->makeInvisibleBox->setEnabled(true);
+//     ui->makeInvisibleBox->setChecked(x > 0);
+// }
 
-void ToolOptionWidget::setPressure(int x)
-{
-    QSignalBlocker b(ui->usePressureBox);
-    ui->usePressureBox->setEnabled(true);
-    ui->usePressureBox->setChecked(x > 0);
-}
+// void ToolOptionWidget::setPressure(int x)
+// {
+//     QSignalBlocker b(ui->usePressureBox);
+//     ui->usePressureBox->setEnabled(true);
+//     ui->usePressureBox->setChecked(x > 0);
+// }
 
-void ToolOptionWidget::setPreserveAlpha(int x)
-{
-    QSignalBlocker b(ui->preserveAlphaBox);
-    ui->preserveAlphaBox->setEnabled(true);
-    ui->preserveAlphaBox->setChecked(x > 0);
-}
+// void ToolOptionWidget::setPreserveAlpha(int x)
+// {
+//     QSignalBlocker b(ui->preserveAlphaBox);
+//     ui->preserveAlphaBox->setEnabled(true);
+//     ui->preserveAlphaBox->setChecked(x > 0);
+// }
 
-void ToolOptionWidget::setVectorMergeEnabled(int x)
-{
-    QSignalBlocker b(ui->vectorMergeBox);
-    ui->vectorMergeBox->setEnabled(true);
-    ui->vectorMergeBox->setChecked(x > 0);
-}
+// void ToolOptionWidget::setVectorMergeEnabled(int x)
+// {
+//     QSignalBlocker b(ui->vectorMergeBox);
+//     ui->vectorMergeBox->setEnabled(true);
+//     ui->vectorMergeBox->setChecked(x > 0);
+// }
 
-void ToolOptionWidget::setAA(int x)
-{
-    QSignalBlocker b(ui->useAABox);
-    ui->useAABox->setEnabled(true);
-    ui->useAABox->setVisible(false);
+// void ToolOptionWidget::setAA(int x)
+// {
+//     QSignalBlocker b(ui->useAABox);
+//     ui->useAABox->setEnabled(true);
+//     ui->useAABox->setVisible(false);
 
-    auto layerType = editor()->layers()->currentLayer()->type();
+//     auto layerType = editor()->layers()->currentLayer()->type();
 
-    if (layerType == Layer::BITMAP)
-    {
-        if (x == -1)
-        {
-            ui->useAABox->setEnabled(false);
-            ui->useAABox->setVisible(false);
-        }
-        else
-        {
-            ui->useAABox->setVisible(true);
-        }
-        ui->useAABox->setChecked(x > 0);
-    }
-}
+//     if (layerType == Layer::BITMAP)
+//     {
+//         if (x == -1)
+//         {
+//             ui->useAABox->setEnabled(false);
+//             ui->useAABox->setVisible(false);
+//         }
+//         else
+//         {
+//             ui->useAABox->setVisible(true);
+//         }
+//         ui->useAABox->setChecked(x > 0);
+//     }
+// }
 
-void ToolOptionWidget::setStabilizerLevel(int x)
-{
-    ui->inpolLevelsCombo->setCurrentIndex(qBound(0, x, ui->inpolLevelsCombo->count() - 1));
-}
+// void ToolOptionWidget::setStabilizerLevel(int x)
+// {
+//     ui->inpolLevelsCombo->setCurrentIndex(qBound(0, x, ui->inpolLevelsCombo->count() - 1));
+// }
 
-void ToolOptionWidget::setFillContour(int useFill)
-{
-    QSignalBlocker b(ui->fillContourBox);
-    ui->fillContourBox->setEnabled(true);
-    ui->fillContourBox->setChecked(useFill > 0);
-}
+// void ToolOptionWidget::setFillContour(int useFill)
+// {
+//     QSignalBlocker b(ui->fillContourBox);
+//     ui->fillContourBox->setEnabled(true);
+//     ui->fillContourBox->setChecked(useFill > 0);
+// }
 
-void ToolOptionWidget::setBezier(bool useBezier)
-{
-    QSignalBlocker b(ui->useBezierBox);
-    ui->useBezierBox->setChecked(useBezier);
-}
+// void ToolOptionWidget::setBezier(bool useBezier)
+// {
+//     QSignalBlocker b(ui->useBezierBox);
+//     ui->useBezierBox->setChecked(useBezier);
+// }
 
-void ToolOptionWidget::setClosedPath(bool useClosedPath)
-{
-    QSignalBlocker b(ui->useClosedPathBox);
-    ui->useClosedPathBox->setChecked(useClosedPath);
-}
+// void ToolOptionWidget::setClosedPath(bool useClosedPath)
+// {
+//     QSignalBlocker b(ui->useClosedPathBox);
+//     ui->useClosedPathBox->setChecked(useClosedPath);
+// }
 
-void ToolOptionWidget::setShowSelectionInfo(bool showSelectionInfo)
-{
-    QSignalBlocker b(ui->showInfoBox);
-    ui->showInfoBox->setChecked(showSelectionInfo);
-}
+// void ToolOptionWidget::setShowSelectionInfo(bool showSelectionInfo)
+// {
+//     QSignalBlocker b(ui->showInfoBox);
+//     ui->showInfoBox->setChecked(showSelectionInfo);
+// }
 
 void ToolOptionWidget::disableAllOptions()
 {
-    ui->sizeSlider->hide();
-    ui->brushSpinBox->hide();
-    ui->featherSlider->hide();
-    ui->featherSpinBox->hide();
-    ui->useFeatherBox->hide();
-    ui->useBezierBox->hide();
-    ui->useClosedPathBox->hide();
-    ui->usePressureBox->hide();
-    ui->makeInvisibleBox->hide();
-    ui->preserveAlphaBox->hide();
-    ui->vectorMergeBox->hide();
-    ui->useAABox->hide();
-    ui->inpolLevelsCombo->hide();
-    ui->fillContourBox->hide();
-    ui->showInfoBox->hide();
-    ui->stabilizerLabel->hide();
+    // ui->sizeSlider->hide();
+    // ui->brushSpinBox->hide();
+    // ui->featherSlider->hide();
+    // ui->featherSpinBox->hide();
+    // ui->useFeatherBox->hide();
+    // ui->useBezierBox->hide();
+    // ui->useClosedPathBox->hide();
+    // ui->usePressureBox->hide();
+    // ui->makeInvisibleBox->hide();
+    // ui->preserveAlphaBox->hide();
+    // ui->vectorMergeBox->hide();
+    // ui->useAABox->hide();
+    // ui->inpolLevelsCombo->hide();
+    // ui->fillContourBox->hide();
+    // ui->showInfoBox->hide();
+    // ui->stabilizerLabel->hide();
 }

--- a/app/src/tooloptionwidget.cpp
+++ b/app/src/tooloptionwidget.cpp
@@ -176,7 +176,9 @@ void ToolOptionWidget::setVisibility(BaseTool* tool)
     mBucketOptionsWidget->setVisible(tool->type() == BUCKET);
     mBucketOptionsWidget->updateUI();
     mCameraOptionsWidget->setVisible(tool->type() == CAMERA);
-    mStrokeOptionsWidget->setVisible(tool->category() == STROKETOOL && tool->type() != BUCKET);
+    mCameraOptionsWidget->updateUI();
+    mStrokeOptionsWidget->setVisible(tool->category() == STROKETOOL);
+    mStrokeOptionsWidget->updateUI();
 
     // ui->sizeSlider->setVisible(tool->isPropertyEnabled(WIDTH));
     // ui->brushSpinBox->setVisible(tool->isPropertyEnabled(WIDTH));

--- a/app/src/tooloptionwidget.cpp
+++ b/app/src/tooloptionwidget.cpp
@@ -31,6 +31,7 @@ GNU General Public License for more details.
 #include "stroketool.h"
 #include "toolmanager.h"
 
+
 ToolOptionWidget::ToolOptionWidget(QWidget* parent) : BaseDockWidget(parent)
 {
     setWindowTitle(tr("Options", "Window title of tool option panel like pen width, feather etc.."));
@@ -54,16 +55,10 @@ void ToolOptionWidget::initUI()
     ui->scrollAreaWidgetContents->layout()->addWidget(mBucketOptionsWidget);
     ui->scrollAreaWidgetContents->layout()->addWidget(mCameraOptionsWidget);
     ui->scrollAreaWidgetContents->layout()->addWidget(mStrokeOptionsWidget);
+    ui->scrollAreaWidgetContents->layout()->addItem(new QSpacerItem(0, 0, QSizePolicy::MinimumExpanding, QSizePolicy::Expanding));
 
-    // QSettings settings(PENCIL2D, PENCIL2D);
-
-    // ui->sizeSlider->init(tr("Width"), SpinSlider::EXPONENT, SpinSlider::INTEGER, StrokeTool::WIDTH_MIN, StrokeTool::WIDTH_MAX);
-    // ui->sizeSlider->setValue(settings.value("brushWidth", "3").toDouble());
-    // ui->brushSpinBox->setValue(settings.value("brushWidth", "3").toDouble());
-
-    // ui->featherSlider->init(tr("Feather"), SpinSlider::LOG, SpinSlider::INTEGER, StrokeTool::FEATHER_MIN, StrokeTool::FEATHER_MAX);
-    // ui->featherSlider->setValue(settings.value("brushFeather", "5").toDouble());
-    // ui->featherSpinBox->setValue(settings.value("brushFeather", "5").toDouble());
+    makeConnectionToEditor(editor());
+    updateUI();
 }
 
 void ToolOptionWidget::updateUI()
@@ -72,98 +67,12 @@ void ToolOptionWidget::updateUI()
     Q_ASSERT(currentTool);
 
     setVisibility(currentTool);
-
-    // TODO: should we cast to tool type here and get the specific properties object?
-    // or is there a smarter way?
-    // const Properties* p = currentTool->getProperties();
-
-    // if (currentTool->isPropertyEnabled(WIDTH))
-    // {
-    //     setPenWidth(p.width());
-    // }
-    // if (currentTool->isPropertyEnabled(FEATHER))
-    // {
-    //     setPenFeather(p.feather());
-    // }
-    // setUseFeather(p.useFeather());
-    // setPressure(p.usePressure());
-    // setPenInvisibility(p.invisibility());
-    // setAA(p.useAntiAliasing());
-    // setStabilizerLevel(p.stabilizerLevel());
-    // setFillContour(p.useFillContour());
-    // setShowSelectionInfo(p.showSelectionInfo());
-    // setClosedPath(p.closedPath());
 }
-
-void ToolOptionWidget::createUI()
-{}
 
 void ToolOptionWidget::makeConnectionToEditor(Editor* editor)
 {
-    auto toolManager = editor->tools();
-
-    // connect(ui->useBezierBox, &QCheckBox::clicked, toolManager, &ToolManager::setBezier);
-    // connect(ui->useClosedPathBox, &QCheckBox::clicked, toolManager, &ToolManager::setClosedPath);
-    // connect(ui->usePressureBox, &QCheckBox::clicked, toolManager, &ToolManager::setPressure);
-    // connect(ui->makeInvisibleBox, &QCheckBox::clicked, toolManager, &ToolManager::setInvisibility);
-    // connect(ui->preserveAlphaBox, &QCheckBox::clicked, toolManager, &ToolManager::setPreserveAlpha);
-
-    // connect(ui->sizeSlider, &SpinSlider::valueChanged, toolManager, [=](qreal value) {
-    //     toolManager->setToolProperty(toolManager->currentTool()->type(), ToolPropertyType::WIDTH, value);
-    // });
-    // connect(ui->featherSlider, &SpinSlider::valueChanged, toolManager, &ToolManager::setFeather);
-
-    // auto spinboxValueChanged = static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged);
-    // connect(ui->brushSpinBox, spinboxValueChanged, toolManager, &ToolManager::setWidth);
-    // clearFocusOnFinished(ui->brushSpinBox);
-    // connect(ui->featherSpinBox, spinboxValueChanged, toolManager, &ToolManager::setFeather);
-    // clearFocusOnFinished(ui->featherSpinBox);
-
-    // connect(ui->useFeatherBox, &QCheckBox::clicked, toolManager, &ToolManager::setUseFeather);
-
-    // connect(ui->vectorMergeBox, &QCheckBox::clicked, toolManager, &ToolManager::setVectorMergeEnabled);
-    // connect(ui->useAABox, &QCheckBox::clicked, toolManager, &ToolManager::setAA);
-
-    // connect(ui->inpolLevelsCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), toolManager, &ToolManager::setStabilizerLevel);
-
-    // connect(ui->fillContourBox, &QCheckBox::clicked, toolManager, &ToolManager::setUseFillContour);
-
-    // connect(ui->showInfoBox, &QCheckBox::clicked, toolManager, &ToolManager::setShowSelectionInfo);
-
-    connect(toolManager, &ToolManager::toolChanged, this, &ToolOptionWidget::onToolChanged);
-    // connect(toolManager, &ToolManager::toolPropertyChanged, this, &ToolOptionWidget::onToolPropertyChanged);
-}
-
-void ToolOptionWidget::onToolPropertyChanged(ToolType, ToolPropertyType ePropertyType)
-{
-    // const Properties& p = editor()->tools()->currentTool()->properties;
-
-    // switch (ePropertyType)
-    // {
-    // case WIDTH: setPenWidth(p.width()); break;
-    // case FEATHER: setPenFeather(p.feather); break;
-    // case USEFEATHER: setUseFeather(p.useFeather); break;
-    // case PRESSURE: setPressure(p.pressure); break;
-    // case INVISIBILITY: setPenInvisibility(p.invisibility); break;
-    // case PRESERVEALPHA: setPreserveAlpha(p.preserveAlpha); break;
-    // case VECTORMERGE: setVectorMergeEnabled(p.vectorMergeEnabled); break;
-    // case ANTI_ALIASING: setAA(p.useAA); break;
-    // case STABILIZATION: setStabilizerLevel(p.stabilizerLevel); break;
-    // case FILLCONTOUR: setFillContour(p.useFillContour); break;
-    // case SHOWSELECTIONINFO: setShowSelectionInfo(p.showSelectionInfo); break;
-    // case BEZIER: setBezier(p.bezier_state); break;
-    // case CLOSEDPATH: setClosedPath(p.closedPolylinePath); break;
-    // case CAMERAPATH: { break; }
-    // case TOLERANCE: break;
-    // case USETOLERANCE: break;
-    // case BUCKETFILLEXPAND: break;
-    // case USEBUCKETFILLEXPAND: break;
-    // case BUCKETFILLLAYERREFERENCEMODE: break;
-    // case FILL_MODE: break;
-    // default:
-    //     Q_ASSERT(false);
-    //     break;
-    // }
+    connect(editor->tools(), &ToolManager::toolChanged, this, &ToolOptionWidget::onToolChanged);
+    connect(editor->layers(), &LayerManager::currentLayerChanged, this, &ToolOptionWidget::onLayerChanged);
 }
 
 void ToolOptionWidget::setVisibility(BaseTool* tool)
@@ -171,87 +80,29 @@ void ToolOptionWidget::setVisibility(BaseTool* tool)
     Q_ASSERT(mBucketOptionsWidget);
     Q_ASSERT(mCameraOptionsWidget);
 
-    disableAllOptions();
-
     mBucketOptionsWidget->setVisible(tool->type() == BUCKET);
     mBucketOptionsWidget->updateUI();
     mCameraOptionsWidget->setVisible(tool->type() == CAMERA);
     mCameraOptionsWidget->updateUI();
     mStrokeOptionsWidget->setVisible(tool->category() == STROKETOOL);
     mStrokeOptionsWidget->updateUI();
-
-    // ui->sizeSlider->setVisible(tool->isPropertyEnabled(WIDTH));
-    // ui->brushSpinBox->setVisible(tool->isPropertyEnabled(WIDTH));
-    // ui->featherSlider->setVisible(tool->isPropertyEnabled(FEATHER));
-    // ui->featherSpinBox->setVisible(tool->isPropertyEnabled(FEATHER));
-    // ui->useFeatherBox->setVisible(tool->isPropertyEnabled(USEFEATHER));
-    // ui->useBezierBox->setVisible(tool->isPropertyEnabled(BEZIER));
-    // ui->useClosedPathBox->setVisible(tool->isPropertyEnabled(CLOSEDPATH));
-    // ui->usePressureBox->setVisible(tool->isPropertyEnabled(PRESSURE));
-    // ui->makeInvisibleBox->setVisible(tool->isPropertyEnabled(INVISIBILITY));
-    // ui->preserveAlphaBox->setVisible(tool->isPropertyEnabled(PRESERVEALPHA));
-    // ui->useAABox->setVisible(tool->isPropertyEnabled(ANTI_ALIASING));
-    // ui->stabilizerLabel->setVisible(tool->isPropertyEnabled(STABILIZATION));
-    // ui->inpolLevelsCombo->setVisible(tool->isPropertyEnabled(STABILIZATION));
-    // ui->fillContourBox->setVisible(tool->isPropertyEnabled(FILLCONTOUR));
-    // ui->showInfoBox->setVisible(tool->isPropertyEnabled(SHOWSELECTIONINFO));
-
-    // auto currentLayerType = editor()->layers()->currentLayer()->type();
-    // auto propertyType = editor()->tools()->currentTool()->type();
-
-    // if (currentLayerType == Layer::VECTOR)
-    // {
-    //     switch (propertyType)
-    //     {
-    //     case SMUDGE:
-    //         ui->sizeSlider->setVisible(false);
-    //         ui->brushSpinBox->setVisible(false);
-    //         ui->usePressureBox->setVisible(false);
-    //         ui->featherSlider->setVisible(false);
-    //         ui->featherSpinBox->setVisible(false);
-    //         ui->useFeatherBox->setVisible(false);
-    //         break;
-    //     case PENCIL:
-    //         ui->sizeSlider->setVisible(false);
-    //         ui->brushSpinBox->setVisible(false);
-    //         ui->usePressureBox->setVisible(false);
-    //         break;
-    //     default:
-    //         ui->sizeSlider->setLabel(tr("Width"));
-    //         ui->useAABox->setVisible(false);
-    //         break;
-    //     }
-    // }
-    // else
-    // {
-    //     switch (propertyType)
-    //     {
-    //     case PENCIL:
-    //         ui->fillContourBox->setVisible(false);
-    //         break;
-    //     case BUCKET:
-    //         ui->brushSpinBox->setVisible(false);
-    //         ui->sizeSlider->setVisible(false);
-    //         break;
-    //     case SELECT:
-    //     case MOVE:
-    //         ui->sizeSlider->setVisible(false);
-    //         ui->brushSpinBox->setVisible(false);
-    //         ui->usePressureBox->setVisible(false);
-    //         ui->featherSlider->setVisible(false);
-    //         ui->featherSpinBox->setVisible(false);
-    //         ui->useFeatherBox->setVisible(false);
-    //         break;
-    //     default:
-    //         ui->makeInvisibleBox->setVisible(false);
-    //         break;
-    //     }
-    // }
 }
 
-void ToolOptionWidget::onToolChanged(ToolType)
+void ToolOptionWidget::onLayerChanged(int layerIndex)
 {
-    updateUI();
+    LayerManager* layerManager = editor()->layers();
+    Layer* layer = layerManager->getLayer(layerIndex);
+    if (layer->type() != layerManager->currentLayer()->type()) {
+        return;
+    }
+
+    setVisibility(editor()->tools()->currentTool());
+}
+
+void ToolOptionWidget::onToolChanged(ToolType toolType)
+{
+    BaseTool* tool = editor()->tools()->getTool(toolType);
+    setVisibility(tool);
 }
 
 // void ToolOptionWidget::setPenWidth(qreal width)
@@ -363,23 +214,3 @@ void ToolOptionWidget::onToolChanged(ToolType)
 //     QSignalBlocker b(ui->showInfoBox);
 //     ui->showInfoBox->setChecked(showSelectionInfo);
 // }
-
-void ToolOptionWidget::disableAllOptions()
-{
-    // ui->sizeSlider->hide();
-    // ui->brushSpinBox->hide();
-    // ui->featherSlider->hide();
-    // ui->featherSpinBox->hide();
-    // ui->useFeatherBox->hide();
-    // ui->useBezierBox->hide();
-    // ui->useClosedPathBox->hide();
-    // ui->usePressureBox->hide();
-    // ui->makeInvisibleBox->hide();
-    // ui->preserveAlphaBox->hide();
-    // ui->vectorMergeBox->hide();
-    // ui->useAABox->hide();
-    // ui->inpolLevelsCombo->hide();
-    // ui->fillContourBox->hide();
-    // ui->showInfoBox->hide();
-    // ui->stabilizerLabel->hide();
-}

--- a/app/src/tooloptionwidget.h
+++ b/app/src/tooloptionwidget.h
@@ -35,6 +35,7 @@ class Editor;
 class BaseTool;
 class BucketOptionsWidget;
 class CameraOptionsWidget;
+class StrokeOptionsWidget;
 
 
 class ToolOptionWidget : public BaseDockWidget
@@ -54,19 +55,19 @@ public slots:
     void onToolChanged(ToolType);
 
 private:
-    void setPenWidth(qreal);
-    void setPenFeather(qreal);
-    void setUseFeather(bool);
-    void setPenInvisibility(int);
-    void setPressure(int);
-    void setPreserveAlpha(int);
-    void setVectorMergeEnabled(int);
-    void setAA(int);
-    void setStabilizerLevel(int);
-    void setFillContour(int);
-    void setBezier(bool);
-    void setClosedPath(bool);
-    void setShowSelectionInfo(bool);
+    // void setPenWidth(qreal);
+    // void setPenFeather(qreal);
+    // void setUseFeather(bool);
+    // void setPenInvisibility(int);
+    // void setPressure(int);
+    // void setPreserveAlpha(int);
+    // void setVectorMergeEnabled(int);
+    // void setAA(int);
+    // void setStabilizerLevel(int);
+    // void setFillContour(int);
+    // void setBezier(bool);
+    // void setClosedPath(bool);
+    // void setShowSelectionInfo(bool);
 
     void disableAllOptions();
     void setVisibility(BaseTool*);
@@ -77,6 +78,7 @@ private:
 
     BucketOptionsWidget* mBucketOptionsWidget = nullptr;
     CameraOptionsWidget* mCameraOptionsWidget = nullptr;
+    StrokeOptionsWidget* mStrokeOptionsWidget = nullptr;
 };
 
 #endif // TOOLOPTIONDOCKWIDGET_H

--- a/app/src/tooloptionwidget.h
+++ b/app/src/tooloptionwidget.h
@@ -24,19 +24,12 @@ namespace Ui
 {
     class ToolOptions;
 }
-class QToolButton;
-class SpinSlider;
-class QCheckBox;
-class QComboBox;
-class QSpinBox;
-class QDoubleSpinBox;
-class QGroupBox;
+
 class Editor;
 class BaseTool;
 class BucketOptionsWidget;
 class CameraOptionsWidget;
 class StrokeOptionsWidget;
-
 
 class ToolOptionWidget : public BaseDockWidget
 {
@@ -55,21 +48,7 @@ public slots:
     void onLayerChanged(int index);
 
 private:
-    // void setPenWidth(qreal);
-    // void setPenFeather(qreal);
-    // void setUseFeather(bool);
-    // void setPenInvisibility(int);
-    // void setPressure(int);
-    // void setPreserveAlpha(int);
-    // void setVectorMergeEnabled(int);
-    // void setAA(int);
-    // void setStabilizerLevel(int);
-    // void setFillContour(int);
-    // void setBezier(bool);
-    // void setClosedPath(bool);
-    // void setShowSelectionInfo(bool);
-
-    void setVisibility(BaseTool*);
+    void setWidgetVisibility(BaseTool*);
 
 private:
     Ui::ToolOptions* ui = nullptr;

--- a/app/src/tooloptionwidget.h
+++ b/app/src/tooloptionwidget.h
@@ -51,8 +51,8 @@ public:
     void makeConnectionToEditor(Editor* editor);
 
 public slots:
-    void onToolPropertyChanged(ToolType, ToolPropertyType);
     void onToolChanged(ToolType);
+    void onLayerChanged(int index);
 
 private:
     // void setPenWidth(qreal);
@@ -69,9 +69,7 @@ private:
     // void setClosedPath(bool);
     // void setShowSelectionInfo(bool);
 
-    void disableAllOptions();
     void setVisibility(BaseTool*);
-    void createUI();
 
 private:
     Ui::ToolOptions* ui = nullptr;

--- a/app/ui/strokeoptionswidget.ui
+++ b/app/ui/strokeoptionswidget.ui
@@ -7,13 +7,16 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>264</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
+   </property>
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -27,264 +30,195 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="frameShape">
-      <enum>QFrame::Shape::NoFrame</enum>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="SpinSlider" name="sizeSlider" native="true">
+       <property name="toolTip">
+        <string>Set Stroke Width &lt;br&gt;&lt;b&gt;[SHIFT]+drag&lt;/b&gt;&lt;br&gt;for quick adjustment</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="sizeSpinBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>60</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="minimum">
+        <double>0.500000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>200.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.500000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="SpinSlider" name="featherSlider" native="true">
+       <property name="toolTip">
+        <string>Set Stroke Feather &lt;br&gt;&lt;b&gt;[CTRL]+drag&lt;/b&gt;&lt;br&gt;for quick adjustment</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="featherSpinBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>60</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="minimum">
+        <double>0.100000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>99.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>5.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,1">
+     <item>
+      <widget class="QLabel" name="stabilizerLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Stabilizer</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="inpolLevelsCombo">
+       <property name="toolTip">
+        <string>Use stabilizer to interpolate strokes</string>
+       </property>
+       <property name="currentText">
+        <string comment="Stablizer level">None</string>
+       </property>
+       <item>
+        <property name="text">
+         <string comment="Stabilizer option">None</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string comment="Stabilizer option">Simple</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string comment="Stabilizer option">Strong</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <property name="topMargin">
+      <number>0</number>
      </property>
-     <property name="frameShadow">
-      <enum>QFrame::Shadow::Plain</enum>
-     </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>400</width>
-        <height>300</height>
-       </rect>
-      </property>
-      <property name="autoFillBackground">
-       <bool>true</bool>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="leftMargin">
-        <number>3</number>
+     <item>
+      <widget class="QCheckBox" name="useFeatherBox">
+       <property name="toolTip">
+        <string>Enable or disable feathering</string>
        </property>
-       <property name="topMargin">
-        <number>3</number>
+       <property name="text">
+        <string>Use Feather</string>
        </property>
-       <property name="rightMargin">
-        <number>3</number>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="fillContourBox">
+       <property name="toolTip">
+        <string>Contour will be filled</string>
        </property>
-       <property name="bottomMargin">
-        <number>3</number>
+       <property name="text">
+        <string>Fill Contour</string>
        </property>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <widget class="SpinSlider" name="sizeSlider" native="true">
-           <property name="toolTip">
-            <string>Set Stroke Width &lt;br&gt;&lt;b&gt;[SHIFT]+drag&lt;/b&gt;&lt;br&gt;for quick adjustment</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QDoubleSpinBox" name="sizeSpinBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>60</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="minimum">
-            <double>0.500000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>200.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>1.500000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="SpinSlider" name="featherSlider" native="true">
-           <property name="toolTip">
-            <string>Set Stroke Feather &lt;br&gt;&lt;b&gt;[CTRL]+drag&lt;/b&gt;&lt;br&gt;for quick adjustment</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QDoubleSpinBox" name="featherSpinBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>60</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="minimum">
-            <double>0.100000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>99.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>5.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QCheckBox" name="useFeatherBox">
-           <property name="toolTip">
-            <string>Enable or disable feathering</string>
-           </property>
-           <property name="text">
-            <string>Use Feather</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="fillContourBox">
-           <property name="toolTip">
-            <string>Contour will be filled</string>
-           </property>
-           <property name="text">
-            <string>Fill Contour</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="useClosedPathBox">
-           <property name="toolTip">
-            <string>Close Polyline path (hold Ctrl to temporarily invert)</string>
-           </property>
-           <property name="text">
-            <string>Closed Path</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="useBezierBox">
-           <property name="toolTip">
-            <string>Use Bézier curves to create curved lines</string>
-           </property>
-           <property name="text">
-            <string comment="Tool options">Bézier</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="usePressureBox">
-           <property name="toolTip">
-            <string>Vary strokes based on pressure when drawing on a tablet</string>
-           </property>
-           <property name="text">
-            <string comment="Tool options">Pressure</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="useAABox">
-           <property name="toolTip">
-            <string>Use anti-aliasing to create smooth edges</string>
-           </property>
-           <property name="text">
-            <string comment="Brush AA">Anti-Aliasing</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="makeInvisibleBox">
-           <property name="toolTip">
-            <string>Make invisible</string>
-           </property>
-           <property name="text">
-            <string comment="Tool options">Invisible</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,1">
-         <item>
-          <widget class="QLabel" name="stabilizerLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Stabilizer</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="inpolLevelsCombo">
-           <property name="toolTip">
-            <string>Use stabilizer to interpolate strokes</string>
-           </property>
-           <property name="currentText">
-            <string comment="Stablizer level">None</string>
-           </property>
-           <item>
-            <property name="text">
-             <string comment="Stabilizer option">None</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string comment="Stabilizer option">Simple</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string comment="Stabilizer option">Strong</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <spacer name="verticalSpacer1">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Policy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </widget>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="useClosedPathBox">
+       <property name="toolTip">
+        <string>Close Polyline path (hold Ctrl to temporarily invert)</string>
+       </property>
+       <property name="text">
+        <string>Closed Path</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="useBezierBox">
+       <property name="toolTip">
+        <string>Use Bézier curves to create curved lines</string>
+       </property>
+       <property name="text">
+        <string comment="Tool options">Bézier</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="usePressureBox">
+       <property name="toolTip">
+        <string>Vary strokes based on pressure when drawing on a tablet</string>
+       </property>
+       <property name="text">
+        <string comment="Tool options">Pressure</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="useAABox">
+       <property name="toolTip">
+        <string>Use anti-aliasing to create smooth edges</string>
+       </property>
+       <property name="text">
+        <string comment="Brush AA">Anti-Aliasing</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="makeInvisibleBox">
+       <property name="toolTip">
+        <string>Make invisible</string>
+       </property>
+       <property name="text">
+        <string comment="Tool options">Invisible</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/app/ui/strokeoptionswidget.ui
+++ b/app/ui/strokeoptionswidget.ui
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StrokeOptionsWidget</class>
+ <widget class="QWidget" name="StrokeOptionsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::Shape::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Shadow::Plain</enum>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>400</width>
+        <height>300</height>
+       </rect>
+      </property>
+      <property name="autoFillBackground">
+       <bool>true</bool>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="leftMargin">
+        <number>3</number>
+       </property>
+       <property name="topMargin">
+        <number>3</number>
+       </property>
+       <property name="rightMargin">
+        <number>3</number>
+       </property>
+       <property name="bottomMargin">
+        <number>3</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="SpinSlider" name="sizeSlider" native="true">
+           <property name="toolTip">
+            <string>Set Stroke Width &lt;br&gt;&lt;b&gt;[SHIFT]+drag&lt;/b&gt;&lt;br&gt;for quick adjustment</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="sizeSpinBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="minimum">
+            <double>0.500000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>200.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>1.500000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="SpinSlider" name="featherSlider" native="true">
+           <property name="toolTip">
+            <string>Set Stroke Feather &lt;br&gt;&lt;b&gt;[CTRL]+drag&lt;/b&gt;&lt;br&gt;for quick adjustment</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="featherSpinBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="minimum">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>99.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>5.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="useFeatherBox">
+           <property name="toolTip">
+            <string>Enable or disable feathering</string>
+           </property>
+           <property name="text">
+            <string>Use Feather</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="fillContourBox">
+           <property name="toolTip">
+            <string>Contour will be filled</string>
+           </property>
+           <property name="text">
+            <string>Fill Contour</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="useClosedPathBox">
+           <property name="toolTip">
+            <string>Close Polyline path (hold Ctrl to temporarily invert)</string>
+           </property>
+           <property name="text">
+            <string>Closed Path</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="useBezierBox">
+           <property name="toolTip">
+            <string>Use Bézier curves to create curved lines</string>
+           </property>
+           <property name="text">
+            <string comment="Tool options">Bézier</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="usePressureBox">
+           <property name="toolTip">
+            <string>Vary strokes based on pressure when drawing on a tablet</string>
+           </property>
+           <property name="text">
+            <string comment="Tool options">Pressure</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="useAABox">
+           <property name="toolTip">
+            <string>Use anti-aliasing to create smooth edges</string>
+           </property>
+           <property name="text">
+            <string comment="Brush AA">Anti-Aliasing</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="makeInvisibleBox">
+           <property name="toolTip">
+            <string>Make invisible</string>
+           </property>
+           <property name="text">
+            <string comment="Tool options">Invisible</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,1">
+         <item>
+          <widget class="QLabel" name="stabilizerLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Stabilizer</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="inpolLevelsCombo">
+           <property name="toolTip">
+            <string>Use stabilizer to interpolate strokes</string>
+           </property>
+           <property name="currentText">
+            <string comment="Stablizer level">None</string>
+           </property>
+           <item>
+            <property name="text">
+             <string comment="Stabilizer option">None</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string comment="Stabilizer option">Simple</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string comment="Stabilizer option">Strong</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <spacer name="verticalSpacer1">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SpinSlider</class>
+   <extends>QWidget</extends>
+   <header>spinslider.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/app/ui/tooloptions.ui
+++ b/app/ui/tooloptions.ui
@@ -21,16 +21,16 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
-    <number>3</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>3</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>3</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>3</number>
+    <number>0</number>
    </property>
    <item>
     <widget class="QScrollArea" name="scrollArea">
@@ -42,22 +42,28 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>132</width>
-        <height>195</height>
+        <width>138</width>
+        <height>201</height>
        </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <property name="leftMargin">
-        <number>0</number>
+        <number>3</number>
        </property>
        <property name="topMargin">
-        <number>0</number>
+        <number>3</number>
        </property>
        <property name="rightMargin">
         <number>3</number>
        </property>
        <property name="bottomMargin">
-        <number>0</number>
+        <number>3</number>
        </property>
       </layout>
      </widget>

--- a/app/ui/tooloptions.ui
+++ b/app/ui/tooloptions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>140</width>
-    <height>355</height>
+    <height>203</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -19,27 +19,21 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
-    <number>0</number>
+    <number>3</number>
    </property>
    <property name="topMargin">
-    <number>0</number>
+    <number>3</number>
    </property>
    <property name="rightMargin">
-    <number>0</number>
+    <number>3</number>
    </property>
    <property name="bottomMargin">
-    <number>0</number>
+    <number>3</number>
    </property>
    <item>
     <widget class="QScrollArea" name="scrollArea">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -48,290 +42,29 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>153</width>
-        <height>340</height>
+        <width>132</width>
+        <height>195</height>
        </rect>
       </property>
-      <property name="autoFillBackground">
-       <bool>true</bool>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
        <property name="leftMargin">
-        <number>3</number>
+        <number>0</number>
        </property>
        <property name="topMargin">
-        <number>3</number>
+        <number>0</number>
        </property>
        <property name="rightMargin">
         <number>3</number>
        </property>
        <property name="bottomMargin">
-        <number>3</number>
+        <number>0</number>
        </property>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <widget class="SpinSlider" name="sizeSlider" native="true">
-           <property name="toolTip">
-            <string>Set Stroke Width &lt;br&gt;&lt;b&gt;[SHIFT]+drag&lt;/b&gt;&lt;br&gt;for quick adjustment</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QDoubleSpinBox" name="brushSpinBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>60</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="minimum">
-            <double>0.500000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>200.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>1.500000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="SpinSlider" name="featherSlider" native="true">
-           <property name="toolTip">
-            <string>Set Stroke Feather &lt;br&gt;&lt;b&gt;[CTRL]+drag&lt;/b&gt;&lt;br&gt;for quick adjustment</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QDoubleSpinBox" name="featherSpinBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>60</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="minimum">
-            <double>0.100000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>99.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>5.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QCheckBox" name="useFeatherBox">
-           <property name="toolTip">
-            <string>Enable or disable feathering</string>
-           </property>
-           <property name="text">
-            <string>Use Feather</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="showInfoBox">
-           <property name="text">
-            <string>Show Size and Diff.</string>
-           </property>
-           <property name="checked">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="fillContourBox">
-           <property name="toolTip">
-            <string>Contour will be filled</string>
-           </property>
-           <property name="text">
-            <string>Fill Contour</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="useClosedPathBox">
-           <property name="toolTip">
-            <string>Close Polyline path (hold Ctrl to temporarily invert)</string>
-           </property>
-           <property name="text">
-            <string>Closed Path</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="useBezierBox">
-           <property name="toolTip">
-            <string>Use Bézier curves to create curved lines</string>
-           </property>
-           <property name="text">
-            <string comment="Tool options">Bézier</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="usePressureBox">
-           <property name="toolTip">
-            <string>Vary strokes based on pressure when drawing on a tablet</string>
-           </property>
-           <property name="text">
-            <string comment="Tool options">Pressure</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="useAABox">
-           <property name="toolTip">
-            <string>Use anti-aliasing to create smooth edges</string>
-           </property>
-           <property name="text">
-            <string comment="Brush AA">Anti-Aliasing</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="makeInvisibleBox">
-           <property name="toolTip">
-            <string>Make invisible</string>
-           </property>
-           <property name="text">
-            <string comment="Tool options">Invisible</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="preserveAlphaBox">
-           <property name="toolTip">
-            <string>Preserve Alpha</string>
-           </property>
-           <property name="text">
-            <string comment="Tool options">Alpha</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="vectorMergeBox">
-           <property name="toolTip">
-            <string>Merge vector lines when they are close together</string>
-           </property>
-           <property name="text">
-            <string comment="Vector line merge (Tool options)">Merge</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,1">
-         <item>
-          <widget class="QLabel" name="stabilizerLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Stabilizer</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="inpolLevelsCombo">
-           <property name="toolTip">
-            <string>Use stabilizer to interpolate strokes</string>
-           </property>
-           <property name="currentText">
-            <string comment="Stablizer level">None</string>
-           </property>
-           <item>
-            <property name="text">
-             <string comment="Stabilizer option">None</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string comment="Stabilizer option">Simple</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string comment="Stabilizer option">Strong</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="verticalSpacer1">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </widget>
     </widget>
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>SpinSlider</class>
-   <extends>QWidget</extends>
-   <header>spinslider.h</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -88,6 +88,7 @@ HEADERS +=  \
     src/tool/smudgetool.h \
     src/tool/strokeinterpolator.h \
     src/tool/stroketool.h \
+    src/tool/toolsettings.h \
     src/util/blitrect.h \
     src/util/cameraeasingtype.h \
     src/util/camerafieldoption.h \

--- a/core_lib/src/graphics/bitmap/bitmapbucket.h
+++ b/core_lib/src/graphics/bitmap/bitmapbucket.h
@@ -35,7 +35,7 @@ class BitmapBucket
 {
 public:
     explicit BitmapBucket();
-    explicit BitmapBucket(Editor* editor, QColor color, QRect maxFillRegion, QPointF fillPoint, Properties properties);
+    explicit BitmapBucket(Editor* editor, QColor color, QRect maxFillRegion, QPointF fillPoint, BucketSettings properties);
 
     /** Will paint at the given point, given that it makes sense.. canUse is always called prior to painting
      *
@@ -82,7 +82,7 @@ private:
     bool mFilledOnce = false;
     bool mUseDragToFill = false;
 
-    Properties mProperties;
+    BucketSettings mProperties;
 };
 
 #endif // BITMAPBUCKET_H

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -68,7 +68,6 @@ bool ScribbleArea::init()
     mMouseFilterTimer = new QTimer(this);
 
     connect(mPrefs, &PreferenceManager::optionChanged, this, &ScribbleArea::settingUpdated);
-    connect(mEditor->tools(), &ToolManager::toolPropertyChanged, this, &ScribbleArea::onToolPropertyUpdated);
     connect(mEditor->tools(), &ToolManager::toolChanged, this, &ScribbleArea::onToolChanged);
 
     connect(mDoubleClickTimer, &QTimer::timeout, this, &ScribbleArea::handleDoubleClick);
@@ -286,18 +285,6 @@ void ScribbleArea::invalidatePainterCaches()
     mCameraPainter.resetCache();
     mCanvasPainter.resetLayerCache();
     updateFrame();
-}
-
-void ScribbleArea::onToolPropertyUpdated(ToolType, ToolPropertyType type)
-{
-    switch (type)
-    {
-    case ToolPropertyType::CAMERA_SHOWPATH_CHECKED:
-        onFrameModified(mEditor->currentFrame());
-        break;
-    default:
-        break;
-    }
 }
 
 void ScribbleArea::onToolChanged(ToolType)

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 #include <QPixmapCache>
 #include <QTimer>
 
+#include "basetool.h"
 #include "pointerevent.h"
 #include "beziercurve.h"
 #include "object.h"
@@ -291,7 +292,7 @@ void ScribbleArea::onToolPropertyUpdated(ToolType, ToolPropertyType type)
 {
     switch (type)
     {
-    case ToolPropertyType::CAMERAPATH:
+    case ToolPropertyType::CAMERA_SHOWPATH_CHECKED:
         onFrameModified(mEditor->currentFrame());
         break;
     default:
@@ -800,10 +801,6 @@ void ScribbleArea::paintBitmapBuffer()
         case BRUSH:
         case PEN:
         case PENCIL:
-            if (currentTool()->properties.preserveAlpha)
-            {
-                cm = QPainter::CompositionMode_SourceOver;
-            }
             break;
         default: //nothing
             break;
@@ -1048,7 +1045,14 @@ void ScribbleArea::paintSelectionVisuals(QPainter &painter)
     if (currentSelectionRect.isEmpty()) { return; }
 
     TransformParameters params = { currentSelectionRect, editor()->view()->getView(), selectMan->selectionTransform() };
-    mSelectionPainter.paint(painter, object, mEditor->currentLayerIndex(), currentTool(), params);
+
+    // TODO: this should not use SELECT tool specifically.. we need to fetch this from SELECT or move tool respectively
+    // consider creating a TRANSFORM tool category.
+    mSelectionPainter.paint(painter,
+                            object,
+                            mEditor->currentLayerIndex(),
+                            static_cast<const SelectionSettings*>(editor()->tools()->getTool(SELECT)->getProperties()),
+                            params);
     emit selectionUpdated();
 }
 

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1051,7 +1051,7 @@ void ScribbleArea::paintSelectionVisuals(QPainter &painter)
     mSelectionPainter.paint(painter,
                             object,
                             mEditor->currentLayerIndex(),
-                            static_cast<const SelectionSettings*>(editor()->tools()->getTool(SELECT)->getProperties()),
+                            static_cast<const SelectionSettings*>(editor()->tools()->getTool(SELECT)->getSettings()),
                             params);
     emit selectionUpdated();
 }

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1051,7 +1051,7 @@ void ScribbleArea::paintSelectionVisuals(QPainter &painter)
     mSelectionPainter.paint(painter,
                             object,
                             mEditor->currentLayerIndex(),
-                            static_cast<const SelectionSettings*>(editor()->tools()->getTool(SELECT)->getSettings()),
+                            static_cast<const SelectionSettings*>(editor()->tools()->getTool(SELECT)->settings()),
                             params);
     emit selectionUpdated();
 }

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -108,9 +108,6 @@ public:
     /** Object updated, invalidate all cache */
     void onObjectLoaded();
 
-    /** Tool property updated, invalidate cache and frame if needed */
-    void onToolPropertyUpdated(ToolType, ToolPropertyType);
-
     /** Tool changed, invalidate cache and frame if needed */
     void onToolChanged(ToolType);
 

--- a/core_lib/src/managers/toolmanager.cpp
+++ b/core_lib/src/managers/toolmanager.cpp
@@ -17,6 +17,7 @@ GNU General Public License for more details.
 #include "toolmanager.h"
 
 #include <cmath>
+#include "stroketool.h"
 #include "pentool.h"
 #include "penciltool.h"
 #include "brushtool.h"
@@ -98,6 +99,22 @@ BaseTool* ToolManager::getTool(ToolType eToolType)
     return mToolSetHash[eToolType];
 }
 
+BaseTool* ToolManager::getTool(ToolCategory eToolCategory)
+{
+    switch (eToolCategory) {
+        case ToolCategory::STROKETOOL: {
+            if (currentTool()->category() == eToolCategory) {
+                return currentTool();
+            } else {
+                return nullptr;
+            }
+        }
+        case ToolCategory::BASETOOL: {
+            return currentTool();
+        }
+    }
+}
+
 void ToolManager::setDefaultTool()
 {
     // Set default tool
@@ -148,191 +165,9 @@ void ToolManager::resetAllTools()
 
     foreach(BaseTool* tool, mToolSetHash)
     {
-        tool->resetToDefault();
+        tool->resetSettings();
     }
     qDebug("tools restored to default settings");
-}
-
-void ToolManager::setWidth(float newWidth)
-{
-    if (std::isnan(newWidth) || newWidth < 0)
-    {
-        newWidth = 1.f;
-    }
-
-    currentTool()->setWidth(static_cast<qreal>(newWidth));
-    emit toolPropertyChanged(currentTool()->type(), WIDTH);
-}
-
-void ToolManager::setFeather(float newFeather)
-{
-    if (std::isnan(newFeather) || newFeather < 0)
-    {
-        newFeather = 0.f;
-    }
-
-    currentTool()->setFeather(static_cast<qreal>(newFeather));
-    emit toolPropertyChanged(currentTool()->type(), FEATHER);
-}
-
-void ToolManager::setUseFeather(bool usingFeather)
-{
-    int usingAA = currentTool()->properties.useAA;
-    int value = propertySwitch(usingFeather, usingAA);
-
-    currentTool()->setAA(value);
-    currentTool()->setUseFeather(usingFeather);
-    emit toolPropertyChanged(currentTool()->type(), USEFEATHER);
-    emit toolPropertyChanged(currentTool()->type(), ANTI_ALIASING);
-}
-
-void ToolManager::setInvisibility(bool isInvisible)
-{
-    currentTool()->setInvisibility(isInvisible);
-    emit toolPropertyChanged(currentTool()->type(), INVISIBILITY);
-}
-
-void ToolManager::setPreserveAlpha(bool isPreserveAlpha)
-{
-    currentTool()->setPreserveAlpha(isPreserveAlpha);
-    emit toolPropertyChanged(currentTool()->type(), PRESERVEALPHA);
-}
-
-void ToolManager::setVectorMergeEnabled(bool isVectorMergeEnabled)
-{
-    currentTool()->setVectorMergeEnabled(isVectorMergeEnabled);
-    emit toolPropertyChanged(currentTool()->type(), VECTORMERGE);
-}
-
-void ToolManager::setBezier(bool isBezierOn)
-{
-    currentTool()->setBezier(isBezierOn);
-    emit toolPropertyChanged(currentTool()->type(), BEZIER);
-}
-
-void ToolManager::setClosedPath(bool isPathClosed)
-{
-    currentTool()->setClosedPath(isPathClosed);
-    emit toolPropertyChanged(currentTool()->type(), CLOSEDPATH);
-}
-
-void ToolManager::setPressure(bool isPressureOn)
-{
-    currentTool()->setPressure(isPressureOn);
-    emit toolPropertyChanged(currentTool()->type(), PRESSURE);
-}
-
-void ToolManager::setAA(int usingAA)
-{
-    currentTool()->setAA(usingAA);
-    emit toolPropertyChanged(currentTool()->type(), ANTI_ALIASING);
-}
-
-void ToolManager::setFillMode(int mode)
-{
-    currentTool()->setFillMode(mode);
-    emit toolPropertyChanged(currentTool()->type(), FILL_MODE);
-}
-
-void ToolManager::setStabilizerLevel(int level)
-{
-    currentTool()->setStabilizerLevel(level);
-    emit toolPropertyChanged(currentTool()->type(), STABILIZATION);
-}
-
-void ToolManager::setTolerance(int newTolerance)
-{
-    newTolerance = qMax(0, newTolerance);
-
-    currentTool()->setTolerance(newTolerance);
-    emit toolPropertyChanged(currentTool()->type(), TOLERANCE);
-}
-
-void ToolManager::setBucketColorToleranceEnabled(bool enabled)
-{
-    currentTool()->setToleranceEnabled(enabled);
-    emit toolPropertyChanged(currentTool()->type(), USETOLERANCE);
-}
-
-void ToolManager::setBucketFillExpandEnabled(bool expandValue)
-{
-    currentTool()->setFillExpandEnabled(expandValue);
-    emit toolPropertyChanged(currentTool()->type(), USEBUCKETFILLEXPAND);
-}
-
-void ToolManager::setBucketFillExpand(int expandValue)
-{
-    currentTool()->setFillExpand(expandValue);
-    emit toolPropertyChanged(currentTool()->type(), BUCKETFILLEXPAND);
-}
-
-void ToolManager::setBucketFillReferenceMode(int referenceMode)
-{
-    currentTool()->setFillReferenceMode(referenceMode);
-    emit toolPropertyChanged(currentTool()->type(), BUCKETFILLLAYERREFERENCEMODE);
-}
-
-void ToolManager::setUseFillContour(bool useFillContour)
-{
-    currentTool()->setUseFillContour(useFillContour);
-    emit toolPropertyChanged(currentTool()->type(), FILLCONTOUR);
-}
-
-void ToolManager::setShowSelectionInfo(bool b)
-{
-    currentTool()->setShowSelectionInfo(b);
-}
-
-void ToolManager::setShowCameraPath(bool enabled)
-{
-    CameraTool* cameraTool = static_cast<CameraTool*>(getTool(CAMERA));
-    cameraTool->setShowCameraPath(enabled);
-    emit toolPropertyChanged(cameraTool->type(), CAMERAPATH);
-}
-
-void ToolManager::resetCameraPath()
-{
-    CameraTool* cameraTool = static_cast<CameraTool*>(getTool(CAMERA));
-    cameraTool->resetCameraPath();
-    emit toolPropertyChanged(cameraTool->type(), CAMERAPATH);
-}
-
-void ToolManager::resetCameraTransform(CameraFieldOption option)
-{
-    CameraTool* cameraTool = static_cast<CameraTool*>(getTool(CAMERA));
-    cameraTool->resetTransform(option);
-}
-
-void ToolManager::setCameraPathDotColor(int dotColorNum)
-{
-    CameraTool* cameraTool = static_cast<CameraTool*>(getTool(CAMERA));
-    cameraTool->setPathDotColorType(static_cast<DotColorType>(dotColorNum));
-    emit toolPropertyChanged(cameraTool->type(), CAMERAPATH);
-}
-
-bool ToolManager::bucketReferenceModeIsCurrentLayer(int referenceMode) const
-{
-    return referenceMode == 0;
-}
-
-// Switches on/off two actions
-// eg. if x = true, then y = false
-int ToolManager::propertySwitch(bool condition, int tool)
-{
-    int value = 0;
-    int newValue = 0;
-
-    if (condition == true)
-    {
-        value = -1;
-        newValue = mOldValue;
-        mOldValue = tool;
-    }
-    else if (condition == false)
-    {
-        value = (newValue == 1) ? 1 : mOldValue;
-    }
-    return value;
 }
 
 void ToolManager::tabletSwitchToEraser()

--- a/core_lib/src/managers/toolmanager.h
+++ b/core_lib/src/managers/toolmanager.h
@@ -21,10 +21,11 @@ GNU General Public License for more details.
 #include <QObject>
 #include <QHash>
 #include "basetool.h"
+#include "pencildef.h"
 #include "basemanager.h"
 #include "camerafieldoption.h"
 
-class ScribbleArea;
+class StrokeTool;
 
 class ToolManager : public BaseManager
 {
@@ -39,6 +40,7 @@ public:
 
     BaseTool* currentTool() const;
     BaseTool* getTool(ToolType eToolType);
+    BaseTool* getTool(ToolCategory eToolCategory);
     void setDefaultTool();
     void setCurrentTool(ToolType eToolType);
     void tabletSwitchToEraser();
@@ -51,8 +53,6 @@ public:
     void cleanupAllToolsData();
     bool leavingThisTool();
 
-    int propertySwitch(bool condition, int property);
-
 signals:
     void toolChanged(ToolType);
     void toolPropertyChanged(ToolType, ToolPropertyType);
@@ -60,49 +60,18 @@ signals:
 public slots:
     void resetAllTools();
 
-    void setWidth(float);
-    void setFeather(float);
-
-    void setUseFeather(bool);
-    void setInvisibility(bool);
-    void setPreserveAlpha(bool);
-    void setVectorMergeEnabled(bool);
-    void setBezier(bool);
-    void setClosedPath(bool);
-    void setPressure(bool);
-    void setAA(int);
-    void setFillMode(int);
-    void setStabilizerLevel(int);
-    void setTolerance(int);
-    void setBucketColorToleranceEnabled(bool enabled);
-    void setBucketFillExpandEnabled(bool enabled);
-    void setBucketFillReferenceMode(int referenceMode);
-    void setBucketFillExpand(int);
-    void setUseFillContour(bool);
-    void setShowSelectionInfo(bool b);
-    void setShowCameraPath(bool);
-    void resetCameraPath();
-    void setCameraPathDotColor(int);
-    void resetCameraTransform(CameraFieldOption option);
-
-    /// Layer mode will be enforced by the the choice the reference mode selected.
-    /// @return Returns true if reference mode is ``current layer`, otherwise false.
-    bool bucketReferenceModeIsCurrentLayer(int referenceMode) const;
-
 private:
     void setTemporaryTool(ToolType eToolType);
 
     BaseTool* mCurrentTool = nullptr;
     BaseTool* mTabletEraserTool = nullptr;
     BaseTool* mTemporaryTool = nullptr;
+
     Qt::KeyboardModifiers mTemporaryTriggerModifiers = Qt::NoModifier;
     QFlags<Qt::Key> mTemporaryTriggerKeys;
     Qt::MouseButtons mTemporaryTriggerMouseButtons = Qt::NoButton;
 
     QHash<ToolType, BaseTool*> mToolSetHash;
-
-    int mOldValue = 0;
-
 };
 
 #endif // TOOLMANAGER_H

--- a/core_lib/src/managers/toolmanager.h
+++ b/core_lib/src/managers/toolmanager.h
@@ -55,7 +55,6 @@ public:
 
 signals:
     void toolChanged(ToolType);
-    void toolPropertyChanged(ToolType, ToolPropertyType);
 
 public slots:
     void resetAllTools();

--- a/core_lib/src/selectionpainter.cpp
+++ b/core_lib/src/selectionpainter.cpp
@@ -18,7 +18,6 @@ GNU General Public License for more details.
 
 #include "object.h"
 #include "qpainter.h"
-#include "basetool.h"
 
 SelectionPainter::SelectionPainter()
 {
@@ -27,7 +26,7 @@ SelectionPainter::SelectionPainter()
 void SelectionPainter::paint(QPainter& painter,
                              const Object* object,
                              int layerIndex,
-                             BaseTool* tool,
+                             const SelectionSettings* toolProperties,
                              TransformParameters& tParams)
 {
     Layer* layer = object->getLayer(layerIndex);
@@ -53,34 +52,31 @@ void SelectionPainter::paint(QPainter& painter,
         painter.drawPolygon(projectedSelectionPolygon);
     }
 
-    if (tool->type() == SELECT || tool->type() == MOVE)
-    {
-        painter.setPen(Qt::SolidLine);
-        painter.setBrush(QBrush(Qt::gray));
-        int radius = HANDLE_WIDTH / 2;
+    painter.setPen(Qt::SolidLine);
+    painter.setBrush(QBrush(Qt::gray));
+    int radius = HANDLE_WIDTH / 2;
 
-        const QRectF topLeftCorner = QRectF(projectedSelectionPolygon[0].x() - radius,
-                                            projectedSelectionPolygon[0].y() - radius,
+    const QRectF topLeftCorner = QRectF(projectedSelectionPolygon[0].x() - radius,
+                                        projectedSelectionPolygon[0].y() - radius,
+                                        HANDLE_WIDTH, HANDLE_WIDTH);
+    painter.drawRect(topLeftCorner);
+
+    const QRectF topRightCorner = QRectF(projectedSelectionPolygon[1].x() - radius,
+                                         projectedSelectionPolygon[1].y() - radius,
+                                         HANDLE_WIDTH, HANDLE_WIDTH);
+    painter.drawRect(topRightCorner);
+
+    const QRectF bottomRightCorner = QRectF(projectedSelectionPolygon[2].x() - radius,
+                                            projectedSelectionPolygon[2].y() - radius,
                                             HANDLE_WIDTH, HANDLE_WIDTH);
-        painter.drawRect(topLeftCorner);
+    painter.drawRect(bottomRightCorner);
 
-        const QRectF topRightCorner = QRectF(projectedSelectionPolygon[1].x() - radius,
-                                             projectedSelectionPolygon[1].y() - radius,
-                                             HANDLE_WIDTH, HANDLE_WIDTH);
-        painter.drawRect(topRightCorner);
+    const QRectF bottomLeftCorner = QRectF(projectedSelectionPolygon[3].x() - radius,
+                                           projectedSelectionPolygon[3].y() - radius,
+                                           HANDLE_WIDTH, HANDLE_WIDTH);
+    painter.drawRect(bottomLeftCorner);
 
-        const QRectF bottomRightCorner = QRectF(projectedSelectionPolygon[2].x() - radius,
-                                                projectedSelectionPolygon[2].y() - radius,
-                                                HANDLE_WIDTH, HANDLE_WIDTH);
-        painter.drawRect(bottomRightCorner);
-
-        const QRectF bottomLeftCorner = QRectF(projectedSelectionPolygon[3].x() - radius,
-                                               projectedSelectionPolygon[3].y() - radius,
-                                               HANDLE_WIDTH, HANDLE_WIDTH);
-        painter.drawRect(bottomLeftCorner);
-    }
-
-    if (tool->properties.showSelectionInfo) {
+    if (toolProperties->showSelectionInfo()) {
         paintSelectionInfo(painter, transform, tParams.viewTransform, tParams.originalSelectionRectF, projectedSelectionPolygon);
     }
 }

--- a/core_lib/src/selectionpainter.h
+++ b/core_lib/src/selectionpainter.h
@@ -21,9 +21,10 @@ GNU General Public License for more details.
 #include <QPolygonF>
 #include <QTransform>
 
+#include "toolsettings.h"
+
 class QPainter;
 class Object;
-class BaseTool;
 
 struct TransformParameters
 {
@@ -38,7 +39,7 @@ class SelectionPainter
 public:
     SelectionPainter();
 
-    void paint(QPainter& painter, const Object* object, int layerIndex, BaseTool* tool, TransformParameters& transformParameters);
+    void paint(QPainter& painter, const Object* object, int layerIndex, const SelectionSettings* toolProperties, TransformParameters& transformParameters);
 
 private:
     void paintSelectionInfo(QPainter& painter, const QTransform& mergedTransform, const QTransform& viewTransform, const QRectF& selectionRect, const QPolygonF& projectedPolygonF);

--- a/core_lib/src/tool/basetool.cpp
+++ b/core_lib/src/tool/basetool.cpp
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 #include "scribblearea.h"
 #include "strokeinterpolator.h"
 #include "pointerevent.h"
+#include "layermanager.h"
 
 QString BaseTool::TypeName(ToolType type)
 {
@@ -76,6 +77,16 @@ void BaseTool::resetSettings()
         QSettings settings(PENCIL2D, PENCIL2D);
         getProperties()->setDefaults();
     }
+}
+
+bool BaseTool::isPropertyEnabled(int rawType)
+{
+    Layer* currentLayer = mEditor->layers()->currentLayer();
+    if (!currentLayer) {
+        return false;
+    }
+
+    return mPropertyUsed[rawType].contains(currentLayer->type());
 }
 
 QCursor BaseTool::cursor()

--- a/core_lib/src/tool/basetool.cpp
+++ b/core_lib/src/tool/basetool.cpp
@@ -49,18 +49,6 @@ QString BaseTool::TypeName(ToolType type)
 
 BaseTool::BaseTool(QObject* parent) : QObject(parent)
 {
-    mPropertyEnabled.insert(WIDTH, false);
-    mPropertyEnabled.insert(FEATHER, false);
-    mPropertyEnabled.insert(USEFEATHER, false);
-    mPropertyEnabled.insert(PRESSURE, false);
-    mPropertyEnabled.insert(INVISIBILITY, false);
-    mPropertyEnabled.insert(PRESERVEALPHA, false);
-    mPropertyEnabled.insert(BEZIER, false);
-    mPropertyEnabled.insert(CLOSEDPATH, false);
-    mPropertyEnabled.insert(ANTI_ALIASING, false);
-    mPropertyEnabled.insert(FILL_MODE, false);
-    mPropertyEnabled.insert(STABILIZATION, false);
-    mPropertyEnabled.insert(CAMERA_SHOWPATH_CHECKED, false);
 }
 
 void BaseTool::initialize(Editor* editor)

--- a/core_lib/src/tool/basetool.cpp
+++ b/core_lib/src/tool/basetool.cpp
@@ -63,9 +63,24 @@ BaseTool::BaseTool(QObject* parent) : QObject(parent)
     mPropertyEnabled.insert(CAMERA_SHOWPATH_CHECKED, false);
 }
 
-BaseTool::BaseTool(QObject* parent, ToolSettings* settings) : QObject(parent),
-    mSettings(settings)
+void BaseTool::initialize(Editor* editor)
 {
+    Q_ASSERT(editor);
+    mEditor = editor;
+    mScribbleArea = editor->getScribbleArea();
+    Q_ASSERT(mScribbleArea);
+    createSettings(nullptr);
+
+    loadSettings();
+}
+
+void BaseTool::createSettings(ToolSettings* settings)
+{
+    if (settings == nullptr) {
+        mSettings = new ToolSettings();
+    } else {
+        mSettings = settings;
+    }
 }
 
 void BaseTool::saveSettings()
@@ -108,16 +123,6 @@ bool BaseTool::leavingThisTool()
    saveSettings();
 
    return true;
-}
-
-void BaseTool::initialize(Editor* editor)
-{
-    Q_ASSERT(editor);
-    mEditor = editor;
-    mScribbleArea = editor->getScribbleArea();
-    Q_ASSERT(mScribbleArea);
-
-    loadSettings();
 }
 
 void BaseTool::pointerPressEvent(PointerEvent* event)

--- a/core_lib/src/tool/basetool.cpp
+++ b/core_lib/src/tool/basetool.cpp
@@ -65,17 +65,17 @@ BaseTool::BaseTool(QObject* parent) : QObject(parent)
 
 void BaseTool::saveSettings()
 {
-    if (getProperties()) {
+    if (getSettings()) {
         QSettings settings(PENCIL2D, PENCIL2D);
-        getProperties()->save(settings);
+        getSettings()->save(settings);
     }
 }
 
 void BaseTool::resetSettings()
 {
-    if (getProperties()) {
+    if (getSettings()) {
         QSettings settings(PENCIL2D, PENCIL2D);
-        getProperties()->setDefaults();
+        getSettings()->setDefaults();
     }
 }
 

--- a/core_lib/src/tool/basetool.cpp
+++ b/core_lib/src/tool/basetool.cpp
@@ -41,6 +41,7 @@ QString BaseTool::TypeName(ToolType type)
         map[BUCKET] = tr("Bucket");
         map[EYEDROPPER] = tr("Eyedropper");
         map[BRUSH] = tr("Brush");
+        map[CAMERA] = tr("Camera");
     }
     return map.at(type);
 }
@@ -58,7 +59,23 @@ BaseTool::BaseTool(QObject* parent) : QObject(parent)
     mPropertyEnabled.insert(ANTI_ALIASING, false);
     mPropertyEnabled.insert(FILL_MODE, false);
     mPropertyEnabled.insert(STABILIZATION, false);
-    mPropertyEnabled.insert(CAMERAPATH, false);
+    mPropertyEnabled.insert(CAMERA_SHOWPATH_CHECKED, false);
+}
+
+void BaseTool::saveSettings()
+{
+    if (getProperties()) {
+        QSettings settings(PENCIL2D, PENCIL2D);
+        getProperties()->save(settings);
+    }
+}
+
+void BaseTool::resetSettings()
+{
+    if (getProperties()) {
+        QSettings settings(PENCIL2D, PENCIL2D);
+        getProperties()->setDefaults();
+    }
 }
 
 QCursor BaseTool::cursor()
@@ -125,113 +142,4 @@ bool BaseTool::isDrawingTool()
 bool BaseTool::isActive() const
 {
     return false;
-}
-
-void BaseTool::setWidth(const qreal width)
-{
-    properties.width = width;
-}
-
-void BaseTool::setFeather(const qreal feather)
-{
-    properties.feather = feather;
-}
-
-void BaseTool::setUseFeather(const bool usingFeather)
-{
-    properties.useFeather = usingFeather;
-}
-
-void BaseTool::setInvisibility(const bool invisibility)
-{
-    properties.invisibility = invisibility;
-}
-
-void BaseTool::setBezier(const bool _bezier_state)
-{
-    properties.bezier_state = _bezier_state;
-}
-
-void BaseTool::setClosedPath(const bool closed)
-{
-    properties.closedPolylinePath = closed;
-}
-
-void BaseTool::setPressure(const bool pressure)
-{
-    properties.pressure = pressure;
-}
-
-void BaseTool::setPreserveAlpha(const bool preserveAlpha)
-{
-    properties.preserveAlpha = preserveAlpha;
-}
-
-void BaseTool::setVectorMergeEnabled(const bool vectorMergeEnabled)
-{
-    properties.vectorMergeEnabled = vectorMergeEnabled;
-}
-
-void BaseTool::setAA(const int useAA)
-{
-    properties.useAA = useAA;
-}
-
-void BaseTool::setFillMode(const int mode)
-{
-    properties.fillMode = mode;
-}
-
-void BaseTool::setStabilizerLevel(const int level)
-{
-    properties.stabilizerLevel = level;
-}
-
-void BaseTool::setTolerance(const int tolerance)
-{
-    properties.tolerance = tolerance;
-}
-
-void BaseTool::setToleranceEnabled(const bool enabled)
-{
-    properties.toleranceEnabled = enabled;
-}
-
-void BaseTool::setFillExpand(const int fillExpandValue)
-{
-    properties.bucketFillExpand = fillExpandValue;
-}
-
-void BaseTool::setFillReferenceMode(int referenceMode)
-{
-    properties.bucketFillReferenceMode = referenceMode;
-}
-
-void BaseTool::setFillExpandEnabled(const bool enabled)
-{
-    properties.bucketFillExpandEnabled = enabled;
-}
-
-void BaseTool::setUseFillContour(const bool useFillContour)
-{
-    properties.useFillContour = useFillContour;
-}
-
-void BaseTool::setShowSelectionInfo(const bool b)
-{
-    properties.showSelectionInfo = b;
-}
-
-void BaseTool::setShowCameraPath(const bool showCameraPath)
-{
-    properties.cameraShowPath = showCameraPath;
-}
-
-void BaseTool::setPathDotColorType(const DotColorType dotColorType)
-{
-    properties.cameraPathDotColorType = dotColorType;
-}
-
-void BaseTool::resetCameraPath()
-{
 }

--- a/core_lib/src/tool/basetool.cpp
+++ b/core_lib/src/tool/basetool.cpp
@@ -63,19 +63,23 @@ BaseTool::BaseTool(QObject* parent) : QObject(parent)
     mPropertyEnabled.insert(CAMERA_SHOWPATH_CHECKED, false);
 }
 
+BaseTool::BaseTool(QObject* parent, ToolSettings* settings) : QObject(parent),
+    mSettings(settings)
+{
+}
+
 void BaseTool::saveSettings()
 {
-    if (getSettings()) {
-        QSettings settings(PENCIL2D, PENCIL2D);
-        getSettings()->save(settings);
+    if (settings()) {
+        QSettings storedSettings(PENCIL2D, PENCIL2D);
+        settings()->save(storedSettings);
     }
 }
 
 void BaseTool::resetSettings()
 {
-    if (getSettings()) {
-        QSettings settings(PENCIL2D, PENCIL2D);
-        getSettings()->setDefaults();
+    if (settings()) {
+        settings()->setDefaults();
     }
 }
 

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -25,6 +25,7 @@ GNU General Public License for more details.
 #include <QHash>
 #include <QEvent>
 #include "pencildef.h"
+#include "toolsettings.h"
 
 class QPixmap;
 class Editor;
@@ -34,32 +35,6 @@ class QKeyEvent;
 class QMouseEvent;
 class QTabletEvent;
 class PointerEvent;
-
-class Properties
-{
-public:
-    qreal width = 1.0;
-    qreal feather = 1.0;
-    bool  pressure = true;
-    int   invisibility = 0;
-    int   preserveAlpha = 0;
-    bool  vectorMergeEnabled = false;
-    bool  bezier_state = false;
-    bool  closedPolylinePath = false;
-    bool  useFeather = true;
-    int   useAA = 0;
-    int   fillMode = 0;
-    int   stabilizerLevel = 0;
-    qreal tolerance = 0;
-    bool toleranceEnabled = false;
-    int bucketFillExpand = 0;
-    bool bucketFillExpandEnabled = 0;
-    int bucketFillReferenceMode = 0;
-    bool  useFillContour = false;
-    bool  showSelectionInfo = true;
-    bool  cameraShowPath = true;
-    DotColorType cameraPathDotColorType = DotColorType::RED;
-};
 
 const int ON = 1;
 const int OFF = 0;
@@ -78,8 +53,12 @@ public:
     void initialize(Editor* editor);
 
     virtual ToolType type() = 0;
+    virtual ToolCategory category() { return ToolCategory::BASETOOL; }
+
     virtual void loadSettings() = 0;
-    virtual void saveSettings() = 0;
+    void saveSettings();
+    void resetSettings();
+
     virtual QCursor cursor();
 
     virtual void pointerPressEvent(PointerEvent*) = 0;
@@ -95,7 +74,6 @@ public:
     virtual bool leaveEvent(QEvent*) { return false; }
 
     virtual void clearToolData() {}
-    virtual void resetToDefault() {}
 
     /** Check if the tool is active.
      *
@@ -106,29 +84,7 @@ public:
      */
     virtual bool isActive() const;
 
-    virtual void setWidth(const qreal width);
-    virtual void setFeather(const qreal feather);
-
-    virtual void setInvisibility(const bool invisibility);
-    virtual void setBezier(const bool bezier_state);
-    virtual void setClosedPath(const bool closed);
-    virtual void setPressure(const bool pressure);
-    virtual void setUseFeather(const bool usingFeather);
-    virtual void setPreserveAlpha(const bool preserveAlpha);
-    virtual void setVectorMergeEnabled(const bool vectorMergeEnabled);
-    virtual void setAA(const int useAA);
-    virtual void setFillMode(const int mode);
-    virtual void setStabilizerLevel(const int level);
-    virtual void setTolerance(const int tolerance);
-    virtual void setToleranceEnabled(const bool enabled);
-    virtual void setFillExpand(const int fillExpandValue);
-    virtual void setFillExpandEnabled(const bool enabled);
-    virtual void setFillReferenceMode(int referenceMode);
-    virtual void setUseFillContour(const bool useFillContour);
-    virtual void setShowSelectionInfo(const bool b);
-    virtual void setShowCameraPath(const bool showCameraPath);
-    virtual void setPathDotColorType(const DotColorType dotColorType);
-    virtual void resetCameraPath();
+    virtual ToolSettings* getProperties() { return nullptr; }
 
     virtual void paint(QPainter& painter, const QRect& blitRect) { Q_UNUSED(painter) Q_UNUSED(blitRect) }
 
@@ -139,8 +95,6 @@ public:
     /// `leavingThisTool` will handle the cleanup of `active` connections
     virtual bool enteringThisTool() { return true; }
 
-    Properties properties;
-
     bool isPropertyEnabled(ToolPropertyType t) { return mPropertyEnabled[t]; }
     bool isDrawingTool();
 
@@ -148,8 +102,8 @@ signals:
     bool isActiveChanged(ToolType, bool);
 
 protected:
-    Editor* editor() { return mEditor; }
 
+    Editor* editor() { return mEditor; }
     QHash<ToolPropertyType, bool> mPropertyEnabled;
 
     Editor* mEditor = nullptr;

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -47,6 +47,7 @@ class BaseTool : public QObject
     Q_OBJECT
 protected:
     explicit BaseTool(QObject* parent);
+    explicit BaseTool(QObject* parent, ToolSettings* settings);
 public:
     static QString TypeName(ToolType);
     QString typeName() { return TypeName(type()); }
@@ -85,7 +86,7 @@ public:
      */
     virtual bool isActive() const;
 
-    virtual ToolSettings* getSettings() { return nullptr; }
+    virtual ToolSettings* settings() { return mSettings; }
 
     virtual void paint(QPainter& painter, const QRect& blitRect) { Q_UNUSED(painter) Q_UNUSED(blitRect) }
 
@@ -108,6 +109,7 @@ protected:
     Editor* editor() { return mEditor; }
     QHash<ToolPropertyType, bool> mPropertyEnabled;
     QHash<int, QSet<Layer::LAYER_TYPE>> mPropertyUsed;
+    ToolSettings* mSettings = nullptr;
 
     Editor* mEditor = nullptr;
     ScribbleArea* mScribbleArea = nullptr;

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -85,7 +85,7 @@ public:
      */
     virtual bool isActive() const;
 
-    virtual ToolSettings* getProperties() { return nullptr; }
+    virtual ToolSettings* getSettings() { return nullptr; }
 
     virtual void paint(QPainter& painter, const QRect& blitRect) { Q_UNUSED(painter) Q_UNUSED(blitRect) }
 

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -47,7 +47,6 @@ class BaseTool : public QObject
     Q_OBJECT
 protected:
     explicit BaseTool(QObject* parent);
-    explicit BaseTool(QObject* parent, ToolSettings* settings);
 public:
     static QString TypeName(ToolType);
     QString typeName() { return TypeName(type()); }
@@ -57,6 +56,7 @@ public:
     virtual ToolType type() const = 0;
     virtual ToolCategory category() const { return ToolCategory::BASETOOL; }
 
+    virtual void createSettings(ToolSettings* settings = nullptr);
     virtual void loadSettings() = 0;
     void saveSettings();
     void resetSettings();
@@ -86,7 +86,7 @@ public:
      */
     virtual bool isActive() const;
 
-    virtual ToolSettings* settings() { return mSettings; }
+    virtual ToolSettings* settings() { Q_ASSERT(mSettings); return mSettings; }
 
     virtual void paint(QPainter& painter, const QRect& blitRect) { Q_UNUSED(painter) Q_UNUSED(blitRect) }
 

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -26,6 +26,7 @@ GNU General Public License for more details.
 #include <QEvent>
 #include "pencildef.h"
 #include "toolsettings.h"
+#include "layer.h"
 
 class QPixmap;
 class Editor;
@@ -52,8 +53,8 @@ public:
 
     void initialize(Editor* editor);
 
-    virtual ToolType type() = 0;
-    virtual ToolCategory category() { return ToolCategory::BASETOOL; }
+    virtual ToolType type() const = 0;
+    virtual ToolCategory category() const { return ToolCategory::BASETOOL; }
 
     virtual void loadSettings() = 0;
     void saveSettings();
@@ -96,6 +97,7 @@ public:
     virtual bool enteringThisTool() { return true; }
 
     bool isPropertyEnabled(ToolPropertyType t) { return mPropertyEnabled[t]; }
+    bool isPropertyEnabled(int rawType);
     bool isDrawingTool();
 
 signals:
@@ -105,6 +107,7 @@ protected:
 
     Editor* editor() { return mEditor; }
     QHash<ToolPropertyType, bool> mPropertyEnabled;
+    QHash<int, QSet<Layer::LAYER_TYPE>> mPropertyUsed;
 
     Editor* mEditor = nullptr;
     ScribbleArea* mScribbleArea = nullptr;

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -97,7 +97,6 @@ public:
     /// `leavingThisTool` will handle the cleanup of `active` connections
     virtual bool enteringThisTool() { return true; }
 
-    bool isPropertyEnabled(ToolPropertyType t) { return mPropertyEnabled[t]; }
     bool isPropertyEnabled(int rawType);
     bool isDrawingTool();
 
@@ -107,7 +106,6 @@ signals:
 protected:
 
     Editor* editor() { return mEditor; }
-    QHash<ToolPropertyType, bool> mPropertyEnabled;
     QHash<int, QSet<Layer::LAYER_TYPE>> mPropertyUsed;
     ToolSettings* mSettings = nullptr;
 

--- a/core_lib/src/tool/basetool.h
+++ b/core_lib/src/tool/basetool.h
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 #include <QCursor>
 #include <QPainter>
 #include <QHash>
+#include <QSet>
 #include <QEvent>
 #include "pencildef.h"
 #include "toolsettings.h"

--- a/core_lib/src/tool/brushtool.cpp
+++ b/core_lib/src/tool/brushtool.cpp
@@ -53,14 +53,19 @@ void BrushTool::loadSettings()
     mPropertyEnabled[PRESSURE] = true;
     mPropertyEnabled[INVISIBILITY] = true;
     mPropertyEnabled[STABILIZATION] = true;
+    mPropertyUsed[StrokeSettings::WIDTH_VALUE] = { Layer::BITMAP, Layer::VECTOR };
+    mPropertyUsed[StrokeSettings::FEATHER_VALUE] = { Layer::BITMAP };
+    mPropertyUsed[StrokeSettings::PRESSURE_ON] = { Layer::BITMAP, Layer::VECTOR };
+    mPropertyUsed[StrokeSettings::INVISIBILITY_ON] = { Layer::VECTOR };
+    mPropertyUsed[StrokeSettings::STABILIZATION_VALUE] = { Layer::BITMAP, Layer::VECTOR };
 
     QSettings settings(PENCIL2D, PENCIL2D);
 
     QHash<int, PropertyInfo> info;
     info[StrokeSettings::WIDTH_VALUE] = { 1.0, 100.0, 24.0 };
     info[StrokeSettings::FEATHER_VALUE] = { 1.0, 99.0, 48.0 };
-    info[StrokeSettings::PRESSURE_ON] = { true };
-    info[StrokeSettings::INVISIBILITY_ON] = { false };
+    info[StrokeSettings::PRESSURE_ON] = true;
+    info[StrokeSettings::INVISIBILITY_ON] = false;
     info[StrokeSettings::STABILIZATION_VALUE] = { StabilizationLevel::NONE, StabilizationLevel::STRONG, StabilizationLevel::STRONG } ;
 
     properties.load(typeName(), settings, info);

--- a/core_lib/src/tool/brushtool.cpp
+++ b/core_lib/src/tool/brushtool.cpp
@@ -39,7 +39,7 @@ BrushTool::BrushTool(QObject* parent) : StrokeTool(parent)
 {
 }
 
-ToolType BrushTool::type()
+ToolType BrushTool::type() const
 {
     return BRUSH;
 }

--- a/core_lib/src/tool/brushtool.cpp
+++ b/core_lib/src/tool/brushtool.cpp
@@ -68,7 +68,7 @@ void BrushTool::loadSettings()
     info[StrokeSettings::INVISIBILITY_ON] = false;
     info[StrokeSettings::STABILIZATION_VALUE] = { StabilizationLevel::NONE, StabilizationLevel::STRONG, StabilizationLevel::STRONG } ;
 
-    properties.load(typeName(), settings, info);
+    mStrokeSettings->load(typeName(), settings, info);
 
     mQuickSizingProperties.insert(Qt::ShiftModifier, WIDTH);
     mQuickSizingProperties.insert(Qt::ControlModifier, FEATHER);
@@ -109,9 +109,9 @@ void BrushTool::pointerMoveEvent(PointerEvent* event)
     {
         mCurrentPressure = mInterpolator.getPressure();
         drawStroke();
-        if (properties.stabilizerLevel() != mInterpolator.getStabilizerLevel())
+        if (mStrokeSettings->stabilizerLevel() != mInterpolator.getStabilizerLevel())
         {
-            mInterpolator.setStabilizerLevel(properties.stabilizerLevel());
+            mInterpolator.setStabilizerLevel(mStrokeSettings->stabilizerLevel());
         }
     }
 
@@ -156,13 +156,13 @@ void BrushTool::paintAt(QPointF point)
     Layer* layer = mEditor->layers()->currentLayer();
     if (layer->type() == Layer::BITMAP)
     {
-        qreal pressure = (properties.usePressure()) ? mCurrentPressure : 1.0;
-        qreal opacity = (properties.usePressure()) ? (mCurrentPressure * 0.5) : 1.0;
-        qreal brushWidth = properties.width() * pressure;
+        qreal pressure = (mStrokeSettings->usePressure()) ? mCurrentPressure : 1.0;
+        qreal opacity = (mStrokeSettings->usePressure()) ? (mCurrentPressure * 0.5) : 1.0;
+        qreal brushWidth = mStrokeSettings->width() * pressure;
         mCurrentWidth = brushWidth;
         mScribbleArea->drawBrush(point,
                                  brushWidth,
-                                 properties.feather(),
+                                 mStrokeSettings->feather(),
                                  mEditor->color()->frontColor(),
                                  QPainter::CompositionMode_SourceOver,
                                  opacity,
@@ -179,9 +179,9 @@ void BrushTool::drawStroke()
 
     if (layer->type() == Layer::BITMAP)
     {
-        qreal pressure = (properties.usePressure()) ? mCurrentPressure : 1.0;
-        qreal opacity = (properties.usePressure()) ? (mCurrentPressure * 0.5) : 1.0;
-        qreal brushWidth = properties.width() * pressure;
+        qreal pressure = (mStrokeSettings->usePressure()) ? mCurrentPressure : 1.0;
+        qreal opacity = (mStrokeSettings->usePressure()) ? (mCurrentPressure * 0.5) : 1.0;
+        qreal brushWidth = mStrokeSettings->width() * pressure;
         mCurrentWidth = brushWidth;
 
         qreal brushStep = (0.5 * brushWidth);
@@ -199,7 +199,7 @@ void BrushTool::drawStroke()
 
             mScribbleArea->drawBrush(point,
                                      brushWidth,
-                                     properties.feather(),
+                                     mStrokeSettings->feather(),
                                      mEditor->color()->frontColor(),
                                      QPainter::CompositionMode_SourceOver,
                                      opacity,
@@ -228,8 +228,8 @@ void BrushTool::drawStroke()
     }
     else if (layer->type() == Layer::VECTOR)
     {
-        qreal pressure = (properties.usePressure()) ? mCurrentPressure : 1;
-        qreal brushWidth = properties.width() * pressure;
+        qreal pressure = (mStrokeSettings->usePressure()) ? mCurrentPressure : 1;
+        qreal brushWidth = mStrokeSettings->width() * pressure;
 
         QPen pen(mEditor->color()->frontColor(),
                  brushWidth,
@@ -261,11 +261,11 @@ void BrushTool::paintVectorStroke(Layer* layer)
         qreal tol = mScribbleArea->getCurveSmoothing() / mEditor->view()->scaling();
 
         BezierCurve curve(mStrokePoints, mStrokePressures, tol);
-        curve.setWidth(properties.width());
-        curve.setFeather(properties.feather());
+        curve.setWidth(mStrokeSettings->width());
+        curve.setFeather(mStrokeSettings->feather());
         curve.setFilled(false);
-        curve.setInvisibility(properties.invisibility());
-        curve.setVariableWidth(properties.usePressure());
+        curve.setInvisibility(mStrokeSettings->invisibility());
+        curve.setVariableWidth(mStrokeSettings->usePressure());
         curve.setColorNumber(mEditor->color()->frontColorNumber());
 
         VectorImage* vectorImage = static_cast<VectorImage*>(layer->getLastKeyFrameAtPosition(mEditor->currentFrame()));

--- a/core_lib/src/tool/brushtool.cpp
+++ b/core_lib/src/tool/brushtool.cpp
@@ -48,11 +48,6 @@ void BrushTool::loadSettings()
 {
     StrokeTool::loadSettings();
 
-    mPropertyEnabled[WIDTH] = true;
-    mPropertyEnabled[FEATHER] = true;
-    mPropertyEnabled[PRESSURE] = true;
-    mPropertyEnabled[INVISIBILITY] = true;
-    mPropertyEnabled[STABILIZATION] = true;
     mPropertyUsed[StrokeSettings::WIDTH_VALUE] = { Layer::BITMAP, Layer::VECTOR };
     mPropertyUsed[StrokeSettings::FEATHER_VALUE] = { Layer::BITMAP };
     mPropertyUsed[StrokeSettings::PRESSURE_ON] = { Layer::BITMAP, Layer::VECTOR };
@@ -70,8 +65,8 @@ void BrushTool::loadSettings()
 
     mStrokeSettings->load(typeName(), settings, info);
 
-    mQuickSizingProperties.insert(Qt::ShiftModifier, WIDTH);
-    mQuickSizingProperties.insert(Qt::ControlModifier, FEATHER);
+    mQuickSizingProperties.insert(Qt::ShiftModifier, StrokeSettings::WIDTH_VALUE);
+    mQuickSizingProperties.insert(Qt::ControlModifier, StrokeSettings::FEATHER_VALUE);
 }
 
 QCursor BrushTool::cursor()

--- a/core_lib/src/tool/brushtool.h
+++ b/core_lib/src/tool/brushtool.h
@@ -29,8 +29,9 @@ class BrushTool : public StrokeTool
 
 public:
     explicit BrushTool(QObject* parent = 0);
-    ToolType type() override;
-    ToolCategory category() override { return STROKETOOL; }
+
+    ToolType type() const override;
+    ToolCategory category() const override { return STROKETOOL; }
 
     void loadSettings() override;
     QCursor cursor() override;

--- a/core_lib/src/tool/brushtool.h
+++ b/core_lib/src/tool/brushtool.h
@@ -30,9 +30,9 @@ class BrushTool : public StrokeTool
 public:
     explicit BrushTool(QObject* parent = 0);
     ToolType type() override;
+    ToolCategory category() override { return STROKETOOL; }
+
     void loadSettings() override;
-    void saveSettings() override;
-    void resetToDefault() override;
     QCursor cursor() override;
 
     void pointerMoveEvent(PointerEvent*) override;
@@ -42,12 +42,6 @@ public:
     void drawStroke();
     void paintVectorStroke(Layer* layer);
     void paintAt(QPointF point);
-
-    void setWidth(const qreal width) override;
-    void setFeather(const qreal feather) override;
-    void setPressure(const bool pressure) override;
-    void setInvisibility(const bool invisibility) override;
-    void setStabilizerLevel(const int level) override;
 
 protected:
     QPointF mLastBrushPoint;

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -38,6 +38,12 @@ BucketTool::BucketTool(QObject* parent) : BaseTool(parent)
 {
 }
 
+void BucketTool::createSettings(ToolSettings*)
+{
+    mSettings = new BucketSettings();
+    BaseTool::createSettings(mSettings);
+}
+
 void BucketTool::loadSettings()
 {
     mPropertyEnabled[TOLERANCE] = true;
@@ -63,7 +69,7 @@ void BucketTool::loadSettings()
     info[BucketSettings::FILLLAYERREFERENCEMODE_VALUE] = { 0, 1, 0 };
     info[BucketSettings::FILLMODE_VALUE] = { 0, 2, 0 };
 
-    properties.load(typeName(), settings, info);
+    mSettings->load(typeName(), settings, info);
 }
 
 QCursor BucketTool::cursor()
@@ -93,7 +99,7 @@ void BucketTool::pointerPressEvent(PointerEvent* event)
                                  mEditor->color()->frontColor(),
                                  layerCam ? layerCam->getViewAtFrame(mEditor->currentFrame()).inverted().mapRect(layerCam->getViewRect()) : QRect(),
                                  getCurrentPoint(),
-                                 properties);
+                                 *mSettings);
 
     // Because we can change layer to on the fly, but we do not act reactively
     // on it, it's necessary to invalidate layer cache on press event.
@@ -165,7 +171,7 @@ void BucketTool::paintVector(Layer* layer)
         vectorImage->fillSelectedPath(mEditor->color()->frontColorNumber());
     }
 
-    vectorImage->applyWidthToSelection(properties.fillThickness());
+    vectorImage->applyWidthToSelection(mSettings->fillThickness());
     vectorImage->applyColorToSelectedCurve(mEditor->color()->frontColorNumber());
     vectorImage->applyColorToSelectedArea(mEditor->color()->frontColorNumber());
 
@@ -181,43 +187,43 @@ void BucketTool::applyChanges()
 
 void BucketTool::setStrokeThickness(qreal width)
 {
-    properties.setBaseValue(BucketSettings::FILLTHICKNESS_VALUE, width);
+    mSettings->setBaseValue(BucketSettings::FILLTHICKNESS_VALUE, width);
     editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::WIDTH);
 }
 
 void BucketTool::setTolerance(int tolerance)
 {
-    properties.setBaseValue(BucketSettings::TOLERANCE_VALUE, tolerance);
+    mSettings->setBaseValue(BucketSettings::TOLERANCE_VALUE, tolerance);
     editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::TOLERANCE);
 }
 
 void BucketTool::setToleranceON(bool isON)
 {
-    properties.setBaseValue(BucketSettings::TOLERANCE_ON, isON);
+    mSettings->setBaseValue(BucketSettings::TOLERANCE_ON, isON);
     editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::USETOLERANCE);
 }
 
 void BucketTool::setFillExpand(int fillExpandValue)
 {
-    properties.setBaseValue(BucketSettings::FILLEXPAND_VALUE, fillExpandValue);
+    mSettings->setBaseValue(BucketSettings::FILLEXPAND_VALUE, fillExpandValue);
     editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::BUCKETFILLEXPAND);
 }
 
 void BucketTool::setFillExpandON(bool isON)
 {
-    properties.setBaseValue(BucketSettings::FILLEXPAND_ON, isON);
+    mSettings->setBaseValue(BucketSettings::FILLEXPAND_ON, isON);
     editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::USEBUCKETFILLEXPAND);
 }
 
 void BucketTool::setFillReferenceMode(int referenceMode)
 {
-    properties.setBaseValue(BucketSettings::FILLLAYERREFERENCEMODE_VALUE, referenceMode);
+    mSettings->setBaseValue(BucketSettings::FILLLAYERREFERENCEMODE_VALUE, referenceMode);
     editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::BUCKETFILLLAYERREFERENCEMODE);
 }
 
 void BucketTool::setFillMode(int mode)
 {
-    properties.setBaseValue(BucketSettings::FILLMODE_VALUE, mode);
+    mSettings->setBaseValue(BucketSettings::FILLMODE_VALUE, mode);
     editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::FILL_MODE);
 }
 

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -46,9 +46,6 @@ void BucketTool::createSettings(ToolSettings*)
 
 void BucketTool::loadSettings()
 {
-    mPropertyEnabled[TOLERANCE] = true;
-    mPropertyEnabled[WIDTH] = true;
-    mPropertyEnabled[FILL_MODE] = true;
     mPropertyUsed[BucketSettings::FILLTHICKNESS_VALUE] = { Layer::VECTOR };
     mPropertyUsed[BucketSettings::TOLERANCE_VALUE] = { Layer::BITMAP };
     mPropertyUsed[BucketSettings::TOLERANCE_ON] = { Layer::BITMAP };
@@ -188,43 +185,43 @@ void BucketTool::applyChanges()
 void BucketTool::setStrokeThickness(qreal width)
 {
     mSettings->setBaseValue(BucketSettings::FILLTHICKNESS_VALUE, width);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::WIDTH);
+    emit strokeThicknessChanged(width);
 }
 
 void BucketTool::setTolerance(int tolerance)
 {
     mSettings->setBaseValue(BucketSettings::TOLERANCE_VALUE, tolerance);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::TOLERANCE);
+    emit toleranceChanged(tolerance);
 }
 
 void BucketTool::setToleranceON(bool isON)
 {
     mSettings->setBaseValue(BucketSettings::TOLERANCE_ON, isON);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::USETOLERANCE);
+    emit toleranceONChanged(isON);
 }
 
 void BucketTool::setFillExpand(int fillExpandValue)
 {
     mSettings->setBaseValue(BucketSettings::FILLEXPAND_VALUE, fillExpandValue);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::BUCKETFILLEXPAND);
+    emit fillExpandChanged(fillExpandValue);
 }
 
 void BucketTool::setFillExpandON(bool isON)
 {
     mSettings->setBaseValue(BucketSettings::FILLEXPAND_ON, isON);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::USEBUCKETFILLEXPAND);
+    emit fillExpandONChanged(isON);
 }
 
 void BucketTool::setFillReferenceMode(int referenceMode)
 {
     mSettings->setBaseValue(BucketSettings::FILLLAYERREFERENCEMODE_VALUE, referenceMode);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::BUCKETFILLLAYERREFERENCEMODE);
+    emit fillReferenceModeChanged(referenceMode);
 }
 
 void BucketTool::setFillMode(int mode)
 {
     mSettings->setBaseValue(BucketSettings::FILLMODE_VALUE, mode);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::FILL_MODE);
+    emit fillModeChanged(mode);
 }
 
 QPointF BucketTool::getCurrentPoint() const

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -58,10 +58,10 @@ void BucketTool::loadSettings()
 
     QHash<int, PropertyInfo> info;
 
-    info[BucketSettings::FILLTHICKNESS_VALUE] = { 0.0, 100.0, 4.0 };
-    info[BucketSettings::TOLERANCE_VALUE] = { 0, 100, 32 };
+    info[BucketSettings::FILLTHICKNESS_VALUE] = { 1.0, 100.0, 4.0 };
+    info[BucketSettings::TOLERANCE_VALUE] = { 1, 100, 32 };
     info[BucketSettings::TOLERANCE_ON] = false;
-    info[BucketSettings::FILLEXPAND_VALUE] = { 0, 25, 2 };
+    info[BucketSettings::FILLEXPAND_VALUE] = { 1, 25, 2 };
     info[BucketSettings::FILLEXPAND_ON] = true;
     info[BucketSettings::FILLLAYERREFERENCEMODE_VALUE] = { 0, 1, 0 };
     info[BucketSettings::FILLMODE_VALUE] = { 0, 2, 0 };

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -43,6 +43,13 @@ void BucketTool::loadSettings()
     mPropertyEnabled[TOLERANCE] = true;
     mPropertyEnabled[WIDTH] = true;
     mPropertyEnabled[FILL_MODE] = true;
+    mPropertyUsed[BucketSettings::FILLTHICKNESS_VALUE] = { Layer::VECTOR };
+    mPropertyUsed[BucketSettings::TOLERANCE_VALUE] = { Layer::BITMAP };
+    mPropertyUsed[BucketSettings::TOLERANCE_ON] = { Layer::BITMAP };
+    mPropertyUsed[BucketSettings::FILLEXPAND_VALUE] = { Layer::BITMAP };
+    mPropertyUsed[BucketSettings::FILLEXPAND_ON] = { Layer::BITMAP };
+    mPropertyUsed[BucketSettings::FILLLAYERREFERENCEMODE_VALUE] = { Layer::BITMAP };
+    mPropertyUsed[BucketSettings::FILLMODE_VALUE] = { Layer::BITMAP };
 
     QSettings settings(PENCIL2D, PENCIL2D);
 

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -53,7 +53,7 @@ void BucketTool::loadSettings()
 
     QHash<int, PropertyInfo> info;
 
-    info[BucketSettings::WIDTH_VALUE] = { 0.0, 100.0, 4.0 };
+    info[BucketSettings::FILLTHICKNESS_VALUE] = { 0.0, 100.0, 4.0 };
     info[BucketSettings::TOLERANCE_VALUE] = { 0, 100, 32 };
     info[BucketSettings::TOLERANCE_ON] = false;
     info[BucketSettings::FILLEXPAND_VALUE] = { 0, 25, 2 };
@@ -169,7 +169,7 @@ void BucketTool::paintVector(Layer* layer)
         vectorImage->fillSelectedPath(mEditor->color()->frontColorNumber());
     }
 
-    vectorImage->applyWidthToSelection(properties.thickness());
+    vectorImage->applyWidthToSelection(properties.fillThickness());
     vectorImage->applyColorToSelectedCurve(mEditor->color()->frontColorNumber());
     vectorImage->applyColorToSelectedArea(mEditor->color()->frontColorNumber());
 
@@ -218,7 +218,7 @@ void BucketTool::drawStroke()
 
 void BucketTool::setWidth(qreal width)
 {
-    properties.setBaseValue(BucketSettings::WIDTH_VALUE, width);
+    properties.setBaseValue(BucketSettings::FILLTHICKNESS_VALUE, width);
     editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::WIDTH);
 }
 

--- a/core_lib/src/tool/buckettool.h
+++ b/core_lib/src/tool/buckettool.h
@@ -26,16 +26,17 @@ GNU General Public License for more details.
 class Layer;
 class VectorImage;
 
-class BucketTool : public StrokeTool
+class BucketTool : public BaseTool
 {
     Q_OBJECT
 public:
     explicit BucketTool(QObject* parent = nullptr);
-    ToolType type() override;
-    ToolCategory category() override { return STROKETOOL; }
+
+    QCursor cursor() override;
+    ToolType type() const override { return BUCKET; }
+    ToolCategory category() const override { return STROKETOOL; }
 
     void loadSettings() override;
-    QCursor cursor() override;
 
     void pointerPressEvent(PointerEvent*) override;
     void pointerMoveEvent(PointerEvent*) override;
@@ -43,11 +44,10 @@ public:
 
     void paintBitmap();
     void paintVector(Layer* layer);
-    void drawStroke();
 
     void applyChanges();
 
-    void setWidth(qreal width) override;
+    void setStrokeThickness(qreal width);
     void setTolerance(int tolerance);
     void setFillExpand(int fillExpandValue);
     void setFillReferenceMode(int referenceMode);
@@ -55,7 +55,14 @@ public:
     void setToleranceON(bool isON);
     void setFillExpandON(bool isON);
 
+    QPointF getCurrentPoint() const;
+    QPointF getCurrentPixel() const;
+    // {
+    //     return mInterpolator.getLastPixel();
+    // }
+
     ToolSettings* getProperties() override { return &properties; }
+
 
 private:
 
@@ -65,6 +72,8 @@ private:
     bool mFilledOnMove = false;
 
     BucketSettings properties;
+    StrokeInterpolator mInterpolator;
+    const UndoSaveState* mUndoSaveState = nullptr;
 };
 
 #endif // BUCKETTOOL_H

--- a/core_lib/src/tool/buckettool.h
+++ b/core_lib/src/tool/buckettool.h
@@ -36,6 +36,7 @@ public:
     ToolType type() const override { return BUCKET; }
     ToolCategory category() const override { return BASETOOL; }
 
+    void createSettings(ToolSettings*) override;
     void loadSettings() override;
 
     void pointerPressEvent(PointerEvent*) override;
@@ -57,12 +58,8 @@ public:
 
     QPointF getCurrentPoint() const;
     QPointF getCurrentPixel() const;
-    // {
-    //     return mInterpolator.getLastPixel();
-    // }
 
-    ToolSettings* settings() override { return &properties; }
-
+    ToolSettings* settings() override { return mSettings; }
 
 private:
 
@@ -71,7 +68,7 @@ private:
 
     bool mFilledOnMove = false;
 
-    BucketSettings properties;
+    BucketSettings* mSettings = nullptr;
     StrokeInterpolator mInterpolator;
     const UndoSaveState* mUndoSaveState = nullptr;
 };

--- a/core_lib/src/tool/buckettool.h
+++ b/core_lib/src/tool/buckettool.h
@@ -61,7 +61,7 @@ public:
     //     return mInterpolator.getLastPixel();
     // }
 
-    ToolSettings* getSettings() override { return &properties; }
+    ToolSettings* settings() override { return &properties; }
 
 
 private:

--- a/core_lib/src/tool/buckettool.h
+++ b/core_lib/src/tool/buckettool.h
@@ -34,7 +34,7 @@ public:
 
     QCursor cursor() override;
     ToolType type() const override { return BUCKET; }
-    ToolCategory category() const override { return STROKETOOL; }
+    ToolCategory category() const override { return BASETOOL; }
 
     void loadSettings() override;
 
@@ -61,7 +61,7 @@ public:
     //     return mInterpolator.getLastPixel();
     // }
 
-    ToolSettings* getProperties() override { return &properties; }
+    ToolSettings* getSettings() override { return &properties; }
 
 
 private:

--- a/core_lib/src/tool/buckettool.h
+++ b/core_lib/src/tool/buckettool.h
@@ -61,6 +61,15 @@ public:
 
     ToolSettings* settings() override { return mSettings; }
 
+signals:
+    void fillModeChanged(int mode);
+    void fillReferenceModeChanged(int referenceMode);
+    void fillExpandONChanged(bool isON);
+    void fillExpandChanged(int fillExpandValue);
+    void toleranceONChanged(bool isON);
+    void toleranceChanged(int width);
+    void strokeThicknessChanged(qreal width);
+
 private:
 
     BitmapBucket mBitmapBucket;

--- a/core_lib/src/tool/buckettool.h
+++ b/core_lib/src/tool/buckettool.h
@@ -32,22 +32,14 @@ class BucketTool : public StrokeTool
 public:
     explicit BucketTool(QObject* parent = nullptr);
     ToolType type() override;
+    ToolCategory category() override { return STROKETOOL; }
+
     void loadSettings() override;
-    void saveSettings() override;
-    void resetToDefault() override;
     QCursor cursor() override;
 
     void pointerPressEvent(PointerEvent*) override;
     void pointerMoveEvent(PointerEvent*) override;
     void pointerReleaseEvent(PointerEvent*) override;
-
-    void setTolerance(const int tolerance) override;
-    void setToleranceEnabled(const bool enabled) override;
-    void setWidth(const qreal width) override;
-    void setFillExpand(const int fillExpandValue) override;
-    void setFillExpandEnabled(const bool enabled) override;
-    void setFillReferenceMode(int referenceMode) override;
-    void setFillMode(int mode) override;
 
     void paintBitmap();
     void paintVector(Layer* layer);
@@ -55,12 +47,24 @@ public:
 
     void applyChanges();
 
+    void setWidth(qreal width) override;
+    void setTolerance(int tolerance);
+    void setFillExpand(int fillExpandValue);
+    void setFillReferenceMode(int referenceMode);
+    void setFillMode(int mode);
+    void setToleranceON(bool isON);
+    void setFillExpandON(bool isON);
+
+    ToolSettings* getProperties() override { return &properties; }
+
 private:
 
     BitmapBucket mBitmapBucket;
     VectorImage* vectorImage = nullptr;
 
     bool mFilledOnMove = false;
+
+    BucketSettings properties;
 };
 
 #endif // BUCKETTOOL_H

--- a/core_lib/src/tool/cameratool.cpp
+++ b/core_lib/src/tool/cameratool.cpp
@@ -218,27 +218,27 @@ void CameraTool::updateMoveMode(const QPointF& pos)
     }
 }
 
-void CameraTool::performAction(ToolActionType actionType)
+void CameraTool::performAction(ActionType actionType)
 {
     switch (actionType)
     {
-        case CAMERA_PATH_RESET: {
+        case RESET_PATH: {
             resetCameraPath();
             break;
         }
-        case CAMERA_RESET_FIELD: {
+        case RESET_FIELD: {
             resetTransform(CameraFieldOption::RESET_FIELD);
             break;
         }
-        case CAMERA_RESET_ROTATION: {
+        case RESET_ROTATION: {
             resetTransform(CameraFieldOption::RESET_ROTATION);
             break;
         }
-        case CAMERA_RESET_SCALING: {
+        case RESET_SCALING: {
             resetTransform(CameraFieldOption::RESET_ROTATION);
             break;
         }
-        case CAMERA_RESET_TRANSLATION: {
+        case RESET_TRANSLATION: {
             resetTransform(CameraFieldOption::RESET_TRANSLATION);
             break;
         }
@@ -252,6 +252,9 @@ void CameraTool::setCameraPathON(bool isON)
     Q_ASSERT(layer->type() == Layer::CAMERA);
     layer->setShowCameraPath(isON);
     mSettings->setBaseValue(CameraSettings::SHOWPATH_ON, isON);
+    emit cameraPathONChanged(isON);
+
+    emit mEditor->frameModified(mEditor->currentFrame());
 }
 
 void CameraTool::setPathDotColorType(DotColorType pathDotColor)
@@ -261,6 +264,9 @@ void CameraTool::setPathDotColorType(DotColorType pathDotColor)
 
     layer->updateDotColor(pathDotColor);
     mSettings->setBaseValue(CameraSettings::PATH_DOTCOLOR_TYPE, static_cast<int>(pathDotColor));
+    emit pathColorChanged(pathDotColor);
+
+    emit mEditor->frameModified(mEditor->currentFrame());
 }
 
 void CameraTool::resetCameraPath()
@@ -269,7 +275,8 @@ void CameraTool::resetCameraPath()
     Q_ASSERT(layer->type() == Layer::CAMERA);
 
     layer->setPathMovedAtFrame(mEditor->currentFrame(), false);
-    mEditor->updateFrame();
+
+    emit mEditor->frameModified(mEditor->currentFrame());
 }
 
 void CameraTool::resetTransform(CameraFieldOption option)
@@ -301,7 +308,7 @@ void CameraTool::transformCamera(const QPointF& pos, Qt::KeyboardModifiers keyMo
 
     transformView(layer, mCamMoveMode, pos, mTransformOffset, -angleDeg, mEditor->currentFrame());
 
-    mEditor->updateFrame();
+    emit mEditor->frameModified(mEditor->currentFrame());
     mTransformOffset = pos;
 }
 
@@ -311,7 +318,7 @@ void CameraTool::transformCameraPath(const QPointF& pos)
     LayerCamera* layer = static_cast<LayerCamera*>(editor()->layers()->currentLayer());
 
     layer->updatePathControlPointAtFrame(pos, mDragPathFrame);
-    mEditor->updateFrame();
+    emit mEditor->frameModified(mEditor->currentFrame());
 }
 
 int CameraTool::constrainedRotation(const qreal rotatedAngle, const int rotationIncrement) const

--- a/core_lib/src/tool/cameratool.cpp
+++ b/core_lib/src/tool/cameratool.cpp
@@ -38,12 +38,17 @@ GNU General Public License for more details.
 
 CameraTool::CameraTool(QObject* object) : BaseTool(object)
 {
-
 }
 
 CameraTool::~CameraTool()
 {
     saveSettings();
+}
+
+void CameraTool::createSettings(ToolSettings*)
+{
+    mSettings = new CameraSettings();
+    BaseTool::createSettings(mSettings);
 }
 
 void CameraTool::loadSettings()
@@ -62,7 +67,7 @@ void CameraTool::loadSettings()
                                                  static_cast<int>(DotColorType::BLACK) };
     info[CameraSettings::SHOWPATH_ON] = false;
 
-    properties.load(typeName(), settings, info);
+    mSettings->load(typeName(), settings, info);
 
     connect(mEditor->preference(), &PreferenceManager::optionChanged, this, &CameraTool::updateSettings);
 
@@ -102,8 +107,8 @@ void CameraTool::updateProperties()
     if (!layer || layer->type() != Layer::CAMERA) { return; }
 
     LayerCamera* layerCam = static_cast<LayerCamera*>(layer);
-    properties.setBaseValue(CameraSettings::PATH_DOTCOLOR_TYPE, static_cast<int>(layerCam->getDotColorType()));
-    properties.setBaseValue(CameraSettings::SHOWPATH_ON, layerCam->getShowCameraPath());
+    mSettings->setBaseValue(CameraSettings::PATH_DOTCOLOR_TYPE, static_cast<int>(layerCam->getDotColorType()));
+    mSettings->setBaseValue(CameraSettings::SHOWPATH_ON, layerCam->getShowCameraPath());
 }
 
 void CameraTool::updateSettings(const SETTING setting)
@@ -190,7 +195,7 @@ void CameraTool::updateMoveMode(const QPointF& pos)
     {
         mCamMoveMode = getCameraMoveMode(pos,
                                          selectionTolerance);
-    } else if (properties.showPath()) {
+    } else if (mSettings->showPath()) {
         int keyPos = cam->firstKeyFramePosition();
         while (keyPos <= cam->getMaxKeyFramePosition())
         {
@@ -246,7 +251,7 @@ void CameraTool::setCameraPathON(bool isON)
 
     Q_ASSERT(layer->type() == Layer::CAMERA);
     layer->setShowCameraPath(isON);
-    properties.setBaseValue(CameraSettings::SHOWPATH_ON, isON);
+    mSettings->setBaseValue(CameraSettings::SHOWPATH_ON, isON);
 }
 
 void CameraTool::setPathDotColorType(DotColorType pathDotColor)
@@ -255,7 +260,7 @@ void CameraTool::setPathDotColorType(DotColorType pathDotColor)
     Q_ASSERT(layer->type() == Layer::CAMERA);
 
     layer->updateDotColor(pathDotColor);
-    properties.setBaseValue(CameraSettings::PATH_DOTCOLOR_TYPE, static_cast<int>(pathDotColor));
+    mSettings->setBaseValue(CameraSettings::PATH_DOTCOLOR_TYPE, static_cast<int>(pathDotColor));
 }
 
 void CameraTool::resetCameraPath()

--- a/core_lib/src/tool/cameratool.cpp
+++ b/core_lib/src/tool/cameratool.cpp
@@ -53,13 +53,15 @@ void CameraTool::createSettings(ToolSettings*)
 
 void CameraTool::loadSettings()
 {
-    mPropertyEnabled[CAMERA_SHOWPATH_CHECKED] = true;
     connect(mEditor->layers(), &LayerManager::currentLayerChanged, this, &CameraTool::updateProperties);
     connect(mEditor, &Editor::objectLoaded, this, &CameraTool::updateProperties);
 
     mRotationIncrement = mEditor->preference()->getInt(SETTING::ROTATION_INCREMENT);
 
     QSettings settings(PENCIL2D, PENCIL2D);
+
+    mPropertyUsed[CameraSettings::SHOWPATH_ON] = { Layer::CAMERA };
+    mPropertyUsed[CameraSettings::PATH_DOTCOLOR_TYPE] = { Layer::CAMERA };
 
     QHash<int, PropertyInfo> info;
     info[CameraSettings::PATH_DOTCOLOR_TYPE] = { static_cast<int>(DotColorType::BLACK),

--- a/core_lib/src/tool/cameratool.h
+++ b/core_lib/src/tool/cameratool.h
@@ -44,12 +44,22 @@ class Camera;
 class CameraTool : public BaseTool
 {
     Q_OBJECT
+
 public:
     explicit CameraTool(QObject* object);
     ~CameraTool() override;
 
+    enum ActionType {
+        RESET_PATH,
+        RESET_FIELD,
+        RESET_ROTATION,
+        RESET_TRANSLATION,
+        RESET_SCALING
+    };
+
     QCursor cursor() override;
     ToolType type() const override { return ToolType::CAMERA; }
+    bool isActive() const override { return true; }
 
     void paint(QPainter& painter, const QRect&) override;
 
@@ -69,7 +79,11 @@ public:
 
     ToolSettings* settings() override { return mSettings; }
 
-    void performAction(ToolActionType actionType);
+    void performAction(ActionType actionType);
+
+signals:
+    void pathColorChanged(DotColorType colorType);
+    void cameraPathONChanged(bool isON);
 
 private:
 

--- a/core_lib/src/tool/cameratool.h
+++ b/core_lib/src/tool/cameratool.h
@@ -66,7 +66,7 @@ public:
 
     void transformView(LayerCamera* layerCamera, CameraMoveType mode, const QPointF& point, const QPointF& offset, qreal angle, int frameNumber) const;
 
-    ToolSettings* getProperties() override { return &properties; }
+    ToolSettings* getSettings() override { return &properties; }
 
     void performAction(ToolActionType actionType);
 

--- a/core_lib/src/tool/cameratool.h
+++ b/core_lib/src/tool/cameratool.h
@@ -53,6 +53,7 @@ public:
 
     void paint(QPainter& painter, const QRect&) override;
 
+    void createSettings(ToolSettings*) override;
     void loadSettings() override;
 
     void pointerPressEvent(PointerEvent* event) override;
@@ -66,7 +67,7 @@ public:
 
     void transformView(LayerCamera* layerCamera, CameraMoveType mode, const QPointF& point, const QPointF& offset, qreal angle, int frameNumber) const;
 
-    ToolSettings* settings() override { return &properties; }
+    ToolSettings* settings() override { return mSettings; }
 
     void performAction(ToolActionType actionType);
 
@@ -114,7 +115,7 @@ private:
     QColor mHandleDisabledColor;
     QColor mHandleTextColor;
 
-    CameraSettings properties;
+    CameraSettings* mSettings = nullptr;
 };
 
 #endif // CAMERATOOL_H

--- a/core_lib/src/tool/cameratool.h
+++ b/core_lib/src/tool/cameratool.h
@@ -49,7 +49,7 @@ public:
     ~CameraTool() override;
 
     QCursor cursor() override;
-    ToolType type() override { return ToolType::CAMERA; }
+    ToolType type() const override { return ToolType::CAMERA; }
 
     void paint(QPainter& painter, const QRect&) override;
 

--- a/core_lib/src/tool/cameratool.h
+++ b/core_lib/src/tool/cameratool.h
@@ -54,18 +54,21 @@ public:
     void paint(QPainter& painter, const QRect&) override;
 
     void loadSettings() override;
-    void saveSettings() override;
 
     void pointerPressEvent(PointerEvent* event) override;
     void pointerReleaseEvent(PointerEvent* event) override;
     void pointerMoveEvent(PointerEvent* event) override;
 
-    void setShowCameraPath(const bool showCameraPath) override;
-    void resetCameraPath() override;
-    void setPathDotColorType(const DotColorType pathDotColor) override;
+    void setCameraPathON(bool isON);
+    void resetCameraPath();
+    void setPathDotColorType(DotColorType pathDotColor);
     void resetTransform(CameraFieldOption option);
 
     void transformView(LayerCamera* layerCamera, CameraMoveType mode, const QPointF& point, const QPointF& offset, qreal angle, int frameNumber) const;
+
+    ToolSettings* getProperties() override { return &properties; }
+
+    void performAction(ToolActionType actionType);
 
 private:
 
@@ -110,6 +113,8 @@ private:
     QColor mHandleColor;
     QColor mHandleDisabledColor;
     QColor mHandleTextColor;
+
+    CameraSettings properties;
 };
 
 #endif // CAMERATOOL_H

--- a/core_lib/src/tool/cameratool.h
+++ b/core_lib/src/tool/cameratool.h
@@ -66,7 +66,7 @@ public:
 
     void transformView(LayerCamera* layerCamera, CameraMoveType mode, const QPointF& point, const QPointF& offset, qreal angle, int frameNumber) const;
 
-    ToolSettings* getSettings() override { return &properties; }
+    ToolSettings* settings() override { return &properties; }
 
     void performAction(ToolActionType actionType);
 

--- a/core_lib/src/tool/erasertool.cpp
+++ b/core_lib/src/tool/erasertool.cpp
@@ -97,9 +97,9 @@ void EraserTool::pointerMoveEvent(PointerEvent* event)
     {
         mCurrentPressure = mInterpolator.getPressure();
         updateStrokes();
-        if (properties.stabilizerLevel() != mInterpolator.getStabilizerLevel())
+        if (mStrokeSettings->stabilizerLevel() != mInterpolator.getStabilizerLevel())
         {
-            mInterpolator.setStabilizerLevel(properties.stabilizerLevel());
+            mInterpolator.setStabilizerLevel(mStrokeSettings->stabilizerLevel());
         }
     }
 
@@ -139,19 +139,19 @@ void EraserTool::paintAt(QPointF point)
     Layer* layer = mEditor->layers()->currentLayer();
     if (layer->type() == Layer::BITMAP)
     {
-        qreal pressure = (properties.usePressure()) ? mCurrentPressure : 1.0;
-        qreal opacity = (properties.usePressure()) ? (mCurrentPressure * 0.5) : 1.0;
-        qreal brushWidth = properties.width() * pressure;
+        qreal pressure = (mStrokeSettings->usePressure()) ? mCurrentPressure : 1.0;
+        qreal opacity = (mStrokeSettings->usePressure()) ? (mCurrentPressure * 0.5) : 1.0;
+        qreal brushWidth = mStrokeSettings->width() * pressure;
         mCurrentWidth = brushWidth;
 
         mScribbleArea->drawBrush(point,
                                  brushWidth,
-                                 properties.feather(),
+                                 mStrokeSettings->feather(),
                                  QColor(255, 255, 255, 255),
                                  QPainter::CompositionMode_SourceOver,
                                  opacity,
-                                 properties.useFeather(),
-                                 properties.useAntiAliasing() == ON);
+                                 mStrokeSettings->useFeather(),
+                                 mStrokeSettings->useAntiAliasing() == ON);
     }
 }
 
@@ -164,9 +164,9 @@ void EraserTool::drawStroke()
 
     if (layer->type() == Layer::BITMAP)
     {
-        qreal pressure = (properties.usePressure()) ? mCurrentPressure : 1.0;
-        qreal opacity = (properties.usePressure()) ? (mCurrentPressure * 0.5) : 1.0;
-        qreal brushWidth = properties.width() * pressure;
+        qreal pressure = (mStrokeSettings->usePressure()) ? mCurrentPressure : 1.0;
+        qreal opacity = (mStrokeSettings->usePressure()) ? (mCurrentPressure * 0.5) : 1.0;
+        qreal brushWidth = mStrokeSettings->width() * pressure;
         mCurrentWidth = brushWidth;
 
         qreal brushStep = (0.5 * brushWidth);
@@ -186,12 +186,12 @@ void EraserTool::drawStroke()
 
             mScribbleArea->drawBrush(point,
                                      brushWidth,
-                                     properties.feather(),
+                                     mStrokeSettings->feather(),
                                      Qt::white,
                                      QPainter::CompositionMode_SourceOver,
                                      opacity,
-                                     properties.useFeather(),
-                                     properties.useAntiAliasing() == ON);
+                                     mStrokeSettings->useFeather(),
+                                     mStrokeSettings->useAntiAliasing() == ON);
             if (i == (steps - 1))
             {
                 mLastBrushPoint = getCurrentPoint();
@@ -200,8 +200,8 @@ void EraserTool::drawStroke()
     }
     else if (layer->type() == Layer::VECTOR)
     {
-        mCurrentWidth = properties.width();
-        if (properties.usePressure())
+        mCurrentWidth = mStrokeSettings->width();
+        if (mStrokeSettings->usePressure())
         {
             mCurrentWidth = (mCurrentWidth + (mInterpolator.getPressure() * mCurrentWidth)) * 0.5;
         }
@@ -247,7 +247,7 @@ void EraserTool::updateStrokes()
 
     if (layer->type() == Layer::VECTOR)
     {
-        qreal radius = properties.width() / 2;
+        qreal radius = mStrokeSettings->width() / 2;
 
         VectorImage* currKey = static_cast<VectorImage*>(layer->getLastKeyFrameAtPosition(mEditor->currentFrame()));
         QList<VertexRef> nearbyVertices = currKey->getVerticesCloseTo(getCurrentPoint(), radius);

--- a/core_lib/src/tool/erasertool.cpp
+++ b/core_lib/src/tool/erasertool.cpp
@@ -35,7 +35,7 @@ EraserTool::EraserTool(QObject* parent) : StrokeTool(parent)
 {
 }
 
-ToolType EraserTool::type()
+ToolType EraserTool::type() const
 {
     return ERASER;
 }

--- a/core_lib/src/tool/erasertool.cpp
+++ b/core_lib/src/tool/erasertool.cpp
@@ -44,17 +44,16 @@ void EraserTool::loadSettings()
 {
     StrokeTool::loadSettings();
 
-    mPropertyEnabled[WIDTH] = true;
-    mPropertyEnabled[USEFEATHER] = true;
-    mPropertyEnabled[FEATHER] = true;
-    mPropertyEnabled[USEFEATHER] = true;
-    mPropertyEnabled[PRESSURE] = true;
-    mPropertyEnabled[STABILIZATION] = true;
-    mPropertyEnabled[ANTI_ALIASING] = true;
-
     QSettings settings(PENCIL2D, PENCIL2D);
 
     QHash<int, PropertyInfo> info;
+
+    mPropertyUsed[StrokeSettings::WIDTH_VALUE] = { Layer::BITMAP, Layer::VECTOR };
+    mPropertyUsed[StrokeSettings::FEATHER_VALUE] = { Layer::BITMAP };
+    mPropertyUsed[StrokeSettings::FEATHER_ON] = { Layer::BITMAP };
+    mPropertyUsed[StrokeSettings::PRESSURE_ON] = { Layer::BITMAP, Layer::VECTOR };
+    mPropertyUsed[StrokeSettings::STABILIZATION_VALUE] = { Layer::BITMAP, Layer::VECTOR };
+    mPropertyUsed[StrokeSettings::ANTI_ALIASING_ON] = { Layer::BITMAP };
 
     info[StrokeSettings::WIDTH_VALUE] = { WIDTH_MIN, WIDTH_MAX, 24.0 };
     info[StrokeSettings::FEATHER_VALUE] = { FEATHER_MIN, FEATHER_MAX, 48.0 };
@@ -63,8 +62,8 @@ void EraserTool::loadSettings()
     info[StrokeSettings::STABILIZATION_VALUE] = { StabilizationLevel::NONE, StabilizationLevel::STRONG, StabilizationLevel::NONE };
     info[StrokeSettings::ANTI_ALIASING_ON] = true;
 
-    mQuickSizingProperties.insert(Qt::ShiftModifier, WIDTH);
-    mQuickSizingProperties.insert(Qt::ControlModifier, FEATHER);
+    mQuickSizingProperties.insert(Qt::ShiftModifier, StrokeSettings::WIDTH_VALUE);
+    mQuickSizingProperties.insert(Qt::ControlModifier, StrokeSettings::FEATHER_VALUE);
 }
 
 QCursor EraserTool::cursor()

--- a/core_lib/src/tool/erasertool.h
+++ b/core_lib/src/tool/erasertool.h
@@ -26,8 +26,8 @@ class EraserTool : public StrokeTool
 
 public:
     explicit EraserTool(QObject* parent = nullptr);
-    ToolType type() override;
-    ToolCategory category() override { return STROKETOOL; }
+    ToolType type() const override;
+    ToolCategory category() const override { return STROKETOOL; }
 
     void loadSettings() override;
     QCursor cursor() override;

--- a/core_lib/src/tool/erasertool.h
+++ b/core_lib/src/tool/erasertool.h
@@ -27,9 +27,9 @@ class EraserTool : public StrokeTool
 public:
     explicit EraserTool(QObject* parent = nullptr);
     ToolType type() override;
+    ToolCategory category() override { return STROKETOOL; }
+
     void loadSettings() override;
-    void saveSettings() override;
-    void resetToDefault() override;
     QCursor cursor() override;
 
     void pointerMoveEvent(PointerEvent*) override;
@@ -40,13 +40,6 @@ public:
     void paintAt(QPointF point);
     void removeVectorPaint();
     void updateStrokes();
-
-    void setWidth(const qreal width) override;
-    void setFeather(const qreal feather) override;
-    void setUseFeather(const bool usingFeather) override;
-    void setPressure(const bool pressure) override;
-    void setAA(const int aa) override;
-    void setStabilizerLevel(const int level) override;
 
 protected:
     QPointF mLastBrushPoint;

--- a/core_lib/src/tool/eyedroppertool.cpp
+++ b/core_lib/src/tool/eyedroppertool.cpp
@@ -39,14 +39,6 @@ EyedropperTool::EyedropperTool(QObject* parent) : BaseTool(parent)
 
 void EyedropperTool::loadSettings()
 {
-    properties.width = -1;
-    properties.feather = -1;
-    properties.useFeather = false;
-    properties.useAA = -1;
-}
-
-void EyedropperTool::saveSettings()
-{
 }
 
 QCursor EyedropperTool::cursor()

--- a/core_lib/src/tool/eyedroppertool.h
+++ b/core_lib/src/tool/eyedroppertool.h
@@ -30,7 +30,6 @@ public:
     explicit EyedropperTool( QObject* parent = 0 );
     ToolType type() override { return EYEDROPPER; }
     void loadSettings() override;
-    void saveSettings() override;
     QCursor cursor() override;
     QCursor cursor( const QColor color );
 

--- a/core_lib/src/tool/eyedroppertool.h
+++ b/core_lib/src/tool/eyedroppertool.h
@@ -28,7 +28,9 @@ class EyedropperTool : public BaseTool
     Q_OBJECT
 public:
     explicit EyedropperTool( QObject* parent = 0 );
-    ToolType type() override { return EYEDROPPER; }
+
+    ToolType type() const override { return EYEDROPPER; }
+
     void loadSettings() override;
     QCursor cursor() override;
     QCursor cursor( const QColor color );

--- a/core_lib/src/tool/handtool.cpp
+++ b/core_lib/src/tool/handtool.cpp
@@ -35,18 +35,8 @@ HandTool::HandTool(QObject* parent) : BaseTool(parent)
 
 void HandTool::loadSettings()
 {
-    properties.width = -1;
-    properties.feather = -1;
-    properties.useFeather = false;
-    properties.stabilizerLevel = -1;
-    properties.useAA = -1;
-
     mDeltaFactor = mEditor->preference()->isOn(SETTING::INVERT_DRAG_ZOOM_DIRECTION) ? -1 : 1;
     connect(mEditor->preference(), &PreferenceManager::optionChanged, this, &HandTool::updateSettings);
-}
-
-void HandTool::saveSettings()
-{
 }
 
 void HandTool::updateSettings(const SETTING setting)

--- a/core_lib/src/tool/handtool.h
+++ b/core_lib/src/tool/handtool.h
@@ -29,7 +29,6 @@ public:
     explicit HandTool( QObject* parent = 0 );
     ToolType type() override { return HAND; }
     void loadSettings() override;
-    void saveSettings() override;
     QCursor cursor() override;
 
     void pointerPressEvent(PointerEvent *) override;

--- a/core_lib/src/tool/handtool.h
+++ b/core_lib/src/tool/handtool.h
@@ -27,7 +27,8 @@ class HandTool : public BaseTool
     Q_OBJECT
 public:
     explicit HandTool( QObject* parent = 0 );
-    ToolType type() override { return HAND; }
+
+    ToolType type() const override { return HAND; }
     void loadSettings() override;
     QCursor cursor() override;
 

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -52,7 +52,7 @@ void MoveTool::loadSettings()
 
     QHash<int, PropertyInfo> info;
 
-    info[SHOWSELECTIONINFO] = false;
+    info[SelectionSettings::SHOWSELECTIONINFO_ON] = false;
     properties.load(typeName(), settings, info);
 
     connect(mEditor->preference(), &PreferenceManager::optionChanged, this, &MoveTool::updateSettings);

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -44,6 +44,12 @@ ToolType MoveTool::type() const
     return MOVE;
 }
 
+void MoveTool::createSettings(ToolSettings*)
+{
+    mSettings = new SelectionSettings();
+    BaseTool::createSettings(mSettings);
+}
+
 void MoveTool::loadSettings()
 {
     mRotationIncrement = mEditor->preference()->getInt(SETTING::ROTATION_INCREMENT);
@@ -53,7 +59,7 @@ void MoveTool::loadSettings()
     QHash<int, PropertyInfo> info;
 
     info[SelectionSettings::SHOWSELECTIONINFO_ON] = false;
-    properties.load(typeName(), settings, info);
+    mSettings->load(typeName(), settings, info);
 
     connect(mEditor->preference(), &PreferenceManager::optionChanged, this, &MoveTool::updateSettings);
 }
@@ -338,7 +344,7 @@ bool MoveTool::isActive() const {
 
 void MoveTool::setShowSelectionInfo(bool b)
 {
-    properties.setBaseValue(SelectionSettings::SHOWSELECTIONINFO_ON, b);
+    mSettings->setBaseValue(SelectionSettings::SHOWSELECTIONINFO_ON, b);
 }
 
 Layer* MoveTool::currentPaintableLayer()

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -39,7 +39,7 @@ MoveTool::MoveTool(QObject* parent) : BaseTool(parent)
 {
 }
 
-ToolType MoveTool::type()
+ToolType MoveTool::type() const
 {
     return MOVE;
 }

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -46,26 +46,16 @@ ToolType MoveTool::type()
 
 void MoveTool::loadSettings()
 {
-    properties.width = -1;
-    properties.feather = -1;
-    properties.useFeather = false;
-    properties.stabilizerLevel = -1;
-    properties.useAA = -1;
     mRotationIncrement = mEditor->preference()->getInt(SETTING::ROTATION_INCREMENT);
     QSettings settings(PENCIL2D, PENCIL2D);
-    properties.showSelectionInfo = settings.value("ShowSelectionInfo").toBool();
     mPropertyEnabled[SHOWSELECTIONINFO] = true;
 
+    QHash<int, PropertyInfo> info;
+
+    info[SHOWSELECTIONINFO] = false;
+    properties.load(typeName(), settings, info);
+
     connect(mEditor->preference(), &PreferenceManager::optionChanged, this, &MoveTool::updateSettings);
-}
-
-void MoveTool::saveSettings()
-{
-    QSettings settings(PENCIL2D, PENCIL2D);
-
-    settings.setValue("ShowSelectionInfo", properties.showSelectionInfo);
-
-    settings.sync();
 }
 
 QCursor MoveTool::cursor()
@@ -346,18 +336,9 @@ bool MoveTool::isActive() const {
            (mEditor->select()->somethingSelected() || mEditor->overlays()->getMoveMode() != MoveMode::NONE);
 }
 
-void MoveTool::resetToDefault()
+void MoveTool::setShowSelectionInfo(bool b)
 {
-    setShowSelectionInfo(false);
-}
-
-void MoveTool::setShowSelectionInfo(const bool b)
-{
-    properties.showSelectionInfo = b;
-
-    QSettings settings(PENCIL2D, PENCIL2D);
-    settings.setValue("ShowSelectionInfo", b);
-
+    properties.setBaseValue(SelectionSettings::SHOWSELECTIONINFO_ON, b);
 }
 
 Layer* MoveTool::currentPaintableLayer()

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -54,8 +54,8 @@ void MoveTool::loadSettings()
 {
     mRotationIncrement = mEditor->preference()->getInt(SETTING::ROTATION_INCREMENT);
     QSettings settings(PENCIL2D, PENCIL2D);
-    mPropertyEnabled[SHOWSELECTIONINFO] = true;
 
+    mPropertyUsed[SelectionSettings::SHOWSELECTIONINFO_ON] = { Layer::BITMAP, Layer::VECTOR };
     QHash<int, PropertyInfo> info;
 
     info[SelectionSettings::SHOWSELECTIONINFO_ON] = false;

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -34,7 +34,6 @@ public:
     explicit MoveTool(QObject* parent);
     ToolType type() override;
     void loadSettings() override;
-    void saveSettings() override;
     QCursor cursor() override;
     QCursor cursor(MoveMode mode) const;
 
@@ -45,8 +44,9 @@ public:
     bool leavingThisTool() override;
     bool isActive() const override;
 
-    void resetToDefault() override;
-    void setShowSelectionInfo(const bool b) override;
+    void setShowSelectionInfo(bool b);
+
+    ToolSettings* getProperties() override { return &properties; }
 
 private:
     void applyTransformation();
@@ -69,6 +69,8 @@ private:
     QPointF mOffset;
 
     const UndoSaveState* mUndoSaveState = nullptr;
+
+    SelectionSettings properties;
 };
 
 #endif

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -32,10 +32,12 @@ class MoveTool : public BaseTool
     Q_OBJECT
 public:
     explicit MoveTool(QObject* parent);
-    ToolType type() override;
-    void loadSettings() override;
     QCursor cursor() override;
+
     QCursor cursor(MoveMode mode) const;
+    ToolType type() const override;
+
+    void loadSettings() override;
 
     void pointerPressEvent(PointerEvent*) override;
     void pointerReleaseEvent(PointerEvent*) override;

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -37,6 +37,7 @@ public:
     QCursor cursor(MoveMode mode) const;
     ToolType type() const override;
 
+    void createSettings(ToolSettings*) override;
     void loadSettings() override;
 
     void pointerPressEvent(PointerEvent*) override;
@@ -48,7 +49,7 @@ public:
 
     void setShowSelectionInfo(bool b);
 
-    ToolSettings* settings() override { return &properties; }
+    ToolSettings* settings() override { return mSettings; }
 
 private:
     void applyTransformation();
@@ -72,7 +73,7 @@ private:
 
     const UndoSaveState* mUndoSaveState = nullptr;
 
-    SelectionSettings properties;
+    SelectionSettings* mSettings;
 };
 
 #endif

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -48,7 +48,7 @@ public:
 
     void setShowSelectionInfo(bool b);
 
-    ToolSettings* getProperties() override { return &properties; }
+    ToolSettings* getSettings() override { return &properties; }
 
 private:
     void applyTransformation();

--- a/core_lib/src/tool/movetool.h
+++ b/core_lib/src/tool/movetool.h
@@ -48,7 +48,7 @@ public:
 
     void setShowSelectionInfo(bool b);
 
-    ToolSettings* getSettings() override { return &properties; }
+    ToolSettings* settings() override { return &properties; }
 
 private:
     void applyTransformation();

--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -47,6 +47,11 @@ void PencilTool::loadSettings()
     mPropertyEnabled[STABILIZATION] = true;
     mPropertyEnabled[FILLCONTOUR] = true;
 
+    mPropertyUsed[StrokeSettings::WIDTH_VALUE] = { Layer::BITMAP };
+    mPropertyUsed[StrokeSettings::PRESSURE_ON] = { Layer::BITMAP };
+    mPropertyUsed[StrokeSettings::FILLCONTOUR_ON] = { Layer::VECTOR };
+    mPropertyUsed[StrokeSettings::STABILIZATION_VALUE] = { Layer::BITMAP, Layer::VECTOR };
+
     QSettings settings(PENCIL2D, PENCIL2D);
 
     QHash<int, PropertyInfo> info;

--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -63,7 +63,7 @@ void PencilTool::loadSettings()
     info[StrokeSettings::STABILIZATION_VALUE] = { StabilizationLevel::NONE, StabilizationLevel::STRONG, StabilizationLevel::STRONG };
     info[StrokeSettings::FILLCONTOUR_ON] = false;
 
-    properties.load(typeName(), settings, info);
+    mStrokeSettings->load(typeName(), settings, info);
 
     mQuickSizingProperties.insert(Qt::ShiftModifier, WIDTH);
 }
@@ -109,9 +109,9 @@ void PencilTool::pointerMoveEvent(PointerEvent* event)
     {
         mCurrentPressure = mInterpolator.getPressure();
         drawStroke();
-        if (properties.stabilizerLevel() != mInterpolator.getStabilizerLevel())
+        if (mStrokeSettings->stabilizerLevel() != mInterpolator.getStabilizerLevel())
         {
-            mInterpolator.setStabilizerLevel(properties.stabilizerLevel());
+            mInterpolator.setStabilizerLevel(mStrokeSettings->stabilizerLevel());
         }
     }
     StrokeTool::pointerMoveEvent(event);
@@ -153,10 +153,10 @@ void PencilTool::paintAt(QPointF point)
     Layer* layer = mEditor->layers()->currentLayer();
     if (layer->type() == Layer::BITMAP)
     {
-        qreal opacity = (properties.usePressure()) ? (mCurrentPressure * 0.5) : 1.0;
-        qreal pressure = (properties.usePressure()) ? mCurrentPressure : 1.0;
-        qreal brushWidth = properties.width() * pressure;
-        qreal fixedBrushFeather = properties.feather();
+        qreal opacity = (mStrokeSettings->usePressure()) ? (mCurrentPressure * 0.5) : 1.0;
+        qreal pressure = (mStrokeSettings->usePressure()) ? mCurrentPressure : 1.0;
+        qreal brushWidth = mStrokeSettings->width() * pressure;
+        qreal fixedBrushFeather = mStrokeSettings->feather();
 
         mCurrentWidth = brushWidth;
         mScribbleArea->drawPencil(point,
@@ -177,12 +177,12 @@ void PencilTool::drawStroke()
 
     if (layer->type() == Layer::BITMAP)
     {
-        qreal pressure = (properties.usePressure()) ? mCurrentPressure : 1.0;
-        qreal opacity = (properties.usePressure()) ? (mCurrentPressure * 0.5) : 1.0;
-        qreal brushWidth = properties.width() * pressure;
+        qreal pressure = (mStrokeSettings->usePressure()) ? mCurrentPressure : 1.0;
+        qreal opacity = (mStrokeSettings->usePressure()) ? (mCurrentPressure * 0.5) : 1.0;
+        qreal brushWidth = mStrokeSettings->width() * pressure;
         mCurrentWidth = brushWidth;
 
-        qreal fixedBrushFeather = properties.feather();
+        qreal fixedBrushFeather = mStrokeSettings->feather();
         qreal brushStep = qMax(1.0, (0.5 * brushWidth));
 
         QPointF a = mLastBrushPoint;
@@ -246,7 +246,7 @@ void PencilTool::paintVectorStroke(Layer* layer)
     if (vectorImage == nullptr) { return; } // Can happen if the first frame is deleted while drawing
     vectorImage->addCurve(curve, qAbs(mEditor->view()->scaling()), false);
 
-    if (properties.useFillContour())
+    if (mStrokeSettings->useFillContour())
     {
         vectorImage->fillContour(mStrokePoints,
                                  mEditor->color()->frontColorNumber());

--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -41,12 +41,6 @@ void PencilTool::loadSettings()
 {
     StrokeTool::loadSettings();
 
-    mPropertyEnabled[WIDTH] = true;
-    mPropertyEnabled[PRESSURE] = true;
-    mPropertyEnabled[VECTORMERGE] = false;
-    mPropertyEnabled[STABILIZATION] = true;
-    mPropertyEnabled[FILLCONTOUR] = true;
-
     mPropertyUsed[StrokeSettings::WIDTH_VALUE] = { Layer::BITMAP };
     mPropertyUsed[StrokeSettings::PRESSURE_ON] = { Layer::BITMAP };
     mPropertyUsed[StrokeSettings::FILLCONTOUR_ON] = { Layer::VECTOR };
@@ -65,7 +59,7 @@ void PencilTool::loadSettings()
 
     mStrokeSettings->load(typeName(), settings, info);
 
-    mQuickSizingProperties.insert(Qt::ShiftModifier, WIDTH);
+    mQuickSizingProperties.insert(Qt::ShiftModifier, StrokeSettings::WIDTH_VALUE);
 }
 
 QCursor PencilTool::cursor()

--- a/core_lib/src/tool/penciltool.h
+++ b/core_lib/src/tool/penciltool.h
@@ -29,10 +29,10 @@ class PencilTool : public StrokeTool
 public:
     explicit PencilTool(QObject* parent);
     ToolType type() override { return PENCIL; }
+    ToolCategory category() override { return STROKETOOL; }
+
     void loadSettings() override;
-    void saveSettings() override;
     QCursor cursor() override;
-    void resetToDefault() override;
 
     void pointerPressEvent(PointerEvent*) override;
     void pointerMoveEvent(PointerEvent*) override;
@@ -41,15 +41,6 @@ public:
     void drawStroke();
     void paintAt(QPointF point);
     void paintVectorStroke(Layer* layer);
-
-    void setWidth(const qreal width) override;
-    void setFeather(const qreal feather) override;
-    void setUseFeather(const bool useFeather) override;
-    void setInvisibility(const bool invisibility) override;
-    void setPressure(const bool pressure) override;
-    void setPreserveAlpha(const bool preserveAlpha) override;
-    void setStabilizerLevel(const int level) override;
-    void setUseFillContour(const bool useFillContour) override;
 
 private:
     QPointF mLastBrushPoint{ 0, 0 };

--- a/core_lib/src/tool/penciltool.h
+++ b/core_lib/src/tool/penciltool.h
@@ -28,8 +28,9 @@ class PencilTool : public StrokeTool
     Q_OBJECT
 public:
     explicit PencilTool(QObject* parent);
-    ToolType type() override { return PENCIL; }
-    ToolCategory category() override { return STROKETOOL; }
+
+    ToolType type() const override { return PENCIL; }
+    ToolCategory category() const override { return STROKETOOL; }
 
     void loadSettings() override;
     QCursor cursor() override;

--- a/core_lib/src/tool/pentool.cpp
+++ b/core_lib/src/tool/pentool.cpp
@@ -93,9 +93,9 @@ void PenTool::pointerMoveEvent(PointerEvent* event)
     {
         mCurrentPressure = mInterpolator.getPressure();
         drawStroke();
-        if (properties.stabilizerLevel() != mInterpolator.getStabilizerLevel())
+        if (mStrokeSettings->stabilizerLevel() != mInterpolator.getStabilizerLevel())
         {
-            mInterpolator.setStabilizerLevel(properties.stabilizerLevel());
+            mInterpolator.setStabilizerLevel(mStrokeSettings->stabilizerLevel());
         }
     }
 
@@ -139,14 +139,14 @@ void PenTool::paintAt(QPointF point)
     Layer* layer = mEditor->layers()->currentLayer();
     if (layer->type() == Layer::BITMAP)
     {
-        qreal pressure = (properties.usePressure()) ? mCurrentPressure : 1.0;
-        qreal brushWidth = properties.width() * pressure;
+        qreal pressure = (mStrokeSettings->usePressure()) ? mCurrentPressure : 1.0;
+        qreal brushWidth = mStrokeSettings->width() * pressure;
         mCurrentWidth = brushWidth;
 
         mScribbleArea->drawPen(point,
                                brushWidth,
                                mEditor->color()->frontColor(),
-                               properties.useAntiAliasing());
+                               mStrokeSettings->useAntiAliasing());
     }
 }
 
@@ -159,8 +159,8 @@ void PenTool::drawStroke()
 
     if (layer->type() == Layer::BITMAP)
     {
-        qreal pressure = (properties.usePressure()) ? mCurrentPressure : 1.0;
-        qreal brushWidth = properties.width() * pressure;
+        qreal pressure = (mStrokeSettings->usePressure()) ? mCurrentPressure : 1.0;
+        qreal brushWidth = mStrokeSettings->width() * pressure;
         mCurrentWidth = brushWidth;
 
         // TODO: Make popup widget for less important properties,
@@ -180,7 +180,7 @@ void PenTool::drawStroke()
             mScribbleArea->drawPen(point,
                                    brushWidth,
                                    mEditor->color()->frontColor(),
-                                   properties.useAntiAliasing());
+                                   mStrokeSettings->useAntiAliasing());
 
             if (i == (steps - 1))
             {
@@ -190,8 +190,8 @@ void PenTool::drawStroke()
     }
     else if (layer->type() == Layer::VECTOR)
     {
-        qreal pressure = (properties.usePressure()) ? mCurrentPressure : 1.0;
-        qreal brushWidth = properties.width() * pressure;
+        qreal pressure = (mStrokeSettings->usePressure()) ? mCurrentPressure : 1.0;
+        qreal brushWidth = mStrokeSettings->width() * pressure;
 
         QPen pen(mEditor->color()->frontColor(),
                  brushWidth,
@@ -218,11 +218,11 @@ void PenTool::paintVectorStroke(Layer* layer)
     qreal tol = mScribbleArea->getCurveSmoothing() / mEditor->view()->scaling();
 
     BezierCurve curve(mStrokePoints, mStrokePressures, tol);
-    curve.setWidth(properties.width());
-    curve.setFeather(properties.feather());
+    curve.setWidth(mStrokeSettings->width());
+    curve.setFeather(mStrokeSettings->feather());
     curve.setFilled(false);
-    curve.setInvisibility(properties.invisibility());
-    curve.setVariableWidth(properties.usePressure());
+    curve.setInvisibility(mStrokeSettings->invisibility());
+    curve.setVariableWidth(mStrokeSettings->usePressure());
     curve.setColorNumber(mEditor->color()->frontColorNumber());
 
     auto pLayerVector = static_cast<LayerVector*>(layer);

--- a/core_lib/src/tool/pentool.cpp
+++ b/core_lib/src/tool/pentool.cpp
@@ -40,13 +40,12 @@ void PenTool::loadSettings()
 {
     StrokeTool::loadSettings();
 
-    mPropertyEnabled[WIDTH] = true;
-    mPropertyEnabled[PRESSURE] = true;
-    mPropertyEnabled[VECTORMERGE] = true;
-    mPropertyEnabled[ANTI_ALIASING] = true;
-    mPropertyEnabled[STABILIZATION] = true;
-
     QSettings settings(PENCIL2D, PENCIL2D);
+
+    mPropertyUsed[StrokeSettings::WIDTH_VALUE] = { Layer::BITMAP, Layer::VECTOR };
+    mPropertyUsed[StrokeSettings::PRESSURE_ON] = { Layer::BITMAP, Layer::VECTOR };
+    mPropertyUsed[StrokeSettings::ANTI_ALIASING_ON] = { Layer::BITMAP };
+    mPropertyUsed[StrokeSettings::STABILIZATION_VALUE] = { Layer::BITMAP, Layer::VECTOR };
 
     QHash<int, PropertyInfo> info;
 
@@ -55,7 +54,7 @@ void PenTool::loadSettings()
     info[StrokeSettings::ANTI_ALIASING_ON] = true;
     info[StrokeSettings::STABILIZATION_VALUE] = { StabilizationLevel::NONE, StabilizationLevel::STRONG, StabilizationLevel::STRONG };
 
-    mQuickSizingProperties.insert(Qt::ShiftModifier, WIDTH);
+    mQuickSizingProperties.insert(Qt::ShiftModifier, StrokeSettings::WIDTH_VALUE);
 }
 
 QCursor PenTool::cursor()

--- a/core_lib/src/tool/pentool.h
+++ b/core_lib/src/tool/pentool.h
@@ -27,8 +27,9 @@ class PenTool : public StrokeTool
     Q_OBJECT
 public:
     PenTool(QObject* parent = 0);
-    ToolType type() override { return PEN; }
-    ToolCategory category() override { return STROKETOOL; }
+
+    ToolType type() const override { return PEN; }
+    ToolCategory category() const override { return STROKETOOL; }
 
     void loadSettings() override;
     QCursor cursor() override;

--- a/core_lib/src/tool/pentool.h
+++ b/core_lib/src/tool/pentool.h
@@ -28,10 +28,10 @@ class PenTool : public StrokeTool
 public:
     PenTool(QObject* parent = 0);
     ToolType type() override { return PEN; }
+    ToolCategory category() override { return STROKETOOL; }
+
     void loadSettings() override;
-    void saveSettings() override;
     QCursor cursor() override;
-    void resetToDefault() override;
 
     void pointerPressEvent(PointerEvent*) override;
     void pointerMoveEvent(PointerEvent*) override;
@@ -40,11 +40,6 @@ public:
     void drawStroke();
     void paintAt(QPointF point);
     void paintVectorStroke(Layer *layer);
-
-    void setWidth(const qreal width) override;
-    void setPressure(const bool pressure) override;
-    void setAA(const int AA) override;
-    void setStabilizerLevel(const int level) override;
 
 private:
     QPointF mLastBrushPoint;

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -31,8 +31,7 @@ GNU General Public License for more details.
 #include "vectorimage.h"
 
 
-PolylineTool::PolylineTool(QObject* parent) : StrokeTool(parent),
-    mSettings(PolyLineSettings(properties))
+PolylineTool::PolylineTool(QObject* parent) : StrokeTool(parent)
 {
 }
 

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -31,14 +31,19 @@ GNU General Public License for more details.
 #include "vectorimage.h"
 
 
-PolylineTool::PolylineTool(QObject* parent) : StrokeTool(parent, new PolylineSettings())
+PolylineTool::PolylineTool(QObject* parent) : StrokeTool(parent)
 {
-    mSettings = static_cast<PolylineSettings*>(mStrokeSettings);
 }
 
 ToolType PolylineTool::type() const
 {
     return POLYLINE;
+}
+
+void PolylineTool::createSettings(ToolSettings *)
+{
+    mSettings = new PolylineSettings();
+    StrokeTool::createSettings(mSettings);
 }
 
 void PolylineTool::loadSettings()

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -338,4 +338,11 @@ void PolylineTool::endPolyline(QList<QPointF> points)
 void PolylineTool::setUseBezier(bool useBezier)
 {
     mSettings.setBaseValue(PolyLineSettings::BEZIER_ON, useBezier);
+    emit useBezierChanged(useBezier);
+}
+
+void PolylineTool::setClosePath(bool closePath)
+{
+    mSettings.setBaseValue(PolyLineSettings::CLOSEDPATH_ON, closePath);
+    emit closePathChanged(closePath);
 }

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -35,7 +35,7 @@ PolylineTool::PolylineTool(QObject* parent) : StrokeTool(parent)
 {
 }
 
-ToolType PolylineTool::type()
+ToolType PolylineTool::type() const
 {
     return POLYLINE;
 }

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -50,11 +50,6 @@ void PolylineTool::loadSettings()
 {
     StrokeTool::loadSettings();
 
-    mPropertyEnabled[WIDTH] = true;
-    mPropertyEnabled[BEZIER] = true;
-    mPropertyEnabled[CLOSEDPATH] = true;
-    mPropertyEnabled[ANTI_ALIASING] = true;
-
     mPropertyUsed[StrokeSettings::WIDTH_VALUE] = { Layer::BITMAP, Layer::VECTOR };
     mPropertyUsed[PolylineSettings::CLOSEDPATH_ON] = { Layer::BITMAP, Layer::VECTOR };
     mPropertyUsed[PolylineSettings::BEZIER_ON] = { Layer::BITMAP };
@@ -71,7 +66,7 @@ void PolylineTool::loadSettings()
 
     mSettings->load(typeName(), settings, info);
 
-    mQuickSizingProperties.insert(Qt::ShiftModifier, WIDTH);
+    mQuickSizingProperties.insert(Qt::ShiftModifier, StrokeSettings::WIDTH_VALUE);
 }
 
 bool PolylineTool::leavingThisTool()

--- a/core_lib/src/tool/polylinetool.h
+++ b/core_lib/src/tool/polylinetool.h
@@ -27,8 +27,9 @@ class PolylineTool : public StrokeTool
     Q_OBJECT
 public:
     explicit PolylineTool(QObject* parent = 0);
-    ToolType type() override;
-    ToolCategory category() override { return STROKETOOL; }
+
+    ToolType type() const override;
+    ToolCategory category() const override { return STROKETOOL; }
 
     void loadSettings() override;
     QCursor cursor() override;

--- a/core_lib/src/tool/polylinetool.h
+++ b/core_lib/src/tool/polylinetool.h
@@ -28,10 +28,10 @@ class PolylineTool : public StrokeTool
 public:
     explicit PolylineTool(QObject* parent = 0);
     ToolType type() override;
+    ToolCategory category() override { return STROKETOOL; }
+
     void loadSettings() override;
-    void saveSettings() override;
     QCursor cursor() override;
-    void resetToDefault() override;
 
     void pointerPressEvent(PointerEvent*) override;
     void pointerReleaseEvent(PointerEvent*) override;
@@ -43,14 +43,11 @@ public:
 
     void clearToolData() override;
 
-    void setWidth(const qreal width) override;
-    void setFeather(const qreal feather) override;
-    void setAA(const int AA) override;
-    void setClosedPath(const bool closed) override;
-
     bool leavingThisTool() override;
 
     bool isActive() const override;
+
+    ToolSettings* getProperties() override { return &properties; }
 
 private:
     QList<QPointF> mPoints;
@@ -60,6 +57,8 @@ private:
     void removeLastPolylineSegment();
     void cancelPolyline();
     void endPolyline(QList<QPointF> points);
+
+    PolyLineSettings properties;
 };
 
 #endif // POLYLINETOOL_H

--- a/core_lib/src/tool/polylinetool.h
+++ b/core_lib/src/tool/polylinetool.h
@@ -34,6 +34,8 @@ public:
     void loadSettings() override;
     QCursor cursor() override;
 
+    void setUseBezier(bool useBezier);
+
     void pointerPressEvent(PointerEvent*) override;
     void pointerReleaseEvent(PointerEvent*) override;
     void pointerMoveEvent(PointerEvent* event) override;
@@ -48,7 +50,7 @@ public:
 
     bool isActive() const override;
 
-    ToolSettings* getProperties() override { return &properties; }
+    ToolSettings* getSettings() override { return &mSettings; }
 
 private:
     QList<QPointF> mPoints;
@@ -59,7 +61,7 @@ private:
     void cancelPolyline();
     void endPolyline(QList<QPointF> points);
 
-    PolyLineSettings properties;
+    PolyLineSettings mSettings;
 };
 
 #endif // POLYLINETOOL_H

--- a/core_lib/src/tool/polylinetool.h
+++ b/core_lib/src/tool/polylinetool.h
@@ -51,13 +51,15 @@ public:
 
     bool isActive() const override;
 
-    ToolSettings* getSettings() override { return &mSettings; }
+    ToolSettings* settings() override { return mSettings; }
 
 signals:
     void useBezierChanged(bool useBezier);
     void closePathChanged(bool closePath);
 
+
 private:
+    PolylineSettings* mSettings = nullptr;
     QList<QPointF> mPoints;
     bool mClosedPathOverrideEnabled = false;
 
@@ -66,7 +68,6 @@ private:
     void cancelPolyline();
     void endPolyline(QList<QPointF> points);
 
-    PolyLineSettings mSettings;
 };
 
 #endif // POLYLINETOOL_H

--- a/core_lib/src/tool/polylinetool.h
+++ b/core_lib/src/tool/polylinetool.h
@@ -31,6 +31,7 @@ public:
     ToolType type() const override;
     ToolCategory category() const override { return STROKETOOL; }
 
+    void createSettings(ToolSettings *) override;
     void loadSettings() override;
     QCursor cursor() override;
 

--- a/core_lib/src/tool/polylinetool.h
+++ b/core_lib/src/tool/polylinetool.h
@@ -35,6 +35,7 @@ public:
     QCursor cursor() override;
 
     void setUseBezier(bool useBezier);
+    void setClosePath(bool closePath);
 
     void pointerPressEvent(PointerEvent*) override;
     void pointerReleaseEvent(PointerEvent*) override;
@@ -51,6 +52,10 @@ public:
     bool isActive() const override;
 
     ToolSettings* getSettings() override { return &mSettings; }
+
+signals:
+    void useBezierChanged(bool useBezier);
+    void closePathChanged(bool closePath);
 
 private:
     QList<QPointF> mPoints;

--- a/core_lib/src/tool/selecttool.cpp
+++ b/core_lib/src/tool/selecttool.cpp
@@ -30,6 +30,12 @@ SelectTool::SelectTool(QObject* parent) : BaseTool(parent)
 {
 }
 
+void SelectTool::createSettings(ToolSettings*)
+{
+    mSettings = new SelectionSettings();
+    BaseTool::createSettings(mSettings);
+}
+
 void SelectTool::loadSettings()
 {
     QSettings settings(PENCIL2D, PENCIL2D);
@@ -38,7 +44,7 @@ void SelectTool::loadSettings()
     QHash<int, PropertyInfo> info;
 
     info[SelectionSettings::SHOWSELECTIONINFO_ON] = false;
-    properties.load(typeName(), settings, info);
+    mSettings->load(typeName(), settings, info);
 }
 
 QCursor SelectTool::cursor()

--- a/core_lib/src/tool/selecttool.cpp
+++ b/core_lib/src/tool/selecttool.cpp
@@ -32,22 +32,13 @@ SelectTool::SelectTool(QObject* parent) : BaseTool(parent)
 
 void SelectTool::loadSettings()
 {
-    properties.width = -1;
-    properties.feather = -1;
-    properties.stabilizerLevel = -1;
-    properties.useAA = -1;
     QSettings settings(PENCIL2D, PENCIL2D);
-    properties.showSelectionInfo = settings.value("ShowSelectionInfo").toBool();
     mPropertyEnabled[SHOWSELECTIONINFO] = true;
-}
 
-void SelectTool::saveSettings()
-{
-    QSettings settings(PENCIL2D, PENCIL2D);
+    QHash<int, PropertyInfo> info;
 
-    settings.setValue("ShowSelectionInfo", properties.showSelectionInfo);
-
-    settings.sync();
+    info[SelectionSettings::SHOWSELECTIONINFO_ON] = false;
+    properties.load(typeName(), settings, info);
 }
 
 QCursor SelectTool::cursor()
@@ -88,16 +79,6 @@ QCursor SelectTool::cursor()
         break;
     }
     return QCursor(mCursorPixmap);
-}
-
-void SelectTool::resetToDefault()
-{
-    setShowSelectionInfo(false);
-}
-
-void SelectTool::setShowSelectionInfo(const bool b)
-{
-    properties.showSelectionInfo = b;
 }
 
 void SelectTool::beginSelection(Layer* currentLayer, const QPointF& pos)

--- a/core_lib/src/tool/selecttool.cpp
+++ b/core_lib/src/tool/selecttool.cpp
@@ -39,9 +39,10 @@ void SelectTool::createSettings(ToolSettings*)
 void SelectTool::loadSettings()
 {
     QSettings settings(PENCIL2D, PENCIL2D);
-    mPropertyEnabled[SHOWSELECTIONINFO] = true;
 
     QHash<int, PropertyInfo> info;
+
+    mPropertyUsed[SelectionSettings::SHOWSELECTIONINFO_ON] = { Layer::BITMAP, Layer::VECTOR };
 
     info[SelectionSettings::SHOWSELECTIONINFO_ON] = false;
     mSettings->load(typeName(), settings, info);

--- a/core_lib/src/tool/selecttool.h
+++ b/core_lib/src/tool/selecttool.h
@@ -33,7 +33,9 @@ class SelectTool : public BaseTool
 
 public:
     explicit SelectTool(QObject* parent = nullptr);
-    ToolType type() override { return SELECT; }
+
+    ToolType type() const override { return SELECT; }
+
     void loadSettings() override;
     QCursor cursor() override;
 

--- a/core_lib/src/tool/selecttool.h
+++ b/core_lib/src/tool/selecttool.h
@@ -36,6 +36,7 @@ public:
 
     ToolType type() const override { return SELECT; }
 
+    void createSettings(ToolSettings*) override;
     void loadSettings() override;
     QCursor cursor() override;
 
@@ -70,7 +71,7 @@ private:
 
     const UndoSaveState* mUndoState = nullptr;
 
-    SelectionSettings properties;
+    SelectionSettings* mSettings = nullptr;
 };
 
 #endif

--- a/core_lib/src/tool/selecttool.h
+++ b/core_lib/src/tool/selecttool.h
@@ -35,11 +35,7 @@ public:
     explicit SelectTool(QObject* parent = nullptr);
     ToolType type() override { return SELECT; }
     void loadSettings() override;
-    void saveSettings() override;
     QCursor cursor() override;
-
-    void resetToDefault() override;
-    void setShowSelectionInfo(const bool b) override;
 
 private:
 
@@ -71,6 +67,8 @@ private:
     QPixmap mCursorPixmap = QPixmap(24, 24);
 
     const UndoSaveState* mUndoState = nullptr;
+
+    SelectionSettings properties;
 };
 
 #endif

--- a/core_lib/src/tool/smudgetool.cpp
+++ b/core_lib/src/tool/smudgetool.cpp
@@ -37,7 +37,7 @@ SmudgeTool::SmudgeTool(QObject* parent) : StrokeTool(parent)
     toolMode = 0; // tool mode
 }
 
-ToolType SmudgeTool::type()
+ToolType SmudgeTool::type() const
 {
     return SMUDGE;
 }

--- a/core_lib/src/tool/smudgetool.cpp
+++ b/core_lib/src/tool/smudgetool.cpp
@@ -54,7 +54,7 @@ void SmudgeTool::loadSettings()
     info[StrokeSettings::WIDTH_VALUE] = { WIDTH_MIN, WIDTH_MAX, 24.0 };
     info[StrokeSettings::FEATHER_VALUE] = { FEATHER_MIN, FEATHER_MAX, 48.0 };
 
-    properties.load(typeName(), settings, info);
+    mStrokeSettings->load(typeName(), settings, info);
 
     mQuickSizingProperties.insert(Qt::ShiftModifier, WIDTH);
     mQuickSizingProperties.insert(Qt::ControlModifier, FEATHER);
@@ -278,9 +278,9 @@ void SmudgeTool::drawStroke()
     }
 
     qreal opacity = 1.0;
-    mCurrentWidth = properties.width();
-    qreal brushWidth = mCurrentWidth + 0.0 * properties.feather();
-    qreal offset = qMax(0.0, mCurrentWidth - 0.5 * properties.feather()) / brushWidth;
+    mCurrentWidth = mStrokeSettings->width();
+    qreal brushWidth = mCurrentWidth + 0.0 * mStrokeSettings->feather();
+    qreal offset = qMax(0.0, mCurrentWidth - 0.5 * mStrokeSettings->feather()) / brushWidth;
     //opacity = currentPressure; // todo: Probably not interesting?!
     //brushWidth = brushWidth * opacity;
 

--- a/core_lib/src/tool/smudgetool.cpp
+++ b/core_lib/src/tool/smudgetool.cpp
@@ -46,18 +46,18 @@ void SmudgeTool::loadSettings()
 {
     StrokeTool::loadSettings();
 
-    mPropertyEnabled[WIDTH] = true;
-    mPropertyEnabled[FEATHER] = true;
-
     QHash<int, PropertyInfo> info;
     QSettings settings(PENCIL2D, PENCIL2D);
+    mPropertyUsed[StrokeSettings::WIDTH_VALUE] = { Layer::BITMAP };
+    mPropertyUsed[StrokeSettings::FEATHER_VALUE] = { Layer::BITMAP };
+
     info[StrokeSettings::WIDTH_VALUE] = { WIDTH_MIN, WIDTH_MAX, 24.0 };
     info[StrokeSettings::FEATHER_VALUE] = { FEATHER_MIN, FEATHER_MAX, 48.0 };
 
     mStrokeSettings->load(typeName(), settings, info);
 
-    mQuickSizingProperties.insert(Qt::ShiftModifier, WIDTH);
-    mQuickSizingProperties.insert(Qt::ControlModifier, FEATHER);
+    mQuickSizingProperties.insert(Qt::ShiftModifier, StrokeSettings::WIDTH_VALUE);
+    mQuickSizingProperties.insert(Qt::ControlModifier, StrokeSettings::FEATHER_VALUE);
 }
 
 bool SmudgeTool::emptyFrameActionEnabled()

--- a/core_lib/src/tool/smudgetool.cpp
+++ b/core_lib/src/tool/smudgetool.cpp
@@ -49,49 +49,15 @@ void SmudgeTool::loadSettings()
     mPropertyEnabled[WIDTH] = true;
     mPropertyEnabled[FEATHER] = true;
 
+    QHash<int, PropertyInfo> info;
     QSettings settings(PENCIL2D, PENCIL2D);
-    properties.width = settings.value("smudgeWidth", 24.0).toDouble();
-    properties.feather = settings.value("smudgeFeather", 48.0).toDouble();
-    properties.pressure = false;
-    properties.stabilizerLevel = -1;
+    info[StrokeSettings::WIDTH_VALUE] = { WIDTH_MIN, WIDTH_MAX, 24.0 };
+    info[StrokeSettings::FEATHER_VALUE] = { FEATHER_MIN, FEATHER_MAX, 48.0 };
+
+    properties.load(typeName(), settings, info);
 
     mQuickSizingProperties.insert(Qt::ShiftModifier, WIDTH);
     mQuickSizingProperties.insert(Qt::ControlModifier, FEATHER);
-}
-
-void SmudgeTool::saveSettings()
-{
-    QSettings settings(PENCIL2D, PENCIL2D);
-
-    settings.setValue("smudgeWidth", properties.width);
-    settings.setValue("smudgeFeather", properties.feather);
-    settings.setValue("smudgePressure", properties.pressure);
-
-    settings.sync();
-}
-
-void SmudgeTool::resetToDefault()
-{
-    setWidth(24.0);
-    setFeather(48.0);
-}
-
-void SmudgeTool::setWidth(const qreal width)
-{
-    // Set current property
-    properties.width = width;
-}
-
-void SmudgeTool::setFeather(const qreal feather)
-{
-    // Set current property
-    properties.feather = feather;
-}
-
-void SmudgeTool::setPressure(const bool pressure)
-{
-    // Set current property
-    properties.pressure = pressure;
 }
 
 bool SmudgeTool::emptyFrameActionEnabled()
@@ -312,9 +278,9 @@ void SmudgeTool::drawStroke()
     }
 
     qreal opacity = 1.0;
-    mCurrentWidth = properties.width;
-    qreal brushWidth = mCurrentWidth + 0.0 * properties.feather;
-    qreal offset = qMax(0.0, mCurrentWidth - 0.5 * properties.feather) / brushWidth;
+    mCurrentWidth = properties.width();
+    qreal brushWidth = mCurrentWidth + 0.0 * properties.feather();
+    qreal offset = qMax(0.0, mCurrentWidth - 0.5 * properties.feather()) / brushWidth;
     //opacity = currentPressure; // todo: Probably not interesting?!
     //brushWidth = brushWidth * opacity;
 

--- a/core_lib/src/tool/smudgetool.h
+++ b/core_lib/src/tool/smudgetool.h
@@ -25,8 +25,9 @@ class SmudgeTool : public StrokeTool
     Q_OBJECT
 public:
     explicit SmudgeTool(QObject* parent = 0);
-    ToolType type() override;
-    ToolCategory category() override { return STROKETOOL; }
+
+    ToolType type() const override;
+    ToolCategory category() const override { return STROKETOOL; }
 
     uint toolMode;  // 0=normal/smooth 1=smudge - todo: move to basetool? could be useful
     void loadSettings() override;

--- a/core_lib/src/tool/smudgetool.h
+++ b/core_lib/src/tool/smudgetool.h
@@ -26,10 +26,10 @@ class SmudgeTool : public StrokeTool
 public:
     explicit SmudgeTool(QObject* parent = 0);
     ToolType type() override;
+    ToolCategory category() override { return STROKETOOL; }
+
     uint toolMode;  // 0=normal/smooth 1=smudge - todo: move to basetool? could be useful
     void loadSettings() override;
-    void saveSettings() override;
-    void resetToDefault() override;
     QCursor cursor() override;
 
     void pointerPressEvent(PointerEvent *) override;
@@ -40,10 +40,6 @@ public:
     bool keyReleaseEvent(QKeyEvent *) override;
 
     void drawStroke();
-
-    void setWidth( const qreal width ) override;
-    void setFeather( const qreal feather ) override;
-    void setPressure( const bool pressure ) override;
 
 protected:
     bool emptyFrameActionEnabled() override;

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -60,6 +60,19 @@ void StrokeTool::loadSettings()
     mQuickSizingEnabled = mEditor->preference()->isOn(SETTING::QUICK_SIZING);
     mCanvasCursorEnabled = mEditor->preference()->isOn(SETTING::CANVAS_CURSOR);
 
+    QSettings settings(PENCIL2D, PENCIL2D);
+    QHash<int, PropertyInfo> info;
+    info[StrokeSettings::WIDTH_VALUE] = { 1.0, 100.0, 24.0 };
+    info[StrokeSettings::FEATHER_VALUE] = { 1.0, 99.0, 48.0 };
+    info[StrokeSettings::FEATHER_ON] = false;
+    info[StrokeSettings::PRESSURE_ON] = false;
+    info[StrokeSettings::INVISIBILITY_ON] = false;
+    info[StrokeSettings::STABILIZATION_VALUE] = { StabilizationLevel::NONE, StabilizationLevel::STRONG, StabilizationLevel::STRONG };
+    info[StrokeSettings::ANTI_ALIASING_ON] = false;
+    info[StrokeSettings::FILLCONTOUR_ON] = false;
+
+    properties.load(typeName(), settings, info);
+
     /// Given the way that we update preferences currently, this connection should not be removed
     /// when the tool is not active.
     connect(mEditor->preference(), &PreferenceManager::optionChanged, this, &StrokeTool::onPreferenceChanged);

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -306,7 +306,7 @@ void StrokeTool::updateCanvasCursor()
                                  brushWidth * featherWidthFactor);
     options.showCursor = mCanvasCursorEnabled;
     options.isAdjusting = msIsAdjusting && mQuickSizingEnabled;
-    options.useFeather = mPropertyEnabled[FEATHER];
+    options.useFeather = mStrokeSettings->useFeather();
 
     mCanvasCursorPainter.preparePainter(options, mEditor->view()->getView());
 
@@ -337,14 +337,14 @@ bool StrokeTool::startAdjusting(Qt::KeyboardModifiers modifiers)
     const QPointF& currentPoint = getCurrentPoint();
     auto propertyType = mQuickSizingProperties.value(modifiers);
     switch (propertyType) {
-    case WIDTH: {
+    case StrokeSettings::WIDTH_VALUE: {
         const qreal factor = 0.5;
         const qreal rad = mStrokeSettings->width() * factor;
         const qreal distance = QLineF(currentPressPoint - QPointF(rad, rad), currentPoint).length();
         mAdjustPosition = currentPressPoint - QPointF(distance * factor, distance * factor);
         break;
     }
-    case FEATHER: {
+    case StrokeSettings::FEATHER_VALUE: {
         const qreal factor = 0.5;
         const qreal cursorRad = mStrokeSettings->width() * factor;
         const qreal featherWidthFactor = MathUtils::normalize(mStrokeSettings->feather(), 0.0, FEATHER_MAX);
@@ -376,14 +376,14 @@ void StrokeTool::adjustCursor(Qt::KeyboardModifiers modifiers)
 {
     switch (mQuickSizingProperties.value(modifiers))
     {
-    case WIDTH: {
+    case StrokeSettings::WIDTH_VALUE: {
         // The adjusted position is based on the radius of the circle, so in order to
         // map it back to its original value, we can multiply by the factor we divided with
         const qreal newValue = QLineF(mAdjustPosition, getCurrentPoint()).length() * 2.0;
         setWidth(newValue);
         break;
     }
-    case FEATHER: {
+    case StrokeSettings::FEATHER_VALUE: {
         // The radius of the width is the max value we can get
         const qreal inputMin = 0.0;
         const qreal inputMax = mStrokeSettings->width() * 0.5;

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -50,15 +50,8 @@ const qreal StrokeTool::WIDTH_MAX = 200.;
 bool StrokeTool::msIsAdjusting = false;
 bool StrokeTool::mQuickSizingEnabled = false;
 
-StrokeTool::StrokeTool(QObject* parent, ToolSettings* settings) : BaseTool(parent, settings)
+StrokeTool::StrokeTool(QObject* parent) : BaseTool(parent)
 {
-    if (settings == nullptr) {
-        mStrokeSettings = new StrokeSettings();
-        mSettings = mStrokeSettings;
-    } else {
-        mStrokeSettings = static_cast<StrokeSettings*>(settings);
-    }
-
     detectWhichOSX();
 }
 
@@ -69,6 +62,17 @@ StrokeTool::~StrokeTool()
         // lifetime of the program.
         delete(mStrokeSettings);
         mStrokeSettings = nullptr;
+    }
+}
+
+void StrokeTool::createSettings(ToolSettings* settings)
+{
+    if (settings == nullptr) {
+        mStrokeSettings = new StrokeSettings();
+        BaseTool::createSettings(mStrokeSettings);
+    } else {
+        mStrokeSettings = static_cast<StrokeSettings*>(settings);
+        BaseTool::createSettings(settings);
     }
 }
 

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -391,47 +391,47 @@ void StrokeTool::paint(QPainter& painter, const QRect& blitRect)
 void StrokeTool::setStablizationLevel(int level)
 {
     properties.setBaseValue(StrokeSettings::STABILIZATION_VALUE, level);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::STABILIZATION);
+    emit stabilizationLevelChanged(level);
 }
 
 void StrokeTool::setFeatherON(bool isON)
 {
     properties.setBaseValue(StrokeSettings::FEATHER_ON, isON);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::USEFEATHER);
+    emit featherONChanged(isON);
 }
 
 void StrokeTool::setFeather(qreal feather)
 {
     properties.setBaseValue(StrokeSettings::FEATHER_VALUE, feather);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::FEATHER);
+    emit featherChanged(feather);
 }
 
 void StrokeTool::setWidth(qreal width)
 {
     properties.setBaseValue(StrokeSettings::WIDTH_VALUE, width);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::WIDTH);
+    emit widthChanged(width);
 }
 
 void StrokeTool::setPressureON(bool isON)
 {
     properties.setBaseValue(StrokeSettings::PRESSURE_ON, isON);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::PRESSURE);
+    emit pressureONChanged(isON);
 }
 
 void StrokeTool::setFillContourON(bool isON)
 {
     properties.setBaseValue(StrokeSettings::FILLCONTOUR_ON, isON);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::FILLCONTOUR);
+    emit fillContourONChanged(isON);
 }
 
 void StrokeTool::setAntiAliasingON(bool isON)
 {
     properties.setBaseValue(StrokeSettings::ANTI_ALIASING_ON, isON);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::ANTI_ALIASING);
+    emit antiAliasingONChanged(isON);
 }
 
 void StrokeTool::setInvisibilityON(bool isON)
 {
     properties.setBaseValue(StrokeSettings::INVISIBILITY_ON, isON);
-    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::INVISIBILITY);
+    emit invisibilityONChanged(isON);
 }

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -422,33 +422,3 @@ void StrokeTool::setInvisibilityON(bool isON)
     properties.setBaseValue(StrokeSettings::INVISIBILITY_ON, isON);
     editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::INVISIBILITY);
 }
-
-// void StrokeTool::setProperty(Properties::Type type, int value)
-// {
-//     StrokeProperties::Type strokeType = static_cast<StrokeProperties::Type>(type);
-//     properties.set(strokeType, value);
-// }
-
-// void StrokeTool::setProperty(Properties::Type type, qreal value)
-// {
-//     StrokeProperties::Type strokeType = static_cast<StrokeProperties::Type>(type);
-//     switch (strokeType)
-//     {
-//         case StrokeProperties::WIDTH_VALUE: {
-//             if (std::isnan(value) || value < 0)
-//             {
-//                 value = 1.f;
-//             }
-//         }
-//     default:
-//         break;
-//     }
-
-//     properties.set(type, value);
-// }
-
-// void StrokeTool::setProperty(Properties::Type type, bool value)
-// {
-//     StrokeProperties::Type strokeType = static_cast<StrokeProperties::Type>(type);
-//     properties.set(type, value);
-// }

--- a/core_lib/src/tool/stroketool.cpp
+++ b/core_lib/src/tool/stroketool.cpp
@@ -255,8 +255,8 @@ bool StrokeTool::leaveEvent(QEvent*)
 
 void StrokeTool::updateCanvasCursor()
 {
-    const qreal brushWidth = properties.width;
-    const qreal brushFeather = properties.feather;
+    const qreal brushWidth = properties.width();
+    const qreal brushFeather = properties.feather();
 
     const QPointF& cursorPos = msIsAdjusting ? mAdjustPosition : getCurrentPoint();
     const qreal cursorRad = brushWidth * 0.5;
@@ -305,15 +305,15 @@ bool StrokeTool::startAdjusting(Qt::KeyboardModifiers modifiers)
     switch (propertyType) {
     case WIDTH: {
         const qreal factor = 0.5;
-        const qreal rad = properties.width * factor;
+        const qreal rad = properties.width() * factor;
         const qreal distance = QLineF(currentPressPoint - QPointF(rad, rad), currentPoint).length();
         mAdjustPosition = currentPressPoint - QPointF(distance * factor, distance * factor);
         break;
     }
     case FEATHER: {
         const qreal factor = 0.5;
-        const qreal cursorRad = properties.width * factor;
-        const qreal featherWidthFactor = MathUtils::normalize(properties.feather, 0.0, FEATHER_MAX);
+        const qreal cursorRad = properties.width() * factor;
+        const qreal featherWidthFactor = MathUtils::normalize(properties.feather(), 0.0, FEATHER_MAX);
         const qreal offset = (cursorRad * featherWidthFactor) * factor;
         const qreal distance = QLineF(currentPressPoint - QPointF(offset, offset), currentPoint).length();
         mAdjustPosition = currentPressPoint - QPointF(distance, distance);
@@ -346,14 +346,13 @@ void StrokeTool::adjustCursor(Qt::KeyboardModifiers modifiers)
         // The adjusted position is based on the radius of the circle, so in order to
         // map it back to its original value, we can multiply by the factor we divided with
         const qreal newValue = QLineF(mAdjustPosition, getCurrentPoint()).length() * 2.0;
-
-        mEditor->tools()->setWidth(qBound(WIDTH_MIN, newValue, WIDTH_MAX));
+        setWidth(newValue);
         break;
     }
     case FEATHER: {
         // The radius of the width is the max value we can get
         const qreal inputMin = 0.0;
-        const qreal inputMax = properties.width * 0.5;
+        const qreal inputMax = properties.width() * 0.5;
         const qreal distance = QLineF(mAdjustPosition, getCurrentPoint()).length();
         const qreal outputMax = FEATHER_MAX;
         const qreal outputMin = 0.0;
@@ -361,7 +360,7 @@ void StrokeTool::adjustCursor(Qt::KeyboardModifiers modifiers)
         // We flip min and max here in order to get the inverted value for the UI
         const qreal mappedValue = MathUtils::map(distance, inputMin, inputMax, outputMax, outputMin);
 
-        mEditor->tools()->setFeather(qBound(FEATHER_MIN, mappedValue, FEATHER_MAX));
+        setFeather(mappedValue);
         break;
     }
     default:
@@ -375,3 +374,81 @@ void StrokeTool::paint(QPainter& painter, const QRect& blitRect)
 {
     mCanvasCursorPainter.paint(painter, blitRect);
 }
+
+void StrokeTool::setStablizationLevel(int level)
+{
+    properties.setBaseValue(StrokeSettings::STABILIZATION_VALUE, level);
+    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::STABILIZATION);
+}
+
+void StrokeTool::setFeatherON(bool isON)
+{
+    properties.setBaseValue(StrokeSettings::FEATHER_ON, isON);
+    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::USEFEATHER);
+}
+
+void StrokeTool::setFeather(qreal feather)
+{
+    properties.setBaseValue(StrokeSettings::FEATHER_VALUE, feather);
+    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::FEATHER);
+}
+
+void StrokeTool::setWidth(qreal width)
+{
+    properties.setBaseValue(StrokeSettings::WIDTH_VALUE, width);
+    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::WIDTH);
+}
+
+void StrokeTool::setPressureON(bool isON)
+{
+    properties.setBaseValue(StrokeSettings::PRESSURE_ON, isON);
+    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::PRESSURE);
+}
+
+void StrokeTool::setFillContourON(bool isON)
+{
+    properties.setBaseValue(StrokeSettings::FILLCONTOUR_ON, isON);
+    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::FILLCONTOUR);
+}
+
+void StrokeTool::setAntiAliasingON(bool isON)
+{
+    properties.setBaseValue(StrokeSettings::ANTI_ALIASING_ON, isON);
+    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::ANTI_ALIASING);
+}
+
+void StrokeTool::setInvisibilityON(bool isON)
+{
+    properties.setBaseValue(StrokeSettings::INVISIBILITY_ON, isON);
+    editor()->tools()->toolPropertyChanged(type(), ToolPropertyType::INVISIBILITY);
+}
+
+// void StrokeTool::setProperty(Properties::Type type, int value)
+// {
+//     StrokeProperties::Type strokeType = static_cast<StrokeProperties::Type>(type);
+//     properties.set(strokeType, value);
+// }
+
+// void StrokeTool::setProperty(Properties::Type type, qreal value)
+// {
+//     StrokeProperties::Type strokeType = static_cast<StrokeProperties::Type>(type);
+//     switch (strokeType)
+//     {
+//         case StrokeProperties::WIDTH_VALUE: {
+//             if (std::isnan(value) || value < 0)
+//             {
+//                 value = 1.f;
+//             }
+//         }
+//     default:
+//         break;
+//     }
+
+//     properties.set(type, value);
+// }
+
+// void StrokeTool::setProperty(Properties::Type type, bool value)
+// {
+//     StrokeProperties::Type strokeType = static_cast<StrokeProperties::Type>(type);
+//     properties.set(type, value);
+// }

--- a/core_lib/src/tool/stroketool.h
+++ b/core_lib/src/tool/stroketool.h
@@ -74,6 +74,16 @@ public:
     virtual void setFillContourON(bool isON);
     virtual void setInvisibilityON(bool isON);
 
+signals:
+    void widthChanged(qreal value);
+    void featherChanged(qreal value);
+    void pressureONChanged(bool isON);
+    void featherONChanged(bool isON);
+    void antiAliasingONChanged(bool isON);
+    void fillContourONChanged(bool isON);
+    void invisibilityONChanged(bool isON);
+    void stabilizationLevelChanged(int level);
+
 public slots:
     void onPreferenceChanged(SETTING setting);
     void onViewUpdated();

--- a/core_lib/src/tool/stroketool.h
+++ b/core_lib/src/tool/stroketool.h
@@ -35,7 +35,8 @@ class StrokeTool : public BaseTool
     Q_OBJECT
 
 public:
-    explicit StrokeTool(QObject* parent);
+    explicit StrokeTool(QObject* parent, ToolSettings* settings = nullptr);
+    ~StrokeTool();
 
     void startStroke(PointerEvent::InputType inputType);
     void drawStroke();
@@ -101,8 +102,6 @@ protected:
     virtual void stopAdjusting();
     virtual void adjustCursor(Qt::KeyboardModifiers modifiers);
 
-    ToolSettings* getSettings() override { return &properties; }
-
     static bool mQuickSizingEnabled;
     static bool msIsAdjusting;
 
@@ -135,7 +134,7 @@ protected:
 
     const UndoSaveState* mUndoSaveState = nullptr;
 
-    StrokeSettings properties;
+    StrokeSettings* mStrokeSettings = nullptr;
 };
 
 #endif // STROKETOOL_H

--- a/core_lib/src/tool/stroketool.h
+++ b/core_lib/src/tool/stroketool.h
@@ -91,7 +91,7 @@ protected:
     virtual void stopAdjusting();
     virtual void adjustCursor(Qt::KeyboardModifiers modifiers);
 
-    ToolSettings* getProperties() override { return &properties; }
+    ToolSettings* getSettings() override { return &properties; }
 
     static bool mQuickSizingEnabled;
     static bool msIsAdjusting;

--- a/core_lib/src/tool/stroketool.h
+++ b/core_lib/src/tool/stroketool.h
@@ -35,7 +35,7 @@ class StrokeTool : public BaseTool
     Q_OBJECT
 
 public:
-    explicit StrokeTool(QObject* parent, ToolSettings* settings = nullptr);
+    explicit StrokeTool(QObject* parent);
     ~StrokeTool();
 
     void startStroke(PointerEvent::InputType inputType);
@@ -52,6 +52,7 @@ public:
     static const qreal WIDTH_MIN;
     static const qreal WIDTH_MAX;
 
+    void createSettings(ToolSettings* settings) override;
     void loadSettings() override;
     bool isActive() const override { return mInterpolator.isActive(); }
 

--- a/core_lib/src/tool/stroketool.h
+++ b/core_lib/src/tool/stroketool.h
@@ -106,7 +106,7 @@ protected:
     static bool mQuickSizingEnabled;
     static bool msIsAdjusting;
 
-    QHash<Qt::KeyboardModifiers, ToolPropertyType> mQuickSizingProperties;
+    QHash<Qt::KeyboardModifiers, int> mQuickSizingProperties;
     bool mFirstDraw = false;
 
     QList<QPointF> mStrokePoints;

--- a/core_lib/src/tool/stroketool.h
+++ b/core_lib/src/tool/stroketool.h
@@ -52,7 +52,7 @@ public:
     static const qreal WIDTH_MAX;
 
     void loadSettings() override;
-    bool isActive() const override { return mInterpolator.isActive(); };
+    bool isActive() const override { return mInterpolator.isActive(); }
 
     bool keyPressEvent(QKeyEvent* event) override;
     void pointerPressEvent(PointerEvent* event) override;
@@ -64,6 +64,15 @@ public:
     bool handleQuickSizing(PointerEvent* event);
 
     void paint(QPainter& painter, const QRect& blitRect) override;
+
+    virtual void setStablizationLevel(int level);
+    virtual void setWidth(qreal width);
+    virtual void setFeather(qreal feather);
+    virtual void setPressureON(bool isON);
+    virtual void setFeatherON(bool isON);
+    virtual void setAntiAliasingON(bool isON);
+    virtual void setFillContourON(bool isON);
+    virtual void setInvisibilityON(bool isON);
 
 public slots:
     void onPreferenceChanged(SETTING setting);
@@ -81,6 +90,8 @@ protected:
     virtual bool startAdjusting(Qt::KeyboardModifiers modifiers);
     virtual void stopAdjusting();
     virtual void adjustCursor(Qt::KeyboardModifiers modifiers);
+
+    ToolSettings* getProperties() override { return &properties; }
 
     static bool mQuickSizingEnabled;
     static bool msIsAdjusting;
@@ -113,6 +124,8 @@ protected:
     StrokeInterpolator mInterpolator;
 
     const UndoSaveState* mUndoSaveState = nullptr;
+
+    StrokeSettings properties;
 };
 
 #endif // STROKETOOL_H

--- a/core_lib/src/tool/toolsettings.h
+++ b/core_lib/src/tool/toolsettings.h
@@ -110,22 +110,22 @@ struct PropertyInfo
     }
 
     qreal getMaxReal() const {
-        if (mValueType == REAL) {
+        if (mValueType != REAL) {
             return -1.0;
         }
 
         return mMaxValue.realValue;
     }
 
-    qreal getMinInt() const {
+    int getMinInt() const {
         if (mValueType != INTEGER) {
-            return -1.0;
+            return -1;
         }
         return mMinValue.intValue;
     }
 
     int getMaxInt() const {
-        if (mValueType == INTEGER) {
+        if (mValueType != INTEGER) {
             return -1;
         }
 
@@ -150,7 +150,7 @@ struct PropertyInfo
 
     /// Returns the default value as an real, otherwise -1 if it hasn't been specified or the type doesn't match
     int defaultInt() {
-        if (mValueType == INTEGER) {
+        if (mValueType != INTEGER) {
             return -1;
         }
         return mDefaultValue.intValue;
@@ -158,7 +158,7 @@ struct PropertyInfo
 
     /// Returns the default value as an real, otherwise -1.0 if it hasn't been specified or the type doesn't match
     qreal defaultReal() {
-        if (mValueType == REAL) {
+        if (mValueType != REAL) {
             return -1.0;
         }
         return mDefaultValue.realValue;
@@ -166,7 +166,7 @@ struct PropertyInfo
 
     /// Returns the default value as an bool, otherwise false if it hasn't been specified or the type doesn't match
     bool defaultBool() {
-        if (mValueType == BOOL) {
+        if (mValueType != BOOL) {
             return false;
         }
         return mDefaultValue.boolValue;

--- a/core_lib/src/tool/toolsettings.h
+++ b/core_lib/src/tool/toolsettings.h
@@ -197,6 +197,8 @@ private:
 
 struct ToolSettings
 {
+    virtual ~ToolSettings() {}
+
     void load(const QString& toolIdentifier, QSettings& settings, QHash<int, PropertyInfo> props) {
         mIdentifier = toolIdentifier.toLower();
 
@@ -367,7 +369,7 @@ struct StrokeSettings: public ToolSettings
 /// This struct is an example of how we can
 /// share settings among tools rather than duplicating logic, eg. polyline uses settings from StrokeSettings.
 /// The same could be done for PencilTool, BrushTool, Eraser etc...
-struct PolyLineSettings: public StrokeSettings
+struct PolylineSettings: public StrokeSettings
 {
     enum Type {
         START           = 200,
@@ -379,7 +381,7 @@ struct PolyLineSettings: public StrokeSettings
     };
 
     QString identifier(int typeRaw) const override {
-        auto type = static_cast<PolyLineSettings::Type>(typeRaw);
+        auto type = static_cast<PolylineSettings::Type>(typeRaw);
         QString propertyID = ToolSettings::identifier(typeRaw);
         switch (type)
         {

--- a/core_lib/src/tool/toolsettings.h
+++ b/core_lib/src/tool/toolsettings.h
@@ -200,7 +200,7 @@ struct ToolSettings
     void load(const QString& toolIdentifier, const QSettings& settings, QHash<int, PropertyInfo> props) {
         mIdentifier = toolIdentifier.toLower();
 
-        mProps = props;
+        mProps.insert(props);
 
         for (auto it = props.begin(); it != props.end(); ++it) {
             PropertyInfo& info = it.value();

--- a/core_lib/src/tool/toolsettings.h
+++ b/core_lib/src/tool/toolsettings.h
@@ -1,0 +1,492 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+
+#ifndef TOOLSETTINGS_H
+#define TOOLSETTINGS_H
+
+#include <QHash>
+#include <QSettings>
+
+#include "pencildef.h"
+
+struct PropertyInfo
+{
+    enum ValueType {
+        INTEGER,
+        REAL,
+        BOOL,
+        INVALID
+    };
+
+    PropertyInfo() {
+        mValueType = INVALID;
+        mBaseValue.intValue = -1;
+    }
+    PropertyInfo(int min, int max, int defaultValue)
+        : mValueType(INTEGER) {
+        setBaseValue(defaultValue);
+        mMinValue.intValue = min;
+        mMaxValue.intValue = max;
+        mDefaultValue.intValue = defaultValue;
+    }
+    PropertyInfo(qreal min, qreal max, qreal defaultValue)
+        : mValueType(REAL) {
+        setBaseValue(defaultValue);
+        mMinValue.realValue = min;
+        mMaxValue.realValue = max;
+        mDefaultValue.realValue = defaultValue;
+    }
+
+    PropertyInfo(bool base, bool defaultValue)
+        : mValueType(BOOL) {
+        setBaseValue(base);
+        mMinValue.boolValue = base;
+        mMaxValue.boolValue = base;
+        mDefaultValue.boolValue = defaultValue;
+    }
+
+    PropertyInfo(bool base) : PropertyInfo(base, base) {}
+    PropertyInfo(int base) : PropertyInfo(base, base, base) {}
+    PropertyInfo(qreal base) : PropertyInfo(base, base, base) {}
+
+    void setBaseValue(int newValue) {
+        Q_ASSERT(mValueType == INTEGER);
+        mBaseValue.intValue = newValue;
+    }
+    void setBaseValue(qreal newValue) {
+        Q_ASSERT(mValueType == REAL);
+        mBaseValue.realValue = newValue;
+    }
+    void setBaseValue(bool newValue) {
+        Q_ASSERT(mValueType == BOOL);
+        mBaseValue.boolValue = newValue;
+    }
+
+    int getInt() const {
+        if (mValueType != INTEGER) {
+            Q_ASSERT(false);
+            return -1;
+        }
+
+        return qBound(mMinValue.intValue, mBaseValue.intValue, mMaxValue.intValue);
+    }
+
+    qreal getReal() const {
+        if (mValueType != REAL) {
+            Q_ASSERT(false);
+            return -1.0;
+        }
+
+        return qBound(mMinValue.realValue, mBaseValue.realValue, mMaxValue.realValue);
+    }
+
+    bool getBool() const {
+        if (mValueType != BOOL) {
+            Q_ASSERT(false);
+            return false;
+        }
+        return mBaseValue.boolValue;
+    }
+
+    qreal getMinReal() const {
+        if (mValueType != REAL) {
+            return -1.0;
+        }
+        return mMinValue.realValue;
+    }
+
+    qreal getMaxReal() const {
+        if (mValueType == REAL) {
+            return -1.0;
+        }
+
+        return mMaxValue.realValue;
+    }
+
+    qreal getMinInt() const {
+        if (mValueType != INTEGER) {
+            return -1.0;
+        }
+        return mMinValue.intValue;
+    }
+
+    int getMaxInt() const {
+        if (mValueType == INTEGER) {
+            return -1;
+        }
+
+        return mMaxValue.intValue;
+    }
+
+    void resetBaseValue() {
+        switch (mValueType) {
+        case INTEGER:
+            mBaseValue.intValue = mDefaultValue.intValue;
+            break;
+        case REAL:
+            mBaseValue.realValue = mDefaultValue.realValue;
+            break;
+        case BOOL:
+            mBaseValue.boolValue = mDefaultValue.boolValue;
+            break;
+        case INVALID:
+            break;
+        }
+    }
+
+    /// Returns the default value as an real, otherwise -1 if it hasn't been specified or the type doesn't match
+    int defaultInt() {
+        if (mValueType == INTEGER) {
+            return -1;
+        }
+        return mDefaultValue.intValue;
+    }
+
+    /// Returns the default value as an real, otherwise -1.0 if it hasn't been specified or the type doesn't match
+    qreal defaultReal() {
+        if (mValueType == REAL) {
+            return -1.0;
+        }
+        return mDefaultValue.realValue;
+    }
+
+    /// Returns the default value as an bool, otherwise false if it hasn't been specified or the type doesn't match
+    bool defaultBool() {
+        if (mValueType == BOOL) {
+            return false;
+        }
+        return mDefaultValue.boolValue;
+    }
+
+    ValueType type() const { return mValueType; }
+    bool isType(ValueType type) const { return mValueType == type; }
+    bool hasValue() {
+        return mValueType != INVALID;
+    }
+
+private:
+
+    // This union is only meant ot store simple values.
+    // Do not attempt to store complicated objects in here.
+    union ValueUnion {
+        int intValue;
+        qreal realValue;
+        bool boolValue;
+    };
+
+    ValueType mValueType;
+    ValueUnion mBaseValue;
+    ValueUnion mMinValue;
+    ValueUnion mMaxValue;
+    ValueUnion mDefaultValue;
+};
+
+struct ToolSettings
+{
+    void load(const QString& toolIdentifier, const QSettings& settings, QHash<int, PropertyInfo> props) {
+        mIdentifier = toolIdentifier.toLower();
+
+        mProps = props;
+
+        for (auto it = props.begin(); it != props.end(); ++it) {
+            PropertyInfo& info = it.value();
+            const QString& settingName = identifier(it.key());
+            switch (info.type()) {
+            case PropertyInfo::INTEGER: {
+                QVariant value = settings.value(settingName, info.defaultInt());
+                info.setBaseValue(value.toInt());
+                break;
+            }
+            case PropertyInfo::REAL: {
+                QVariant value = settings.value(settingName, info.defaultReal());
+                info.setBaseValue(value.toReal());
+                break;
+            }
+            case PropertyInfo::BOOL: {
+                QVariant value = settings.value(settingName, info.defaultBool());
+                info.setBaseValue(value.toBool());
+                break;
+            }
+            case PropertyInfo::INVALID: {
+                Q_ASSERT_X(false, __func__, "Wrong state, expected a value type but got INVALID. You've probably misconfigured the property. "
+                                            "Ensure the property has been setup correctly and try again.");
+                break;
+            }
+            }
+        }
+    }
+
+    void save(QSettings& settings) {
+        for (auto it = mProps.begin(); it != mProps.end(); ++it) {
+
+            QString propertyId = identifier(it.key());
+            switch (it.value().type())
+            {
+            case PropertyInfo::INTEGER:
+                settings.setValue(propertyId, it.value().getInt());
+                break;
+            case PropertyInfo::REAL:
+                settings.setValue(propertyId, it.value().getReal());
+                break;
+            case PropertyInfo::BOOL:
+                settings.setValue(propertyId, it.value().getBool());
+                break;
+            case PropertyInfo::INVALID:
+                Q_ASSERT_X(false, __func__, "Wrong state, expected a value type but got INVALID. You've probably misconfigured the property. "
+                                        "Ensure the property has been setup correctly and try again.");
+                break;
+            }
+        }
+        settings.sync();
+    }
+
+    void setBaseValue(int typeRaw, const PropertyInfo& value) {
+        switch (value.type())
+        {
+        case PropertyInfo::INTEGER:
+            mProps[typeRaw].setBaseValue(value.getInt());
+            break;
+        case PropertyInfo::REAL:
+            mProps[typeRaw].setBaseValue(value.getReal());
+            break;
+        case PropertyInfo::BOOL:
+            mProps[typeRaw].setBaseValue(value.getBool());
+            break;
+        case PropertyInfo::INVALID:
+            Q_ASSERT_X(false, __func__, "Expected value but got INVALID. Make sure the property has been setup properly before trying to set its base value.");
+            break;
+        }
+    }
+
+    void setDefaults() {
+        for (auto it = mProps.begin(); it != mProps.end(); ++it) {
+            it.value().resetBaseValue();
+        }
+    }
+
+    virtual QString identifier(int typeRaw) const = 0;
+
+protected:
+    QString mIdentifier = "unidentified";
+    QHash<int, PropertyInfo> mProps;
+};
+
+
+struct PolyLineSettings: public ToolSettings
+{
+    enum Type {
+        WIDTH_VALUE,
+        CLOSEDPATH_ON,
+        BEZIER_ON,
+        ANTI_ALIASING_ON,
+    };
+
+    QString identifier(int typeRaw) const override {
+        auto type = static_cast<PolyLineSettings::Type>(typeRaw);
+
+        QString propertyID;
+        switch (type)
+        {
+        case WIDTH_VALUE:
+            propertyID = "Width";
+            break;
+        case CLOSEDPATH_ON:
+            propertyID = "ClosedPathEnabled";
+            break;
+        case BEZIER_ON:
+            propertyID = "BezierEnabled";
+            break;
+        case ANTI_ALIASING_ON:
+            propertyID = "AntiAliasingEnabled";
+            break;
+        }
+
+        return mIdentifier + propertyID;
+    }
+
+    qreal width() const { return mProps[WIDTH_VALUE].getReal(); }
+    bool closedPath() const { return mProps[CLOSEDPATH_ON].getBool(); }
+    bool useBezier() const { return mProps[BEZIER_ON].getBool(); }
+    bool useAntiAliasing() const { return mProps[ANTI_ALIASING_ON].getBool(); }
+};
+
+struct StrokeSettings: public ToolSettings
+{
+
+    enum Type {
+        WIDTH_VALUE,
+        FEATHER_VALUE,
+        STABILIZATION_VALUE,
+        PRESSURE_ON,
+        INVISIBILITY_ON,
+        FEATHER_ON,
+        ANTI_ALIASING_ON,
+        FILLCONTOUR_ON,
+    };
+
+    QString identifier(int typeRaw) const override {
+        auto type = static_cast<StrokeSettings::Type>(typeRaw);
+        QString propertyID;
+        switch (type)
+        {
+        case WIDTH_VALUE:
+            propertyID = "Width";
+            break;
+        case FEATHER_VALUE:
+            propertyID = "Feather";
+            break;
+        case STABILIZATION_VALUE:
+            propertyID = "LineStabilization";
+            break;
+        case PRESSURE_ON:
+            propertyID = "Pressure";
+            break;
+        case INVISIBILITY_ON:
+            propertyID = "Invisibility";
+            break;
+        case FEATHER_ON:
+            propertyID = "UseFeather";
+            break;
+        case ANTI_ALIASING_ON:
+            propertyID = "UseAA";
+            break;
+        case FILLCONTOUR_ON:
+            propertyID = "FillContour";
+            break;
+        }
+
+        return mIdentifier + propertyID;
+    }
+
+    qreal width() const { return mProps[WIDTH_VALUE].getReal(); }
+    qreal feather() const { return mProps[FEATHER_VALUE].getReal(); }
+    int stabilizerLevel() const { return mProps[STABILIZATION_VALUE].getInt(); }
+    bool usePressure() const { return mProps[PRESSURE_ON].getBool(); }
+    bool invisibility() const { return mProps[INVISIBILITY_ON].getBool(); }
+    bool useFeather() const { return mProps[FEATHER_ON].getBool(); }
+    bool useAntiAliasing() const { return mProps[ANTI_ALIASING_ON].getBool(); }
+    bool useFillContour() const { return mProps[FILLCONTOUR_ON].getBool(); }
+};
+
+struct BucketSettings: public ToolSettings
+{
+    enum Type {
+        WIDTH_VALUE,
+        TOLERANCE_VALUE,
+        FILLEXPAND_VALUE,
+        FILLLAYERREFERENCEMODE_VALUE,
+        FILLMODE_VALUE,
+        STABILIZATION_VALUE,
+        TOLERANCE_ON,
+        FILLEXPAND_ON
+    };
+
+    QString identifier(int typeRaw) const override {
+        auto type = static_cast<BucketSettings::Type>(typeRaw);
+        QString propertyID;
+        switch (type)
+        {
+        case WIDTH_VALUE:
+            propertyID = "FillThickness";
+            break;
+        case TOLERANCE_VALUE:
+            propertyID = "Tolerance";
+            break;
+        case TOLERANCE_ON:
+            propertyID = "ToleranceEnabled";
+            break;
+        case FILLEXPAND_ON:
+            propertyID = "FillExpandEnabled";
+            break;
+        case FILLEXPAND_VALUE:
+            propertyID = "FillExpand";
+            break;
+        case FILLLAYERREFERENCEMODE_VALUE:
+            propertyID = "FillReferenceMode";
+            break;
+        case STABILIZATION_VALUE:
+            propertyID = "StabilizationLevel";
+            break;
+        case FILLMODE_VALUE:
+            propertyID = "FillMode";
+            break;
+        }
+
+        return mIdentifier + propertyID;
+    }
+
+    qreal thickness() const { return mProps[WIDTH_VALUE].getReal(); }
+    int tolerance() const { return mProps[TOLERANCE_VALUE].getInt(); }
+    int fillExpandAmount() const { return mProps[FILLEXPAND_VALUE].getInt(); }
+    int fillReferenceMode() const { return mProps[FILLLAYERREFERENCEMODE_VALUE].getInt(); }
+    int fillMode() const { return mProps[FILLMODE_VALUE].getInt(); }
+    int stabilizerLevel() const { return mProps[STABILIZATION_VALUE].getInt(); }
+    bool useTolerance() const { return mProps[TOLERANCE_ON].getBool(); }
+    bool useFillExpand() const { return mProps[FILLEXPAND_ON].getBool(); }
+};
+
+struct CameraSettings: public ToolSettings
+{
+    enum Type {
+        SHOWPATH_ON,
+        PATH_DOTCOLOR_TYPE
+    };
+
+    QString identifier(int typeRaw) const override {
+        auto type = static_cast<CameraSettings::Type>(typeRaw);
+        QString propertyID;
+
+        switch (type)
+        {
+        case SHOWPATH_ON:
+            propertyID = "ShowPath";
+            break;
+        case PATH_DOTCOLOR_TYPE:
+            propertyID = "PathDotColorType";
+        }
+
+        return mIdentifier + propertyID;
+    }
+
+    bool showPath() const { return mProps[SHOWPATH_ON].getBool(); }
+    DotColorType dotColorType() const { return static_cast<DotColorType>(mProps[PATH_DOTCOLOR_TYPE].getInt()); }
+};
+
+// Used by both select and move tool
+struct SelectionSettings: public ToolSettings
+{
+    enum Type {
+        SHOWSELECTIONINFO_ON
+    };
+
+    QString identifier(int typeRaw) const override {
+        auto type = static_cast<SelectionSettings::Type>(typeRaw);
+        QString propertyID;
+        switch (type)
+        {
+            case SHOWSELECTIONINFO_ON:
+                propertyID = "ShowSelectionInfoEnabled";
+            break;
+        }
+
+        return mIdentifier + propertyID;
+    }
+
+    bool showSelectionInfo() const { return mProps[SHOWSELECTIONINFO_ON].getBool(); }
+};
+
+#endif // TOOLSETTINGS_H

--- a/core_lib/src/tool/toolsettings.h
+++ b/core_lib/src/tool/toolsettings.h
@@ -259,6 +259,11 @@ struct ToolSettings
         }
     }
 
+    PropertyInfo getInfo(int rawPropertyType) const
+    {
+        return mProps[rawPropertyType];
+    }
+
     void setDefaults() {
         for (auto it = mProps.begin(); it != mProps.end(); ++it) {
             it.value().resetBaseValue();

--- a/core_lib/src/tool/toolsettings.h
+++ b/core_lib/src/tool/toolsettings.h
@@ -297,8 +297,7 @@ struct PolyLineSettings: public ToolSettings
 
     QString identifier(int typeRaw) const override {
         auto type = static_cast<PolyLineSettings::Type>(typeRaw);
-
-        QString propertyID;
+        QString propertyID = "invalid";
         switch (type)
         {
         case WIDTH_VALUE:
@@ -340,7 +339,7 @@ struct StrokeSettings: public ToolSettings
 
     QString identifier(int typeRaw) const override {
         auto type = static_cast<StrokeSettings::Type>(typeRaw);
-        QString propertyID;
+        QString propertyID = "invalid";
         switch (type)
         {
         case WIDTH_VALUE:
@@ -385,7 +384,7 @@ struct StrokeSettings: public ToolSettings
 struct BucketSettings: public ToolSettings
 {
     enum Type {
-        WIDTH_VALUE,
+        FILLTHICKNESS_VALUE,
         TOLERANCE_VALUE,
         FILLEXPAND_VALUE,
         FILLLAYERREFERENCEMODE_VALUE,
@@ -397,10 +396,10 @@ struct BucketSettings: public ToolSettings
 
     QString identifier(int typeRaw) const override {
         auto type = static_cast<BucketSettings::Type>(typeRaw);
-        QString propertyID;
+        QString propertyID = "invalid";
         switch (type)
         {
-        case WIDTH_VALUE:
+        case FILLTHICKNESS_VALUE:
             propertyID = "FillThickness";
             break;
         case TOLERANCE_VALUE:
@@ -429,7 +428,7 @@ struct BucketSettings: public ToolSettings
         return mIdentifier + propertyID;
     }
 
-    qreal thickness() const { return mProps[WIDTH_VALUE].getReal(); }
+    qreal fillThickness() const { return mProps[FILLTHICKNESS_VALUE].getReal(); }
     int tolerance() const { return mProps[TOLERANCE_VALUE].getInt(); }
     int fillExpandAmount() const { return mProps[FILLEXPAND_VALUE].getInt(); }
     int fillReferenceMode() const { return mProps[FILLLAYERREFERENCEMODE_VALUE].getInt(); }
@@ -448,7 +447,7 @@ struct CameraSettings: public ToolSettings
 
     QString identifier(int typeRaw) const override {
         auto type = static_cast<CameraSettings::Type>(typeRaw);
-        QString propertyID;
+        QString propertyID = "invalid";
 
         switch (type)
         {
@@ -475,7 +474,7 @@ struct SelectionSettings: public ToolSettings
 
     QString identifier(int typeRaw) const override {
         auto type = static_cast<SelectionSettings::Type>(typeRaw);
-        QString propertyID;
+        QString propertyID = "invalid";
         switch (type)
         {
             case SHOWSELECTIONINFO_ON:

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -27,6 +27,12 @@ GNU General Public License for more details.
 #define S__GIT_TIMESTAMP TOSTRING(GIT_TIMESTAMP)
 #define S__GIT_COMMIT_HASH TOSTRING(GIT_CURRENT_SHA1)
 
+enum ToolCategory: int
+{
+    BASETOOL    = 0,
+    STROKETOOL  = 1
+};
+
 enum ToolType : int
 {
     INVALID_TOOL = -1,
@@ -45,6 +51,19 @@ enum ToolType : int
     TOOL_TYPE_COUNT
 };
 
+/// This list should consist of all tool properties
+/// Each tool or Tool category, depending on the granularity of the Property should
+/// follow this naming convention: <TOOL>_<DESCRIPTION>_<VALUE|TYPE|CHECKED>
+///
+/// eg. CAMERA_PATH_DOTCOLOR_TYPE because we're dealing with an enum
+///
+/// - Use Value for int, real and similar
+/// - Use TYPE for enum values
+/// - Use CHECKED for bool states
+///
+/// Adding a property here means you intend to store the value in pencil settings
+/// So it can be retrieved again upon the next launch
+///
 enum ToolPropertyType
 {
     WIDTH,
@@ -66,8 +85,28 @@ enum ToolPropertyType
     BUCKETFILLEXPAND,
     USEBUCKETFILLEXPAND,
     BUCKETFILLLAYERREFERENCEMODE,
-    CAMERAPATH,
+    CAMERA_SHOWPATH_CHECKED,
+    CAMERA_PATH_DOTCOLOR_TYPE,
 };
+
+
+/// This list should consist of all tool actions
+/// Each tool or Tool category, depending on the granularity of the Action should
+/// follow this naming convention: <TOOL>_<KEY>_<DESCRIPTION>
+///
+/// eg. CAMERA_RESET_FIELD, where RESET is the KEY and FIELD is the description.
+///
+enum ToolActionType {
+    CAMERA_PATH_RESET,
+    CAMERA_RESET_FIELD,
+    CAMERA_RESET_ROTATION,
+    CAMERA_RESET_TRANSLATION,
+    CAMERA_RESET_SCALING
+};
+
+// enum CameraActionType {
+
+// };
 
 enum class DotColorType {
     RED,
@@ -321,6 +360,7 @@ const static int MaxFramesBound = 9999;
 #define SETTING_NEW_UNDO_REDO_ON        "NewUndoRedoOn"
 #define SETTING_UNDO_REDO_MAX_STEPS     "UndoRedoMaxSteps"
 
+#define SETTING_BUCKET_FILLTHICKNESS "fillThickness"
 #define SETTING_BUCKET_TOLERANCE "Tolerance"
 #define SETTING_BUCKET_TOLERANCE_ON "BucketToleranceEnabled"
 #define SETTING_BUCKET_FILL_EXPAND "BucketFillExpand"

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -51,43 +51,6 @@ enum ToolType : int
     TOOL_TYPE_COUNT
 };
 
-/// This list should consist of all tool properties
-/// Each tool or Tool category, depending on the granularity of the Property should
-/// follow this naming convention: <TOOL>_<DESCRIPTION>_<VALUE|TYPE|CHECKED>
-///
-/// eg. CAMERA_PATH_DOTCOLOR_TYPE because we're dealing with an enum
-///
-/// - Use Value for int, real and similar
-/// - Use TYPE for enum values
-/// - Use CHECKED for bool states
-///
-/// Adding a property here means you intend to store the value in pencil settings
-/// So it can be retrieved again upon the next launch
-///
-enum ToolPropertyType
-{
-    WIDTH,
-    FEATHER,
-    PRESSURE,
-    INVISIBILITY,
-    PRESERVEALPHA,
-    BEZIER,
-    CLOSEDPATH,
-    USEFEATHER,
-    VECTORMERGE,
-    ANTI_ALIASING,
-    FILL_MODE,
-    STABILIZATION,
-    TOLERANCE,
-    FILLCONTOUR,
-    SHOWSELECTIONINFO,
-    USETOLERANCE,
-    BUCKETFILLEXPAND,
-    USEBUCKETFILLEXPAND,
-    BUCKETFILLLAYERREFERENCEMODE,
-    CAMERA_SHOWPATH_CHECKED,
-    CAMERA_PATH_DOTCOLOR_TYPE,
-};
 enum class DotColorType {
     RED,
     BLUE,

--- a/core_lib/src/util/pencildef.h
+++ b/core_lib/src/util/pencildef.h
@@ -88,26 +88,6 @@ enum ToolPropertyType
     CAMERA_SHOWPATH_CHECKED,
     CAMERA_PATH_DOTCOLOR_TYPE,
 };
-
-
-/// This list should consist of all tool actions
-/// Each tool or Tool category, depending on the granularity of the Action should
-/// follow this naming convention: <TOOL>_<KEY>_<DESCRIPTION>
-///
-/// eg. CAMERA_RESET_FIELD, where RESET is the KEY and FIELD is the description.
-///
-enum ToolActionType {
-    CAMERA_PATH_RESET,
-    CAMERA_RESET_FIELD,
-    CAMERA_RESET_ROTATION,
-    CAMERA_RESET_TRANSLATION,
-    CAMERA_RESET_SCALING
-};
-
-// enum CameraActionType {
-
-// };
-
 enum class DotColorType {
     RED,
     BLUE,

--- a/tests/src/test_bitmapbucket.cpp
+++ b/tests/src/test_bitmapbucket.cpp
@@ -15,7 +15,7 @@
 
 #include "basetool.h"
 
-void dragAndFill(QPointF movePoint, Editor* editor, QColor color, QRect bounds, Properties properties, int fillCountThreshold) {
+void dragAndFill(QPointF movePoint, Editor* editor, QColor color, QRect bounds, BucketSettings properties, int fillCountThreshold) {
     int moveX = 0;
 
     BitmapBucket bucket = BitmapBucket(editor, color, bounds, movePoint, properties);
@@ -67,16 +67,23 @@ TEST_CASE("BitmapBucket - Fill drag behaviour across four segments")
     editor->setObject(obj);
     editor->init();
 
-    Properties properties;
+    BucketSettings properties;
 
     QDir dir;
     QString resultsPath = dir.currentPath() + "/fill-drag-test/";
 
     dir.mkpath(resultsPath);
 
-    properties.bucketFillReferenceMode = 0;
-    properties.bucketFillExpandEnabled = false;
-    properties.fillMode = 0;
+    QSettings settings;
+
+    QHash<int, PropertyInfo> info;
+
+    info[BucketSettings::FILLLAYERREFERENCEMODE_VALUE] = 0;
+    info[BucketSettings::FILLEXPAND_ON] = false;
+    info[BucketSettings::FILLMODE_VALUE] = 0;
+    info[BucketSettings::TOLERANCE_VALUE] = 25;
+    info[BucketSettings::TOLERANCE_ON] = true;
+    properties.load("BucketTest", settings, info);
 
     QColor fillColor = QColor(255,255,0,100);
 
@@ -94,7 +101,7 @@ TEST_CASE("BitmapBucket - Fill drag behaviour across four segments")
         Layer* strokeLayer = editor->layers()->currentLayer();
         SECTION("When reference is current layer, only transparent color is filled")
         {
-            properties.bucketFillReferenceMode = 0;
+            properties.setBaseValue(BucketSettings::FILLLAYERREFERENCEMODE_VALUE, 0);
             dragAndFill(pressPoint, editor, fillColor, beforeFill.bounds(), properties, 4);
 
             BitmapImage* image = static_cast<LayerBitmap*>(strokeLayer)->getLastBitmapImageAtFrame(1);
@@ -106,7 +113,7 @@ TEST_CASE("BitmapBucket - Fill drag behaviour across four segments")
 
         SECTION("When reference is all layers, only transparent color is filled")
         {
-            properties.bucketFillReferenceMode = 1;
+            properties.setBaseValue(BucketSettings::FILLLAYERREFERENCEMODE_VALUE, 1);
 
             dragAndFill(pressPoint, editor, fillColor, beforeFill.bounds(), properties, 4);
 
@@ -121,10 +128,10 @@ TEST_CASE("BitmapBucket - Fill drag behaviour across four segments")
     SECTION("Filling on current layer - layer is pre-filled") {
 
         // Fill mode is set to `replace` because it makes it easier to compare colors...
-        properties.fillMode = 1;
+        properties.setBaseValue(BucketSettings::FILLMODE_VALUE, 1);
         Layer* strokeLayer = editor->layers()->currentLayer();
         SECTION("When reference is current layer, only pixels matching the fill color are filled"){
-            properties.bucketFillReferenceMode = 0;
+            properties.setBaseValue(BucketSettings::FILLLAYERREFERENCEMODE_VALUE, 0);
 
             dragAndFill(pressPoint, editor, fillColor, beforeFill.bounds(), properties, 4);
             BitmapImage* image = static_cast<LayerBitmap*>(strokeLayer)->getLastBitmapImageAtFrame(1);
@@ -141,7 +148,7 @@ TEST_CASE("BitmapBucket - Fill drag behaviour across four segments")
 
         SECTION("When reference is all layers")
         {
-            properties.bucketFillReferenceMode = 1;
+            properties.setBaseValue(BucketSettings::FILLLAYERREFERENCEMODE_VALUE, 1);
 
             dragAndFill(pressPoint, editor, fillColor, beforeFill.bounds(), properties, 4);
             BitmapImage* image = static_cast<LayerBitmap*>(strokeLayer)->getLastBitmapImageAtFrame(1);


### PR DESCRIPTION
Currently all our tool properties are exposed to BaseTool, for all kinds of reasons this is not good, one of the reasons being that BaseTool ends up knowing too much about its derived types and Tool property data is also "leaked" to various other widgets who has access to BaseTool. 

My proposal for solving that is called ToolSettings. The ToolSettings struct controls the settings of all our tool properties and allows extensibility through inheritance.

### ToolSettings
ToolSettings controls the following:
- loading properties
- Saving properties
- Resetting properties
- Setting BaseValue
- Retrieve min, max, default and base value through a PropertyInfo structure.

The most important method to call is `load` which should be called by each respective tool as part of the initialization. The load method will then setup the ToolSettings model with an identifier, an instance of QSettings and a QHash with tool properties being added.

The identifier is currently set to the name of the tool but this could easily become layer type + tool name.

To declare the properties of a tool, you must specify the min, max and default properties like so:

Here's an example what that could look like:
```c++
info[BucketSettings::FILLTHICKNESS_VALUE] = { 1.0, 100.0, 4.0 }; // min, max, default
info[BucketSettings::TOLERANCE_VALUE] = { 1, 100, 32 };
info[BucketSettings::TOLERANCE_ON] = false; // default
```

You might be wondering... what about the base value? we used to fetch that from QSettings, sometimes from the widget, other times from the tools `load` method. This is now handled by the ToolSettings::load method which Internally carries the responsibility of either fetching the value we have stored via QSettings or using the values we provide through the QHash above.

#### ToolSettings::Type Key
Right now each ToolSettings must have its own `Type` enum with a start and end value. I've picked an arbitrary 100 numbers range which should be sufficient for never having to change the bounds but i'm open to other suggestions.

I also thought about having a big enum like we had with `ToolPropertyType`, the naming would be something like:
```c++
class enum ToolSettingsType
{
	STROKETOOL_WIDTH_VALUE,
	STROKETOOL_FEATHER_VALUE,
	STROKETOOL_STABLIZATION_VALUE,
	STROKETOOL_STABLIZATION_ON
	BUCKETTOOL_.....
	POLYLINETOOL_......
}
```

The biggest reason I can think of for going in that direction would be to be able to use the enum as a key rather than an integer.

If people like that better, i'm open to change it to that instead. For now though there are assertions in various places to make it easy to spot when you try to access, load or save a value on the wrong model and that's has been sufficient so far.

#### Setting baseValue
When we do need to update the baseValue, we do so through `ToolSettings::setBaseValue` which takes in a integer as key and a PropertyInfo as value.

`mSettings->setBaseValue(StrokeSettings::WIDTH_VALUE, 1.0);`
As opposed to
`mSettings->setBaseValue(100, PropertyInfo(1.0));`

I thought about creating a different ToolSetting model for all our different Stroke tools but decided against it for sake of the size of the PR. I did want to see whether my model could actually deliver on potential extensibility needs and as such created PolylineSettings to prove that specifically. So if we were to decouple say EraserTool from StrokeSettings, then following the setup of PolylineSettings would be the way to go.

#### Tool property name alignment
Prior to this PR, there was no naming convention for tool settings, meaning that whatever came to mind could be used a setting and there was no correlation between the setting and the tool except the name it shared eg "brush".

I've tried to align this by creating the ToolSettings::identifier. Granted, someone still has to write it but it's now tied to the specific ToolSettings struct and not some arbitrary combination of names.

When the setting is saved now is will be put a group for the given tool, meaning you should be able to find a toolsetting like so: brushTool/Width where brushTool is the ToolSettings identifier and /Width is the name of the specific setting identifier.

### GUI Communication and Responsibility
Rather than going through ToolManager to update tool properties and requiring other listeners to know about ToolPropertyType, I decided to make a tighter coupling between a tool and it's respective tool widget. You can see the result of that in for example BucketOptionsWidget.

The only responsibility of the widget now is to add GUI elements, their labeling and things that's generally UI bound. The rest now comes from ToolSettings. The widget no longer has to nor should be allowed to update its stored/QSettings settings, nor should it set base, min or max values itself. This data now comes from the ToolSettings model and is setup prior to calling the widget and updating any property requires going through the model.

Updating a GUI elements in relation to a UI change builds on a UI -> Model -> UI update cycle. similar to MVVM but we don't have ViewModels so ignoring that part it's just: 

UI -> Model
```c++
connect(ui->expandSlider, &SpinSlider::valueChanged, [=](int value) {
        mBucketTool->setFillExpand(value);
    });
```

Model -> UI
```c++
connect(mBucketTool, &BucketTool::fillExpandChanged, this, [=](int value) {
       setFillExpand(value);
    });
```

#### UI visibility
Another thing the tool options widget no longer needs to be concerned with, is the relation between what the tool can do for the given layer type. Rather than having a fixed map of which tool properties are enabled in general, each tool now declare what propreties are `usable` as part of `BaseTool::loadSettings` like so:

```c++
mPropertyUsed[BucketSettings::FILLTHICKNESS_VALUE] = { Layer::VECTOR };
mPropertyUsed[BucketSettings::TOLERANCE_VALUE] = { Layer::BITMAP };
mPropertyUsed[BucketSettings::TOLERANCE_ON] = { Layer::BITMAP };
mPropertyUsed[BucketSettings::FILLEXPAND_VALUE] = { Layer::BITMAP };
mPropertyUsed[BucketSettings::FILLEXPAND_ON] = { Layer::BITMAP };
mPropertyUsed[BucketSettings::FILLLAYERREFERENCEMODE_VALUE] = { Layer::BITMAP };
mPropertyUsed[BucketSettings::FILLMODE_VALUE] = { Layer::BITMAP };
``` 

For the widget this means that the visibility logic becomes as simple as this:
```c++
void BucketOptionsWidget::updatePropertyVisibility()
{
    ui->strokeThicknessSlider->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLTHICKNESS_VALUE));
    ui->strokeThicknessSpinBox->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::FILLTHICKNESS_VALUE));
    ui->colorToleranceCheckbox->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::TOLERANCE_ON));
    ui->colorToleranceSlider->setVisible(mBucketTool->isPropertyEnabled(BucketSettings::TOLERANCE_VALUE));
....
}
```

I haven't quite decided who will be responsible for notifying about layer change and tool change updates to the UI. For now it's the main ToolOptions widget but that's still open for debate. 

### What's missing or still in the air:
- [ ] Settings name migration. A tool to migrate from the old QSettings names to the new ones.
- [ ] Create a SelectionOptions widget or do we simply add it back to the general ToolOptionsWidget?
- [ ] Boolean naming convention.. eg. ON vs Enabled, Use... we use a bit of both however I like ON for the Enum... just not everywhere else... writing brushWidthON is worse than brushWidthEnabled.
- [ ] Use min/max in the rest of the Tool option Widgets
