### PR TITLE
Timeline: Remove ability to add keyframe on double-click

### DIFF
--- a/app/src/timelinecells.cpp
+++ b/app/src/timelinecells.cpp
@@ -1131,7 +1131,6 @@ void TimeLineCells::mouseDoubleClickEvent(QMouseEvent* event)
         if (mType == TIMELINE_CELL_TYPE::Tracks && (layerNumber != -1) && (frameNumber > 0) && layerNumber < mEditor->object()->getLayerCount())
         {
             mEditor->scrubTo(frameNumber);
-            emit insertNewKeyFrame();
 
             // The release event will toggle the frame on again, so we make sure it gets
             // deselected now instead.


### PR DESCRIPTION
The amount of feedback we've received regarding this feature has made me re-think its existence.
As such I think it's appropriate to remove it again before the next bug fix release.