### PR TITLE
Ensure QDebug is included for all qDebug uses

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -34,6 +34,7 @@ GNU General Public License for more details.
 #include <QClipboard>
 #include <QToolBar>
 #include <QToolButton>
+#include <QDebug>
 
 // core_lib headers
 #include "pencildef.h"

--- a/app/src/popupcolorpalettewidget.cpp
+++ b/app/src/popupcolorpalettewidget.cpp
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #include <QGraphicsDropShadowEffect>
 #include <QPushButton>
 #include <QKeyEvent>
+#include <QDebug>
 #include "colorbox.h"
 #include "editor.h"
 #include "scribblearea.h"

--- a/app/src/timelinecells.cpp
+++ b/app/src/timelinecells.cpp
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 #include <QPainter>
 #include <QRegularExpression>
 #include <QSettings>
+#include <QDebug>
 
 #include "camerapropertiesdialog.h"
 #include "editor.h"

--- a/core_lib/src/managers/toolmanager.cpp
+++ b/core_lib/src/managers/toolmanager.cpp
@@ -17,6 +17,7 @@ GNU General Public License for more details.
 #include "toolmanager.h"
 
 #include <cmath>
+#include <QDebug>
 #include "pentool.h"
 #include "penciltool.h"
 #include "brushtool.h"

--- a/core_lib/src/soundplayer.cpp
+++ b/core_lib/src/soundplayer.cpp
@@ -18,6 +18,7 @@ GNU General Public License for more details.
 #include <QAudioOutput>
 #include <QMediaPlayer>
 #include <QFile>
+#include <QDebug>
 #include "soundclip.h"
 #include "util.h"
 

--- a/core_lib/src/structure/filemanager.cpp
+++ b/core_lib/src/structure/filemanager.cpp
@@ -18,6 +18,7 @@ GNU General Public License for more details.
 #include "filemanager.h"
 
 #include <ctime>
+#include <QDebug>
 #include <QDir>
 #include <QVersionNumber>
 #include "qminiz.h"


### PR DESCRIPTION
Ensure each file that uses `qDebug` (not commented out) has a direct include of the `QDebug` header.

When cherry-picked to `v0.7.0`, this fixed Fedora’s [`Pencil2D` package](https://src.fedoraproject.org/rpms/Pencil2D) failing to build with Qt 6.9 where the implicit/indirect includes have changed from 6.8:

```
src/soundplayer.cpp: In lambda function:
src/soundplayer.cpp:123:15: error: invalid use of incomplete type ‘class QDebug’
  123 |         qDebug() << "MediaPlayer Error: " << err;
In file included from /usr/include/qt6/QtCore/qglobal.h:45,
                 from /usr/include/qt6/QtCore/qnamespace.h:12,
                 from /usr/include/qt6/QtCore/qobjectdefs.h:12,
                 from /usr/include/qt6/QtCore/qobject.h:10,
                 from /usr/include/qt6/QtCore/QObject:1,
                 from src/corelib-pch.h:7:
/usr/include/qt6/QtCore/qtypeinfo.h:15:7: note: forward declaration of ‘class QDebug’
   15 | class QDebug;
      |       ^~~~~~
src/soundplayer.cpp: In lambda function:
src/soundplayer.cpp:128:15: error: invalid use of incomplete type ‘class QDebug’
  128 |         qDebug() << "MediaPlayer durationChanged :" << duration;
/usr/include/qt6/QtCore/qtypeinfo.h:15:7: note: forward declaration of ‘class QDebug’
   15 | class QDebug;
      |       ^~~~~~
```

Technically, the [`QDebug` header is the appropriate include for the `QDebug` class](https://doc.qt.io/qt-6/qdebug.html), but we should [`#include <QtLogging>` for the `qDebug` macro](https://doc.qt.io/qt-6/qtlogging.html#qDebug). I didn’t make that change here since there is currently no direct use of the `QtLogging` header in Pencil2D, but it wouldn’t be a bad follow-up idea.