### PR TITLE
UI Feature: Improve toolbox flow layout

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -90,6 +90,7 @@ HEADERS += \
     src/generalpage.h \
     src/shortcutspage.h \
     src/timelinepage.h \
+    src/toolboxwidget.h \
     src/toolspage.h \
     src/basedockwidget.h \
     src/colorbox.h \
@@ -142,6 +143,7 @@ SOURCES += \
     src/generalpage.cpp \
     src/shortcutspage.cpp \
     src/timelinepage.cpp \
+    src/toolboxwidget.cpp \
     src/toolspage.cpp \
     src/basedockwidget.cpp \
     src/colorbox.cpp \

--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -30,6 +30,7 @@ GNU General Public License for more details.
 #include "viewmanager.h"
 #include "layermanager.h"
 #include "scribblearea.h"
+#include "toolmanager.h"
 #include "soundmanager.h"
 #include "playbackmanager.h"
 #include "colormanager.h"
@@ -940,6 +941,12 @@ void ActionCommands::changeallKeyframeLineColor()
         }
         mEditor->updateFrame();
     }
+}
+
+
+void ActionCommands::resetAllTools()
+{
+    mEditor->tools()->resetAllTools();
 }
 
 void ActionCommands::help()

--- a/app/src/actioncommands.h
+++ b/app/src/actioncommands.h
@@ -65,6 +65,8 @@ public:
     void GotoPrevKeyFrame();
     Status addNewKey();
 
+    void resetAllTools();
+
     /** Will insert a keyframe at the current position and push connected frames to the right */
     Status insertKeyFrameAtCurrentPosition();
     void removeKey();

--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -170,7 +170,7 @@ void MainWindow2::createDockWidgets()
     mToolOptions = new ToolOptionWidget(this);
     mToolOptions->setObjectName("ToolOption");
 
-    mToolBox = new ToolBoxWidget(this);
+    mToolBox = new ToolBoxDockWidget(this);
     mToolBox->setObjectName("ToolBox");
 
     mDockWidgets
@@ -409,19 +409,37 @@ void MainWindow2::createMenus()
     connect(ui->actionReverse_Frames_Order, &QAction::triggered, mCommands, &ActionCommands::reverseSelectedFrames);
     connect(ui->actionRemove_Frames, &QAction::triggered, mCommands, &ActionCommands::removeSelectedFrames);
 
-    //--- Tool Menu ---
-    connect(ui->actionMove, &QAction::triggered, mToolBox, &ToolBoxWidget::moveOn);
-    connect(ui->actionSelect, &QAction::triggered, mToolBox, &ToolBoxWidget::selectOn);
-    connect(ui->actionBrush, &QAction::triggered, mToolBox, &ToolBoxWidget::brushOn);
-    connect(ui->actionPolyline, &QAction::triggered, mToolBox, &ToolBoxWidget::polylineOn);
-    connect(ui->actionSmudge, &QAction::triggered, mToolBox, &ToolBoxWidget::smudgeOn);
-    connect(ui->actionPen, &QAction::triggered, mToolBox, &ToolBoxWidget::penOn);
-    connect(ui->actionHand, &QAction::triggered, mToolBox, &ToolBoxWidget::handOn);
-    connect(ui->actionPencil, &QAction::triggered, mToolBox, &ToolBoxWidget::pencilOn);
-    connect(ui->actionBucket, &QAction::triggered, mToolBox, &ToolBoxWidget::bucketOn);
-    connect(ui->actionEyedropper, &QAction::triggered, mToolBox, &ToolBoxWidget::eyedropperOn);
-    connect(ui->actionEraser, &QAction::triggered, mToolBox, &ToolBoxWidget::eraserOn);
-    connect(ui->actionResetToolsDefault, &QAction::triggered, mEditor->tools(), &ToolManager::resetAllTools);
+
+    auto toolsActionGroup = new QActionGroup(this);
+    toolsActionGroup->setExclusive(true);
+    toolsActionGroup->addAction(ui->actionMove);
+    toolsActionGroup->addAction(ui->actionSelect);
+    toolsActionGroup->addAction(ui->actionBrush);
+    toolsActionGroup->addAction(ui->actionPolyline);
+    toolsActionGroup->addAction(ui->actionSmudge);
+    toolsActionGroup->addAction(ui->actionPen);
+    toolsActionGroup->addAction(ui->actionHand);
+    toolsActionGroup->addAction(ui->actionPencil);
+    toolsActionGroup->addAction(ui->actionBucket);
+    toolsActionGroup->addAction(ui->actionEyedropper);
+    toolsActionGroup->addAction(ui->actionEraser);
+    toolsActionGroup->addAction(ui->actionResetToolsDefault);
+
+    connect(toolsActionGroup, &QActionGroup::triggered, this, [&](QAction* action) {
+        if (action == ui->actionMove) mToolBox->setActiveTool(MOVE);
+        else if (action == ui->actionSelect) mToolBox->setActiveTool(SELECT);
+        else if (action == ui->actionBrush) mToolBox->setActiveTool(BRUSH);
+        else if (action == ui->actionPolyline) mToolBox->setActiveTool(POLYLINE);
+        else if (action == ui->actionSmudge) mToolBox->setActiveTool(SMUDGE);
+        else if (action == ui->actionPen) mToolBox->setActiveTool(PEN);
+        else if (action == ui->actionHand) mToolBox->setActiveTool(HAND);
+        else if (action == ui->actionPencil) mToolBox->setActiveTool(PENCIL);
+        else if (action == ui->actionBucket) mToolBox->setActiveTool(BUCKET);
+        else if (action == ui->actionEyedropper) mToolBox->setActiveTool(EYEDROPPER);
+        else if (action == ui->actionEraser) mToolBox->setActiveTool(ERASER);
+        else if (action == ui->actionResetToolsDefault) mCommands->resetAllTools();
+        else Q_UNREACHABLE();
+    });
 
     //--- Window Menu ---
     QMenu* winMenu = ui->menuWindows;
@@ -1446,7 +1464,7 @@ void MainWindow2::makeConnections(Editor* editor, ColorInspector* colorInspector
 void MainWindow2::makeConnections(Editor* editor, ScribbleArea* scribbleArea)
 {
     connect(editor->tools(), &ToolManager::toolChanged, scribbleArea, &ScribbleArea::updateToolCursor);
-    connect(editor->tools(), &ToolManager::toolChanged, mToolBox, &ToolBoxWidget::onToolSetActive);
+    connect(editor->tools(), &ToolManager::toolChanged, mToolBox, &ToolBoxDockWidget::setActiveTool);
     connect(editor->tools(), &ToolManager::toolPropertyChanged, scribbleArea, &ScribbleArea::updateToolCursor);
 
 

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -31,7 +31,7 @@ class ColorPaletteWidget;
 class OnionSkinWidget;
 class ToolOptionWidget;
 class TimeLine;
-class ToolBoxWidget;
+class ToolBoxDockWidget;
 class PreferencesDialog;
 class PreviewWidget;
 class ColorBox;
@@ -157,7 +157,7 @@ private:
     ColorBox*             mColorBox = nullptr;
     ColorPaletteWidget*   mColorPalette = nullptr;
     ToolOptionWidget*     mToolOptions = nullptr;
-    ToolBoxWidget*        mToolBox = nullptr;
+    ToolBoxDockWidget*        mToolBox = nullptr;
     RecentFileMenu*       mRecentFileMenu = nullptr;
     PreferencesDialog*    mPrefDialog = nullptr;
     //PreviewWidget*      mPreview = nullptr;

--- a/app/src/toolbox.cpp
+++ b/app/src/toolbox.cpp
@@ -67,7 +67,7 @@ void ToolBoxDockWidget::initUI()
 
 void ToolBoxDockWidget::setActiveTool(ToolType type)
 {
-    mWidget->setToolChecked(type);
+    mWidget->setActiveTool(type);
 }
 
 void ToolBoxDockWidget::updateUI()

--- a/app/src/toolbox.cpp
+++ b/app/src/toolbox.cpp
@@ -16,7 +16,6 @@ GNU General Public License for more details.
 */
 
 #include "toolbox.h"
-#include "ui_toolboxwidget.h"
 
 #include <cmath>
 
@@ -25,6 +24,8 @@ GNU General Public License for more details.
 #include <QKeySequence>
 #include <QResizeEvent>
 #include <QDebug>
+#include <QScrollBar>
+#include <QBoxLayout>
 
 #include "flowlayout.h"
 #include "spinslider.h"
@@ -32,312 +33,53 @@ GNU General Public License for more details.
 #include "toolmanager.h"
 #include "layermanager.h"
 #include "pencilsettings.h"
-#include "toolboxlayout.h"
 
-// ----------------------------------------------------------------------------------
-QString GetToolTips(QString strCommandName)
+ToolBoxDockWidget::ToolBoxDockWidget(QWidget* parent) :
+    BaseDockWidget(parent)
 {
-    strCommandName = QString("shortcuts/") + strCommandName;
-    QKeySequence keySequence(pencilSettings().value(strCommandName).toString());
-    return QString("<b>%1</b>").arg(keySequence.toString()); // don't tr() this string.
+    mWidget = new ToolBoxWidget(this);
+
+    setWindowTitle(tr("Tools", "Window title of Tools"));
 }
 
-ToolBoxWidget::ToolBoxWidget(QWidget* parent) :
-    BaseDockWidget(parent),
-    ui(new Ui::ToolBoxWidget)
-{
-    ui->setupUi(this);
-}
-
-ToolBoxWidget::~ToolBoxWidget()
+ToolBoxDockWidget::~ToolBoxDockWidget()
 {
     QSettings settings(PENCIL2D, PENCIL2D);
     settings.setValue("ToolBoxGeom", this->saveGeometry());
-    delete ui;
 }
 
-void ToolBoxWidget::initUI()
+void ToolBoxDockWidget::initUI()
 {
-#ifdef __APPLE__
-    // Only Mac needs this. ToolButton is naturally borderless on Win/Linux.
-    QString sStyle =
-        "QToolButton { border: 0px; }"
-        "QToolButton:pressed { border: 1px solid #ADADAD; border-radius: 2px; background-color: #D5D5D5; }"
-        "QToolButton:checked { border: 1px solid #ADADAD; border-radius: 2px; background-color: #D5D5D5; }";
-    ui->pencilButton->setStyleSheet(sStyle);
-    ui->selectButton->setStyleSheet(sStyle);
-    ui->moveButton->setStyleSheet(sStyle);
-    ui->handButton->setStyleSheet(sStyle);
-    ui->penButton->setStyleSheet(sStyle);
-    ui->eraserButton->setStyleSheet(sStyle);
-    ui->polylineButton->setStyleSheet(sStyle);
-    ui->bucketButton->setStyleSheet(sStyle);
-    ui->brushButton->setStyleSheet(sStyle);
-    ui->eyedropperButton->setStyleSheet(sStyle);
-    ui->smudgeButton->setStyleSheet(sStyle);
-#endif
+    mWidget->setEditor(editor());
+    mWidget->initUI();
 
-    ui->pencilButton->setToolTip( tr( "Pencil Tool (%1): Sketch with pencil" )
-        .arg( GetToolTips( CMD_TOOL_PENCIL ) ) );
-    ui->selectButton->setToolTip( tr( "Select Tool (%1): Select an object" )
-        .arg( GetToolTips( CMD_TOOL_SELECT ) ) );
-    ui->moveButton->setToolTip( tr( "Move Tool (%1): Move an object" )
-        .arg( GetToolTips( CMD_TOOL_MOVE ) ) );
-    ui->handButton->setToolTip( tr( "Hand Tool (%1): Move the canvas" )
-        .arg( GetToolTips( CMD_TOOL_HAND ) ) );
-    ui->penButton->setToolTip( tr( "Pen Tool (%1): Sketch with pen" )
-        .arg( GetToolTips( CMD_TOOL_PEN ) ) );
-    ui->eraserButton->setToolTip( tr( "Eraser Tool (%1): Erase" )
-        .arg( GetToolTips( CMD_TOOL_ERASER ) ) );
-    ui->polylineButton->setToolTip( tr( "Polyline Tool (%1): Create line/curves" )
-        .arg( GetToolTips( CMD_TOOL_POLYLINE ) ) );
-    ui->bucketButton->setToolTip( tr( "Paint Bucket Tool (%1): Fill selected area with a color" )
-        .arg( GetToolTips( CMD_TOOL_BUCKET ) ) );
-    ui->brushButton->setToolTip( tr( "Brush Tool (%1): Paint smooth stroke with a brush" )
-        .arg( GetToolTips( CMD_TOOL_BRUSH ) ) );
-    ui->eyedropperButton->setToolTip( tr( "Eyedropper Tool (%1): "
-            "Set color from the stage<br>[ALT] for instant access" )
-        .arg( GetToolTips( CMD_TOOL_EYEDROPPER ) ) );
-    ui->smudgeButton->setToolTip( tr( "Smudge Tool (%1):<br>Edit polyline/curves<br>"
-            "Liquify bitmap pixels<br> (%1)+[Alt]: Smooth" )
-        .arg( GetToolTips( CMD_TOOL_SMUDGE ) ) );
+    setWidget(mWidget);
+    setContentsMargins(0,0,0,0);
 
-    ui->pencilButton->setWhatsThis( tr( "Pencil Tool (%1)" )
-        .arg( GetToolTips( CMD_TOOL_PENCIL ) ) );
-    ui->selectButton->setWhatsThis( tr( "Select Tool (%1)" )
-        .arg( GetToolTips( CMD_TOOL_SELECT ) ) );
-    ui->moveButton->setWhatsThis( tr( "Move Tool (%1)" )
-        .arg( GetToolTips( CMD_TOOL_MOVE ) ) );
-    ui->handButton->setWhatsThis( tr( "Hand Tool (%1)" )
-        .arg( GetToolTips( CMD_TOOL_HAND ) ) );
-    ui->penButton->setWhatsThis( tr( "Pen Tool (%1)" )
-        .arg( GetToolTips( CMD_TOOL_PEN ) ) );
-    ui->eraserButton->setWhatsThis( tr( "Eraser Tool (%1)" )
-        .arg( GetToolTips( CMD_TOOL_ERASER ) ) );
-    ui->polylineButton->setWhatsThis( tr( "Polyline Tool (%1)" )
-        .arg( GetToolTips( CMD_TOOL_POLYLINE ) ) );
-    ui->bucketButton->setWhatsThis( tr( "Paint Bucket Tool (%1)" )
-        .arg( GetToolTips( CMD_TOOL_BUCKET ) ) );
-    ui->brushButton->setWhatsThis( tr( "Brush Tool (%1)" )
-        .arg( GetToolTips( CMD_TOOL_BRUSH ) ) );
-    ui->eyedropperButton->setWhatsThis( tr( "Eyedropper Tool (%1)" )
-        .arg( GetToolTips( CMD_TOOL_EYEDROPPER ) ) );
-    ui->smudgeButton->setWhatsThis( tr( "Smudge Tool (%1)" )
-        .arg( GetToolTips( CMD_TOOL_SMUDGE ) ) );
-
-    connect(ui->pencilButton, &QToolButton::clicked, this, &ToolBoxWidget::pencilOn);
-    connect(ui->eraserButton, &QToolButton::clicked, this, &ToolBoxWidget::eraserOn);
-    connect(ui->selectButton, &QToolButton::clicked, this, &ToolBoxWidget::selectOn);
-    connect(ui->moveButton, &QToolButton::clicked, this, &ToolBoxWidget::moveOn);
-    connect(ui->penButton, &QToolButton::clicked, this, &ToolBoxWidget::penOn);
-    connect(ui->handButton, &QToolButton::clicked, this, &ToolBoxWidget::handOn);
-    connect(ui->polylineButton, &QToolButton::clicked, this, &ToolBoxWidget::polylineOn);
-    connect(ui->bucketButton, &QToolButton::clicked, this, &ToolBoxWidget::bucketOn);
-    connect(ui->eyedropperButton, &QToolButton::clicked, this, &ToolBoxWidget::eyedropperOn);
-    connect(ui->brushButton, &QToolButton::clicked, this, &ToolBoxWidget::brushOn);
-    connect(ui->smudgeButton, &QToolButton::clicked, this, &ToolBoxWidget::smudgeOn);
-
-    connect(editor()->layers(), &LayerManager::currentLayerChanged, this, &ToolBoxWidget::onLayerDidChange);
-
-    mFlowlayout = new ToolBoxLayout(nullptr, 3,3,3);
-
-    mFlowlayout->addWidget(ui->pencilButton);
-    mFlowlayout->addWidget(ui->eraserButton);
-    mFlowlayout->addWidget(ui->selectButton);
-    mFlowlayout->addWidget(ui->moveButton);
-    mFlowlayout->addWidget(ui->penButton);
-    mFlowlayout->addWidget(ui->handButton);
-    mFlowlayout->addWidget(ui->polylineButton);
-    mFlowlayout->addWidget(ui->bucketButton);
-    mFlowlayout->addWidget(ui->eyedropperButton);
-    mFlowlayout->addWidget(ui->brushButton);
-    mFlowlayout->addWidget(ui->smudgeButton);
-
-    delete ui->scrollAreaWidgetContents_2->layout();
-    ui->scrollAreaWidgetContents_2->setLayout(mFlowlayout);
+    connect(editor()->layers(), &LayerManager::currentLayerChanged, this, &ToolBoxDockWidget::onLayerDidChange);
 
     QSettings settings(PENCIL2D, PENCIL2D);
     restoreGeometry(settings.value("ToolBoxGeom").toByteArray());
 
     // Important to set the proper minimumSize;
-    ui->scrollArea->setMinimumSize(minimumSizeHint());
+    setMinimumSize(mWidget->minimumSize());
 }
 
-int ToolBoxWidget::getMinHeightForWidth(int width) const
+void ToolBoxDockWidget::setActiveTool(ToolType type)
 {
-    int layoutHeight = mFlowlayout->heightForWidth(width);
-    if (this->isFloating()) {
-        return layoutHeight;
-    } else {
-        return layoutHeight + BaseDockWidget::minimumSizeHint().height();
-    }
+    mWidget->setToolChecked(type);
 }
 
-QSize ToolBoxWidget::minimumSizeHint() const
+void ToolBoxDockWidget::updateUI()
 {
-    return QSize(mFlowlayout->minimumSize().width(), getMinHeightForWidth(width()));
+    mWidget->updateUI();
 }
 
-void ToolBoxWidget::resizeEvent(QResizeEvent *event)
-{
-    BaseDockWidget::resizeEvent(event);
-
-    updateLayoutAlignment();
-}
-
-void ToolBoxWidget::updateLayoutAlignment()
-{
-    mFlowlayout->invalidate();
-    if (mFlowlayout->rows() > 1) {
-        mFlowlayout->setAlignment(Qt::AlignJustify);
-    } else {
-        mFlowlayout->setAlignment(Qt::AlignHCenter);
-    }
-
-    mFlowlayout->activate();
-}
-
-void ToolBoxWidget::updateUI()
-{
-}
-
-void ToolBoxWidget::onToolSetActive(ToolType toolType)
-{
-    deselectAllTools();
-    switch (toolType) {
-    case ToolType::BRUSH:
-        ui->brushButton->setChecked(true);
-        break;
-    case ToolType::PEN:
-        ui->penButton->setChecked(true);
-        break;
-    case ToolType::PENCIL:
-        ui->pencilButton->setChecked(true);
-        break;
-    case ToolType::SELECT:
-        ui->selectButton->setChecked(true);
-        break;
-    case ToolType::HAND:
-        ui->handButton->setChecked(true);
-        break;
-    case ToolType::MOVE:
-    case ToolType::CAMERA:
-        ui->moveButton->setChecked(true);
-        break;
-    case ToolType::ERASER:
-        ui->eraserButton->setChecked(true);
-        break;
-    case ToolType::POLYLINE:
-        ui->polylineButton->setChecked(true);
-        break;
-    case ToolType::SMUDGE:
-        ui->smudgeButton->setChecked(true);
-        break;
-    case ToolType::BUCKET:
-        ui->bucketButton->setChecked(true);
-        break;
-    case ToolType::EYEDROPPER:
-        ui->eyedropperButton->setChecked(true);
-        break;
-    default:
-        break;
-    }
-}
-
-void ToolBoxWidget::pencilOn()
-{
-    toolOn(PENCIL, ui->pencilButton);
-}
-
-void ToolBoxWidget::eraserOn()
-{
-    toolOn(ERASER, ui->eraserButton);
-}
-
-void ToolBoxWidget::selectOn()
-{
-    toolOn(SELECT, ui->selectButton);
-}
-
-void ToolBoxWidget::moveOn()
-{
-    if (editor()->layers()->currentLayer()->type() == Layer::CAMERA) {
-        toolOn(CAMERA, ui->moveButton);
-    } else {
-        toolOn(MOVE, ui->moveButton);
-    }
-}
-
-void ToolBoxWidget::penOn()
-{
-    toolOn(PEN, ui->penButton);
-}
-
-void ToolBoxWidget::handOn()
-{
-    toolOn(HAND, ui->handButton);
-}
-
-void ToolBoxWidget::polylineOn()
-{
-    toolOn(POLYLINE, ui->polylineButton);
-}
-
-void ToolBoxWidget::bucketOn()
-{
-    toolOn(BUCKET, ui->bucketButton);
-}
-
-void ToolBoxWidget::eyedropperOn()
-{
-    toolOn(EYEDROPPER, ui->eyedropperButton);
-}
-
-void ToolBoxWidget::brushOn()
-{
-    toolOn(BRUSH, ui->brushButton);
-}
-
-void ToolBoxWidget::smudgeOn()
-{
-    toolOn(SMUDGE, ui->smudgeButton);
-}
-
-void ToolBoxWidget::deselectAllTools()
-{
-    ui->pencilButton->setChecked(false);
-    ui->eraserButton->setChecked(false);
-    ui->selectButton->setChecked(false);
-    ui->moveButton->setChecked(false);
-    ui->handButton->setChecked(false);
-    ui->penButton->setChecked(false);
-    ui->polylineButton->setChecked(false);
-    ui->bucketButton->setChecked(false);
-    ui->eyedropperButton->setChecked(false);
-    ui->brushButton->setChecked(false);
-    ui->smudgeButton->setChecked(false);
-}
-
-void ToolBoxWidget::toolOn(ToolType toolType, QToolButton* toolButton)
-{
-    if (editor()->tools()->currentTool()->type() == toolType) {
-        // Prevent un-checking the current tool and do nothing
-        toolButton->setChecked(true);
-        return;
-    }
-    if (!editor()->tools()->leavingThisTool())
-    {
-        toolButton->setChecked(false);
-        return;
-    }
-    editor()->tools()->setCurrentTool(toolType);
-}
-
-void ToolBoxWidget::onLayerDidChange(int)
+void ToolBoxDockWidget::onLayerDidChange(int)
 {
     BaseTool* currentTool = editor()->tools()->currentTool();
     if (currentTool->type() == MOVE || currentTool->type() == CAMERA)
     {
-        moveOn();
+        mWidget->moveOn();
     }
 }

--- a/app/src/toolbox.h
+++ b/app/src/toolbox.h
@@ -27,6 +27,7 @@ class SpinSlider;
 class DisplayOptionWidget;
 class ToolOptionWidget;
 class Editor;
+class ToolBoxLayout;
 
 namespace Ui {
 class ToolBoxWidget;
@@ -60,12 +61,18 @@ public slots:
 
 protected:
     void resizeEvent(QResizeEvent* event) override;
+    QSize minimumSizeHint() const override;
 
 private:
+    void updateLayoutAlignment();
     void deselectAllTools();
     void toolOn(ToolType toolType, QToolButton* toolButton);
 
+    int getMinHeightForWidth(int width) const;
+
     Ui::ToolBoxWidget* ui = nullptr;
+
+    ToolBoxLayout* mFlowlayout = nullptr;
 };
 
 #endif

--- a/app/src/toolbox.h
+++ b/app/src/toolbox.h
@@ -14,11 +14,13 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 */
-#ifndef TOOLBOXWIDGET_H
-#define TOOLBOXWIDGET_H
+#ifndef TOOLBOXDOCKWIDGET_H
+#define TOOLBOXDOCKWIDGET_H
 
 #include "pencildef.h"
 #include "basedockwidget.h"
+
+#include "toolboxwidget.h"
 
 class QToolButton;
 class QGridLayout;
@@ -27,52 +29,25 @@ class SpinSlider;
 class DisplayOptionWidget;
 class ToolOptionWidget;
 class Editor;
-class ToolBoxLayout;
+class FlowLayout;
 
-namespace Ui {
-class ToolBoxWidget;
-}
-
-class ToolBoxWidget : public BaseDockWidget
+class ToolBoxDockWidget : public BaseDockWidget
 {
     Q_OBJECT
 
 public:
-    ToolBoxWidget(QWidget* parent);
-    ~ToolBoxWidget() override;
+    ToolBoxDockWidget(QWidget* parent);
+    ~ToolBoxDockWidget() override;
 
     void initUI() override;
     void updateUI() override;
 
-public slots:
-    void onToolSetActive(ToolType toolType);
-    void onLayerDidChange(int index);
-    void pencilOn();
-    void eraserOn();
-    void selectOn();
-    void moveOn();
-    void penOn();
-    void handOn();
-    void polylineOn();
-    void bucketOn();
-    void eyedropperOn();
-    void brushOn();
-    void smudgeOn();
-
-protected:
-    void resizeEvent(QResizeEvent* event) override;
-    QSize minimumSizeHint() const override;
+    void setActiveTool(ToolType type);
 
 private:
-    void updateLayoutAlignment();
-    void deselectAllTools();
-    void toolOn(ToolType toolType, QToolButton* toolButton);
+    void onLayerDidChange(int);
 
-    int getMinHeightForWidth(int width) const;
-
-    Ui::ToolBoxWidget* ui = nullptr;
-
-    ToolBoxLayout* mFlowlayout = nullptr;
+    ToolBoxWidget* mWidget = nullptr;
 };
 
 #endif

--- a/app/src/toolboxwidget.cpp
+++ b/app/src/toolboxwidget.cpp
@@ -1,3 +1,20 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+Copyright (C) 2024-2099 Oliver S. Larsen
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
 #include "toolboxwidget.h"
 #include "ui_toolboxwidget.h"
 

--- a/app/src/toolboxwidget.cpp
+++ b/app/src/toolboxwidget.cpp
@@ -129,8 +129,6 @@ void ToolBoxWidget::initUI()
     connect(ui->brushButton, &QToolButton::clicked, this, &ToolBoxWidget::brushOn);
     connect(ui->smudgeButton, &QToolButton::clicked, this, &ToolBoxWidget::smudgeOn);
 
-    connect(mEditor->layers(), &LayerManager::currentLayerChanged, this, &ToolBoxWidget::onLayerDidChange);
-
     mFlowlayout = new ToolBoxLayout(nullptr, 3,3,3);
 
     mFlowlayout->addWidget(ui->pencilButton);
@@ -205,9 +203,8 @@ void ToolBoxWidget::updateUI()
 {
 }
 
-void ToolBoxWidget::setToolChecked(ToolType toolType)
+void ToolBoxWidget::setActiveTool(ToolType toolType)
 {
-    QToolButton* button = nullptr;
     switch (toolType) {
     case ToolType::BRUSH:
         brushOn();
@@ -335,13 +332,4 @@ void ToolBoxWidget::toolOn(ToolType toolType, QToolButton* toolButton)
         return;
     }
     mEditor->tools()->setCurrentTool(toolType);
-}
-
-void ToolBoxWidget::onLayerDidChange(int)
-{
-    BaseTool* currentTool = mEditor->tools()->currentTool();
-    if (currentTool->type() == MOVE || currentTool->type() == CAMERA)
-    {
-        moveOn();
-    }
 }

--- a/app/src/toolboxwidget.cpp
+++ b/app/src/toolboxwidget.cpp
@@ -1,0 +1,330 @@
+#include "toolboxwidget.h"
+#include "ui_toolboxwidget.h"
+
+#include <QScrollBar>
+#include <QResizeEvent>
+#include <QDebug>
+#include <QButtonGroup>
+
+#include "layermanager.h"
+#include "toolmanager.h"
+#include "editor.h"
+#include "pencilsettings.h"
+
+// ----------------------------------------------------------------------------------
+QString GetToolTips(QString strCommandName)
+{
+    strCommandName = QString("shortcuts/") + strCommandName;
+    QKeySequence keySequence(pencilSettings().value(strCommandName).toString());
+    return QString("<b>%1</b>").arg(keySequence.toString()); // don't tr() this string.
+}
+
+ToolBoxWidget::ToolBoxWidget(QWidget* parent)
+    : QWidget(parent), ui(new Ui::ToolBoxWidget)
+{
+    ui->setupUi(this);
+}
+
+ToolBoxWidget::~ToolBoxWidget()
+{
+    delete ui;
+}
+
+void ToolBoxWidget::initUI()
+{
+
+#ifdef __APPLE__
+    // Only Mac needs this. ToolButton is naturally borderless on Win/Linux.
+    QString sStyle =
+        "QToolButton { border: 0px; }"
+        "QToolButton:pressed { border: 1px solid #ADADAD; border-radius: 2px; background-color: #D5D5D5; }"
+        "QToolButton:checked { border: 1px solid #ADADAD; border-radius: 2px; background-color: #D5D5D5; }";
+    ui->pencilButton->setStyleSheet(sStyle);
+    ui->selectButton->setStyleSheet(sStyle);
+    ui->moveButton->setStyleSheet(sStyle);
+    ui->handButton->setStyleSheet(sStyle);
+    ui->penButton->setStyleSheet(sStyle);
+    ui->eraserButton->setStyleSheet(sStyle);
+    ui->polylineButton->setStyleSheet(sStyle);
+    ui->bucketButton->setStyleSheet(sStyle);
+    ui->brushButton->setStyleSheet(sStyle);
+    ui->eyedropperButton->setStyleSheet(sStyle);
+    ui->smudgeButton->setStyleSheet(sStyle);
+#endif
+
+    ui->pencilButton->setToolTip( tr( "Pencil Tool (%1): Sketch with pencil" )
+        .arg( GetToolTips( CMD_TOOL_PENCIL ) ) );
+    ui->selectButton->setToolTip( tr( "Select Tool (%1): Select an object" )
+        .arg( GetToolTips( CMD_TOOL_SELECT ) ) );
+    ui->moveButton->setToolTip( tr( "Move Tool (%1): Move an object" )
+        .arg( GetToolTips( CMD_TOOL_MOVE ) ) );
+    ui->handButton->setToolTip( tr( "Hand Tool (%1): Move the canvas" )
+        .arg( GetToolTips( CMD_TOOL_HAND ) ) );
+    ui->penButton->setToolTip( tr( "Pen Tool (%1): Sketch with pen" )
+        .arg( GetToolTips( CMD_TOOL_PEN ) ) );
+    ui->eraserButton->setToolTip( tr( "Eraser Tool (%1): Erase" )
+        .arg( GetToolTips( CMD_TOOL_ERASER ) ) );
+    ui->polylineButton->setToolTip( tr( "Polyline Tool (%1): Create line/curves" )
+        .arg( GetToolTips( CMD_TOOL_POLYLINE ) ) );
+    ui->bucketButton->setToolTip( tr( "Paint Bucket Tool (%1): Fill selected area with a color" )
+        .arg( GetToolTips( CMD_TOOL_BUCKET ) ) );
+    ui->brushButton->setToolTip( tr( "Brush Tool (%1): Paint smooth stroke with a brush" )
+        .arg( GetToolTips( CMD_TOOL_BRUSH ) ) );
+    ui->eyedropperButton->setToolTip( tr( "Eyedropper Tool (%1): "
+            "Set color from the stage<br>[ALT] for instant access" )
+        .arg( GetToolTips( CMD_TOOL_EYEDROPPER ) ) );
+    ui->smudgeButton->setToolTip( tr( "Smudge Tool (%1):<br>Edit polyline/curves<br>"
+            "Liquify bitmap pixels<br> (%1)+[Alt]: Smooth" )
+        .arg( GetToolTips( CMD_TOOL_SMUDGE ) ) );
+
+    ui->pencilButton->setWhatsThis( tr( "Pencil Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_PENCIL ) ) );
+    ui->selectButton->setWhatsThis( tr( "Select Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_SELECT ) ) );
+    ui->moveButton->setWhatsThis( tr( "Move Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_MOVE ) ) );
+    ui->handButton->setWhatsThis( tr( "Hand Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_HAND ) ) );
+    ui->penButton->setWhatsThis( tr( "Pen Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_PEN ) ) );
+    ui->eraserButton->setWhatsThis( tr( "Eraser Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_ERASER ) ) );
+    ui->polylineButton->setWhatsThis( tr( "Polyline Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_POLYLINE ) ) );
+    ui->bucketButton->setWhatsThis( tr( "Paint Bucket Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_BUCKET ) ) );
+    ui->brushButton->setWhatsThis( tr( "Brush Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_BRUSH ) ) );
+    ui->eyedropperButton->setWhatsThis( tr( "Eyedropper Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_EYEDROPPER ) ) );
+    ui->smudgeButton->setWhatsThis( tr( "Smudge Tool (%1)" )
+        .arg( GetToolTips( CMD_TOOL_SMUDGE ) ) );
+
+    connect(ui->pencilButton, &QToolButton::clicked, this, &ToolBoxWidget::pencilOn);
+    connect(ui->eraserButton, &QToolButton::clicked, this, &ToolBoxWidget::eraserOn);
+    connect(ui->selectButton, &QToolButton::clicked, this, &ToolBoxWidget::selectOn);
+    connect(ui->moveButton, &QToolButton::clicked, this, &ToolBoxWidget::moveOn);
+    connect(ui->penButton, &QToolButton::clicked, this, &ToolBoxWidget::penOn);
+    connect(ui->handButton, &QToolButton::clicked, this, &ToolBoxWidget::handOn);
+    connect(ui->polylineButton, &QToolButton::clicked, this, &ToolBoxWidget::polylineOn);
+    connect(ui->bucketButton, &QToolButton::clicked, this, &ToolBoxWidget::bucketOn);
+    connect(ui->eyedropperButton, &QToolButton::clicked, this, &ToolBoxWidget::eyedropperOn);
+    connect(ui->brushButton, &QToolButton::clicked, this, &ToolBoxWidget::brushOn);
+    connect(ui->smudgeButton, &QToolButton::clicked, this, &ToolBoxWidget::smudgeOn);
+
+    connect(mEditor->layers(), &LayerManager::currentLayerChanged, this, &ToolBoxWidget::onLayerDidChange);
+
+    mFlowlayout = new ToolBoxLayout(nullptr, 3,3,3);
+
+    mFlowlayout->addWidget(ui->pencilButton);
+    mFlowlayout->addWidget(ui->eraserButton);
+    mFlowlayout->addWidget(ui->selectButton);
+    mFlowlayout->addWidget(ui->moveButton);
+    mFlowlayout->addWidget(ui->penButton);
+    mFlowlayout->addWidget(ui->handButton);
+    mFlowlayout->addWidget(ui->polylineButton);
+    mFlowlayout->addWidget(ui->bucketButton);
+    mFlowlayout->addWidget(ui->eyedropperButton);
+    mFlowlayout->addWidget(ui->brushButton);
+    mFlowlayout->addWidget(ui->smudgeButton);
+
+    delete ui->scrollAreaWidgetContents_2->layout();
+    ui->scrollAreaWidgetContents_2->setLayout(mFlowlayout);
+
+    // Important to set the proper minimumSize;
+    ui->scrollArea->setMinimumSize(QSize(1,1));
+    setMinimumSize(mFlowlayout->minimumSize());
+
+    QButtonGroup* buttonGroup = new QButtonGroup(this);
+    buttonGroup->addButton(ui->pencilButton);
+    buttonGroup->addButton(ui->eraserButton);
+    buttonGroup->addButton(ui->selectButton);
+    buttonGroup->addButton(ui->moveButton);
+    buttonGroup->addButton(ui->penButton);
+    buttonGroup->addButton(ui->handButton);
+    buttonGroup->addButton(ui->polylineButton);
+    buttonGroup->addButton(ui->bucketButton);
+    buttonGroup->addButton(ui->eyedropperButton);
+    buttonGroup->addButton(ui->brushButton);
+    buttonGroup->addButton(ui->smudgeButton);
+}
+
+int ToolBoxWidget::getMinHeightForWidth(int width) const
+{
+    return mFlowlayout->heightForWidth(width);
+}
+
+QSize ToolBoxWidget::sizeHint() const
+{
+    return minimumSizeHint();
+}
+
+QSize ToolBoxWidget::minimumSizeHint() const
+{
+    int minWidth = mFlowlayout->minimumSize().width();
+    return QSize(minWidth, getMinHeightForWidth(width()));
+}
+
+void ToolBoxWidget::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+
+    updateLayoutAlignment();
+}
+
+void ToolBoxWidget::updateLayoutAlignment()
+{
+    mFlowlayout->invalidate();
+    if (mFlowlayout->rows() > 1) {
+        mFlowlayout->setAlignment(Qt::AlignJustify);
+    } else {
+        mFlowlayout->setAlignment(Qt::AlignHCenter);
+    }
+
+    mFlowlayout->activate();
+}
+
+void ToolBoxWidget::updateUI()
+{
+}
+
+void ToolBoxWidget::setToolChecked(ToolType toolType)
+{
+    QToolButton* button = nullptr;
+    switch (toolType) {
+    case ToolType::BRUSH:
+        brushOn();
+        break;
+    case ToolType::PEN:
+        penOn();
+        break;
+    case ToolType::PENCIL:
+        pencilOn();
+        break;
+    case ToolType::SELECT:
+        selectOn();
+        break;
+    case ToolType::HAND:
+        handOn();
+        break;
+    case ToolType::MOVE:
+    case ToolType::CAMERA:
+        moveOn();
+        break;
+    case ToolType::ERASER:
+        eraserOn();
+        break;
+    case ToolType::POLYLINE:
+        polylineOn();
+        break;
+    case ToolType::SMUDGE:
+        smudgeOn();
+        break;
+    case ToolType::BUCKET:
+        bucketOn();
+        break;
+    case ToolType::EYEDROPPER:
+        eyedropperOn();
+        break;
+    default:
+        break;
+    }
+}
+
+void ToolBoxWidget::pencilOn()
+{
+    toolOn(PENCIL, ui->pencilButton);
+}
+
+void ToolBoxWidget::eraserOn()
+{
+    toolOn(ERASER, ui->eraserButton);
+}
+
+void ToolBoxWidget::selectOn()
+{
+    toolOn(SELECT, ui->selectButton);
+}
+
+void ToolBoxWidget::moveOn()
+{
+    if (mEditor->layers()->currentLayer()->type() == Layer::CAMERA) {
+        toolOn(CAMERA, ui->moveButton);
+    } else {
+        toolOn(MOVE, ui->moveButton);
+    }
+}
+
+void ToolBoxWidget::penOn()
+{
+    toolOn(PEN, ui->penButton);
+}
+
+void ToolBoxWidget::handOn()
+{
+    toolOn(HAND, ui->handButton);
+}
+
+void ToolBoxWidget::polylineOn()
+{
+    toolOn(POLYLINE, ui->polylineButton);
+}
+
+void ToolBoxWidget::bucketOn()
+{
+    toolOn(BUCKET, ui->bucketButton);
+}
+
+void ToolBoxWidget::eyedropperOn()
+{
+    toolOn(EYEDROPPER, ui->eyedropperButton);
+}
+
+void ToolBoxWidget::brushOn()
+{
+    toolOn(BRUSH, ui->brushButton);
+}
+
+void ToolBoxWidget::smudgeOn()
+{
+    toolOn(SMUDGE, ui->smudgeButton);
+}
+
+void ToolBoxWidget::deselectAllTools()
+{
+    ui->pencilButton->setChecked(false);
+    ui->eraserButton->setChecked(false);
+    ui->selectButton->setChecked(false);
+    ui->moveButton->setChecked(false);
+    ui->handButton->setChecked(false);
+    ui->penButton->setChecked(false);
+    ui->polylineButton->setChecked(false);
+    ui->bucketButton->setChecked(false);
+    ui->eyedropperButton->setChecked(false);
+    ui->brushButton->setChecked(false);
+    ui->smudgeButton->setChecked(false);
+}
+
+void ToolBoxWidget::toolOn(ToolType toolType, QToolButton* toolButton)
+{
+    if (mEditor->tools()->currentTool()->type() == toolType) {
+        // Prevent un-checking the current tool and do nothing
+        toolButton->setChecked(true);
+        return;
+    }
+    if (!mEditor->tools()->leavingThisTool())
+    {
+        toolButton->setChecked(false);
+        return;
+    }
+    mEditor->tools()->setCurrentTool(toolType);
+}
+
+void ToolBoxWidget::onLayerDidChange(int)
+{
+    BaseTool* currentTool = mEditor->tools()->currentTool();
+    if (currentTool->type() == MOVE || currentTool->type() == CAMERA)
+    {
+        moveOn();
+    }
+}

--- a/app/src/toolboxwidget.h
+++ b/app/src/toolboxwidget.h
@@ -44,8 +44,10 @@ public:
     void updateUI();
 
 public slots:
-    void setToolChecked(ToolType toolType);
-    void onLayerDidChange(int index);
+    void setActiveTool(ToolType toolType);
+
+public:
+
     void pencilOn();
     void eraserOn();
     void selectOn();
@@ -58,6 +60,10 @@ public slots:
     void brushOn();
     void smudgeOn();
 
+    void updateLayoutAlignment();
+    void deselectAllTools();
+    void toolOn(ToolType toolType, QToolButton* toolButton);
+
 protected:
     int getMinHeightForWidth(int width) const;
     QSize minimumSizeHint() const override;
@@ -65,10 +71,6 @@ protected:
     void resizeEvent(QResizeEvent* event) override;
 
 private:
-    void updateLayoutAlignment();
-    void deselectAllTools();
-    void toolOn(ToolType toolType, QToolButton* toolButton);
-
     FlowLayout* mFlowlayout = nullptr;
 
     Ui::ToolBoxWidget* ui = nullptr;

--- a/app/src/toolboxwidget.h
+++ b/app/src/toolboxwidget.h
@@ -1,0 +1,61 @@
+#ifndef TOOLBOXWIDGET_H
+#define TOOLBOXWIDGET_H
+
+#include <QObject>
+#include <QToolButton>
+#include <QWidget>
+
+#include "flowlayout.h"
+#include "pencildef.h"
+#include "toolboxlayout.h"
+
+class Editor;
+
+namespace Ui {
+class ToolBoxWidget;
+}
+
+class ToolBoxWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    ToolBoxWidget(QWidget* parent = nullptr);
+    ~ToolBoxWidget() override;
+
+    void setEditor(Editor* editor) { mEditor = editor; }
+    void initUI();
+    void updateUI();
+
+public slots:
+    void setToolChecked(ToolType toolType);
+    void onLayerDidChange(int index);
+    void pencilOn();
+    void eraserOn();
+    void selectOn();
+    void moveOn();
+    void penOn();
+    void handOn();
+    void polylineOn();
+    void bucketOn();
+    void eyedropperOn();
+    void brushOn();
+    void smudgeOn();
+
+protected:
+    int getMinHeightForWidth(int width) const;
+    QSize minimumSizeHint() const override;
+    QSize sizeHint() const override;
+    void resizeEvent(QResizeEvent* event) override;
+
+private:
+    void updateLayoutAlignment();
+    void deselectAllTools();
+    void toolOn(ToolType toolType, QToolButton* toolButton);
+
+    FlowLayout* mFlowlayout = nullptr;
+
+    Ui::ToolBoxWidget* ui = nullptr;
+    Editor* mEditor = nullptr;
+};
+
+#endif // TOOLBOXWIDGET_H

--- a/app/src/toolboxwidget.h
+++ b/app/src/toolboxwidget.h
@@ -1,3 +1,20 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+Copyright (C) 2024-2099 Oliver S. Larsen
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
 #ifndef TOOLBOXWIDGET_H
 #define TOOLBOXWIDGET_H
 

--- a/app/src/tooloptionwidget.cpp
+++ b/app/src/tooloptionwidget.cpp
@@ -52,6 +52,9 @@ void ToolOptionWidget::initUI()
     ui->horizontalLayout_2->addWidget(mBucketOptionsWidget);
     ui->horizontalLayout_2->addWidget(mCameraOptionsWidget);
 
+    mBucketOptionsWidget->setHidden(true);
+    mCameraOptionsWidget->setHidden(true);
+
     QSettings settings(PENCIL2D, PENCIL2D);
 
     ui->sizeSlider->init(tr("Width"), SpinSlider::EXPONENT, SpinSlider::INTEGER, StrokeTool::WIDTH_MIN, StrokeTool::WIDTH_MAX);

--- a/app/ui/toolboxwidget.ui
+++ b/app/ui/toolboxwidget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>ToolBoxWidget</class>
- <widget class="QDockWidget" name="ToolBoxWidget">
+ <widget class="QWidget" name="ToolBoxWidget">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -19,426 +19,424 @@
   <property name="windowTitle">
    <string comment="Window title of tool box">Tools</string>
   </property>
-  <widget class="QWidget" name="toolGroup">
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <property name="spacing">
-     <number>0</number>
-    </property>
-    <property name="leftMargin">
-     <number>0</number>
-    </property>
-    <property name="topMargin">
-     <number>0</number>
-    </property>
-    <property name="rightMargin">
-     <number>0</number>
-    </property>
-    <property name="bottomMargin">
-     <number>0</number>
-    </property>
-    <item>
-     <widget class="QScrollArea" name="scrollArea">
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-      <property name="frameShadow">
-       <enum>QFrame::Plain</enum>
-      </property>
-      <property name="lineWidth">
-       <number>1</number>
-      </property>
-      <property name="widgetResizable">
-       <bool>true</bool>
-      </property>
-      <widget class="QWidget" name="scrollAreaWidgetContents_2">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>32</width>
-         <height>477</height>
-        </rect>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QScrollArea" name="scrollArea">
+       <property name="frameShape">
+        <enum>QFrame::Shape::NoFrame</enum>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <property name="spacing">
-         <number>0</number>
+       <property name="frameShadow">
+        <enum>QFrame::Shadow::Plain</enum>
+       </property>
+       <property name="lineWidth">
+        <number>1</number>
+       </property>
+       <property name="widgetResizable">
+        <bool>true</bool>
+       </property>
+       <widget class="QWidget" name="scrollAreaWidgetContents_2">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>32</width>
+          <height>461</height>
+         </rect>
         </property>
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QToolButton" name="pencilButton">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="icon">
-           <iconset resource="../data/app.qrc">
-            <normaloff>:/icons/themes/playful/tools/tool-pencil.svg</normaloff>:/icons/themes/playful/tools/tool-pencil.svg</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>22</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="autoRaise">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="eraserButton">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="icon">
-           <iconset resource="../data/app.qrc">
-            <normaloff>:/icons/themes/playful/tools/tool-eraser.svg</normaloff>:/icons/themes/playful/tools/tool-eraser.svg</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>22</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="autoRaise">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="selectButton">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="icon">
-           <iconset resource="../data/app.qrc">
-            <normaloff>:/icons/themes/playful/tools/tool-select.svg</normaloff>:/icons/themes/playful/tools/tool-select.svg</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>22</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="autoRaise">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="moveButton">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="icon">
-           <iconset resource="../data/app.qrc">
-            <normaloff>:/icons/themes/playful/tools/tool-move.svg</normaloff>:/icons/themes/playful/tools/tool-move.svg</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>22</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="autoRaise">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="penButton">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="icon">
-           <iconset resource="../data/app.qrc">
-            <normaloff>:/icons/themes/playful/tools/tool-pen.svg</normaloff>:/icons/themes/playful/tools/tool-pen.svg</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>22</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="autoRaise">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="handButton">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="icon">
-           <iconset resource="../data/app.qrc">
-            <normaloff>:/icons/themes/playful/tools/tool-hand.svg</normaloff>:/icons/themes/playful/tools/tool-hand.svg</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>22</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="autoRaise">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="polylineButton">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="icon">
-           <iconset resource="../data/app.qrc">
-            <normaloff>:/icons/themes/playful/tools/tool-polyline.svg</normaloff>:/icons/themes/playful/tools/tool-polyline.svg</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>22</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="autoRaise">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="bucketButton">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="icon">
-           <iconset resource="../data/app.qrc">
-            <normaloff>:/icons/themes/playful/tools/tool-bucket.svg</normaloff>:/icons/themes/playful/tools/tool-bucket.svg</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>22</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="autoRaise">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="eyedropperButton">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="icon">
-           <iconset resource="../data/app.qrc">
-            <normaloff>:/icons/themes/playful/tools/tool-eyedropper.svg</normaloff>:/icons/themes/playful/tools/tool-eyedropper.svg</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>22</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="autoRaise">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="brushButton">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="icon">
-           <iconset resource="../data/app.qrc">
-            <normaloff>:/icons/themes/playful/tools/tool-brush.svg</normaloff>:/icons/themes/playful/tools/tool-brush.svg</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>22</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="autoRaise">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="smudgeButton">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Smudge</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../data/app.qrc">
-            <normaloff>:/icons/themes/playful/tools/tool-smudge.svg</normaloff>:/icons/themes/playful/tools/tool-smudge.svg</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>22</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="autoRaise">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QToolButton" name="pencilButton">
+           <property name="minimumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="icon">
+            <iconset resource="../data/app.qrc">
+             <normaloff>:/icons/themes/playful/tools/tool-pencil.svg</normaloff>:/icons/themes/playful/tools/tool-pencil.svg</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="eraserButton">
+           <property name="minimumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="icon">
+            <iconset resource="../data/app.qrc">
+             <normaloff>:/icons/themes/playful/tools/tool-eraser.svg</normaloff>:/icons/themes/playful/tools/tool-eraser.svg</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="selectButton">
+           <property name="minimumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="icon">
+            <iconset resource="../data/app.qrc">
+             <normaloff>:/icons/themes/playful/tools/tool-select.svg</normaloff>:/icons/themes/playful/tools/tool-select.svg</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="moveButton">
+           <property name="minimumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="icon">
+            <iconset resource="../data/app.qrc">
+             <normaloff>:/icons/themes/playful/tools/tool-move.svg</normaloff>:/icons/themes/playful/tools/tool-move.svg</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="penButton">
+           <property name="minimumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="icon">
+            <iconset resource="../data/app.qrc">
+             <normaloff>:/icons/themes/playful/tools/tool-pen.svg</normaloff>:/icons/themes/playful/tools/tool-pen.svg</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="handButton">
+           <property name="minimumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="icon">
+            <iconset resource="../data/app.qrc">
+             <normaloff>:/icons/themes/playful/tools/tool-hand.svg</normaloff>:/icons/themes/playful/tools/tool-hand.svg</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="polylineButton">
+           <property name="minimumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="icon">
+            <iconset resource="../data/app.qrc">
+             <normaloff>:/icons/themes/playful/tools/tool-polyline.svg</normaloff>:/icons/themes/playful/tools/tool-polyline.svg</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="bucketButton">
+           <property name="minimumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="icon">
+            <iconset resource="../data/app.qrc">
+             <normaloff>:/icons/themes/playful/tools/tool-bucket.svg</normaloff>:/icons/themes/playful/tools/tool-bucket.svg</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="eyedropperButton">
+           <property name="minimumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="icon">
+            <iconset resource="../data/app.qrc">
+             <normaloff>:/icons/themes/playful/tools/tool-eyedropper.svg</normaloff>:/icons/themes/playful/tools/tool-eyedropper.svg</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="brushButton">
+           <property name="minimumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="icon">
+            <iconset resource="../data/app.qrc">
+             <normaloff>:/icons/themes/playful/tools/tool-brush.svg</normaloff>:/icons/themes/playful/tools/tool-brush.svg</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="smudgeButton">
+           <property name="minimumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>32</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Smudge</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../data/app.qrc">
+             <normaloff>:/icons/themes/playful/tools/tool-smudge.svg</normaloff>:/icons/themes/playful/tools/tool-smudge.svg</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
-     </widget>
-    </item>
-   </layout>
-  </widget>
+     </item>
+    </layout>
  </widget>
  <resources>
   <include location="../data/app.qrc"/>

--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -44,6 +44,7 @@ HEADERS +=  \
     src/interface/recentfilemenu.h \
     src/interface/scribblearea.h \
     src/interface/backgroundwidget.h \
+    src/interface/toolboxlayout.h \
     src/interface/undoredocommand.h \
     src/managers/basemanager.h \
     src/managers/overlaymanager.h \
@@ -135,6 +136,7 @@ SOURCES +=  src/graphics/bitmap/bitmapimage.cpp \
     src/interface/recentfilemenu.cpp \
     src/interface/scribblearea.cpp \
     src/interface/backgroundwidget.cpp \
+    src/interface/toolboxlayout.cpp \
     src/interface/undoredocommand.cpp \
     src/managers/basemanager.cpp \
     src/managers/overlaymanager.cpp \

--- a/core_lib/src/interface/flowlayout.cpp
+++ b/core_lib/src/interface/flowlayout.cpp
@@ -217,7 +217,7 @@ RowLayoutInfo FlowLayout::alignHCenterRow(int startIndex, int count, const QRect
 
         const QSize& itemSize = rowItem->sizeHint();
         rowItem->setGeometry(QRect(QPoint(rowOffsetX, rowItem->geometry().y()), itemSize));
-        rowOffsetX += spaceX + itemSize.width();
+        rowOffsetX += row.spacing + itemSize.width();
     }
 
     return row;
@@ -295,10 +295,10 @@ int FlowLayout::applyLayout(const QRect &rect) const
             spaceY = wid->style()->layoutSpacing(
                 QSizePolicy::PushButton, QSizePolicy::PushButton, Qt::Vertical);
 
-        int rowWidth = calculateRowWidth(0, currentRowCount, spaceX);
+        int startRowIndex = i - currentRowCount;
+        int rowWidth = calculateRowWidth(startRowIndex, currentRowCount, spaceX);
 
         if (currentRowCount > 0) {
-            int startRowIndex = i - currentRowCount;
             maxRowCount = qMax(currentRowCount, maxRowCount);
 
             if (rowWidth + item->sizeHint().width() + spaceX >= effectiveRect.width()) {
@@ -311,8 +311,6 @@ int FlowLayout::applyLayout(const QRect &rect) const
                 y = y + lineHeight + spaceY;
                 lineHeight = 0;
                 currentRowCount = 0;
-            } else if (maxRowCount == itemList.length() - 1) {
-                rowAlignments.append(alignHCenterRow(startRowIndex, currentRowCount, effectiveRect, spaceX));
             }
         }
 
@@ -322,7 +320,9 @@ int FlowLayout::applyLayout(const QRect &rect) const
         currentRowCount += 1;
     }
 
-    if (currentRowCount > 0) {
+    if (maxRowCount == itemList.length() - 1) {
+        alignHCenterRow(itemList.length() - currentRowCount, currentRowCount, effectiveRect, spaceX);
+    } else if (currentRowCount > 0) {
         lastLineAlignment(itemList.length() - currentRowCount, currentRowCount, rowAlignments.last(), effectiveRect);
     }
 

--- a/core_lib/src/interface/flowlayout.cpp
+++ b/core_lib/src/interface/flowlayout.cpp
@@ -47,10 +47,28 @@
 ** $QT_END_LICENSE$
 **
 ****************************************************************************/
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
 
 #include <QWidget>
 #include <QLayout>
 #include <QtMath>
+#include <QDebug>
+#include <QDockWidget>
 
 #include "flowlayout.h"
 
@@ -61,10 +79,8 @@ FlowLayout::FlowLayout(QWidget *parent, int margin, int hSpacing, int vSpacing)
 }
 
 FlowLayout::FlowLayout(int margin, int hSpacing, int vSpacing)
-    : m_hSpace(hSpacing), m_vSpace(vSpacing)
-{
-    setContentsMargins(margin, margin, margin, margin);
-}
+    : FlowLayout(nullptr, margin, hSpacing, vSpacing)
+{}
 
 FlowLayout::~FlowLayout()
 {
@@ -114,26 +130,25 @@ QLayoutItem *FlowLayout::takeAt(int index)
         return nullptr;
 }
 
-Qt::Orientations FlowLayout::expandingDirections() const
-{
-    return {};
-}
-
 bool FlowLayout::hasHeightForWidth() const
 {
     return true;
 }
 
+Qt::Orientations FlowLayout::expandingDirections() const
+{
+    return {};
+}
+
 int FlowLayout::heightForWidth(int width) const
 {
-    int height = doLayout(QRect(0, 0, width, 0), true);
-    return height;
+    return calculateHeightForWidth(width);
 }
 
 void FlowLayout::setGeometry(const QRect &rect)
 {
     QLayout::setGeometry(rect);
-    doLayout(rect, false);
+    mNumberOfRows = applyLayout(rect);
 }
 
 QSize FlowLayout::sizeHint() const
@@ -153,65 +168,187 @@ QSize FlowLayout::minimumSize() const
     return size;
 }
 
-int FlowLayout::doLayout(const QRect &rect, bool testOnly) const
+RowLayoutInfo FlowLayout::alignJustifiedRow(int startIndex, int count, const QRect& effectiveRect, int spaceX) const
+{
+
+    int spacing = 0;
+    if (count > 0) {
+        int gapCount = count + 1;
+        int rowWidth = calculateRowWidth(startIndex, count, spaceX);
+        int availableSpace = effectiveRect.width() - rowWidth;
+
+        spacing = (gapCount > 0 && availableSpace > 0)
+                  ? availableSpace / gapCount
+                  : 0;
+    }
+
+    int itemX = effectiveRect.left() + spacing;
+
+    RowLayoutInfo row;
+
+    row.startX = itemX;
+    row.startIndex = startIndex;
+    row.spacing = spaceX + spacing;
+
+    for (int j = startIndex; j < startIndex + count; j += 1) {
+        QLayoutItem *rowItem = itemList.at(j);
+        const QSize& itemSize = rowItem->sizeHint();
+        rowItem->setGeometry(QRect(QPoint(itemX, rowItem->geometry().y()), itemSize));
+        itemX += row.spacing + itemSize.width();
+    }
+
+    return row;
+}
+
+RowLayoutInfo FlowLayout::alignHCenterRow(int startIndex, int count, const QRect &effectiveRect, int spaceX) const
+{
+    int rowWidth = calculateRowWidth(startIndex, count, spaceX);
+    int offset = (effectiveRect.width() - rowWidth) / 2;
+    int rowOffsetX = effectiveRect.left() + offset;
+
+    RowLayoutInfo row;
+
+    row.startX = rowOffsetX;
+    row.startIndex = startIndex;
+    row.spacing = spaceX;
+
+    for (int i = startIndex; i < startIndex + count; i += 1) {
+        QLayoutItem *rowItem = itemList.at(i);
+
+        const QSize& itemSize = rowItem->sizeHint();
+        rowItem->setGeometry(QRect(QPoint(rowOffsetX, rowItem->geometry().y()), itemSize));
+        rowOffsetX += spaceX + itemSize.width();
+    }
+
+    return row;
+}
+
+int FlowLayout::calculateHeightForWidth(int width) const
 {
     int left, top, right, bottom;
     getContentsMargins(&left, &top, &right, &bottom);
-    QRect effectiveRect = rect.adjusted(+left, +top, -right, -bottom);
-    int x = effectiveRect.x();
-    int y = effectiveRect.y();
     int lineHeight = 0;
     int rowCount = 0;
+    int totalRows = 0;
 
-    QLayoutItem *item;
-    int spaceX = 0;
+    int spaceX = horizontalSpacing();
+    int spaceY = verticalSpacing();
+
+    int y = 0;
+
     for (int i = 0; i < itemList.length(); i++) {
-        item = itemList.at(i);
+        QLayoutItem* item = itemList.at(i);
         QWidget *wid = item->widget();
-        spaceX = horizontalSpacing();
+        int rowWidth = calculateRowWidth(0, rowCount, spaceX);
+
         if (spaceX == -1)
             spaceX = wid->style()->layoutSpacing(
                 QSizePolicy::PushButton, QSizePolicy::PushButton, Qt::Horizontal);
-        int spaceY = verticalSpacing();
         if (spaceY == -1)
             spaceY = wid->style()->layoutSpacing(
                 QSizePolicy::PushButton, QSizePolicy::PushButton, Qt::Vertical);
 
-        int nextX = x + item->sizeHint().width() + spaceX;
-        if (nextX - spaceX > effectiveRect.right() && lineHeight > 0) {
-            if(!testOnly && alignment() & Qt::AlignHCenter) {
-                int offset = qFloor((effectiveRect.right() + spaceX - x) / 2);
-                for(int j = i-1; j > i-1-rowCount; j--) {
-                    auto rowItem = itemList.at(j);
-                    rowItem->setGeometry(rowItem->geometry().adjusted(offset, 0, offset, 0));
-                }
-            }
+        if (rowWidth + item->sizeHint().width() + spaceX >= width && lineHeight > 0) {
+            totalRows++;
 
-            x = effectiveRect.x();
-            y = y + lineHeight + spaceY;
-            nextX = x + item->sizeHint().width() + spaceX;
+            y += lineHeight + spaceY;
             lineHeight = 0;
             rowCount = 0;
         }
-        rowCount++;
 
-        if (!testOnly) {
-            item->setGeometry(QRect(QPoint(x, y), item->sizeHint()));
-        }
-
-        x = nextX;
         lineHeight = qMax(lineHeight, item->sizeHint().height());
+        rowCount++;
     }
 
-    if (!testOnly && alignment() & Qt::AlignHCenter) {
-        int offset = qFloor((effectiveRect.right() + spaceX - x) / 2);
-        for (int j = itemList.length()-1; j > itemList.length()-1-rowCount; j--) {
-            auto rowItem = itemList.at(j);
-            rowItem->setGeometry(rowItem->geometry().adjusted(offset, 0, offset, 0));
+
+    return lineHeight + y + top + bottom;
+}
+
+int FlowLayout::applyLayout(const QRect &rect) const
+{
+    int left, top, right, bottom;
+    getContentsMargins(&left, &top, &right, &bottom);
+
+    int spaceX = horizontalSpacing();
+    int spaceY = verticalSpacing();
+
+    QRect effectiveRect = rect.adjusted(+left, +top, -right, -bottom);
+    int x = effectiveRect.x();
+    int y = effectiveRect.y();
+    int lineHeight = 0;
+
+    QLayoutItem *item;
+
+    QVector<RowLayoutInfo> rowAlignments;
+
+    int currentRowCount = 0;
+    int maxRowCount = 0;
+
+    for (int i = 0; i < itemList.length(); i += 1) {
+        item = itemList.at(i);
+        QWidget *wid = item->widget();
+
+        if (spaceX == -1)
+            spaceX = wid->style()->layoutSpacing(
+                QSizePolicy::PushButton, QSizePolicy::PushButton, Qt::Horizontal);
+        if (spaceY == -1)
+            spaceY = wid->style()->layoutSpacing(
+                QSizePolicy::PushButton, QSizePolicy::PushButton, Qt::Vertical);
+
+        int rowWidth = calculateRowWidth(0, currentRowCount, spaceX);
+
+        if (currentRowCount > 0) {
+            int startRowIndex = i - currentRowCount;
+            maxRowCount = qMax(currentRowCount, maxRowCount);
+
+            if (rowWidth + item->sizeHint().width() + spaceX >= effectiveRect.width()) {
+                if (alignment() & Qt::AlignHCenter) {
+                    rowAlignments.append(alignHCenterRow(startRowIndex, currentRowCount, effectiveRect, spaceX));
+                } else if (alignment() & Qt::AlignJustify) {
+                    rowAlignments.append(alignJustifiedRow(startRowIndex, currentRowCount, effectiveRect, spaceX));
+                }
+
+                y = y + lineHeight + spaceY;
+                lineHeight = 0;
+                currentRowCount = 0;
+            } else if (maxRowCount == itemList.length() - 1) {
+                rowAlignments.append(alignHCenterRow(startRowIndex, currentRowCount, effectiveRect, spaceX));
+            }
         }
+
+        item->setGeometry(QRect(QPoint(x, y), item->sizeHint()));
+
+        lineHeight = qMax(lineHeight, item->sizeHint().height());
+        currentRowCount += 1;
     }
 
-    return y + lineHeight - rect.y() + bottom;
+    if (currentRowCount > 0) {
+        lastLineAlignment(itemList.length() - currentRowCount, currentRowCount, rowAlignments.last(), effectiveRect);
+    }
+
+    return maxRowCount;
+}
+
+void FlowLayout::lastLineAlignment(int startIndex, int count, RowLayoutInfo rowInfo, const QRect& effectiveRect) const
+{
+    if (alignment() & Qt::AlignHCenter) {
+        alignHCenterRow(startIndex, count, effectiveRect, rowInfo.spacing);
+    } else if (alignment() & Qt::AlignJustify) {
+        alignJustifiedRow(startIndex, count, effectiveRect, rowInfo.spacing);
+    }
+}
+
+int FlowLayout::calculateRowWidth(int start, int end, int spacing) const
+{
+    if (itemList.isEmpty()) { return 0; }
+
+    int totalWidth = 0;
+    // Calculate the total width of all item in row including spacing
+    for (int i = start; i < start + end; i += 1) {
+        totalWidth += itemList.at(i)->sizeHint().width();
+    }
+
+    return totalWidth + (spacing * (end - 1));
 }
 
 int FlowLayout::smartSpacing(QStyle::PixelMetric pm) const

--- a/core_lib/src/interface/flowlayout.h
+++ b/core_lib/src/interface/flowlayout.h
@@ -47,6 +47,22 @@
 ** $QT_END_LICENSE$
 **
 ****************************************************************************/
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
 
 #ifndef FLOWLAYOUT_H
 #define FLOWLAYOUT_H
@@ -54,6 +70,12 @@
 #include <QLayout>
 #include <QRect>
 #include <QStyle>
+
+struct RowLayoutInfo {
+    int startIndex;
+    int startX;
+    int spacing;
+};
 
 class FlowLayout : public QLayout
 {
@@ -75,13 +97,26 @@ public:
     QSize sizeHint() const override;
     QLayoutItem *takeAt(int index) override;
 
-private:
-    int doLayout(const QRect &rect, bool testOnly) const;
-    int smartSpacing(QStyle::PixelMetric pm) const;
+    int rows() const { return mNumberOfRows; }
+
+protected:
+    virtual void lastLineAlignment(int startIndex, int count, RowLayoutInfo rowInfo, const QRect& effectiveRect) const;
 
     QList<QLayoutItem *> itemList;
-    int m_hSpace;
-    int m_vSpace;
+    int m_hSpace = 0;
+    int m_vSpace = 0;
+
+private:
+    RowLayoutInfo alignHCenterRow(int startIndex, int count, const QRect &effectiveRect, int spaceX) const;
+    RowLayoutInfo alignJustifiedRow(int startIndex, int count, const QRect& effectiveRect, int spaceX) const;
+
+    int calculateHeightForWidth(int width) const;
+    int calculateRowWidth(int start, int end, int spacing) const;
+
+    int applyLayout(const QRect &rect) const;
+    int smartSpacing(QStyle::PixelMetric pm) const;
+
+    int mNumberOfRows = 0;
 };
 
 #endif // FLOWLAYOUT_H

--- a/core_lib/src/interface/toolboxlayout.cpp
+++ b/core_lib/src/interface/toolboxlayout.cpp
@@ -1,0 +1,28 @@
+#include "toolboxlayout.h"
+
+ToolBoxLayout::ToolBoxLayout(QWidget* parent, int margin, int hSpacing, int vSpacing)
+    : FlowLayout(parent, margin, hSpacing, vSpacing)
+{
+
+}
+
+void ToolBoxLayout::lastLineAlignment(int startIndex, int count, RowLayoutInfo rowInfo, const QRect &effectiveRect) const
+{
+    alignRowFromRowInfo(startIndex, count, rowInfo);
+}
+
+void ToolBoxLayout::alignRowFromRowInfo(int startIndex, int count, RowLayoutInfo rowInfo) const
+{
+    int x = rowInfo.startX;
+
+    for (int i = startIndex; i < startIndex + count; i += 1) {
+
+        if (i > itemList.length() - 1) {
+            break;
+        }
+        QLayoutItem *item = itemList.at(i);
+        QSize size = item->geometry().size();
+        item->setGeometry(QRect(QPoint(x, item->geometry().y()), size));
+        x += size.width() + rowInfo.spacing;
+    }
+}

--- a/core_lib/src/interface/toolboxlayout.cpp
+++ b/core_lib/src/interface/toolboxlayout.cpp
@@ -1,3 +1,20 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+Copyright (C) 2024-2099 Oliver S. Larsen
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
 #include "toolboxlayout.h"
 
 ToolBoxLayout::ToolBoxLayout(QWidget* parent, int margin, int hSpacing, int vSpacing)

--- a/core_lib/src/interface/toolboxlayout.h
+++ b/core_lib/src/interface/toolboxlayout.h
@@ -1,0 +1,18 @@
+#ifndef TOOLBOXLAYOUT_H
+#define TOOLBOXLAYOUT_H
+
+#include "flowlayout.h"
+
+class ToolBoxLayout : public FlowLayout
+{
+public:
+    ToolBoxLayout(QWidget* parent, int margin, int hSpacing, int vSpacing);
+
+protected:
+    void lastLineAlignment(int startIndex, int count, RowLayoutInfo rowInfo, const QRect& effectiveRect) const override;
+
+private:
+    void alignRowFromRowInfo(int startIndex, int count, RowLayoutInfo rowInfo) const;
+};
+
+#endif // TOOLBOXLAYOUT_H

--- a/core_lib/src/interface/toolboxlayout.h
+++ b/core_lib/src/interface/toolboxlayout.h
@@ -1,3 +1,20 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+Copyright (C) 2024-2099 Oliver S. Larsen
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
 #ifndef TOOLBOXLAYOUT_H
 #define TOOLBOXLAYOUT_H
 


### PR DESCRIPTION
I've given our FlowLayout class an overhaul.

Pure row height calculation has been moved into its own separate function, rather than mixing everything with the "testOnly" flag. The justified logic has been updated such that it will always try to cram as many items on a line as possible, but still be constrained to a minimum spacing.

The result of that looks like this:

| Before | After |
| ------ | ----- |
| ![old-flowlayout](https://github.com/user-attachments/assets/44186692-5de6-428a-92e1-163cca4d6a49) | ![new-flowlayout](https://github.com/user-attachments/assets/7c36c4ec-55c9-4460-8d2a-8513e6539c37) |

The sizing logic for the Tools widget has been updated as well. If there's only one row, then the items will be aligned centered and otherwise the alignment will change to justified, until all items has been layout. When all items has been layout horizontally, the flow layout will default to centered placement again.

I've also introduced a new ToolBoxLayout class in order to change the alignment of the last line, as it will otherwise align justified with no concern of aligning to lines above.

With this PR, combined with #1913, we will be able to shrink to the following.
![image](https://github.com/user-attachments/assets/284246db-4af9-4e80-a1c6-8ff063db449f)

Note that due to how QDockWidget sizing works, in order to get more control of how the toolbox is layout, I had to move everything into a container widget.
