### PR TITLE
Fix SoundManager calculating frame length incorrectly

### DIFF
--- a/core_lib/src/managers/soundmanager.cpp
+++ b/core_lib/src/managers/soundmanager.cpp
@@ -146,9 +146,8 @@ void SoundManager::onDurationChanged(SoundPlayer* player, int64_t duration)
 
     double fps = static_cast<double>(editor()->fps());
 
-    double frameLength = duration * fps / 1000.0;
-    clip->setLength(static_cast<int>(frameLength));
     clip->setDuration(duration);
+    clip->updateLength(fps);
 
     editor()->layers()->notifyAnimationLengthChanged();
 


### PR DESCRIPTION
SoundManager duplicates SoundClip’s length calculation but without taking the ceil() of the calculated length. This can result in a length of 0 for very short clips, essentially preventing interaction with them. To avoid this, reuse SoundClip’s recalculation mechanism. I believe this is the might be the same issue as reported in [this forum post](https://discuss.pencil2d.org/t/sound-editing-bug-version-0-7/9823?u=j5lx), though the specific durations given don’t particularly make sense to me.