### PR TITLE
Fix polyline not creating a backup on end with keyboard

### DIFF
--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -190,10 +190,13 @@ void PolylineTool::pointerReleaseEvent(PointerEvent* event)
 void PolylineTool::pointerDoubleClickEvent(PointerEvent* event)
 {
     mInterpolator.pointerPressEvent(event);
-    // include the current point before ending the line.
-    mPoints << getCurrentPoint();
+
 
     if (mPoints.size() > 0) {
+        if (mPoints.last() != getCurrentPoint()) {
+            // include the current point before ending the line.
+            mPoints << getCurrentPoint();
+        }
         endPolyline(mPoints);
     }
 }

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -193,9 +193,9 @@ void PolylineTool::pointerDoubleClickEvent(PointerEvent* event)
     // include the current point before ending the line.
     mPoints << getCurrentPoint();
 
-    mEditor->backup(typeName());
-
-    endPolyline(mPoints);
+    if (mPoints.size() > 0) {
+        endPolyline(mPoints);
+    }
 }
 
 
@@ -206,6 +206,8 @@ bool PolylineTool::keyPressEvent(QKeyEvent* event)
     case Qt::Key_Return:
         if (mPoints.size() > 0)
         {
+            // include the current point before ending the line.
+            mPoints << getCurrentPoint();
             endPolyline(mPoints);
             return true;
         }
@@ -280,6 +282,7 @@ void PolylineTool::endPolyline(QList<QPointF> points)
 {
     Layer* layer = mEditor->layers()->currentLayer();
 
+    mEditor->backup(typeName());
     if (layer->type() == Layer::VECTOR)
     {
         BezierCurve curve = BezierCurve(points, properties.bezier_state);


### PR DESCRIPTION
Small fix for a bug that was just reported on the forum. Apparently we've had it for some time...
It might not be as easy to backmerge as some other things because this uses the old backup system where as that's changed in master.

I still think we should include it though.

I also fixed a behaviour inconsistency between keyboard and mouse where as double-clicking would include the current point on end, doing the same with keyboard would not.

source: https://discuss.pencil2d.org/t/the-polyline-tool-acts-weird-when-trying-to-undo/9833/3