### PR TITLE
Filter release candidates out of update checker

### DIFF
--- a/app/src/checkupdatesdialog.cpp
+++ b/app/src/checkupdatesdialog.cpp
@@ -111,7 +111,7 @@ void CheckUpdatesDialog::nightlyBuildCheck()
 {
     mTitleLabel->setText(tr("<b>You are using a Pencil2D nightly build</b>"));
     mDetailLabel->setText(tr("Please go %1 here %2 to check new nightly builds.")
-                          .arg("<a href=\"https://www.pencil2d.org/download/#nightlybuild\">", "</a>"));
+                          .arg("<a href=\"https://www.pencil2d.org/download/nightly/\">", "</a>"));
     mDetailLabel->setOpenExternalLinks(true);
     mProgressBar->setRange(0, 1);
     mProgressBar->setValue(1);

--- a/app/src/checkupdatesdialog.cpp
+++ b/app/src/checkupdatesdialog.cpp
@@ -212,8 +212,12 @@ QString CheckUpdatesDialog::getVersionNumberFromXml(QString xml)
                 xmlReader.readNext();
                 if (xmlReader.name() == QLatin1String("title"))
                 {
-                    QString titleTag = xmlReader.readElementText();
-                    return titleTag.remove(QRegularExpression("^v")); // remove the leading 'v'
+                    QString title = xmlReader.readElementText();
+                    title = title.remove(QRegularExpression("^v")); // remove the leading 'v'
+                    // Ignore release candidate versions
+                    if (!title.contains("Release Candidate")) {
+                        return title;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is a really minimal solution to avoid release candidates from being presented as a new release when users check for updates. The releases.atom does not provide the information necessary to distinguish prereleases from full releases. The nightly build link was wrong so I updated that at the same time.

I would like to eventually use the GitHub API instead, which does provide prerelease information, and fall back to the atom, or perhaps even other sources in case GitHub is down or blocked. However I'm going to leave that as a future improvement as I want to get this fix into v0.7.1. Given how close v0.7.1 is to release, I think this small hack is the best short-term solution.