### PR TITLE
Refactor validateDataPath and fix macOS unit tests

### DIFF
--- a/core_lib/src/util/util.h
+++ b/core_lib/src/util/util.h
@@ -69,6 +69,18 @@ quint64 imageSize(const QImage&);
 QString uniqueString(int len);
 
 /**
+ * Converts a filesystem path to its canonical form, ie. an absolute path with any existing symlinks resolved.
+ *
+ * This function does the same thing as QDir::canonicalPath if a file or directory exists at the path.
+ * If the path does not point to an existing file or directory, then this function will resolve the symlinks only
+ * for the existing parent directories, rather than returning an empty string as QDir::canonicalPath does.
+ * This function may still return a blank string if the path contains dangling symbolic links.
+ *
+ * @param path The path to convert to canonical form.
+ * @return A canonical path, or as close to one as possible.
+ */
+QString closestCanonicalPath(QString path);
+/**
  * Performs safety checks for paths to data directory assets.
  *
  * Validates that the given file path is contained within the given
@@ -83,10 +95,11 @@ QString uniqueString(int len);
  * function if:
  * - An existing file is being modified/appended in-place (not overwritten) in the data directory.
  * - The data directory is not guaranteed to be the immediate parent directory of the file being written.
+ * - The path comes from an untrusted source or could contain sections to navigate up the directory heirarchy (ie. '../')
  *
  * @param filePath A path to a data file.
  * @param dataDir The path to the data directory.
- * @return The valid resolved path, or empty if the path is not valid.
+ * @return The closest canonical resolved path, or empty if the path did not pass validation or contains dangling symbolic links.
  */
 QString validateDataPath(QString filePath, QString dataDirPath);
 

--- a/tests/src/test_layerbitmap.cpp
+++ b/tests/src/test_layerbitmap.cpp
@@ -17,6 +17,7 @@ GNU General Public License for more details.
 
 #include "layerbitmap.h"
 #include "bitmapimage.h"
+#include "util.h"
 
 #include <memory>
 #include <QDir>
@@ -61,7 +62,7 @@ TEST_CASE("Load bitmap layer from XML")
         REQUIRE(frame != nullptr);
         REQUIRE(frame->top() == 0);
         REQUIRE(frame->left() == 0);
-        REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath("001.001.png")));
+        REQUIRE(closestCanonicalPath(frame->fileName()) == closestCanonicalPath(dataDir.filePath("001.001.png")));
     }
 
     SECTION("Multiple frames")
@@ -78,7 +79,7 @@ TEST_CASE("Load bitmap layer from XML")
             REQUIRE(frame != nullptr);
             REQUIRE(frame->top() == 0);
             REQUIRE(frame->left() == 0);
-            REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath(QString("001.%1.png").arg(QString::number(i), 3, QChar('0')))));
+            REQUIRE(closestCanonicalPath(frame->fileName()) == closestCanonicalPath(dataDir.filePath(QString("001.%1.png").arg(QString::number(i), 3, QChar('0')))));
         }
     }
 
@@ -112,6 +113,6 @@ TEST_CASE("Load bitmap layer from XML")
         REQUIRE(frame != nullptr);
         REQUIRE(frame->top() == 0);
         REQUIRE(frame->left() == 0);
-        REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath("subdir/001.001.png")));
+        REQUIRE(closestCanonicalPath(frame->fileName()) == closestCanonicalPath(dataDir.filePath("subdir/001.001.png")));
     }
 }

--- a/tests/src/test_layersound.cpp
+++ b/tests/src/test_layersound.cpp
@@ -17,6 +17,7 @@ GNU General Public License for more details.
 
 #include "layersound.h"
 #include "soundclip.h"
+#include "util.h"
 
 #include <memory>
 #include <QDir>
@@ -63,7 +64,7 @@ TEST_CASE("Load sound layer from XML")
         REQUIRE(soundLayer->keyFrameCount() == 1);
         SoundClip* frame = static_cast<SoundClip*>(soundLayer->getKeyFrameAt(1));
         REQUIRE(frame != nullptr);
-        REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath("sound_001.wav")));
+        REQUIRE(closestCanonicalPath(frame->fileName()) == closestCanonicalPath(dataDir.filePath("sound_001.wav")));
     }
 
     SECTION("Multiple clips")
@@ -78,7 +79,7 @@ TEST_CASE("Load sound layer from XML")
         {
             SoundClip* frame = static_cast<SoundClip*>(soundLayer->getKeyFrameAt(i));
             REQUIRE(frame != nullptr);
-            REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath(QString("sound_%1.wav").arg(QString::number(i), 3, QChar('0')))));
+            REQUIRE(closestCanonicalPath(frame->fileName()) == closestCanonicalPath(dataDir.filePath(QString("sound_%1.wav").arg(QString::number(i), 3, QChar('0')))));
         }
     }
 
@@ -111,6 +112,6 @@ TEST_CASE("Load sound layer from XML")
         REQUIRE(soundLayer->keyFrameCount() == 1);
         SoundClip* frame = static_cast<SoundClip*>(soundLayer->getKeyFrameAt(1));
         REQUIRE(frame != nullptr);
-        REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath("subdir/sound_001.wav")));
+        REQUIRE(closestCanonicalPath(frame->fileName()) == closestCanonicalPath(dataDir.filePath("subdir/sound_001.wav")));
     }
 }

--- a/tests/src/test_layervector.cpp
+++ b/tests/src/test_layervector.cpp
@@ -16,6 +16,7 @@ GNU General Public License for more details.
 #include "catch.hpp"
 
 #include "layervector.h"
+#include "util.h"
 #include "vectorimage.h"
 
 
@@ -71,7 +72,7 @@ TEST_CASE("Load vector layer from XML")
         REQUIRE(vectorLayer->keyFrameCount() == 1);
         VectorImage* frame = static_cast<VectorImage*>(vectorLayer->getKeyFrameAt(1));
         REQUIRE(frame != nullptr);
-        REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath("001.001.vec")));
+        REQUIRE(closestCanonicalPath(frame->fileName()) == closestCanonicalPath(dataDir.filePath("001.001.vec")));
     }
 
     SECTION("Multiple frames")
@@ -86,7 +87,7 @@ TEST_CASE("Load vector layer from XML")
         {
             VectorImage* frame = static_cast<VectorImage*>(vectorLayer->getKeyFrameAt(i));
             REQUIRE(frame != nullptr);
-            REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath(QString("001.%1.vec").arg(QString::number(i), 3, QChar('0')))));
+            REQUIRE(closestCanonicalPath(frame->fileName()) == closestCanonicalPath(dataDir.filePath(QString("001.%1.vec").arg(QString::number(i), 3, QChar('0')))));
         }
     }
 
@@ -119,6 +120,6 @@ TEST_CASE("Load vector layer from XML")
         REQUIRE(vectorLayer->keyFrameCount() == 1);
         VectorImage* frame = static_cast<VectorImage*>(vectorLayer->getKeyFrameAt(1));
         REQUIRE(frame != nullptr);
-        REQUIRE(QDir(frame->fileName()) == QDir(dataDir.filePath("subdir/001.001.vec")));
+        REQUIRE(closestCanonicalPath(frame->fileName()) == closestCanonicalPath(dataDir.filePath("subdir/001.001.vec")));
     }
 }


### PR DESCRIPTION
This PR creates a new function `closestCanonicalPath` that behaves like `QDir::canonicalPath`, except that it will try to resolve symlinks for the nearest existing directory in the path if the path passed as an argument does not exist. For example, if `/symlink` points to the directory `/target`, then `QDir("/symlink/example.txt").canonicalPath()` and `closestCanonicalPath("/symlink/example.txt")` will both return `/target/example.txt` if example.txt exists. If it does not exist, then `QDir::canonicalPath` will output an empty string while this new function will still output `/target/example.txt`.

The motivation for this new function is twofold. It can be used to greatly simplify the implementation of `validateDataPath`, which was much more complex that it would seem on first glance and I suspect did not handle certain edge cases correctly. Secondly, this new function can be used in some unit tests where comparing file path strings was failing because one or more of the directories were symlinks. Existing canonical path functions could not be used because the actual files were not created for the tests.

This supersedes the changes made in #1928 to try to fix the unit tests. In my opinion, `validateDataDir` is not the correct function to use in that situation. The intent of `validateDataDir` is merely to make sure that project file paths do not refer to locations outside of the data directory. But for the failing asserts, what we want to test is that the file path stored in the keyframes points to where the actual files would be located if it was a real project. Equivalent filesystem paths should always resolve to the same string with `closestCanonicalPath` and thus should be safe to use string comparison with.