### PR TITLE
Fix inaccessible top menu bar items

### DIFF
--- a/app/src/basedockwidget.cpp
+++ b/app/src/basedockwidget.cpp
@@ -36,10 +36,11 @@ BaseDockWidget::BaseDockWidget(QWidget* pParent)
     }
 #endif
 
-    mTitleBarWidget = new TitleBarWidget(pParent);
-    mNoTitleBarWidget = new QWidget(pParent);
+    mTitleBarWidget = new TitleBarWidget(this);
+    mNoTitleBarWidget = new QWidget(this);
 
     setTitleBarWidget(mTitleBarWidget);
+    mNoTitleBarWidget->hide();
 
     connect(mTitleBarWidget, &TitleBarWidget::closeButtonPressed, this, &BaseDockWidget::close);
 


### PR DESCRIPTION
BaseDockWidget was creating empty QWidgets that were children of the main window. As children of the main window they were positioned at the top left of the window by default and I guess they were being set to visible when the main window is shown. These didn't render anything because they're empty, but were blocking mouse events for a small area.

By hiding them right away, we prevent this behavior. I also changed the parents of the title bar widgets to be the BaseDockWidget, so they will be moved to the top left of the dock widget instead. I think the BaseDockWidget makes more sense as a parent logically and assures that if the BaseDockWidget is deleted, its title bars will be deleted right away too (the dock widgets currently last the lifetime of the application so this won't make any different right now).

Fixes #1929