### PR TITLE
Bump Qt6 macOS runner to Sonoma

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             container: "ubuntu:22.04"
             qt: 6
           - name: Qt 6 / macOS x86_64
-            os: macos-13
+            os: macos-14
             container:
             qt: 6
           #- name: Qt 6 / macOS arm64


### PR DESCRIPTION
Because Qt6 is no longer available on macOS Ventura.

Since it's the Qt6 build, it should not matter much which image we're running on compatibility wise.