### PR TITLE
Project recovery dialog improvements

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -652,7 +652,7 @@ bool MainWindow2::saveAsNewDocument()
 
 void MainWindow2::openStartupFile(const QString& filename)
 {
-    if (tryRecoverUnsavedProject())
+    if (checkForRecoverableProjects())
     {
         return;
     }
@@ -1568,7 +1568,7 @@ void MainWindow2::displayMessageBoxNoTitle(const QString& body)
     QMessageBox::information(this, nullptr, tr(qPrintable(body)), QMessageBox::Ok);
 }
 
-bool MainWindow2::tryRecoverUnsavedProject()
+bool MainWindow2::checkForRecoverableProjects()
 {
     FileManager fm;
     QStringList recoverables = fm.searchForUnsavedProjects();
@@ -1578,41 +1578,52 @@ bool MainWindow2::tryRecoverUnsavedProject()
         return false;
     }
 
+    foreach (const QString path, recoverables)
+    {
+        if (tryRecoverProject(path))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool MainWindow2::tryRecoverProject(const QString recoverPath)
+{
     QString caption = tr("Restore Project?");
     QString text = tr("Pencil2D didn't close correctly. Would you like to restore the project?");
 
-    QString recoverPath = recoverables[0];
+    QMessageBox msgBox(this);
+    hideQuestionMark(msgBox); // Must be before setDefaultButton
+    msgBox.setWindowTitle(tr("Restore project"));
+    msgBox.setWindowModality(Qt::ApplicationModal);
+    msgBox.setIconPixmap(QPixmap(":/icons/logo.png"));
+    msgBox.setText(QString("<h4>%1</h4>%2").arg(caption, text));
+    msgBox.setInformativeText(QString("<b>%1</b>").arg(retrieveProjectNameFromTempPath(recoverPath)));
+    msgBox.setStandardButtons(QMessageBox::Open | QMessageBox::Discard | QMessageBox::Cancel);
+    msgBox.setDefaultButton(QMessageBox::Cancel);
 
-    QMessageBox* msgBox = new QMessageBox(this);
-    msgBox->setWindowTitle(tr("Restore project"));
-    msgBox->setWindowModality(Qt::ApplicationModal);
-    msgBox->setAttribute(Qt::WA_DeleteOnClose);
-    msgBox->setIconPixmap(QPixmap(":/icons/logo.png"));
-    msgBox->setText(QString("<h4>%1</h4>%2").arg(caption, text));
-    msgBox->setInformativeText(QString("<b>%1</b>").arg(retrieveProjectNameFromTempPath(recoverPath)));
-    msgBox->setStandardButtons(QMessageBox::Open | QMessageBox::Discard);
-    msgBox->setProperty("RecoverPath", recoverPath);
-    hideQuestionMark(*msgBox);
+    int result = msgBox.exec();
 
-    connect(msgBox, &QMessageBox::finished, this, &MainWindow2::startProjectRecovery);
-    msgBox->open();
-    return true;
+    switch (result)
+    {
+    case QMessageBox::Discard:
+        QDir(recoverPath).removeRecursively();
+        return false;
+    case QMessageBox::Cancel:
+        return false;
+    case QMessageBox::Open:
+        return startProjectRecovery(recoverPath);
+    default:
+        Q_ASSERT(false);
+    }
+
+    return false;
 }
 
-void MainWindow2::startProjectRecovery(int result)
+bool MainWindow2::startProjectRecovery(const QString recoverPath)
 {
-    const QMessageBox* msgBox = dynamic_cast<QMessageBox*>(QObject::sender());
-    const QString recoverPath = msgBox->property("RecoverPath").toString();
-
-    if (result == QMessageBox::Discard)
-    {
-        // The user presses discard
-        QDir(recoverPath).removeRecursively();
-        tryLoadPreset();
-        return;
-    }
-    Q_ASSERT(result == QMessageBox::Open);
-
     FileManager fm;
     Object* o = fm.recoverUnsavedProject(recoverPath);
     if (!fm.error().ok())
@@ -1621,7 +1632,7 @@ void MainWindow2::startProjectRecovery(int result)
         const QString title = tr("Recovery Failed.");
         const QString text = tr("Sorry! Pencil2D is unable to restore your project");
         QMessageBox::information(this, title, QString("<h4>%1</h4>%2").arg(title, text));
-        return;
+        return false;
     }
 
     Q_ASSERT(o);
@@ -1632,6 +1643,8 @@ void MainWindow2::startProjectRecovery(int result)
     const QString title = tr("Recovery Succeeded!");
     const QString text = tr("Please save your work immediately to prevent loss of data");
     QMessageBox::information(this, title, QString("<h4>%1</h4>%2").arg(title, text));
+
+    return true;
 }
 
 void MainWindow2::createToolbars()

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -149,8 +149,9 @@ private:
     void makeConnections(Editor*, OnionSkinWidget*);
     void makeConnections(Editor*, StatusBar*);
 
-    bool tryRecoverUnsavedProject();
-    void startProjectRecovery(int result);
+    bool checkForRecoverableProjects();
+    bool tryRecoverProject(const QString recoverPath);
+    bool startProjectRecovery(const QString recoverPath);
 
     // UI: Dock widgets
     ColorBox*             mColorBox = nullptr;


### PR DESCRIPTION
Initially this was a fix for the 'x' button of the project recovery dialog not doing anything, however I ended up adding a couple other changes at the same time. There is now a Cancel option in that dialog which will ignore the unrecovered project until next time the program is started. This is an important option when running multiple Pencil2D instances (which you shouldn't do!), and it is in my opinion the most appropriate behavior to take when a user dismisses the dialog without explicitly choosing to open or delete the unrecovered project. This is also now the button that receives focus by default so if the user happens to press enter before reading the dialog, no harm is done.

I also have added support for handling multiple unrecovered projects. Previously, a dialog would only show up for the first unrecovered project, but now it show a dialog for every unrecovered project unless the user has opened one for recovery. It's not the most elegant solution, but it's not a situation that should come up often.