### PR TITLE
Fix Qt 6.10.1 compatibility

### DIFF
--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -494,7 +494,7 @@ Status Editor::openObject(const QString& strFilePath, const std::function<void(i
     }
     if (!fileInfo.isReadable())
     {
-        dd << QString("Permissions: 0x%1").arg(fileInfo.permissions(), 0, 16);
+        dd << QString("Permissions: 0x%1").arg(static_cast<int>(fileInfo.permissions()), 0, 16);
         return Status(Status::ERROR_FILE_CANNOT_OPEN,
                       dd,
                       tr("Could not open file"),


### PR DESCRIPTION
`QString::arg` no longer accepts arguments of types that implicitly convert to integral types.

https://doc.qt.io/qt-6/qstring.html#arg-2