### PR TITLE
#1947 Build Qt6 macOS app as a universal app

### DIFF
--- a/.github/actions/create-package/create-package.sh
+++ b/.github/actions/create-package/create-package.sh
@@ -95,6 +95,10 @@ create_package_macos() {
   macdeployqt Pencil2D.app
   echo "::endgroup::"
   
+  echo "::group::Verify universal binary"
+  lipo -archs Pencil2D.app/Contents/MacOS/Pencil2D
+  echo "::endgroup::"
+  
   popd >/dev/null
   local qtsuffix="-qt${INPUT_QT}"
   local arch="${INPUT_ARCH}"

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -13,8 +13,14 @@ runs:
     uses: jurplel/install-qt-action@v3
     with:
       arch: ${{inputs.arch}}
-      version: ${{matrix.qt == 6 && '6.4.2' || '5.15.2'}}
+      version: ${{matrix.qt == 6 && '6.5.3' || '5.15.2'}}
       modules: ${{matrix.qt == 6 && 'qtmultimedia' || ''}}
+  - if: runner.os == 'macOS' && inputs.qt == '6'
+    uses: jurplel/install-qt-action@v3
+    with:
+      arch: clang_64
+      version: '6.5.3'
+      modules: 'qtmultimedia'
   - run: ${GITHUB_ACTION_PATH}/install-dependencies.sh
     shell: bash
     env:

--- a/.github/actions/install-dependencies/install-dependencies.sh
+++ b/.github/actions/install-dependencies/install-dependencies.sh
@@ -45,8 +45,13 @@ setup_macos() {
   brew update
   echo "::endgroup::"
   echo "::group::Install Homebrew packages"
-  brew install libarchive qt@${INPUT_QT}
-  brew link qt@${INPUT_QT} --force
+  brew install libarchive
+  # For Qt 6, we use aqtinstall (jurplel/install-qt-action) instead of Homebrew
+  # because Homebrew's Qt 6 arm64 version is problematic
+  if [ "${INPUT_QT}" -eq 5 ]; then
+    brew install qt@${INPUT_QT}
+    brew link qt@${INPUT_QT} --force
+  fi
   echo "/usr/local/opt/libarchive/bin" >> "${GITHUB_PATH}"
   echo "::endgroup::"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,6 @@ jobs:
             arch: x86_64
             container:
             qt: 5
-          #- name: Qt 5 / macOS arm64
-          #  os: macos-latest
-          #  container:
-          #  qt: 5
           - name: Qt 5 / Windows x86
             os: windows-2022
             arch: win32_msvc2019
@@ -52,15 +48,11 @@ jobs:
             os: ubuntu-latest
             container: "ubuntu:22.04"
             qt: 6
-          - name: Qt 6 / macOS x86_64
+          - name: Qt 6 / macOS Universal
             os: macos-14
-            arch: x86_64
+            arch: universal
             container:
             qt: 6
-          #- name: Qt 6 / macOS arm64
-          #  os: macos-latest
-          #  container:
-          #  qt: 6
           - name: Qt 6 / Windows x86_64
             os: windows-2022
             arch: win64_msvc2019_64
@@ -104,6 +96,7 @@ jobs:
           -o build PREFIX=/usr CONFIG-=debug_and_release CONFIG+=release CONFIG+=GIT
           CONFIG+=PENCIL2D_${{ startsWith(github.ref, 'refs/heads/release/') && 'RELEASE' || 'NIGHTLY' }}
           VERSION=${{ env.VERSION_NUMBER }}
+          ${{runner.os == 'macOS' && matrix.qt == 6 && 'QMAKE_APPLE_DEVICE_ARCHS="x86_64 arm64"' || ''}}
 
       - name: Build Pencil2D
         run: ${{runner.os != 'Windows' && '${BUILD_CMD} make -C build' || 'cd build; nmake'}}


### PR DESCRIPTION
Issue #1947 

The Qt6 macOS app is now universal, supports both Apple silicon and Intel mac.

The key is to use the official Qt6 SDK through aqtinstall. The Qt from homebrew just doesn't work, the arm64 build is broken as well (#1846)

Changes:
- Bump Qt6 SDK version to 6.5.3
- Install Qt through aqtinstall for macOS Qt6 build
- Configure qmake with this parameter `QMAKE_APPLE_DEVICE_ARCHS="x86_64 arm64`

Please check the universal build from my branch in the link below.
https://github.com/chchwy/pencil2d/actions/runs/20014174382

I've tested it and confirmed it works on both Apple silicon and Intel mac.

<img width="1662" height="1470" alt="圖片" src="https://github.com/user-attachments/assets/9313dea6-281d-49b8-8253-be09eda8c286" />
