### PR TITLE
#1948 Add CMake build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ Makefile*
 .moc
 moc_predefs.h
 *-pch.h.cpp
-
+app/.qm/*.qm
 Makefile
 Makefile.Debug
 Makefile.Release
@@ -80,6 +80,13 @@ ipch
 .vscode
 
 # Build directory
-build
+build/
+build-*/
 .qtc_clangd
 app/resources.pri
+
+# CMake
+CMakeCache.txt
+compile_commands.json
+cmake-build-*/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,77 @@
+cmake_minimum_required(VERSION 3.21)
+set(CMAKE_OSX_ARCHITECTURES x86_64;arm64)
+
+# Set project name and version
+project(Pencil2D
+    VERSION 0.7.0
+    DESCRIPTION "Pencil2D Animation Software"
+    LANGUAGES CXX
+)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# CMake settings
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# Options
+option(PENCIL2D_NIGHTLY "Nightly build" OFF)
+option(PENCIL2D_RELEASE "Release build" OFF)
+
+# Set version
+if(NOT DEFINED APP_VERSION)
+    set(APP_VERSION "0.0.0.0")
+endif()
+
+message(STATUS "App Version: ${APP_VERSION}")
+
+# Find Qt
+find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
+find_package(Qt6 REQUIRED COMPONENTS
+    Core
+    Widgets
+    Gui
+    Xml
+    Multimedia
+    Svg
+    Network
+    LinguistTools
+)
+
+if(WIN32)
+    # 0x0601 corresponds to Windows 7
+    add_compile_definitions(_WIN32_WINNT=0x0601)
+endif()
+
+# Global definitions
+add_compile_definitions(
+    APP_VERSION="${APP_VERSION}"
+    QT_DEPRECATED_WARNINGS
+    QT_DISABLE_DEPRECATED_UP_TO=0x050F00
+)
+
+if(PENCIL2D_NIGHTLY)
+    add_compile_definitions(PENCIL2D_NIGHTLY_BUILD)
+endif()
+
+if(PENCIL2D_RELEASE)
+    add_compile_definitions(
+        QT_NO_DEBUG_OUTPUT
+        PENCIL2D_RELEASE_BUILD
+    )
+endif()
+
+# MSVC specific flags
+if(MSVC)
+    add_compile_options(/MP)  # Multi-processor compilation
+endif()
+
+# Include subdirectories to build as single executable
+include(core_lib/core_lib.cmake)
+include(app/app.cmake)
+include(tests/tests.cmake)

--- a/app/app.cmake
+++ b/app/app.cmake
@@ -1,0 +1,334 @@
+# Application Sources  
+# This file is included by the root CMakeLists.txt
+# It combines with core_lib sources to build the main executable
+
+# Set sources
+set(APP_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/aboutdialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/actioncommands.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/addtransparencytopaperdialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/app_util.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/app-pch.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/appearance.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/basedockwidget.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/basewidget.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/bucketoptionswidget.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/buttonappearancewatcher.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/cameracontextmenu.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/cameraoptionswidget.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/camerapropertiesdialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/checkupdatesdialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorbox.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorinspector.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorpalettewidget.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorslider.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorwheel.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/commandlineexporter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/commandlineparser.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/doubleprogressdialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/elidedlabel.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/errordialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/exportimagedialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/exportmoviedialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/filedialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/filespage.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/generalpage.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/importexportdialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/importimageseqdialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/importlayersdialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/importpositiondialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/layeropacitydialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/mainwindow2.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/onionskinwidget.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/pegbaralignmentdialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/pencil2d.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/predefinedsetmodel.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/preferencesdialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/presetdialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/repositionframesdialog.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/shortcutfilter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/shortcutspage.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/spinslider.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/statusbar.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/timecontrols.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/timeline.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/timelinecells.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/strokeoptionswidget.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/timelinepage.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/titlebarwidget.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/toolbox.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/toolboxwidget.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/tooloptionwidget.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/toolspage.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/transformoptionswidget.h
+)
+
+set(APP_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/aboutdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/actioncommands.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/addtransparencytopaperdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/app_util.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/basedockwidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/basewidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/bucketoptionswidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/buttonappearancewatcher.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/cameracontextmenu.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/cameraoptionswidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/camerapropertiesdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/checkupdatesdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorbox.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorinspector.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorpalettewidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorslider.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorwheel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/commandlineexporter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/commandlineparser.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/doubleprogressdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/elidedlabel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/errordialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/exportimagedialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/exportmoviedialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/filedialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/filespage.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/generalpage.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/importexportdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/importimageseqdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/importlayersdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/importpositiondialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/layeropacitydialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/mainwindow2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/onionskinwidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/pegbaralignmentdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/pencil2d.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/predefinedsetmodel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/preferencesdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/presetdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/repositionframesdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/shortcutfilter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/shortcutspage.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/spinslider.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/statusbar.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/strokeoptionswidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/timecontrols.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/timeline.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/timelinecells.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/timelinepage.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/titlebarwidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/toolbox.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/toolboxwidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/tooloptionwidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/toolspage.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/transformoptionswidget.cpp
+)
+
+set(APP_FORMS
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/aboutdialog.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/addtransparencytopaperdialog.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/bucketoptionswidget.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/cameraoptionswidget.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/camerapropertiesdialog.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/colorinspector.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/colorpalette.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/doubleprogressdialog.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/errordialog.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/exportimageoptions.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/exportmovieoptions.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/filespage.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/generalpage.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/importexportdialog.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/importimageseqoptions.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/importimageseqpreview.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/importlayersdialog.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/importpositiondialog.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/layeropacitydialog.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/mainwindow2.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/onionskin.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/pegbaralignmentdialog.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/preferencesdialog.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/presetdialog.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/repositionframesdialog.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/shortcutspage.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/strokeoptionswidget.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/timelinepage.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/toolboxwidget.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/tooloptions.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/toolspage.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/ui/transformoptionswidget.ui
+)
+
+set(APP_RESOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/data/app.qrc
+)
+
+# Translation files
+set(APP_TRANSLATIONS
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_ar.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_bg.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_ca.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_cs.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_da.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_de.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_el.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_en.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_es.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_et.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_fa.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_fr.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_he.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_hu_HU.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_id.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_it.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_ja.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_kab.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_ko.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_nb.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_nl_NL.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_pl.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_pt_BR.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_pt.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_ru.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_sl.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_sv.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_tr.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_vi.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_yue.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_zh_CN.ts
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/pencil_zh_TW.ts
+)
+
+# Qt translation support
+qt_add_translation(QM_FILES ${APP_TRANSLATIONS})
+
+# Mirror qmake's embedded translations by generating a qrc that points
+# at the compiled .qm files and adding it to the resource list.
+set(TRANSLATIONS_QRC "${CMAKE_CURRENT_BINARY_DIR}/generated_translations.qrc")
+get_filename_component(TRANSLATIONS_QRC_DIR "${TRANSLATIONS_QRC}" DIRECTORY)
+file(MAKE_DIRECTORY "${TRANSLATIONS_QRC_DIR}")
+
+set(TRANSLATIONS_QRC_CONTENT "<RCC>\n    <qresource prefix=\"/i18n\">\n")
+foreach(QM_FILE ${QM_FILES})
+    cmake_path(CONVERT "${QM_FILE}" TO_CMAKE_PATH_LIST QM_FILE_CMAKE)
+    get_filename_component(QM_FILE_NAME "${QM_FILE}" NAME)
+    string(APPEND TRANSLATIONS_QRC_CONTENT "        <file alias=\"${QM_FILE_NAME}\">${QM_FILE_CMAKE}</file>\n")
+endforeach()
+string(APPEND TRANSLATIONS_QRC_CONTENT "    </qresource>\n</RCC>\n")
+
+file(WRITE "${TRANSLATIONS_QRC}" "${TRANSLATIONS_QRC_CONTENT}")
+set_source_files_properties(${TRANSLATIONS_QRC} PROPERTIES GENERATED TRUE)
+list(APPEND APP_RESOURCES ${TRANSLATIONS_QRC})
+
+
+# Platform-specific source files and configuration
+if(APPLE)
+    set(MACOSX_BUNDLE_ICON_FILE pencil2d.icns)
+    set(MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/app/data/Info.plist)
+    set(APP_ICON_MACOSX ${CMAKE_CURRENT_SOURCE_DIR}/app/data/pencil2d.icns
+                        ${CMAKE_CURRENT_SOURCE_DIR}/app/data/icons/mac_pcl_icon.icns
+                        ${CMAKE_CURRENT_SOURCE_DIR}/app/data/icons/mac_pclx_icon.icns)
+    set_source_files_properties(${APP_ICON_MACOSX} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
+    set(PLATFORM_SOURCES ${CORE_LIB_OBJCXX_SOURCES} ${APP_ICON_MACOSX})
+elseif(WIN32)
+    # Windows resource file - convert version "0.0.0.0" to "0,0,0,0" format
+    string(REPLACE "." "," APP_VERSION_RC "${APP_VERSION}")
+
+    set(PLATFORM_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/app/data/version.rc)
+    set_source_files_properties(
+        ${CMAKE_CURRENT_SOURCE_DIR}/app/data/version.rc
+        PROPERTIES COMPILE_DEFINITIONS "APP_VERSION_RC=${APP_VERSION_RC}"
+    )
+else()
+    set(PLATFORM_SOURCES "")
+endif()
+
+# Create executable combining core_lib and app sources
+add_executable(pencil2d
+    ${CORE_LIB_HEADERS}
+    ${CORE_LIB_SOURCES}
+    ${CORE_LIB_RESOURCES}
+    ${APP_HEADERS}
+    ${APP_SOURCES}
+    ${APP_FORMS}
+    ${APP_RESOURCES}
+    ${QM_FILES}
+    ${PLATFORM_SOURCES}
+)
+
+# Platform-specific target properties
+if(APPLE)
+    set_target_properties(pencil2d PROPERTIES
+        MACOSX_BUNDLE TRUE
+        MACOSX_BUNDLE_BUNDLE_NAME "Pencil2D"
+        MACOSX_BUNDLE_GUI_IDENTIFIER "org.pencil2d.Pencil2D"
+        MACOSX_BUNDLE_INFO_PLIST ${MACOSX_BUNDLE_INFO_PLIST}
+    )
+elseif(WIN32)
+    set_target_properties(pencil2d PROPERTIES
+        WIN32_EXECUTABLE TRUE
+    )
+endif()
+
+# Include directories - combine both core_lib and app
+target_include_directories(pencil2d PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src
+    ${CORE_LIB_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/ui
+)
+
+# Set AUTOUIC search paths for UI files
+set_target_properties(pencil2d PROPERTIES
+    AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/app/ui
+)
+
+# Link libraries
+target_link_libraries(pencil2d PRIVATE
+    Qt6::Core
+    Qt6::Widgets
+    Qt6::Gui
+    Qt6::Xml
+    Qt6::Multimedia
+    Qt6::Svg
+    Qt6::Network
+)
+
+# Platform-specific libraries
+if(APPLE)
+    target_link_libraries(pencil2d PRIVATE ${APPKIT_FRAMEWORK})
+endif()
+
+# Set precompiled header
+
+target_precompile_headers(pencil2d PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/corelib-pch.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/app-pch.h
+)
+
+# Installation
+if(UNIX AND NOT APPLE)
+    # Linux installation
+    install(TARGETS pencil2d DESTINATION bin)
+    
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/app/data/pencil2d
+            DESTINATION share/bash-completion/completions)
+    
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/app/data/_pencil2d
+            DESTINATION share/zsh/site-functions)
+    
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/app/data/org.pencil2d.Pencil2D.metainfo.xml
+            DESTINATION share/metainfo)
+    
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/app/data/org.pencil2d.Pencil2D.xml
+            DESTINATION share/mime/packages)
+    
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/app/data/org.pencil2d.Pencil2D.desktop
+            DESTINATION share/applications)
+    
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/app/data/org.pencil2d.Pencil2D.png
+            DESTINATION share/icons/hicolor/256x256/apps)
+elseif(APPLE)
+    # macOS installation
+    install(TARGETS pencil2d BUNDLE DESTINATION .)
+elseif(WIN32)
+    # Windows installation
+    install(TARGETS pencil2d DESTINATION .)
+endif()

--- a/core_lib/core_lib.cmake
+++ b/core_lib/core_lib.cmake
@@ -1,0 +1,232 @@
+# Core Library Sources
+# This file is included by the root CMakeLists.txt
+# It defines source file lists that will be compiled into the main executable
+
+# Set sources
+set(CORE_LIB_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/activeframepool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/camerapainter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/canvascursorpainter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/canvaspainter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/corelib-pch.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/external/platformhandler.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/bitmap/bitmapbucket.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/bitmap/bitmapimage.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/bitmap/tile.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/bitmap/tiledbuffer.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/vector/bezierarea.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/vector/beziercurve.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/vector/colorref.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/vector/vectorimage.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/vector/vectorselection.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/vector/vertexref.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/backgroundwidget.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/editor.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/flowlayout.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/legacybackupelement.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/recentfilemenu.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/scribblearea.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/toolboxlayout.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/undoredocommand.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/basemanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/clipboardmanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/colormanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/layermanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/overlaymanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/playbackmanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/preferencemanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/selectionmanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/soundmanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/toolmanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/undoredomanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/viewmanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/miniz.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/movieexporter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/movieimporter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/onionskinsubpainter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/overlaypainter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/qminiz.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/selectionpainter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/soundplayer.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/camera.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/filemanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/keyframe.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/layer.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/layerbitmap.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/layercamera.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/layersound.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/layervector.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/object.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/objectdata.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/pegbaraligner.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/soundclip.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/basetool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/brushtool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/buckettool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/cameratool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/erasertool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/eyedroppertool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/handtool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/movetool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/penciltool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/pentool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/polylinetool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/radialoffsettool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/selecttool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/smudgetool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/strokeinterpolator.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/stroketool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/toolproperties.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/transformtool.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/blitrect.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/cameraeasingtype.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/camerafieldoption.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/colordictionary.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/fileformat.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/filetype.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/importimageconfig.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/log.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/mathutils.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/movemode.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/onionskinpainteroptions.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/onionskinpaintstate.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/painterutils.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/pencildef.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/pencilerror.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/pencilsettings.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/pointerevent.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/preferencesdef.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/transform.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/util.h
+)
+
+set(CORE_LIB_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/activeframepool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/camerapainter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/canvascursorpainter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/canvaspainter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/bitmap/bitmapbucket.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/bitmap/bitmapimage.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/bitmap/tile.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/bitmap/tiledbuffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/vector/bezierarea.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/vector/beziercurve.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/vector/colorref.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/vector/vectorimage.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/vector/vectorselection.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/vector/vertexref.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/backgroundwidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/editor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/flowlayout.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/legacybackupelement.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/recentfilemenu.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/scribblearea.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/toolboxlayout.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface/undoredocommand.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/basemanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/clipboardmanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/colormanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/layermanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/overlaymanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/playbackmanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/preferencemanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/selectionmanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/soundmanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/toolmanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/undoredomanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers/viewmanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/miniz.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/movieexporter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/movieimporter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/onionskinsubpainter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/overlaypainter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/qminiz.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/selectionpainter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/soundplayer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/camera.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/filemanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/keyframe.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/layer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/layerbitmap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/layercamera.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/layersound.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/layervector.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/object.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/objectdata.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/pegbaraligner.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure/soundclip.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/basetool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/brushtool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/buckettool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/cameratool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/erasertool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/eyedroppertool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/handtool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/movetool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/penciltool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/pentool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/polylinetool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/radialoffsettool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/selecttool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/smudgetool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/strokeinterpolator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/stroketool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool/transformtool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/blitrect.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/cameraeasingtype.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/fileformat.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/log.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/pencilerror.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/pencilsettings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/pointerevent.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/transform.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/util.cpp
+)
+
+# Platform-specific sources
+if(WIN32)
+    list(APPEND CORE_LIB_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/external/win32/win32.cpp)
+endif()
+
+if(APPLE)
+    list(APPEND CORE_LIB_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/external/macosx/macosxnative.h)
+    list(APPEND CORE_LIB_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/external/macosx/macosx.cpp)
+    list(APPEND CORE_LIB_OBJCXX_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/external/macosx/macosxnative.mm)
+    enable_language(OBJCXX)
+endif()
+
+if(UNIX AND NOT APPLE)
+    list(APPEND CORE_LIB_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/external/linux/linux.cpp)
+endif()
+
+# Resources
+set(CORE_LIB_RESOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/data/core_lib.qrc
+)
+
+# Include directories for core library
+set(CORE_LIB_INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/bitmap
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/graphics/vector
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/interface
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/structure
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/tool
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/managers
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/external
+)
+
+# Add platform-specific include directories
+if(WIN32)
+    list(APPEND CORE_LIB_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/external/win32)
+endif()
+
+if(APPLE)
+    list(APPEND CORE_LIB_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/external/macosx)
+endif()
+
+if(UNIX AND NOT APPLE)
+    list(APPEND CORE_LIB_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/external/linux)
+endif()

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1,0 +1,64 @@
+# Tests
+# This file is included by the root CMakeLists.txt
+
+# Test sources
+set(TEST_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/catch.hpp
+)
+
+set(TEST_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_colormanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_layer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_layerbitmap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_layercamera.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_layermanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_layersound.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_layervector.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_object.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_filemanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_bitmapimage.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_bitmapbucket.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_vectorimage.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_viewmanager.cpp
+)
+
+set(TEST_RESOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/tests.qrc
+)
+
+# Create test executable with core_lib sources
+add_executable(pencil2d_tests
+    ${CORE_LIB_HEADERS}
+    ${CORE_LIB_SOURCES}
+    ${CORE_LIB_OBJCXX_SOURCES}
+    ${CORE_LIB_RESOURCES}
+    ${TEST_HEADERS}
+    ${TEST_SOURCES}
+    ${TEST_RESOURCES}
+)
+
+# Include directories
+target_include_directories(pencil2d_tests PRIVATE
+    ${CORE_LIB_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/ui
+)
+
+# Link libraries
+target_link_libraries(pencil2d_tests PRIVATE
+    Qt6::Core
+    Qt6::Widgets
+    Qt6::Gui
+    Qt6::Xml
+    Qt6::Multimedia
+    Qt6::Svg
+)
+
+# Platform-specific libraries
+if(APPLE)
+    target_link_libraries(pencil2d_tests PRIVATE ${APPKIT_FRAMEWORK})
+endif()
+
+# Enable testing
+enable_testing()
+add_test(NAME pencil2d_tests COMMAND pencil2d_tests)

--- a/util/appveyor-msvc.yml
+++ b/util/appveyor-msvc.yml
@@ -2,10 +2,9 @@
 clone_depth: 1
 
 image:
-  - Visual Studio 2019
+  - Visual Studio 2022
 
 platform:
-  - x86
   - x64
 
 skip_commits:
@@ -15,6 +14,10 @@ skip_commits:
     - util/appveyor-mingw.yml
     - /.github/*
 
+install:
+  - call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - set qt=6.5.3\msvc2019_64
+
 init:
   - ver
   - echo %PLATFORM%
@@ -22,28 +25,19 @@ init:
 before_build:
   - set QTDIR=C:\Qt\%qt%
   - set PATH=%PATH%;%QTDIR%\bin
-  - qmake --version
+  - cmake --version
 
 build_script:
   - cd
   - md build
   - cd build
-  - qmake "..\pencil2d.pro" CONFIG+=GIT CONFIG+=Release CONFIG+=PENCIL2D_NIGHTLY
-  - nmake
+  - cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%QTDIR% -DPENCIL2D_NIGHTLY=ON -DAPP_VERSION=%APPVEYOR_BUILD_VERSION%
+  - cmake --build . --config Release --parallel --target pencil2d
+  - cmake --build . --config Release --parallel --target pencil2d_tests
 
 after_build:
-  - windeployqt "%APPVEYOR_BUILD_FOLDER%\build\app\release\pencil2d.exe"
+  - windeployqt "%APPVEYOR_BUILD_FOLDER%\build\Release\pencil2d.exe"
 
 test_script:
   - echo "Running tests"
-  - tests\release\tests.exe
-
-for:
-- matrix:
-    only:
-      - image: Visual Studio 2019
-  install:
-    - if %PLATFORM%==x86   call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
-    - if %PLATFORM%==x64   call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
-    - if %PLATFORM%==x86   set qt=5.15\msvc2019
-    - if %PLATFORM%==x64   set qt=5.15\msvc2019_64
+  - ctest -C Release --output-on-failure


### PR DESCRIPTION
Issue: #1948 

Introduces CMake as a build system alongside the existing qmake setup

Changes

- `CMakeLists.txt`: Root CMake configuration file
- CMake script of each component `app/app.cmake`, `core_lib/core_lib.cmake` and `tests/tests.cmake`
- This CMake build script targets Qt6 only with C++17 standardta as requirements
- Currently, the CMake build works on AppVeyor
https://ci.appveyor.com/project/chchwy/pencil2d-chchwy-msvc/builds/53208842