### PR TITLE
Improve error handling when saving images

### DIFF
--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -21,6 +21,7 @@ GNU General Public License for more details.
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QImageWriter>
 #include <QPainterPath>
 #include "util.h"
 
@@ -706,10 +707,20 @@ void BitmapImage::drawPath(QPainterPath path, QPen pen, QBrush brush,
 
 Status BitmapImage::writeFile(const QString& filename)
 {
+    DebugDetails dd;
+    dd << "BitmapImage::writeFile";
+    dd << QString("&nbsp;&nbsp;filename = ").append(filename);
+
+    QImageWriter writer(filename);
     if (!mImage.isNull())
     {
-        bool b = mImage.save(filename);
-        return (b) ? Status::OK : Status::FAIL;
+        bool b = writer.write(mImage);
+        if (b) {
+            return Status::OK;
+        } else {
+            dd << QString("&nbsp;&nbsp;Error: %1 (Code %2)").arg(writer.errorString()).arg(static_cast<int>(writer.error()));
+            return Status(Status::FAIL, dd);
+        }
     }
 
     if (bounds().isEmpty())
@@ -719,6 +730,7 @@ Status BitmapImage::writeFile(const QString& filename)
         {
             bool b = f.remove();
             if (!b) {
+                dd << "&nbsp;&nbsp;Error: Image is empty but unable to remove file.";
                 return Status::FAIL;
             }
         }

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -88,9 +88,7 @@ Status LayerBitmap::saveKeyFrameFile(KeyFrame* keyframe, QString path)
 
         DebugDetails dd;
         dd << "LayerBitmap::saveKeyFrame";
-        dd << QString("  KeyFrame.pos() = %1").arg(keyframe->pos());
-        dd << QString("  strFilePath = %1").arg(strFilePath);
-        dd << QString("Error: Failed to save BitmapImage");
+        dd << QString("&nbsp;&nbsp;KeyFrame.pos() = %1").arg(keyframe->pos());
         dd.collect(st.details());
         return Status(Status::FAIL, dd);
     }

--- a/core_lib/src/structure/layersound.cpp
+++ b/core_lib/src/structure/layersound.cpp
@@ -141,9 +141,9 @@ Status LayerSound::saveKeyFrameFile(KeyFrame* key, QString path)
 
             DebugDetails dd;
             dd << "LayerSound::saveKeyFrameFile";
-            dd << QString("  KeyFrame.pos() = %1").arg(key->pos());
-            dd << QString("  Key->fileName() = %1").arg(key->fileName());
-            dd << QString("  FilePath = %1").arg(sDestFileLocation);
+            dd << QString("&nbsp;&nbsp;KeyFrame.pos() = %1").arg(key->pos());
+            dd << QString("&nbsp;&nbsp;Key->fileName() = %1").arg(key->fileName());
+            dd << QString("&nbsp;&nbsp;FilePath = %1").arg(sDestFileLocation);
             dd << QString("Error: Failed to save SoundClip");
             return Status(Status::FAIL, dd);
         }

--- a/core_lib/src/structure/layervector.cpp
+++ b/core_lib/src/structure/layervector.cpp
@@ -93,8 +93,8 @@ Status LayerVector::saveKeyFrameFile(KeyFrame* keyFrame, QString path)
 
         DebugDetails dd;
         dd << "LayerVector::saveKeyFrameFile";
-        dd << QString("  KeyFrame.pos() = %1").arg(keyFrame->pos());
-        dd << QString("  strFilePath = ").append(strFilePath);
+        dd << QString("&nbsp;&nbsp;KeyFrame.pos() = %1").arg(keyFrame->pos());
+        dd << QString("&nbsp;&nbsp;strFilePath = ").append(strFilePath);
         dd << "Error: Failed to save VectorImage";
         dd.collect(st.details());
         return Status(Status::FAIL, dd);

--- a/core_lib/src/structure/object.h
+++ b/core_lib/src/structure/object.h
@@ -147,10 +147,10 @@ public:
     }
 
     // these functions need to be moved to somewhere...
-    bool exportFrames(int frameStart, int frameEnd, const LayerCamera* cameraLayer, QSize exportSize, QString filePath, QString format,
+    Status exportFrames(int frameStart, int frameEnd, const LayerCamera* cameraLayer, QSize exportSize, QString filePath, QString format,
                       bool transparency, bool exportKeyframesOnly, const QString& layerName, bool antialiasing, QProgressDialog* progress, int progressMax) const;
 
-    bool exportIm(int frameStart, const QTransform& view, QSize cameraSize, QSize exportSize, const QString& filePath, const QString& format, bool antialiasing, bool transparency) const;
+    Status exportIm(int frameStart, const QTransform& view, QSize cameraSize, QSize exportSize, const QString& filePath, const QString& format, bool antialiasing, bool transparency) const;
 
     void modification() { modified = true; }
     bool isModified() const { return modified; }


### PR DESCRIPTION
This replaces `QImage::save` with `QImageWriter`, which functions the same but provides error codes and messages if the save fails. I also had to refactor some functions to return Status instead of bool to pass along this information. Some error dialogs were added to present users with that information in the event of an error. This applies to saving bitmap frames as well as exporting bitmap images/sequences.

There have been a couple user reports where the details indicate that images have failed to save, which is not very helpful without the reason *why* the images failed to save. This will provide much more insight into what could be going on if we continue to encounter issues like that.