### PR TITLE
Fix undo/redo being ignored when scrubber is on an empty frame

### DIFF
--- a/core_lib/src/interface/undoredocommand.cpp
+++ b/core_lib/src/interface/undoredocommand.cpp
@@ -218,7 +218,7 @@ BitmapReplaceCommand::BitmapReplaceCommand(const BitmapImage* undoBitmap,
     Layer* layer = editor->layers()->currentLayer();
     redoLayerId = layer->id();
     redoBitmap = *static_cast<LayerBitmap*>(layer)->
-            getBitmapImageAtFrame(editor->currentFrame());
+            getLastBitmapImageAtFrame(editor->currentFrame());
 
     setText(description);
 }
@@ -266,7 +266,7 @@ VectorReplaceCommand::VectorReplaceCommand(const VectorImage* undoVector,
     Layer* layer = editor->layers()->currentLayer();
     redoLayerId = layer->id();
     redoVector = *static_cast<LayerVector*>(layer)->
-            getVectorImageAtFrame(editor->currentFrame());
+            getLastVectorImageAtFrame(editor->currentFrame());
 
     setText(description);
 }

--- a/core_lib/src/interface/undoredocommand.cpp
+++ b/core_lib/src/interface/undoredocommand.cpp
@@ -266,7 +266,7 @@ VectorReplaceCommand::VectorReplaceCommand(const VectorImage* undoVector,
     Layer* layer = editor->layers()->currentLayer();
     redoLayerId = layer->id();
     redoVector = *static_cast<LayerVector*>(layer)->
-            getLastVectorImageAtFrame(editor->currentFrame());
+            getLastVectorImageAtFrame(editor->currentFrame(), 0);
 
     setText(description);
 }

--- a/core_lib/src/managers/undoredomanager.cpp
+++ b/core_lib/src/managers/undoredomanager.cpp
@@ -296,9 +296,10 @@ void UndoRedoManager::initCommonKeyFrameState(UndoSaveState* undoSaveState) cons
     }
 
     const int frameIndex = editor()->currentFrame();
-    if (layer->keyExists(frameIndex))
+    KeyFrame* frame = layer->getLastKeyFrameAtPosition(frameIndex);
+    if (frame)
     {
-        undoSaveState->keyframe = std::unique_ptr<KeyFrame>(layer->getLastKeyFrameAtPosition(frameIndex)->clone());
+        undoSaveState->keyframe = std::unique_ptr<KeyFrame>(frame->clone());
     }
     else if (layer->getKeyFrameWhichCovers(frameIndex) != nullptr)
     {

--- a/core_lib/src/managers/undoredomanager.cpp
+++ b/core_lib/src/managers/undoredomanager.cpp
@@ -296,14 +296,14 @@ void UndoRedoManager::initCommonKeyFrameState(UndoSaveState* undoSaveState) cons
     }
 
     const int frameIndex = editor()->currentFrame();
-    KeyFrame* frame = layer->getLastKeyFrameAtPosition(frameIndex);
-    if (frame)
+    auto keyframe = layer->getKeyFrameWhichCovers(frameIndex);
+    if (keyframe == nullptr)
     {
-        undoSaveState->keyframe = std::unique_ptr<KeyFrame>(frame->clone());
+        keyframe = layer->getLastKeyFrameAtPosition(frameIndex);
     }
-    else if (layer->getKeyFrameWhichCovers(frameIndex) != nullptr)
-    {
-        undoSaveState->keyframe = std::unique_ptr<KeyFrame>(layer->getKeyFrameWhichCovers(frameIndex)->clone());
+
+    if (keyframe != nullptr) {
+        undoSaveState->keyframe = std::unique_ptr<KeyFrame>(keyframe->clone());
     }
 }
 


### PR DESCRIPTION
Small fix for the new undo/redo system.

To reproduce:

In an empty project:
1. Ensure there's a keyframe on frame 1 and put the scrubber on frame 2
2. Draw a stroke
3. Press undo

Expected:
Stroke is undone

Actual:
Nothing happens