### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,6 @@
 name: Documentation Update
+permissions:
+  contents: read
 
 on:
   push: { branches: [ master ] }


### PR DESCRIPTION
Potential fix for [https://github.com/pencil2d/pencil/security/code-scanning/2](https://github.com/pencil2d/pencil/security/code-scanning/2)

In general, to fix this issue, the workflow must include a `permissions` block that explicitly restricts the default `GITHUB_TOKEN` permissions to the minimum required. Because this workflow only needs to read repository contents (source code) and does all write operations via a custom secret token, it can safely set `contents: read`. Adding the `permissions` block at the workflow root will apply to all jobs in this workflow.

The single best fix here is to add a root-level `permissions` section just below the `name` (and above `on:`) in `.github/workflows/docs.yml`, specifying `contents: read`. This documents that the workflow only needs read access to the repository via `GITHUB_TOKEN` and ensures that if the workflow is reused elsewhere or default permissions change, it will still run with least privilege. No other steps, imports, or logic need to change, since pushing to the docs repo already uses `secrets.docs_repo_token`.

Concretely:
- Edit `.github/workflows/docs.yml`.
- After line 1 (`name: Documentation Update`), insert:
  ```yaml
  permissions:
    contents: read
  ```
- Leave all other lines unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
