### PR TITLE
Fix: Canvas not setting focus on tablet event

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -35,6 +35,8 @@ GNU General Public License for more details.
 #include <QToolBar>
 #include <QToolButton>
 #include <QDebug>
+#include <QLineEdit>
+#include <QSpinBox>
 
 // core_lib headers
 #include "pencildef.h"
@@ -1429,6 +1431,7 @@ void MainWindow2::makeConnections(Editor* editor, ScribbleArea* scribbleArea)
     connect(editor->tools(), &ToolManager::toolChanged, mToolBox, &ToolBoxDockWidget::setActiveTool);
     connect(editor->tools(), &ToolManager::toolPropertyChanged, scribbleArea, &ScribbleArea::updateToolCursor);
 
+    connect(scribbleArea, &ScribbleArea::requestFocus, this, &MainWindow2::onFocusRequested);
 
     connect(editor->layers(), &LayerManager::currentLayerChanged, scribbleArea, &ScribbleArea::onLayerChanged);
     connect(editor->layers(), &LayerManager::layerDeleted, scribbleArea, &ScribbleArea::onLayerChanged);
@@ -1556,6 +1559,24 @@ bool MainWindow2::event(QEvent* event)
         emit windowActivated();
     }
     return QMainWindow::event(event);
+}
+
+void MainWindow2::onFocusRequested(QWidget *widget)
+{
+    ScribbleArea* scribbleArea = qobject_cast<ScribbleArea*>(widget);
+
+    QWidget* currentFocus = QApplication::focusWidget();
+
+    bool hasEditingFocus = false;
+
+    if (currentFocus) {
+        hasEditingFocus = qobject_cast<QLineEdit*>(currentFocus) ||
+                    qobject_cast<QAbstractSpinBox*>(currentFocus);
+    }
+
+    if (scribbleArea && !scribbleArea->hasFocus() && !hasEditingFocus) {
+        scribbleArea->setFocus();
+    }
 }
 
 void MainWindow2::displayMessageBox(const QString& title, const QString& body)

--- a/app/src/mainwindow2.h
+++ b/app/src/mainwindow2.h
@@ -103,6 +103,8 @@ public:
     void displayMessageBox(const QString& title, const QString& body);
     void displayMessageBoxNoTitle(const QString& body);
 
+    void onFocusRequested(QWidget* widget);
+
 signals:
     /** Emitted when window regains focus */
     void windowActivated();

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -388,6 +388,8 @@ bool ScribbleArea::event(QEvent *event)
         processed = true;
     } else if (event->type() == QEvent::Enter)
     {
+        emit requestFocus(this);
+
         processed = currentTool()->enterEvent(static_cast<QEnterEvent*>(event)) || processed;
     } else if (event->type() == QEvent::Leave)
     {
@@ -622,6 +624,10 @@ void ScribbleArea::tabletEvent(QTabletEvent *e)
     }
     else if (event.eventType() == PointerEvent::Move)
     {
+        if (!mTabletHasEntered && !hasFocus()) {
+            emit requestFocus(this);
+            mTabletHasEntered = true;
+        }
         if (!(event.buttons() & (Qt::LeftButton | Qt::RightButton)) || mTabletInUse)
         {
             pointerMoveEvent(&event);
@@ -636,6 +642,7 @@ void ScribbleArea::tabletEvent(QTabletEvent *e)
             pointerReleaseEvent(&event);
             mTabletInUse = false;
         }
+        mTabletHasEntered = false;
     }
 
 #if defined Q_OS_LINUX

--- a/core_lib/src/interface/scribblearea.h
+++ b/core_lib/src/interface/scribblearea.h
@@ -132,6 +132,8 @@ signals:
     void multiLayerOnionSkinChanged(bool);
     void selectionUpdated();
 
+    void requestFocus(QWidget* widget);
+
 public slots:
     void clearImage();
     void setCurveSmoothing(int);
@@ -243,6 +245,7 @@ private:
     QPointF mTabletPressPos;
     int mTabletReleaseMillisAgo;
     const int MOUSE_FILTER_THRESHOLD = 200;
+    bool mTabletHasEntered = false;
 
     QTimer* mMouseFilterTimer = nullptr;
 


### PR DESCRIPTION
Whenever you tap on the canvas area with a mouse, it sets the focus to the widget automatically, this is not the case with a tablet. The result of that means that when you first launch the application or when you've set the focus somewhere else, it is difficult to set the focus on ScribbleArea again.

This PR fixes that by letting scribbleArea request focus when needed from either enter or tablet events.

- Fixes an issue where the hand tool could get stuck because the focus is lost
- Fixes an issue where the hand tool doesn't trigger temporarily when using the space bar or right click on the tablet pen
- Fixes an issue where if the focus is somewhere else, tapping the canvas, does not give the focus back to scribblearea.