### PR TITLE
ColorWheel: Remove background palette

### DIFF
--- a/app/src/colorwheel.h
+++ b/app/src/colorwheel.h
@@ -54,7 +54,7 @@ private:
 
     void drawWheelImage(const QSize& newSize);
     void drawSquareImage(const int& hue);
-    void composeWheel(QPixmap& pixmap);
+    void composeWheel(QPixmap& pixmap, QRect blitRect);
 
 private:
     QSize mInitSize{ 20, 20 };


### PR DESCRIPTION
In preparations for @scribblemaniac theme manager PR, this fixes one issue where the palette of the color wheel is not in sync with the application palette (at least on macOS)

This is due to the wheel image not being invalidated when the palette is changed. Ideally we should not have to listen to the palette changing specifically though, so instead i've simply used composition to remove the background instead.