### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Build & Tests
+permissions:
+  contents: read
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/pencil2d/pencil/security/code-scanning/1](https://github.com/pencil2d/pencil/security/code-scanning/1)

In general, the problem is fixed by adding an explicit `permissions` block to the workflow (at the root or per job) that grants only the scopes required. For this CI workflow, the steps only need to read repository contents and upload artifacts; they do not need to write to the repo (no pushes, release creation, or issue/PR modifications). Therefore we can safely restrict `GITHUB_TOKEN` to read-only for `contents`, which is CodeQL’s suggested minimal starting point.

The best minimal, non-functional-change fix is to add a root-level `permissions` block just below the `name:` (or above `jobs:`), setting `contents: read`. Root-level permissions apply to all jobs unless overridden, and this workflow only defines a single job (`build`), so this is sufficient. No imports or additional definitions are needed; `permissions` is a native GitHub Actions key. The change will be confined to `.github/workflows/ci.yml`, adding the block after line 1 (or before line 16) while leaving the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
