### PR TITLE
Fixed Issue #1942 [BUG] Some modifying actions can still be performed

### DIFF
--- a/app/src/actioncommands.cpp
+++ b/app/src/actioncommands.cpp
@@ -844,12 +844,17 @@ void ActionCommands::duplicateKey()
 void ActionCommands::moveFrameForward()
 {
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer)
+    if (layer == nullptr) { return; }
+
+    // Prevent moving keyframe if the layer is not visible, as it can cause confusion to users when they don't see their keyframe move.
+    if (!layer->visible()) {
+        mEditor->getScribbleArea()->showLayerNotVisibleWarning();
+        return;
+    }
+
+    if (layer->moveKeyFrame(mEditor->currentFrame(), 1))
     {
-        if (layer->moveKeyFrame(mEditor->currentFrame(), 1))
-        {
-            mEditor->scrubForward();
-        }
+        mEditor->scrubForward();
     }
     mEditor->layers()->notifyAnimationLengthChanged();
     emit mEditor->framesModified();
@@ -858,12 +863,17 @@ void ActionCommands::moveFrameForward()
 void ActionCommands::moveFrameBackward()
 {
     Layer* layer = mEditor->layers()->currentLayer();
-    if (layer)
+    if (layer == nullptr) { return; }
+
+    // Moving keyframes on hidden layers is not allowed, as it can cause confusion. We show a warning to the user to let them know they need to unhide the layer first.
+    if (!layer->visible()) {
+        mEditor->getScribbleArea()->showLayerNotVisibleWarning();
+        return;
+    }
+
+    if (layer->moveKeyFrame(mEditor->currentFrame(), -1))
     {
-        if (layer->moveKeyFrame(mEditor->currentFrame(), -1))
-        {
-            mEditor->scrubBackward();
-        }
+        mEditor->scrubBackward();
     }
     emit mEditor->framesModified();
 }

--- a/core_lib/src/interface/editor.cpp
+++ b/core_lib/src/interface/editor.cpp
@@ -243,6 +243,12 @@ void Editor::pasteFromPreviousFrame()
         return;
     }
 
+    // Prevents pasting on an invisible layer, as this is likely a mistake and can be confusing for users, so show a warning and prevent the action
+    if (!currentLayer->visible()) {
+        mScribbleArea->showLayerNotVisibleWarning();
+        return;
+    }
+
     if (currentLayer->type() == Layer::BITMAP)
     {
         backup(tr("Paste from Previous Keyframe"));
@@ -356,6 +362,12 @@ void Editor::paste()
     Q_ASSERT(currentLayer != nullptr);
 
     if (!canPaste()) { return; }
+
+    // Prevents pasting on an invisible layer, as this is likely a mistake and can be confusing for users, so show a warning and prevent the action
+    if (!currentLayer->visible()) {
+        mScribbleArea->showLayerNotVisibleWarning();
+        return;
+    }
 
     if (clipboards()->framesIsEmpty()) {
 
@@ -806,6 +818,13 @@ void Editor::selectAll() const
     Layer* layer = layers()->currentLayer();
 
     QRectF rect;
+    
+    // Prevents Selection of an invisible layer, as this is likely a mistake and can be confusing for users, so show a warning and prevent the action
+    if (!layer->visible()) {
+        mScribbleArea->showLayerNotVisibleWarning();
+        return;
+    }
+
     if (layer->type() == Layer::BITMAP)
     {
         // Selects the drawn area (bigger or smaller than the screen). It may be more accurate to select all this way
@@ -989,6 +1008,10 @@ void Editor::switchVisibilityOfLayer(int layerNumber)
 {
     Layer* layer = mObject->getLayer(layerNumber);
     if (layer != nullptr) layer->switchVisibility();
+
+    // Deselect all to prevent confusion, as the user might have selected something on a layer that is now invisible, and this could lead to confusion
+    deselectAll();
+
     mScribbleArea->onLayerChanged();
 
     emit updateTimeLine();

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1474,6 +1474,12 @@ void ScribbleArea::clearImage()
     Layer* layer = mEditor->layers()->currentLayer();
     if (layer == nullptr) { return; }
 
+    // Clearing an invisible layer is likely a mistake, so show a warning and prevent the action
+    if (!layer->visible()) {
+        showLayerNotVisibleWarning();
+        return;
+    }
+
     if (layer->type() == Layer::VECTOR)
     {
         mEditor->backup(tr("Clear Image", "Undo step text"));

--- a/core_lib/src/structure/layer.cpp
+++ b/core_lib/src/structure/layer.cpp
@@ -238,6 +238,10 @@ void Layer::removeFromSelectionList(int position)
 
 bool Layer::moveKeyFrame(int position, int offset)
 {
+    if (!visible()) {
+        return false;
+    }
+
     int newPos = position + offset;
     if (newPos < 1) { return false; }
 

--- a/core_lib/src/tool/selecttool.cpp
+++ b/core_lib/src/tool/selecttool.cpp
@@ -216,6 +216,7 @@ bool SelectTool::maybeDeselect(const QPointF& pos)
  */
 void SelectTool::keepSelection(Layer* currentLayer)
 {
+    
     if (currentLayer->type() == Layer::VECTOR)
     {
         VectorImage* vectorImage = static_cast<LayerVector*>(currentLayer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);


### PR DESCRIPTION
Implemented validation checks for hidden layers across the Clear Frame, Select All, Paste, Paste from Previous Frame, and Move Key operations. Additionally, added an automatic deselect function when switching to a hidden layer to prevent selection artifacts.