### PR TITLE
[GUI] Color slider update and fixes

### DIFF
--- a/app/app.cmake
+++ b/app/app.cmake
@@ -21,6 +21,7 @@ set(APP_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorbox.h
     ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorinspector.h
     ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorpalettewidget.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorpreviewwidget.h
     ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorslider.h
     ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorwheel.h
     ${CMAKE_CURRENT_SOURCE_DIR}/app/src/commandlineexporter.h
@@ -79,6 +80,7 @@ set(APP_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorbox.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorinspector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorpalettewidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorpreviewwidget.h
     ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorslider.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/app/src/colorwheel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/app/src/commandlineexporter.cpp

--- a/app/app.pro
+++ b/app/app.pro
@@ -79,6 +79,7 @@ HEADERS += \
     src/basewidget.h \
     src/appearance.h \
     src/buttonappearancewatcher.h \
+    src/colorpreviewwidget.h \
     src/importlayersdialog.h \
     src/importpositiondialog.h \
     src/layeropacitydialog.h \
@@ -136,6 +137,7 @@ SOURCES += \
     src/addtransparencytopaperdialog.cpp \
     src/basewidget.cpp \
     src/buttonappearancewatcher.cpp \
+    src/colorpreviewwidget.cpp \
     src/importlayersdialog.cpp \
     src/importpositiondialog.cpp \
     src/layeropacitydialog.cpp \

--- a/app/src/colorinspector.cpp
+++ b/app/src/colorinspector.cpp
@@ -66,14 +66,6 @@ void ColorInspector::initUI()
     ui->valueSlider->init(ColorSlider::ColorSpecType::HSV, ColorSlider::ColorType::VAL, mCurrentColor, 0.0, 255.0);
     ui->hsvAlphaSlider->init(ColorSlider::ColorSpecType::HSV, ColorSlider::ColorType::ALPHA, mCurrentColor, 0.0, 255.0);
 
-    QPalette p1 = ui->colorWrapper->palette();
-    p1.setBrush(QPalette::Window, QBrush(QImage(":/background/checkerboard.png")));
-    ui->colorWrapper->setPalette(p1);
-
-    QPalette p2 = ui->color->palette();
-    p2.setColor(QPalette::Window, mCurrentColor);
-    ui->color->setPalette(p2);
-
     connect(ui->colorSpecTabWidget, &QTabWidget::currentChanged, this, &ColorInspector::onColorSpecChanged);
 
     auto onColorChangedSlider = static_cast<void(ColorInspector::*)(const QColor&)>(&ColorInspector::onColorChanged);
@@ -179,9 +171,8 @@ void ColorInspector::updateControls()
     ui->valueSpinBox->setValue(qRound(mCurrentColor.value() / 2.55));
     ui->hsvAlphaSpinBox->setValue(qRound(mCurrentColor.alpha() / 2.55));
 
-    QPalette p = ui->color->palette();
-    p.setColor(QPalette::Window, mCurrentColor);
-    ui->color->setPalette(p);
+
+    ui->colorPreview->setColor(mCurrentColor);
 
     update();
 }

--- a/app/src/colorinspector.cpp
+++ b/app/src/colorinspector.cpp
@@ -200,7 +200,9 @@ void ColorInspector::onColorSpecChanged()
     }
     else
     {
-        mCurrentColor = mCurrentColor.toHsv();
+        if (mCurrentColor.hue() != -1) {
+            mCurrentColor = mCurrentColor.toHsv();
+        }
     }
 
     updateControls();

--- a/app/src/colorinspector.cpp
+++ b/app/src/colorinspector.cpp
@@ -56,15 +56,15 @@ void ColorInspector::initUI()
     }
     onColorSpecChanged();
 
-    ui->redSlider->init(ColorSlider::ColorSpecType::RGB, ColorSlider::ColorType::RED, mCurrentColor, 0.0, 255.0);
-    ui->greenSlider->init(ColorSlider::ColorSpecType::RGB, ColorSlider::ColorType::GREEN, mCurrentColor, 0.0, 255.0);
-    ui->blueSlider->init(ColorSlider::ColorSpecType::RGB, ColorSlider::ColorType::BLUE, mCurrentColor, 0.0, 255.0);
-    ui->rgbAlphaSlider->init(ColorSlider::ColorSpecType::RGB, ColorSlider::ColorType::ALPHA, mCurrentColor, 0.0, 255.0);
+    ui->redSlider->init(ColorSlider::ColorSpecType::RGB, ColorSlider::ColorType::RED, mCurrentColor);
+    ui->greenSlider->init(ColorSlider::ColorSpecType::RGB, ColorSlider::ColorType::GREEN, mCurrentColor);
+    ui->blueSlider->init(ColorSlider::ColorSpecType::RGB, ColorSlider::ColorType::BLUE, mCurrentColor);
+    ui->rgbAlphaSlider->init(ColorSlider::ColorSpecType::RGB, ColorSlider::ColorType::ALPHA, mCurrentColor);
 
-    ui->hueSlider->init(ColorSlider::ColorSpecType::HSV, ColorSlider::ColorType::HUE, mCurrentColor, 0.0, 359.0);
-    ui->saturationSlider->init(ColorSlider::ColorSpecType::HSV, ColorSlider::ColorType::SAT, mCurrentColor, 0.0, 255.0);
-    ui->valueSlider->init(ColorSlider::ColorSpecType::HSV, ColorSlider::ColorType::VAL, mCurrentColor, 0.0, 255.0);
-    ui->hsvAlphaSlider->init(ColorSlider::ColorSpecType::HSV, ColorSlider::ColorType::ALPHA, mCurrentColor, 0.0, 255.0);
+    ui->hueSlider->init(ColorSlider::ColorSpecType::HSV, ColorSlider::ColorType::HUE, mCurrentColor);
+    ui->saturationSlider->init(ColorSlider::ColorSpecType::HSV, ColorSlider::ColorType::SAT, mCurrentColor);
+    ui->valueSlider->init(ColorSlider::ColorSpecType::HSV, ColorSlider::ColorType::VAL, mCurrentColor);
+    ui->hsvAlphaSlider->init(ColorSlider::ColorSpecType::HSV, ColorSlider::ColorType::ALPHA, mCurrentColor);
 
     connect(ui->colorSpecTabWidget, &QTabWidget::currentChanged, this, &ColorInspector::onColorSpecChanged);
 

--- a/app/src/colorpreviewwidget.cpp
+++ b/app/src/colorpreviewwidget.cpp
@@ -1,0 +1,43 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2026 Oliver Stevns Larsen
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+#include "colorpreviewwidget.h"
+
+#include <QPainter>
+#include <QPaintEvent>
+
+ColorPreviewWidget::ColorPreviewWidget(QWidget*)
+{
+
+}
+
+void ColorPreviewWidget::setColor(QColor &color)
+{
+    if (color == mColor) { return; }
+
+    mColor = color;
+    update();
+}
+
+void ColorPreviewWidget::paintEvent(QPaintEvent* event)
+{
+    QPainter painter(this);
+
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(QBrush(mCheckerboard));
+    painter.drawRect(event->rect());
+
+    painter.fillRect(event->rect(), mColor);
+}

--- a/app/src/colorpreviewwidget.cpp
+++ b/app/src/colorpreviewwidget.cpp
@@ -23,7 +23,7 @@ ColorPreviewWidget::ColorPreviewWidget(QWidget*)
 
 }
 
-void ColorPreviewWidget::setColor(QColor &color)
+void ColorPreviewWidget::setColor(const QColor& color)
 {
     if (color == mColor) { return; }
 

--- a/app/src/colorpreviewwidget.cpp
+++ b/app/src/colorpreviewwidget.cpp
@@ -18,7 +18,7 @@ GNU General Public License for more details.
 #include <QPainter>
 #include <QPaintEvent>
 
-ColorPreviewWidget::ColorPreviewWidget(QWidget*)
+ColorPreviewWidget::ColorPreviewWidget(QWidget* parent) : QWidget(parent)
 {
 
 }

--- a/app/src/colorpreviewwidget.h
+++ b/app/src/colorpreviewwidget.h
@@ -23,7 +23,7 @@ class ColorPreviewWidget: public QWidget
 {
     Q_OBJECT
 public:
-    explicit ColorPreviewWidget(QWidget* = nullptr);
+    explicit ColorPreviewWidget(QWidget* parent = nullptr);
 
     void setColor(const QColor& color);
 
@@ -31,8 +31,6 @@ protected:
      void paintEvent(QPaintEvent* event) override;
 
 private:
-
-     QPixmap mColorPreviewPixmap;
      QPixmap mCheckerboard = QPixmap(":/background/checkerboard.png");
 
      QColor mColor;

--- a/app/src/colorpreviewwidget.h
+++ b/app/src/colorpreviewwidget.h
@@ -23,9 +23,9 @@ class ColorPreviewWidget: public QWidget
 {
     Q_OBJECT
 public:
-    ColorPreviewWidget(QWidget* = nullptr);
+    explicit ColorPreviewWidget(QWidget* = nullptr);
 
-    void setColor(QColor& color);
+    void setColor(const QColor& color);
 
 protected:
      void paintEvent(QPaintEvent* event) override;

--- a/app/src/colorpreviewwidget.h
+++ b/app/src/colorpreviewwidget.h
@@ -18,6 +18,8 @@ GNU General Public License for more details.
 
 #include <QObject>
 #include <QWidget>
+#include <QColor>
+#include <QPixmap>
 
 class ColorPreviewWidget: public QWidget
 {

--- a/app/src/colorpreviewwidget.h
+++ b/app/src/colorpreviewwidget.h
@@ -1,0 +1,41 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2026 Oliver Stevns Larsen
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+#ifndef COLORPREVIEWWIDGET_H
+#define COLORPREVIEWWIDGET_H
+
+#include <QObject>
+#include <QWidget>
+
+class ColorPreviewWidget: public QWidget
+{
+    Q_OBJECT
+public:
+    ColorPreviewWidget(QWidget* = nullptr);
+
+    void setColor(QColor& color);
+
+protected:
+     void paintEvent(QPaintEvent* event) override;
+
+private:
+
+     QPixmap mColorPreviewPixmap;
+     QPixmap mCheckerboard = QPixmap(":/background/checkerboard.png");
+
+     QColor mColor;
+};
+
+#endif // COLORPREVIEWWIDGET_H

--- a/app/src/colorslider.cpp
+++ b/app/src/colorslider.cpp
@@ -21,7 +21,6 @@ GNU General Public License for more details.
 #include <QStyleOption>
 #include <QPainter>
 
-
 ColorSlider::ColorSlider(QWidget* parent) : QWidget(parent)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -43,7 +42,13 @@ void ColorSlider::init(ColorSpecType specType, ColorType type, const QColor &col
     update();
 }
 
-void ColorSlider::paintEvent(QPaintEvent *)
+void ColorSlider::setupPicker()
+{
+    QRectF sliderRect = calculatedContentsRect(contentsRect(), this->devicePixelRatioF(), mSliderStyle.borderWidth);
+    mPickerSize = QSizeF(10, sliderRect.bottom() - sliderRect.top() - mSliderStyle.borderWidth);
+}
+
+void ColorSlider::paintEvent(QPaintEvent*)
 {
     drawColorBox(mColor, size());
 
@@ -73,36 +78,36 @@ QLinearGradient ColorSlider::rgbGradient(const QColor &color)
     switch (mColorType)
     {
     case RED:
-        for (; val < mMax; val += 1)
+        for (; val <= mMax; val += 1)
         {
-            mGradient.setColorAt(val / mMax, QColor::fromRgb(val,
+            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromRgb(val,
                                                              255,
                                                              255,
                                                              color.alpha()));
         }
         break;
     case GREEN:
-        for (; val < mMax; val += 1)
+        for (; val <= mMax; val += 1)
         {
-            mGradient.setColorAt(val / mMax, QColor::fromRgb(color.red(),
+            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromRgb(color.red(),
                                                              val,
                                                              color.blue(),
                                                              color.alpha()));
         }
         break;
     case BLUE:
-        for (; val < mMax; val += 1)
+        for (; val <= mMax; val += 1)
         {
-            mGradient.setColorAt(val / mMax, QColor::fromRgb(color.red(),
+            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromRgb(color.red(),
                                                              color.green(),
                                                              val,
                                                              color.alpha()));
         }
         break;
     case ALPHA:
-        for (; val < mMax; val += 1)
+        for (; val <= mMax; val += 1)
         {
-            mGradient.setColorAt(val / mMax, QColor::fromRgb(0,
+            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromRgb(0,
                                                              0,
                                                              0,
                                                              val));
@@ -120,36 +125,36 @@ QLinearGradient ColorSlider::hsvGradient(const QColor &color)
     switch (mColorType)
     {
     case HUE:
-        for (; val < mMax; val += 1)
+        for (; val <= mMax; val += 1)
         {
-            mGradient.setColorAt(val / mMax, QColor::fromHsv(val,
+            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromHsv(val,
                                                              255,
                                                              255,
                                                              color.alpha()));
         }
         break;
     case SAT:
-        for (; val < mMax; val += 1)
+        for (; val <= mMax; val += 1)
         {
-            mGradient.setColorAt(val / mMax, QColor::fromHsv(color.hsvHue(),
+            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromHsv(color.hsvHue(),
                                                              val,
                                                              color.value(),
                                                              color.alpha()));
         }
         break;
     case VAL:
-        for (; val < mMax; val += 1)
+        for (; val <= mMax; val += 1)
         {
-            mGradient.setColorAt(val / mMax, QColor::fromHsv(color.hsvHue(),
+            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromHsv(color.hsvHue(),
                                                              color.hsvSaturation(),
                                                              val,
                                                              color.alpha()));
         }
         break;
     case ALPHA:
-        for (; val < mMax; val += 1)
+        for (; val <= mMax; val += 1)
         {
-            mGradient.setColorAt(val / mMax, QColor::fromHsv(0,
+            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromHsv(0,
                                                              0,
                                                              0,
                                                              val));
@@ -161,6 +166,32 @@ QLinearGradient ColorSlider::hsvGradient(const QColor &color)
     return mGradient;
 }
 
+void ColorSlider::setRgb(const QColor &rgb)
+{
+    mColor.setRgb(rgb.red(),
+                  rgb.green(),
+                  rgb.blue(),
+                  rgb.alpha());
+
+    mPixmapCacheInvalid = true;
+}
+
+void ColorSlider::setHsv(const QColor &hsv)
+{
+    mColor.setHsv(hsv.hsvHue(),
+                  hsv.hsvSaturation(),
+                  hsv.value(),
+                  hsv.alpha());
+
+    mPixmapCacheInvalid = true;
+}
+
+void ColorSlider::resizeEvent(QResizeEvent*)
+{
+    mPixmapCacheInvalid = true;
+    update();
+}
+
 void ColorSlider::drawColorBox(const QColor &color, QSize size)
 {
     QStyleOption option;
@@ -168,58 +199,27 @@ void ColorSlider::drawColorBox(const QColor &color, QSize size)
 
     QBrush backgroundBrush = option.palette.window();
 
-    mBoxPixmapSource = QPixmap(size);
+    if (mPixmapCacheInvalid) {
+        setupPicker();
 
-    QPainter painter(&mBoxPixmapSource);
-    painter.setRenderHint(QPainter::Antialiasing);
+        QRectF sliderRect = calculatedContentsRect(contentsRect(), devicePixelRatioF(), mSliderStyle.borderWidth);
+        mBoxPixmapSource = QPixmap(size * devicePixelRatio());
+        mBoxPixmapSource.setDevicePixelRatio(devicePixelRatioF());
+        mBoxPixmapSource.fill(Qt::transparent);
+        mPixmapCacheInvalid = false;
 
-    painter.fillRect(mBoxPixmapSource.rect(), backgroundBrush);
+        mGradient = QLinearGradient(0,0,sliderRect.width(),0);
+        mGradient = setColorSpec(color);
 
-    mGradient = QLinearGradient(0,0,mBoxPixmapSource.width(),0);
-    mGradient = setColorSpec(color);
+        QPainter painter(&mBoxPixmapSource);
 
-    painter.end();
+        mSliderStyle.customFill = QBrush(mCheckerboardPixmap);
+        drawSliderStyle(painter, sliderRect, mSliderStyle, option.palette);
 
-    // draw checkerboard background
-    painter.begin(&mBoxPixmapSource);
-    QBrush brush2(QBrush(QPixmap(":icons/general/checkerboard_smaller.png")));
-
-    painter.setBrush(brush2);
-    QPen pen2;
-    pen2.setWidthF(0);
-    pen2.setColor(Qt::gray);
-    pen2.setCosmetic(false);
-    painter.setPen(pen2);
-    painter.drawRoundedRect(0,
-                            0,
-                            mBoxPixmapSource.width(),
-                            mBoxPixmapSource.height(),
-                            4,
-                            mBoxPixmapSource.width(),
-                            Qt::SizeMode::AbsoluteSize);
-
-    painter.end();
-
-    painter.begin(&mBoxPixmapSource);
-    painter.setRenderHint(QPainter::Antialiasing);
-
-    QBrush brush(mGradient);
-    QPen pen;
-    pen.setWidthF(0);
-    pen.setColor(Qt::gray);
-    pen.setCosmetic(false);
-    painter.setPen(pen);
-
-    painter.setBrush(brush);
-
-    painter.drawRoundedRect(0,
-                            0,
-                            mBoxPixmapSource.width(),
-                            mBoxPixmapSource.height(),
-                            4,
-                            mBoxPixmapSource.width(),
-                            Qt::SizeMode::AbsoluteSize);
-    painter.end();
+        QBrush brush(mGradient);
+        mSliderStyle.customFill = brush;
+        drawSliderStyle(painter, sliderRect, mSliderStyle, option.palette);
+    }
 }
 
 QSize ColorSlider::sizeHint() const
@@ -241,11 +241,11 @@ void ColorSlider::drawPicker(const QColor &color)
 {
     QPainter painter(this);
     qreal val = 0;
-    QSize mPickerSize = QSize(10, this->height() - 1);
 
-    QPen pen;
-    pen.setWidth(0);
-    pen.setColor(QColor(0, 0, 0, 255));
+    QRectF sliderRect = calculatedContentsRect(contentsRect(), devicePixelRatioF(), mSliderStyle.borderWidth);
+
+    qreal padding = (mSliderStyle.borderWidth * 2);
+    qreal pickerDiff = sliderRect.width() - padding - mPickerSize.width();
 
     switch (mSpecType)
     {
@@ -253,21 +253,13 @@ void ColorSlider::drawPicker(const QColor &color)
         switch (mColorType)
         {
         case HUE:
-            val = color.hsvHueF() * (mBoxPixmapSource.width() - mPickerSize.width());
+            val = color.hsvHueF();
             break;
         case SAT:
-            if ((color.hsvSaturation() > 127 || color.value() < 127) && color.alpha() > 127)
-            {
-                pen.setColor(Qt::white);
-            }
-            val = color.hsvSaturationF() * (mBoxPixmapSource.width() - mPickerSize.width());
+            val = color.hsvSaturationF();
             break;
         case VAL:
-            if (color.value() < 127 && color.alpha() > 127)
-            {
-                pen.setColor(Qt::white);
-            }
-            val = color.valueF() * (mBoxPixmapSource.width() - mPickerSize.width());
+            val = color.valueF();
             break;
         case ALPHA:
             break;
@@ -279,21 +271,13 @@ void ColorSlider::drawPicker(const QColor &color)
         switch (mColorType)
         {
         case RED:
-            val = color.redF() * (mBoxPixmapSource.width() - mPickerSize.width());
+            val = color.redF();
             break;
         case GREEN:
-            if (color.alpha() > 127)
-            {
-                pen.setColor(Qt::white);
-            }
-            val = color.greenF() * (mBoxPixmapSource.width() - mPickerSize.width());
+            val = color.greenF();
             break;
         case BLUE:
-            if (color.alpha() > 127)
-            {
-                pen.setColor(Qt::white);
-            }
-            val = color.blueF() * (mBoxPixmapSource.width() - mPickerSize.width());
+            val = color.blueF();
             break;
         case ALPHA:
             break;
@@ -306,24 +290,46 @@ void ColorSlider::drawPicker(const QColor &color)
     }
     if (mColorType == ALPHA)
     {
-        if (color.alpha() > 127)
-        {
-            pen.setColor(Qt::white);
-        }
-        val = color.alphaF() * (mBoxPixmapSource.width() - mPickerSize.width());
+        val = color.alphaF();
     }
 
+    val = static_cast<int>(sliderRect.left() + mSliderStyle.borderWidth + qMax(mMin, (val * pickerDiff)));
+
+    QPen pen;
+    pen.setJoinStyle(Qt::MiterJoin);
+    pen.setWidthF(mSliderStyle.borderWidth);
+    pen.setColor(QColor(0, 0, 0, 255));
+
+    painter.setRenderHint(QPainter::Antialiasing);
     painter.setPen(pen);
-    painter.drawRect(static_cast<int>(val), 0, mPickerSize.width(), mPickerSize.height());
-    painter.end();
+
+    QRectF outerRect = QRectF(val,
+                              sliderRect.top() + mSliderStyle.borderWidth,
+                              mPickerSize.width(),
+                              mPickerSize.height() - mSliderStyle.borderWidth);
+    painter.drawRoundedRect(outerRect,
+                            mSliderStyle.cachedCornerRadiusX,
+                            mSliderStyle.cachedCornerRadiusY,
+                            Qt::AbsoluteSize);
+
+    painter.setPen(palette().dark().color());
+    painter.drawRoundedRect(outerRect.adjusted(
+                                mSliderStyle.borderWidth,
+                                mSliderStyle.borderWidth,
+                                -mSliderStyle.borderWidth,
+                                -mSliderStyle.borderWidth),
+                            innerCornerRadius(mSliderStyle.cachedCornerRadiusX, mSliderStyle.borderWidth),
+                            innerCornerRadius(mSliderStyle.cachedCornerRadiusY, mSliderStyle.borderWidth),
+                            Qt::AbsoluteSize);
 }
 
 void ColorSlider::colorPicked(QPoint point)
 {
+    QRectF sliderRect = calculatedContentsRect(contentsRect(), devicePixelRatioF(), mSliderStyle.borderWidth);
     QColor colorPicked = mColor;
     int colorMax = static_cast<int>(mMax);
 
-    int colorVal = point.x() * colorMax / mBoxPixmapSource.width();
+    int colorVal = (point.x() - (mPickerSize.width() * 0.5)) * colorMax / (sliderRect.right() - (mPickerSize.width()));
 
     colorVal = (colorVal > colorMax) ? colorMax : colorVal;
     colorVal = (colorVal < 0) ? 0 : colorVal;
@@ -415,6 +421,9 @@ void ColorSlider::colorPicked(QPoint point)
     default:
         Q_UNREACHABLE();
     }
+
     mColor = colorPicked;
+    mPixmapCacheInvalid = true;
+
     emit valueChanged(mColor);
 }

--- a/app/src/colorslider.cpp
+++ b/app/src/colorslider.cpp
@@ -93,11 +93,11 @@ QLinearGradient ColorSlider::setColorSpec(const QColor &color)
 QLinearGradient ColorSlider::rgbGradient(const QColor &color)
 {
     int val = 0;
-    int max = colorSteps();
+    int max = colorTypeMax();
     switch (mColorType)
     {
     case RED:
-        for (; val < max; val += 1)
+        for (; val <= max; val += 1)
         {
             mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromRgb(val,
                                                              255,
@@ -106,7 +106,7 @@ QLinearGradient ColorSlider::rgbGradient(const QColor &color)
         }
         break;
     case GREEN:
-        for (; val < max; val += 1)
+        for (; val <= max; val += 1)
         {
             mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromRgb(color.red(),
                                                              val,
@@ -115,7 +115,7 @@ QLinearGradient ColorSlider::rgbGradient(const QColor &color)
         }
         break;
     case BLUE:
-        for (; val < max; val += 1)
+        for (; val <= max; val += 1)
         {
             mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromRgb(color.red(),
                                                              color.green(),
@@ -124,7 +124,7 @@ QLinearGradient ColorSlider::rgbGradient(const QColor &color)
         }
         break;
     case ALPHA:
-        for (; val < max; val += 1)
+        for (; val <= max; val += 1)
         {
             mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromRgb(0,
                                                              0,
@@ -141,11 +141,11 @@ QLinearGradient ColorSlider::rgbGradient(const QColor &color)
 QLinearGradient ColorSlider::hsvGradient(const QColor &color)
 {
     int val = 0;
-    int max = colorSteps();
+    int max = colorTypeMax();
     switch (mColorType)
     {
     case HUE:
-        for (; val < max; val += 1)
+        for (; val <= max; val += 1)
         {
             mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromHsv(val,
                                                              255,
@@ -154,7 +154,7 @@ QLinearGradient ColorSlider::hsvGradient(const QColor &color)
         }
         break;
     case SAT:
-        for (; val < max; val += 1)
+        for (; val <= max; val += 1)
         {
             mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromHsv(color.hsvHue(),
                                                              val,
@@ -163,7 +163,7 @@ QLinearGradient ColorSlider::hsvGradient(const QColor &color)
         }
         break;
     case VAL:
-        for (; val < max; val += 1)
+        for (; val <= max; val += 1)
         {
             mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromHsv(color.hsvHue(),
                                                              color.hsvSaturation(),
@@ -172,7 +172,7 @@ QLinearGradient ColorSlider::hsvGradient(const QColor &color)
         }
         break;
     case ALPHA:
-        for (; val < max; val += 1)
+        for (; val <= max; val += 1)
         {
             mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromHsv(0,
                                                              0,

--- a/app/src/colorslider.cpp
+++ b/app/src/colorslider.cpp
@@ -44,7 +44,7 @@ void ColorSlider::init(ColorSpecType specType, ColorType type, const QColor &col
 
 void ColorSlider::setupPicker()
 {
-    QRectF sliderRect = SliderGeometry::contentsRect(contentsRect(), this->devicePixelRatioF(), mSliderStyle.borderWidth);
+    QRectF sliderRect = SliderGeometry::contentsRect(contentsRect(), mSliderStyle.borderWidth);
     mPickerSize = QSizeF(10, sliderRect.bottom() - sliderRect.top() - mSliderStyle.borderWidth);
 }
 
@@ -202,7 +202,7 @@ void ColorSlider::drawColorBox(const QColor &color, QSize size)
     if (mPixmapCacheInvalid) {
         setupPicker();
 
-        QRectF sliderRect = SliderGeometry::contentsRect(contentsRect(), devicePixelRatioF(), mSliderStyle.borderWidth);
+        QRectF sliderRect = SliderGeometry::contentsRect(contentsRect(), mSliderStyle.borderWidth);
         mBoxPixmapSource = QPixmap(size * devicePixelRatio());
         mBoxPixmapSource.setDevicePixelRatio(devicePixelRatioF());
         mBoxPixmapSource.fill(Qt::transparent);
@@ -242,10 +242,10 @@ void ColorSlider::drawPicker(const QColor &color)
     QPainter painter(this);
     qreal val = 0;
 
-    QRectF sliderRect = SliderGeometry::contentsRect(contentsRect(), devicePixelRatioF(), mSliderStyle.borderWidth);
-
-    qreal padding = (mSliderStyle.borderWidth * 2);
-    qreal pickerDiff = sliderRect.width() - padding - mPickerSize.width();
+    const qreal borderWidth = mSliderStyle.borderWidth;
+    const qreal inset = SliderGeometry::penStrokeInset(borderWidth);
+    const QRectF innerSliderRect = SliderGeometry::contentsRect(contentsRect(), borderWidth)
+                             .adjusted(borderWidth, borderWidth, -borderWidth, -borderWidth);
 
     switch (mSpecType)
     {
@@ -293,27 +293,35 @@ void ColorSlider::drawPicker(const QColor &color)
         val = color.alphaF();
     }
 
-    val = static_cast<int>(sliderRect.left() + mSliderStyle.borderWidth + qMax(mMin, (val * pickerDiff)));
+    const qreal pickerMaxXPos = innerSliderRect.width() - mPickerSize.width();
+    val = static_cast<int>(innerSliderRect.left() + qMax(mMin, (val * pickerMaxXPos))) + inset;
 
-    QPen pen;
-    pen.setJoinStyle(Qt::MiterJoin);
-    pen.setWidthF(mSliderStyle.borderWidth);
-    pen.setColor(QColor(0, 0, 0, 255));
+    QPen ounterPen;
+    ounterPen.setJoinStyle(Qt::MiterJoin);
+    ounterPen.setWidthF(mSliderStyle.borderWidth);
+    ounterPen.setColor(QColor(0, 0, 0, 255));
 
     painter.setRenderHint(QPainter::Antialiasing);
-    painter.setPen(pen);
+    painter.setPen(ounterPen);
 
-    QRectF outerRect = QRectF(val,
-                              sliderRect.top() + mSliderStyle.borderWidth,
+    QRectF pickerOuterRect = QRectF(val,
+                              innerSliderRect.top(),
                               mPickerSize.width(),
-                              mPickerSize.height() - mSliderStyle.borderWidth);
-    painter.drawRoundedRect(outerRect,
+                              innerSliderRect.height());
+
+    painter.drawRoundedRect(pickerOuterRect,
                             mSliderStyle.cachedCornerRadiusX,
                             mSliderStyle.cachedCornerRadiusY,
                             Qt::AbsoluteSize);
 
-    painter.setPen(palette().dark().color());
-    painter.drawRoundedRect(outerRect.adjusted(
+    QPen innerPen;
+    innerPen.setJoinStyle(Qt::MiterJoin);
+    innerPen.setWidthF(mSliderStyle.borderWidth);
+    innerPen.setColor(palette().dark().color());
+    painter.setPen(innerPen);
+
+    // Draw inner picker
+    painter.drawRoundedRect(pickerOuterRect.adjusted(
                                 mSliderStyle.borderWidth,
                                 mSliderStyle.borderWidth,
                                 -mSliderStyle.borderWidth,
@@ -325,7 +333,7 @@ void ColorSlider::drawPicker(const QColor &color)
 
 void ColorSlider::colorPicked(QPoint point)
 {
-    QRectF sliderRect = SliderGeometry::contentsRect(contentsRect(), devicePixelRatioF(), mSliderStyle.borderWidth);
+    QRectF sliderRect = SliderGeometry::contentsRect(contentsRect(), mSliderStyle.borderWidth);
     QColor colorPicked = mColor;
     int colorMax = static_cast<int>(mMax);
 

--- a/app/src/colorslider.cpp
+++ b/app/src/colorslider.cpp
@@ -217,8 +217,6 @@ void ColorSlider::drawColorBox(const QColor &color, QSize size)
     QStyleOption option;
     option.initFrom(this);
 
-    QBrush backgroundBrush = option.palette.window();
-
     if (mPixmapCacheInvalid) {
         setupPicker();
 
@@ -316,13 +314,13 @@ void ColorSlider::drawPicker(const QColor &color)
     const qreal maxDistance = SliderGeometry::pickerMaxDistance(innerSliderRect.width(), mPickerSize.width());
     val = static_cast<int>(innerSliderRect.left() + qMax(static_cast<qreal>(mMin), (val * maxDistance))) + inset;
 
-    QPen ounterPen;
-    ounterPen.setJoinStyle(Qt::MiterJoin);
-    ounterPen.setWidthF(mSliderStyle.borderWidth);
-    ounterPen.setColor(QColor(0, 0, 0, 255));
+    QPen outerPen;
+    outerPen.setJoinStyle(Qt::MiterJoin);
+    outerPen.setWidthF(mSliderStyle.borderWidth);
+    outerPen.setColor(QColor(0, 0, 0, 255));
 
     painter.setRenderHint(QPainter::Antialiasing);
-    painter.setPen(ounterPen);
+    painter.setPen(outerPen);
 
     QRectF pickerOuterRect = QRectF(val,
                               innerSliderRect.top(),

--- a/app/src/colorslider.cpp
+++ b/app/src/colorslider.cpp
@@ -31,10 +31,8 @@ ColorSlider::~ColorSlider()
 
 }
 
-void ColorSlider::init(ColorSpecType specType, ColorType type, const QColor &color, qreal min, qreal max)
+void ColorSlider::init(ColorSpecType specType, ColorType type, const QColor &color)
 {
-    mMin = min;
-    mMax = max;
     mColor = color;
     mColorType = type;
     mSpecType = specType;
@@ -48,15 +46,35 @@ void ColorSlider::setupPicker()
     mPickerSize = QSizeF(10, sliderRect.bottom() - sliderRect.top() - mSliderStyle.borderWidth);
 }
 
-void ColorSlider::paintEvent(QPaintEvent*)
+void ColorSlider::paintEvent(QPaintEvent* event)
 {
-    drawColorBox(mColor, size());
+    drawColorBox(mColor, event->rect().size());
 
     QPainter painter(this);
     painter.drawPixmap(0, 0, mBoxPixmapSource);
     painter.end();
 
     drawPicker(mColor);
+}
+
+int ColorSlider::colorTypeMax() const
+{
+    switch (mColorType)
+    {
+        case HUE: return 359;
+        case RED:
+        case GREEN:
+        case BLUE:
+        case SAT:
+        case VAL:
+        case ALPHA: return 255;
+        default: Q_UNREACHABLE();
+    }
+}
+
+int ColorSlider::colorSteps() const
+{
+    return colorTypeMax() + 1;
 }
 
 QLinearGradient ColorSlider::setColorSpec(const QColor &color)
@@ -75,39 +93,40 @@ QLinearGradient ColorSlider::setColorSpec(const QColor &color)
 QLinearGradient ColorSlider::rgbGradient(const QColor &color)
 {
     int val = 0;
+    int max = colorSteps();
     switch (mColorType)
     {
     case RED:
-        for (; val <= mMax; val += 1)
+        for (; val < max; val += 1)
         {
-            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromRgb(val,
+            mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromRgb(val,
                                                              255,
                                                              255,
                                                              color.alpha()));
         }
         break;
     case GREEN:
-        for (; val <= mMax; val += 1)
+        for (; val < max; val += 1)
         {
-            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromRgb(color.red(),
+            mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromRgb(color.red(),
                                                              val,
                                                              color.blue(),
                                                              color.alpha()));
         }
         break;
     case BLUE:
-        for (; val <= mMax; val += 1)
+        for (; val < max; val += 1)
         {
-            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromRgb(color.red(),
+            mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromRgb(color.red(),
                                                              color.green(),
                                                              val,
                                                              color.alpha()));
         }
         break;
     case ALPHA:
-        for (; val <= mMax; val += 1)
+        for (; val < max; val += 1)
         {
-            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromRgb(0,
+            mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromRgb(0,
                                                              0,
                                                              0,
                                                              val));
@@ -122,39 +141,40 @@ QLinearGradient ColorSlider::rgbGradient(const QColor &color)
 QLinearGradient ColorSlider::hsvGradient(const QColor &color)
 {
     int val = 0;
+    int max = colorSteps();
     switch (mColorType)
     {
     case HUE:
-        for (; val <= mMax; val += 1)
+        for (; val < max; val += 1)
         {
-            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromHsv(val,
+            mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromHsv(val,
                                                              255,
                                                              255,
                                                              color.alpha()));
         }
         break;
     case SAT:
-        for (; val <= mMax; val += 1)
+        for (; val < max; val += 1)
         {
-            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromHsv(color.hsvHue(),
+            mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromHsv(color.hsvHue(),
                                                              val,
                                                              color.value(),
                                                              color.alpha()));
         }
         break;
     case VAL:
-        for (; val <= mMax; val += 1)
+        for (; val < max; val += 1)
         {
-            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromHsv(color.hsvHue(),
+            mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromHsv(color.hsvHue(),
                                                              color.hsvSaturation(),
                                                              val,
                                                              color.alpha()));
         }
         break;
     case ALPHA:
-        for (; val <= mMax; val += 1)
+        for (; val < max; val += 1)
         {
-            mGradient.setColorAt(static_cast<qreal>(val) / mMax, QColor::fromHsv(0,
+            mGradient.setColorAt(static_cast<qreal>(val) / max, QColor::fromHsv(0,
                                                              0,
                                                              0,
                                                              val));
@@ -293,8 +313,8 @@ void ColorSlider::drawPicker(const QColor &color)
         val = color.alphaF();
     }
 
-    const qreal pickerMaxXPos = innerSliderRect.width() - mPickerSize.width();
-    val = static_cast<int>(innerSliderRect.left() + qMax(mMin, (val * pickerMaxXPos))) + inset;
+    const qreal maxDistance = SliderGeometry::pickerMaxDistance(innerSliderRect.width(), mPickerSize.width());
+    val = static_cast<int>(innerSliderRect.left() + qMax(static_cast<qreal>(mMin), (val * maxDistance))) + inset;
 
     QPen ounterPen;
     ounterPen.setJoinStyle(Qt::MiterJoin);
@@ -333,14 +353,18 @@ void ColorSlider::drawPicker(const QColor &color)
 
 void ColorSlider::colorPicked(QPoint point)
 {
-    QRectF sliderRect = SliderGeometry::contentsRect(contentsRect(), mSliderStyle.borderWidth);
+    qreal borderWidth = mSliderStyle.borderWidth;
+    QRectF innerSliderRect = SliderGeometry::contentsRect(contentsRect(), borderWidth)
+                        .adjusted(borderWidth,
+                                  borderWidth,
+                                  -borderWidth,
+                                  -borderWidth);
     QColor colorPicked = mColor;
-    int colorMax = static_cast<int>(mMax);
+    int colorMax = colorTypeMax();
 
-    int colorVal = (point.x() - (mPickerSize.width() * 0.5)) * colorMax / (sliderRect.right() - (mPickerSize.width()));
-
-    colorVal = (colorVal > colorMax) ? colorMax : colorVal;
-    colorVal = (colorVal < 0) ? 0 : colorVal;
+    qreal pickerCenter = mPickerSize.width() * 0.5;
+    int colorVal = (point.x() - pickerCenter) * colorSteps() / SliderGeometry::pickerMaxDistance(innerSliderRect.width(), mPickerSize.width());
+    colorVal = qBound(mMin, colorVal, colorMax);
 
     switch (mSpecType)
     {

--- a/app/src/colorslider.cpp
+++ b/app/src/colorslider.cpp
@@ -44,7 +44,7 @@ void ColorSlider::init(ColorSpecType specType, ColorType type, const QColor &col
 
 void ColorSlider::setupPicker()
 {
-    QRectF sliderRect = calculatedContentsRect(contentsRect(), this->devicePixelRatioF(), mSliderStyle.borderWidth);
+    QRectF sliderRect = SliderGeometry::contentsRect(contentsRect(), this->devicePixelRatioF(), mSliderStyle.borderWidth);
     mPickerSize = QSizeF(10, sliderRect.bottom() - sliderRect.top() - mSliderStyle.borderWidth);
 }
 
@@ -202,7 +202,7 @@ void ColorSlider::drawColorBox(const QColor &color, QSize size)
     if (mPixmapCacheInvalid) {
         setupPicker();
 
-        QRectF sliderRect = calculatedContentsRect(contentsRect(), devicePixelRatioF(), mSliderStyle.borderWidth);
+        QRectF sliderRect = SliderGeometry::contentsRect(contentsRect(), devicePixelRatioF(), mSliderStyle.borderWidth);
         mBoxPixmapSource = QPixmap(size * devicePixelRatio());
         mBoxPixmapSource.setDevicePixelRatio(devicePixelRatioF());
         mBoxPixmapSource.fill(Qt::transparent);
@@ -214,11 +214,11 @@ void ColorSlider::drawColorBox(const QColor &color, QSize size)
         QPainter painter(&mBoxPixmapSource);
 
         mSliderStyle.customFill = QBrush(mCheckerboardPixmap);
-        drawSliderStyle(painter, sliderRect, mSliderStyle, option.palette);
+        SliderPainter::drawSliderStyle(painter, sliderRect, mSliderStyle, option.palette);
 
         QBrush brush(mGradient);
         mSliderStyle.customFill = brush;
-        drawSliderStyle(painter, sliderRect, mSliderStyle, option.palette);
+        SliderPainter::drawSliderStyle(painter, sliderRect, mSliderStyle, option.palette);
     }
 }
 
@@ -242,7 +242,7 @@ void ColorSlider::drawPicker(const QColor &color)
     QPainter painter(this);
     qreal val = 0;
 
-    QRectF sliderRect = calculatedContentsRect(contentsRect(), devicePixelRatioF(), mSliderStyle.borderWidth);
+    QRectF sliderRect = SliderGeometry::contentsRect(contentsRect(), devicePixelRatioF(), mSliderStyle.borderWidth);
 
     qreal padding = (mSliderStyle.borderWidth * 2);
     qreal pickerDiff = sliderRect.width() - padding - mPickerSize.width();
@@ -318,14 +318,14 @@ void ColorSlider::drawPicker(const QColor &color)
                                 mSliderStyle.borderWidth,
                                 -mSliderStyle.borderWidth,
                                 -mSliderStyle.borderWidth),
-                            innerCornerRadius(mSliderStyle.cachedCornerRadiusX, mSliderStyle.borderWidth),
-                            innerCornerRadius(mSliderStyle.cachedCornerRadiusY, mSliderStyle.borderWidth),
+                            SliderGeometry::innerCornerRadius(mSliderStyle.cachedCornerRadiusX, mSliderStyle.borderWidth),
+                            SliderGeometry::innerCornerRadius(mSliderStyle.cachedCornerRadiusY, mSliderStyle.borderWidth),
                             Qt::AbsoluteSize);
 }
 
 void ColorSlider::colorPicked(QPoint point)
 {
-    QRectF sliderRect = calculatedContentsRect(contentsRect(), devicePixelRatioF(), mSliderStyle.borderWidth);
+    QRectF sliderRect = SliderGeometry::contentsRect(contentsRect(), devicePixelRatioF(), mSliderStyle.borderWidth);
     QColor colorPicked = mColor;
     int colorMax = static_cast<int>(mMax);
 

--- a/app/src/colorslider.cpp
+++ b/app/src/colorslider.cpp
@@ -311,7 +311,7 @@ void ColorSlider::drawPicker(const QColor &color)
         val = color.alphaF();
     }
 
-    const qreal maxDistance = SliderGeometry::pickerMaxDistance(innerSliderRect.width(), mPickerSize.width());
+    const qreal maxDistance = SliderGeometry::pickerUpperBound(innerSliderRect.width(), mPickerSize.width());
     val = static_cast<int>(innerSliderRect.left() + qMax(static_cast<qreal>(mMin), (val * maxDistance))) + inset;
 
     QPen outerPen;
@@ -361,7 +361,7 @@ void ColorSlider::colorPicked(QPoint point)
     int colorMax = colorTypeMax();
 
     qreal pickerCenter = mPickerSize.width() * 0.5;
-    int colorVal = (point.x() - pickerCenter) * colorSteps() / SliderGeometry::pickerMaxDistance(innerSliderRect.width(), mPickerSize.width());
+    int colorVal = (point.x() - pickerCenter) * colorSteps() / SliderGeometry::pickerUpperBound(innerSliderRect.width(), mPickerSize.width());
     colorVal = qBound(mMin, colorVal, colorMax);
 
     switch (mSpecType)

--- a/app/src/colorslider.h
+++ b/app/src/colorslider.h
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #include <QWidget>
 
 #include "drawsliderstyle.h"
+#include "slidergeometry.h"
 
 class ColorSlider : public QWidget
 {

--- a/app/src/colorslider.h
+++ b/app/src/colorslider.h
@@ -96,11 +96,11 @@ private:
 
     QLinearGradient mGradient;
 
-    SliderPainterStyle mSliderStyle {
-        .strokeRole = QPalette::Dark,
-        .hasCustomFill = true,
-        .customFill = QBrush(QPixmap(":icons/general/checkerboard_smaller.png")),
-    };
+    SliderPainterStyle mSliderStyle = SliderPainterStyle(
+        QPalette::Dark,
+        true,
+        QBrush(QPixmap(":icons/general/checkerboard_smaller.png"))
+    );
 
     QPixmap mCheckerboardPixmap = QPixmap(":icons/general/checkerboard_smaller.png");
 };

--- a/app/src/colorslider.h
+++ b/app/src/colorslider.h
@@ -97,9 +97,9 @@ private:
     QLinearGradient mGradient;
 
     SliderPainterStyle mSliderStyle {
+        .strokeRole = QPalette::Dark,
         .hasCustomFill = true,
         .customFill = QBrush(QPixmap(":icons/general/checkerboard_smaller.png")),
-        .strokeRole = QPalette::Dark,
     };
 
     QPixmap mCheckerboardPixmap = QPixmap(":icons/general/checkerboard_smaller.png");

--- a/app/src/colorslider.h
+++ b/app/src/colorslider.h
@@ -19,6 +19,7 @@ GNU General Public License for more details.
 
 #include <QWidget>
 
+#include "drawsliderstyle.h"
 
 class ColorSlider : public QWidget
 {
@@ -50,17 +51,9 @@ public:
 
     QColor color() { return mColor; }
 
-    void setHsv(const QColor& hsv) { mColor.setHsv(hsv.hsvHue(),
-                                                  hsv.hsvSaturation(),
-                                                  hsv.value(),
-                                                  hsv.alpha());
-                                   }
+    void setHsv(const QColor& hsv);
 
-    void setRgb(const QColor& rgb) { mColor.setRgb(rgb.red(),
-                                                  rgb.green(),
-                                                  rgb.blue(),
-                                                  rgb.alpha());
-                                   }
+    void setRgb(const QColor& rgb);
 
     void setColorSpecType(ColorSpecType newType) { this->mSpecType = newType; }
     void setColorType(ColorType newType) { this->mColorType = newType; }
@@ -72,6 +65,7 @@ public:
 
 protected:
     void paintEvent(QPaintEvent* event) override;
+    void resizeEvent(QResizeEvent *event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
 
@@ -80,6 +74,7 @@ signals:
 
 private:
 
+    void setupPicker();
     void drawColorBox(const QColor &color, QSize size);
     void drawPicker(const QColor &color);
     QLinearGradient hsvGradient(const QColor &color);
@@ -87,16 +82,27 @@ private:
 
     void colorPicked(QPoint point);
 
+    bool mPixmapCacheInvalid = true;
     QPixmap mBoxPixmapSource;
 
     QColor mColor;
     qreal mMin = 0.0;
     qreal mMax = 0.0;
 
+    QSizeF mPickerSize = QSize(-1, -1);
+
     ColorType mColorType = ColorType::HUE;
     ColorSpecType mSpecType = ColorSpecType::RGB;
 
     QLinearGradient mGradient;
+
+    SliderPainterStyle mSliderStyle {
+        .hasCustomFill = true,
+        .customFill = QBrush(QPixmap(":icons/general/checkerboard_smaller.png")),
+        .strokeRole = QPalette::Dark,
+    };
+
+    QPixmap mCheckerboardPixmap = QPixmap(":icons/general/checkerboard_smaller.png");
 };
 
 #endif // COLORSLIDER_H

--- a/app/src/colorslider.h
+++ b/app/src/colorslider.h
@@ -46,7 +46,7 @@ public:
     explicit ColorSlider(QWidget* parent);
     ~ColorSlider() override;
 
-    void init(ColorSpecType specType, ColorType type, const QColor &color, qreal min, qreal max);
+    void init(ColorSpecType specType, ColorType type, const QColor &color);
 
     QLinearGradient setColorSpec(const QColor &color);
 
@@ -58,9 +58,6 @@ public:
 
     void setColorSpecType(ColorSpecType newType) { this->mSpecType = newType; }
     void setColorType(ColorType newType) { this->mColorType = newType; }
-
-    void setMin(qreal min) { mMin = min; }
-    void setMax(qreal max) { mMax = max; }
 
     QSize sizeHint() const override;
 
@@ -75,6 +72,9 @@ signals:
 
 private:
 
+    int colorSteps() const;
+    int colorTypeMax() const;
+
     void setupPicker();
     void drawColorBox(const QColor &color, QSize size);
     void drawPicker(const QColor &color);
@@ -87,8 +87,7 @@ private:
     QPixmap mBoxPixmapSource;
 
     QColor mColor;
-    qreal mMin = 0.0;
-    qreal mMax = 0.0;
+    int mMin = 0;
 
     QSizeF mPickerSize = QSize(-1, -1);
 

--- a/app/ui/colorinspector.ui
+++ b/app/ui/colorinspector.ui
@@ -8,7 +8,7 @@
     <x>0</x>
     <y>0</y>
     <width>120</width>
-    <height>263</height>
+    <height>220</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -24,6 +24,9 @@
    </size>
   </property>
   <layout class="QVBoxLayout">
+   <property name="spacing">
+    <number>3</number>
+   </property>
    <property name="leftMargin">
     <number>3</number>
    </property>
@@ -45,7 +48,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="hsvTab">
       <attribute name="title">
@@ -64,36 +67,8 @@
        <property name="bottomMargin">
         <number>3</number>
        </property>
-       <item row="0" column="0">
-        <widget class="QLabel" name="hueLabel">
-         <property name="text">
-          <string>H</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="saturationLabel">
-         <property name="text">
-          <string>S</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="valueLabel">
-         <property name="text">
-          <string>V</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="hsvAlphaLabel">
-         <property name="text">
-          <string>A</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="ColorSlider" name="saturationSlider" native="true">
+       <item row="0" column="1">
+        <widget class="ColorSlider" name="hueSlider" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -102,13 +77,13 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
-        <widget class="ColorSlider" name="hsvAlphaSlider" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+       <item row="2" column="2">
+        <widget class="QSpinBox" name="valueSpinBox">
+         <property name="suffix">
+          <string>%</string>
+         </property>
+         <property name="maximum">
+          <number>100</number>
          </property>
         </widget>
        </item>
@@ -122,8 +97,32 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="ColorSlider" name="hueSlider" native="true">
+       <item row="2" column="0">
+        <widget class="QLabel" name="valueLabel">
+         <property name="text">
+          <string>V</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QSpinBox" name="saturationSpinBox">
+         <property name="suffix">
+          <string>%</string>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="hueLabel">
+         <property name="text">
+          <string>H</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="ColorSlider" name="hsvAlphaSlider" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -142,26 +141,6 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="2">
-        <widget class="QSpinBox" name="saturationSpinBox">
-         <property name="suffix">
-          <string>%</string>
-         </property>
-         <property name="maximum">
-          <number>100</number>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="QSpinBox" name="valueSpinBox">
-         <property name="suffix">
-          <string>%</string>
-         </property>
-         <property name="maximum">
-          <number>100</number>
-         </property>
-        </widget>
-       </item>
        <item row="3" column="2">
         <widget class="QSpinBox" name="hsvAlphaSpinBox">
          <property name="suffix">
@@ -171,6 +150,46 @@
           <number>100</number>
          </property>
         </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="ColorSlider" name="saturationSlider" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="saturationLabel">
+         <property name="text">
+          <string>S</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="hsvAlphaLabel">
+         <property name="text">
+          <string>A</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -191,10 +210,34 @@
        <property name="bottomMargin">
         <number>3</number>
        </property>
-       <item row="3" column="0">
-        <widget class="QLabel" name="rgbAlphaLabel">
+       <item row="2" column="0">
+        <widget class="QLabel" name="blueLabel">
          <property name="text">
-          <string>A</string>
+          <string>B</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QSpinBox" name="redSpinBox">
+         <property name="maximum">
+          <number>255</number>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="ColorSlider" name="blueSlider" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QSpinBox" name="blueSpinBox">
+         <property name="maximum">
+          <number>255</number>
          </property>
         </widget>
        </item>
@@ -205,30 +248,24 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
-        <widget class="ColorSlider" name="rgbAlphaSlider" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+       <item row="3" column="2">
+        <widget class="QSpinBox" name="rgbAlphaSpinBox">
+         <property name="maximum">
+          <number>255</number>
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="ColorSlider" name="redSlider" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="blueLabel">
+       <item row="3" column="0">
+        <widget class="QLabel" name="rgbAlphaLabel">
          <property name="text">
-          <string>B</string>
+          <string>A</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QSpinBox" name="greenSpinBox">
+         <property name="maximum">
+          <number>255</number>
          </property>
         </widget>
        </item>
@@ -242,8 +279,8 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
-        <widget class="ColorSlider" name="blueSlider" native="true">
+       <item row="3" column="1">
+        <widget class="ColorSlider" name="rgbAlphaSlider" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -259,33 +296,31 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="2">
-        <widget class="QSpinBox" name="redSpinBox">
-         <property name="maximum">
-          <number>255</number>
+       <item row="0" column="1">
+        <widget class="ColorSlider" name="redSlider" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
         </widget>
        </item>
-       <item row="1" column="2">
-        <widget class="QSpinBox" name="greenSpinBox">
-         <property name="maximum">
-          <number>255</number>
+       <item row="4" column="2">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="QSpinBox" name="blueSpinBox">
-         <property name="maximum">
-          <number>255</number>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::MinimumExpanding</enum>
          </property>
-        </widget>
-       </item>
-       <item row="3" column="2">
-        <widget class="QSpinBox" name="rgbAlphaSpinBox">
-         <property name="maximum">
-          <number>255</number>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
          </property>
-        </widget>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -297,10 +332,10 @@
       <bool>true</bool>
      </property>
      <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+      <enum>QFrame::Shape::StyledPanel</enum>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
+      <enum>QFrame::Shadow::Raised</enum>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="leftMargin">
@@ -316,15 +351,18 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QLabel" name="color">
-        <property name="autoFillBackground">
-         <bool>true</bool>
+       <widget class="ColorPreviewWidget" name="colorPreview" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::Box</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>50</height>
+         </size>
         </property>
        </widget>
       </item>
@@ -338,6 +376,12 @@
    <class>ColorSlider</class>
    <extends>QWidget</extends>
    <header>colorslider.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ColorPreviewWidget</class>
+   <extends>QWidget</extends>
+   <header>colorpreviewwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/core_lib/core_lib.cmake
+++ b/core_lib/core_lib.cmake
@@ -98,6 +98,8 @@ set(CORE_LIB_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/preferencesdef.h
     ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/transform.h
     ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/util.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/slidergeometry.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/drawsliderstyle.h
 )
 
 set(CORE_LIB_SOURCES
@@ -181,6 +183,8 @@ set(CORE_LIB_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/pointerevent.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/transform.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/util.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/slidergeometry.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core_lib/src/util/drawsliderstyle.cpp
 )
 
 # Platform-specific sources

--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -108,6 +108,7 @@ HEADERS +=  \
     src/util/pencilerror.h \
     src/util/pencilsettings.h \
     src/util/preferencesdef.h \
+    src/util/slidergeometry.h \
     src/util/transform.h \
     src/util/util.h \
     src/util/log.h \
@@ -191,6 +192,7 @@ SOURCES +=  src/graphics/bitmap/bitmapimage.cpp \
     src/util/pencilerror.cpp \
     src/util/pencilsettings.cpp \
     src/util/log.cpp \
+    src/util/slidergeometry.cpp \
     src/util/transform.cpp \
     src/util/util.cpp \
     src/util/pointerevent.cpp \

--- a/core_lib/core_lib.pro
+++ b/core_lib/core_lib.pro
@@ -96,6 +96,7 @@ HEADERS +=  \
     src/util/cameraeasingtype.h \
     src/util/camerafieldoption.h \
     src/util/colordictionary.h \
+    src/util/drawsliderstyle.h \
     src/util/fileformat.h \
     src/util/filetype.h \
     src/util/importimageconfig.h \
@@ -185,6 +186,7 @@ SOURCES +=  src/graphics/bitmap/bitmapimage.cpp \
     src/tool/transformtool.cpp \
     src/util/blitrect.cpp \
     src/util/cameraeasingtype.cpp \
+    src/util/drawsliderstyle.cpp \
     src/util/fileformat.cpp \
     src/util/pencilerror.cpp \
     src/util/pencilsettings.cpp \

--- a/core_lib/src/util/drawsliderstyle.cpp
+++ b/core_lib/src/util/drawsliderstyle.cpp
@@ -43,7 +43,7 @@ void SliderPainter::drawSliderStyle(QPainter& painter, const QRectF& rect, Slide
     painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
 
     QPen pen = resolveColorRole(palette, style.strokeRole);
-    pen.setWidth(style.borderWidth);
+    pen.setWidthF(style.borderWidth);
     painter.setPen(pen);
 
     painter.setBrush(resolveFill(style, palette));

--- a/core_lib/src/util/drawsliderstyle.cpp
+++ b/core_lib/src/util/drawsliderstyle.cpp
@@ -1,0 +1,88 @@
+#include "drawsliderstyle.h"
+
+QColor resolveColorRole(const QPalette& palette, QPalette::ColorRole role)
+{
+    if (role == QPalette::NoRole) {
+        return Qt::transparent;
+    }
+    return palette.color(role);
+}
+
+QBrush resolveFill(const SliderPainterStyle& style, const QPalette& palette)
+{
+    if (style.hasCustomFill) {
+        return style.customFill;
+    } else {
+        return resolveColorRole(palette, style.fillRole);
+    }
+}
+
+void drawSliderStyle(QPainter& painter, const QRectF& rect, SliderPainterStyle& style, const QPalette& palette)
+{
+    updateSliderStyleCache(style, rect.size());
+
+    painter.save();
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
+
+    QPen pen = resolveColorRole(palette, style.strokeRole);
+    pen.setWidth(style.borderWidth);
+    painter.setPen(pen);
+
+    painter.setBrush(resolveFill(style, palette));
+    painter.drawRoundedRect(rect,
+                            style.cachedCornerRadiusX,
+                            style.cachedCornerRadiusY,
+                            Qt::SizeMode::AbsoluteSize);
+
+    painter.restore();
+}
+
+void updateSliderStyleCache(SliderPainterStyle& style, const QSizeF& newSize)
+{
+    if (style.cachedSize == newSize) {
+        return;
+    }
+
+    const qreal minRad = qMin(newSize.width(), newSize.height());
+    const qreal maxRad = qMax(newSize.width(), newSize.height());
+
+    qreal radiusRatio = style.cornerRadiusRatio;
+    qreal absolutePercentage = maxRad * radiusRatio;
+
+    if (minRad * radiusRatio < absolutePercentage) {
+        style.cachedCornerRadiusX = minRad * radiusRatio;
+        style.cachedCornerRadiusY = style.cachedCornerRadiusX;
+    } else {
+        style.cachedCornerRadiusX = absolutePercentage;
+        style.cachedCornerRadiusY = style.cachedCornerRadiusX;
+    }
+    style.cachedSize = newSize;
+}
+
+QRectF subPixelAdjustRectF(const QRectF rect, qreal devicePixelRatio, qreal borderWidth)
+{
+    qreal topLeftRatio = devicePixelRatio > 1 ? 0.0 : 0.5;
+    qreal bottomRightRatio = devicePixelRatio > 1 ? 0.5 : 0.0;
+
+    return QRectF(rect.left() + borderWidth + topLeftRatio,
+                      rect.top() + borderWidth + topLeftRatio,
+                      rect.right() - borderWidth - bottomRightRatio,
+                      rect.bottom() - borderWidth - bottomRightRatio
+                );
+}
+
+QRectF calculatedContentsRect(const QRectF& contentRect, qreal devicePixelRatio, qreal borderWidth)
+{
+    // For non high DPI scaling,
+    // we have to move the coordinate 0.5 pixel to account for anti-aliasing
+    // Otherwise certain lines will look blurry
+
+    return subPixelAdjustRectF(contentRect, devicePixelRatio, borderWidth);
+}
+
+qreal innerCornerRadius(qreal outerRadius, qreal borderWidth)
+{
+    return outerRadius - borderWidth;
+}

--- a/core_lib/src/util/drawsliderstyle.cpp
+++ b/core_lib/src/util/drawsliderstyle.cpp
@@ -50,7 +50,7 @@ void SliderPainter::drawSliderStyle(QPainter& painter, const QRectF& rect, Slide
     painter.drawRoundedRect(rect,
                             style.cachedCornerRadiusX,
                             style.cachedCornerRadiusY,
-                            Qt::SizeMode::AbsoluteSize);
+                            Qt::AbsoluteSize);
 
     painter.restore();
 }

--- a/core_lib/src/util/drawsliderstyle.cpp
+++ b/core_lib/src/util/drawsliderstyle.cpp
@@ -1,3 +1,19 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
 #include "drawsliderstyle.h"
 
 QColor resolveColorRole(const QPalette& palette, QPalette::ColorRole role)
@@ -17,7 +33,7 @@ QBrush resolveFill(const SliderPainterStyle& style, const QPalette& palette)
     }
 }
 
-void drawSliderStyle(QPainter& painter, const QRectF& rect, SliderPainterStyle& style, const QPalette& palette)
+void SliderPainter::drawSliderStyle(QPainter& painter, const QRectF& rect, SliderPainterStyle& style, const QPalette& palette)
 {
     updateSliderStyleCache(style, rect.size());
 
@@ -39,7 +55,7 @@ void drawSliderStyle(QPainter& painter, const QRectF& rect, SliderPainterStyle& 
     painter.restore();
 }
 
-void updateSliderStyleCache(SliderPainterStyle& style, const QSizeF& newSize)
+void SliderPainter::updateSliderStyleCache(SliderPainterStyle& style, const QSizeF& newSize)
 {
     if (style.cachedSize == newSize) {
         return;
@@ -59,30 +75,4 @@ void updateSliderStyleCache(SliderPainterStyle& style, const QSizeF& newSize)
         style.cachedCornerRadiusY = style.cachedCornerRadiusX;
     }
     style.cachedSize = newSize;
-}
-
-QRectF subPixelAdjustRectF(const QRectF rect, qreal devicePixelRatio, qreal borderWidth)
-{
-    qreal topLeftRatio = devicePixelRatio > 1 ? 0.0 : 0.5;
-    qreal bottomRightRatio = devicePixelRatio > 1 ? 0.5 : 0.0;
-
-    return QRectF(rect.left() + borderWidth + topLeftRatio,
-                      rect.top() + borderWidth + topLeftRatio,
-                      rect.right() - borderWidth - bottomRightRatio,
-                      rect.bottom() - borderWidth - bottomRightRatio
-                );
-}
-
-QRectF calculatedContentsRect(const QRectF& contentRect, qreal devicePixelRatio, qreal borderWidth)
-{
-    // For non high DPI scaling,
-    // we have to move the coordinate 0.5 pixel to account for anti-aliasing
-    // Otherwise certain lines will look blurry
-
-    return subPixelAdjustRectF(contentRect, devicePixelRatio, borderWidth);
-}
-
-qreal innerCornerRadius(qreal outerRadius, qreal borderWidth)
-{
-    return outerRadius - borderWidth;
 }

--- a/core_lib/src/util/drawsliderstyle.h
+++ b/core_lib/src/util/drawsliderstyle.h
@@ -1,0 +1,32 @@
+#ifndef DRAWSLIDERSTYLE_H
+#define DRAWSLIDERSTYLE_H
+
+#include <QPainter>
+#include <QPalette>
+
+struct SliderPainterStyle {
+
+    // The filled part of the slider
+    QPalette::ColorRole fillRole     = QPalette::Window;
+
+    // The border of the slider, by default there is none
+    QPalette::ColorRole strokeRole   = QPalette::NoRole;
+
+    bool hasCustomFill = false;
+    QBrush customFill = QBrush();
+
+    float  borderWidth   = 1.0f;
+    float cornerRadiusRatio = 0.2;
+
+    QSizeF cachedSize = {};
+
+    float cachedCornerRadiusX = 0;
+    float cachedCornerRadiusY = 0;
+};
+
+void drawSliderStyle(QPainter& painter, const QRectF& rect, SliderPainterStyle& style, const QPalette& palette);
+void updateSliderStyleCache(SliderPainterStyle& style, const QSizeF& newSize);
+QRectF calculatedContentsRect(const QRectF& contentRect, qreal devicePixelRatio, qreal borderWidth);
+qreal innerCornerRadius(qreal outerRadius, qreal borderWidth);
+
+#endif // DRAWSLIDERSTYLE_H

--- a/core_lib/src/util/drawsliderstyle.h
+++ b/core_lib/src/util/drawsliderstyle.h
@@ -20,7 +20,8 @@ GNU General Public License for more details.
 #include <QPainter>
 #include <QPalette>
 
-struct SliderPainterStyle {
+struct SliderPainterStyle
+{
 
     SliderPainterStyle(QPalette::ColorRole fillRole,
                        QPalette::ColorRole strokeRole,
@@ -65,7 +66,8 @@ struct SliderPainterStyle {
     float cachedCornerRadiusY = 0;
 };
 
-namespace SliderPainter {
+namespace SliderPainter
+{
     void drawSliderStyle(QPainter& painter, const QRectF& rect, SliderPainterStyle& style, const QPalette& palette);
     void updateSliderStyleCache(SliderPainterStyle& style, const QSizeF& newSize);
 }

--- a/core_lib/src/util/drawsliderstyle.h
+++ b/core_lib/src/util/drawsliderstyle.h
@@ -1,3 +1,19 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
 #ifndef DRAWSLIDERSTYLE_H
 #define DRAWSLIDERSTYLE_H
 
@@ -24,9 +40,9 @@ struct SliderPainterStyle {
     float cachedCornerRadiusY = 0;
 };
 
-void drawSliderStyle(QPainter& painter, const QRectF& rect, SliderPainterStyle& style, const QPalette& palette);
-void updateSliderStyleCache(SliderPainterStyle& style, const QSizeF& newSize);
-QRectF calculatedContentsRect(const QRectF& contentRect, qreal devicePixelRatio, qreal borderWidth);
-qreal innerCornerRadius(qreal outerRadius, qreal borderWidth);
+namespace SliderPainter {
+    void drawSliderStyle(QPainter& painter, const QRectF& rect, SliderPainterStyle& style, const QPalette& palette);
+    void updateSliderStyleCache(SliderPainterStyle& style, const QSizeF& newSize);
+}
 
 #endif // DRAWSLIDERSTYLE_H

--- a/core_lib/src/util/drawsliderstyle.h
+++ b/core_lib/src/util/drawsliderstyle.h
@@ -22,6 +22,31 @@ GNU General Public License for more details.
 
 struct SliderPainterStyle {
 
+    SliderPainterStyle(QPalette::ColorRole fillRole,
+                       QPalette::ColorRole strokeRole,
+                       bool hasCustomFill,
+                       QBrush customFill,
+                       float borderWidth,
+                       float cornerRadiusRatio)
+    {
+        this->fillRole = fillRole;
+        this->strokeRole = strokeRole;
+        this->hasCustomFill = hasCustomFill;
+        this->customFill = customFill;
+        this->borderWidth = borderWidth;
+        this->cornerRadiusRatio = cornerRadiusRatio;
+    }
+
+    SliderPainterStyle(QPalette::ColorRole strokeRole,
+                       bool hasCustomFill,
+                       QBrush customFill)
+    {
+        this->strokeRole = strokeRole;
+        this->hasCustomFill = hasCustomFill;
+        this->customFill = customFill;
+    }
+
+
     // The filled part of the slider
     QPalette::ColorRole fillRole     = QPalette::Window;
 

--- a/core_lib/src/util/slidergeometry.cpp
+++ b/core_lib/src/util/slidergeometry.cpp
@@ -16,13 +16,15 @@ GNU General Public License for more details.
 */
 #include "slidergeometry.h"
 
-QRectF SliderGeometry::contentsRect(const QRectF& contentRect, qreal devicePixelRatio, qreal borderWidth)
+QRectF SliderGeometry::contentsRect(const QRectF& rect, qreal borderWidth)
 {
-    // For non high DPI scaling,
-    // we have to move the coordinate 0.5 pixel to account for anti-aliasing
-    // Otherwise certain lines will look blurry
+    qreal inset = SliderGeometry::penStrokeInset(borderWidth);
 
-    return SliderGeometry::subPixelAdjustedRectF(contentRect, devicePixelRatio, borderWidth);
+    return QRectF(rect.left()       + inset,
+                      rect.top()    + inset,
+                      rect.width()  - borderWidth,
+                      rect.height() - borderWidth
+                );
 }
 
 qreal SliderGeometry::innerCornerRadius(qreal outerRadius, qreal borderWidth)
@@ -30,14 +32,7 @@ qreal SliderGeometry::innerCornerRadius(qreal outerRadius, qreal borderWidth)
     return outerRadius - borderWidth;
 }
 
-QRectF SliderGeometry::subPixelAdjustedRectF(const QRectF& rect, qreal devicePixelRatio, qreal borderWidth)
+qreal SliderGeometry::penStrokeInset(qreal borderWidth)
 {
-    qreal topLeftRatio = devicePixelRatio > 1 ? 0.0 : 0.5;
-    qreal bottomRightRatio = devicePixelRatio > 1 ? 0.5 : 0.0;
-
-    return QRectF(rect.left() + borderWidth + topLeftRatio,
-                      rect.top() + borderWidth + topLeftRatio,
-                      rect.right() - borderWidth - bottomRightRatio,
-                      rect.bottom() - borderWidth - bottomRightRatio
-                );
+    return borderWidth * 0.5;
 }

--- a/core_lib/src/util/slidergeometry.cpp
+++ b/core_lib/src/util/slidergeometry.cpp
@@ -36,3 +36,8 @@ qreal SliderGeometry::penStrokeInset(qreal borderWidth)
 {
     return borderWidth * 0.5;
 }
+
+qreal SliderGeometry::pickerMaxDistance(qreal sliderWidth, qreal pickerWidth)
+{
+    return sliderWidth - pickerWidth;
+}

--- a/core_lib/src/util/slidergeometry.cpp
+++ b/core_lib/src/util/slidergeometry.cpp
@@ -1,0 +1,43 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+#include "slidergeometry.h"
+
+QRectF SliderGeometry::contentsRect(const QRectF& contentRect, qreal devicePixelRatio, qreal borderWidth)
+{
+    // For non high DPI scaling,
+    // we have to move the coordinate 0.5 pixel to account for anti-aliasing
+    // Otherwise certain lines will look blurry
+
+    return SliderGeometry::subPixelAdjustedRectF(contentRect, devicePixelRatio, borderWidth);
+}
+
+qreal SliderGeometry::innerCornerRadius(qreal outerRadius, qreal borderWidth)
+{
+    return outerRadius - borderWidth;
+}
+
+QRectF SliderGeometry::subPixelAdjustedRectF(const QRectF& rect, qreal devicePixelRatio, qreal borderWidth)
+{
+    qreal topLeftRatio = devicePixelRatio > 1 ? 0.0 : 0.5;
+    qreal bottomRightRatio = devicePixelRatio > 1 ? 0.5 : 0.0;
+
+    return QRectF(rect.left() + borderWidth + topLeftRatio,
+                      rect.top() + borderWidth + topLeftRatio,
+                      rect.right() - borderWidth - bottomRightRatio,
+                      rect.bottom() - borderWidth - bottomRightRatio
+                );
+}

--- a/core_lib/src/util/slidergeometry.cpp
+++ b/core_lib/src/util/slidergeometry.cpp
@@ -16,6 +16,8 @@ GNU General Public License for more details.
 */
 #include "slidergeometry.h"
 
+#include <QtMath>
+
 QRectF SliderGeometry::contentsRect(const QRectF& rect, qreal borderWidth)
 {
     qreal inset = SliderGeometry::penStrokeInset(borderWidth);
@@ -37,7 +39,12 @@ qreal SliderGeometry::penStrokeInset(qreal borderWidth)
     return borderWidth * 0.5;
 }
 
-qreal SliderGeometry::pickerMaxDistance(qreal sliderWidth, qreal pickerWidth)
+/**
+ *  The max travel distance the picker can be moved compared to the slider width
+ *
+ *  @return How far the picker can be moved compared to the slider trailing bound
+ */
+qreal SliderGeometry::pickerUpperBound(qreal sliderWidth, qreal pickerWidth)
 {
-    return sliderWidth - pickerWidth;
+    return qMax(1.0, sliderWidth - pickerWidth);
 }

--- a/core_lib/src/util/slidergeometry.h
+++ b/core_lib/src/util/slidergeometry.h
@@ -23,6 +23,7 @@ namespace SliderGeometry {
     QRectF contentsRect(const QRectF& rect, qreal borderWidth);
     qreal penStrokeInset(qreal borderWidth);
     qreal innerCornerRadius(qreal outerRadius, qreal borderWidth);
+    qreal pickerMaxDistance(qreal sliderWidth, qreal pickerWidth);
 }
 
 #endif // SLIDERGEOMETRY_H

--- a/core_lib/src/util/slidergeometry.h
+++ b/core_lib/src/util/slidergeometry.h
@@ -1,0 +1,28 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2005-2007 Patrick Corrieri & Pascal Naidon
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+#ifndef SLIDERGEOMETRY_H
+#define SLIDERGEOMETRY_H
+
+#include <QRectF>
+
+namespace SliderGeometry {
+    QRectF contentsRect(const QRectF& contentRect, qreal devicePixelRatio, qreal borderWidth);
+    QRectF subPixelAdjustedRectF(const QRectF& rect, qreal devicePixelRatio, qreal borderWidth);
+    qreal innerCornerRadius(qreal outerRadius, qreal borderWidth);
+}
+
+#endif // SLIDERGEOMETRY_H

--- a/core_lib/src/util/slidergeometry.h
+++ b/core_lib/src/util/slidergeometry.h
@@ -20,8 +20,8 @@ GNU General Public License for more details.
 #include <QRectF>
 
 namespace SliderGeometry {
-    QRectF contentsRect(const QRectF& contentRect, qreal devicePixelRatio, qreal borderWidth);
-    QRectF subPixelAdjustedRectF(const QRectF& rect, qreal devicePixelRatio, qreal borderWidth);
+    QRectF contentsRect(const QRectF& rect, qreal borderWidth);
+    qreal penStrokeInset(qreal borderWidth);
     qreal innerCornerRadius(qreal outerRadius, qreal borderWidth);
 }
 

--- a/core_lib/src/util/slidergeometry.h
+++ b/core_lib/src/util/slidergeometry.h
@@ -19,7 +19,8 @@ GNU General Public License for more details.
 
 #include <QRectF>
 
-namespace SliderGeometry {
+namespace SliderGeometry
+{
     QRectF contentsRect(const QRectF& rect, qreal borderWidth);
     qreal penStrokeInset(qreal borderWidth);
     qreal innerCornerRadius(qreal outerRadius, qreal borderWidth);

--- a/core_lib/src/util/slidergeometry.h
+++ b/core_lib/src/util/slidergeometry.h
@@ -23,7 +23,7 @@ namespace SliderGeometry {
     QRectF contentsRect(const QRectF& rect, qreal borderWidth);
     qreal penStrokeInset(qreal borderWidth);
     qreal innerCornerRadius(qreal outerRadius, qreal borderWidth);
-    qreal pickerMaxDistance(qreal sliderWidth, qreal pickerWidth);
+    qreal pickerUpperBound(qreal sliderWidth, qreal pickerWidth);
 }
 
 #endif // SLIDERGEOMETRY_H


### PR DESCRIPTION
Slider appearance updates and other fixes.

| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/9407f7fd-884c-4250-b433-0866cf6c6352) | ![after](https://github.com/user-attachments/assets/8517a54f-4be0-4c10-b0d2-da59951e6664) |

### Changes
- Slider has been made bigger to make it easier to adjust.
- The corners are now properly clipped, leaving no white or black cutouts.
- Slider now takes devicePixelRatio into account, making it look less pixelated on HiDPI monitors.
- Picker is now drawn within the slider boundary rather than being drawn on top
- Picker outline logic has been simplified. We use two outlines to be able to see it on all colors.
- The cursor position now corresponds to the middle of the picker, rather than shifting closer to the nearest edge as it moves.
- The color preview now has a checkerboard backdrop again.

Lately i've been rather intrigued by Data Oriented Design, so i'm also introducing some some slider painter utility namespaces. I think that this approach actually works better and is cleaner rather than creating painter classes, when the logic should be shared across components. What do you think?

Note: There is a known issue on macOS.. for some reason the spinboxes gets cut on the top and bottom as if something is squeezing it, however all the layout is set to be "preferred" so it shouldn't be possible. I haven't been able to fix this yet.