### PR TITLE
Fix floating widgets disappear on launch

### DIFF
--- a/app/src/mainwindow2.cpp
+++ b/app/src/mainwindow2.cpp
@@ -231,8 +231,10 @@ void MainWindow2::createDockWidgets()
 
     for (BaseDockWidget* w : mDockWidgets)
     {
-        w->setFloating(false);
-        w->show();
+        if (w->isFloating()) {
+            w->show();
+            w->raise();
+        }
         w->updateUI();
     }
 }


### PR DESCRIPTION
In Qt6 the layout system is more strict about when you show something, this means that even though we restore the window state, if the docked widget hasn't been assigned to an area properly or the timing is wrong, then using `setFloating(false)` may simply be ignored.

I tried a bunch of different things to fix it, in the end checking if we're docked and displaying the items works best.
I am not sure why we would want to re-dock them here anyway. if the user wants the UI to be floating, then we should allow that.