### PR TITLE
Layer: Remove increment from getLastKeyFrame

### DIFF
--- a/core_lib/src/canvaspainter.cpp
+++ b/core_lib/src/canvaspainter.cpp
@@ -334,7 +334,7 @@ void CanvasPainter::paintCurrentBitmapFrame(QPainter& painter, const QRect& blit
 void CanvasPainter::paintCurrentVectorFrame(QPainter& painter, const QRect& blitRect, Layer* layer, bool isCurrentLayer)
 {
     LayerVector* vectorLayer = static_cast<LayerVector*>(layer);
-    VectorImage* vectorImage = vectorLayer->getLastVectorImageAtFrame(mFrameNumber, 0);
+    VectorImage* vectorImage = vectorLayer->getLastVectorImageAtFrame(mFrameNumber);
     if (vectorImage == nullptr)
     {
         return;

--- a/core_lib/src/graphics/bitmap/bitmapbucket.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapbucket.cpp
@@ -115,7 +115,7 @@ void BitmapBucket::paint(const QPointF& updatedPoint, std::function<void(BucketS
 {
     const int currentFrameIndex = mEditor->currentFrame();
 
-    BitmapImage* targetImage = static_cast<LayerBitmap*>(mTargetFillToLayer)->getLastBitmapImageAtFrame(currentFrameIndex, 0);
+    BitmapImage* targetImage = static_cast<LayerBitmap*>(mTargetFillToLayer)->getLastBitmapImageAtFrame(currentFrameIndex);
     if (targetImage == nullptr || !targetImage->isLoaded()) { return; } // Can happen if the first frame is deleted while drawing
 
     QPoint point = QPoint(qFloor(updatedPoint.x()), qFloor(updatedPoint.y()));

--- a/core_lib/src/interface/legacybackupelement.cpp
+++ b/core_lib/src/interface/legacybackupelement.cpp
@@ -47,7 +47,7 @@ void BackupLegacyBitmapElement::restore(Editor* editor)
             if (layer->type() == Layer::BITMAP)
             {
                 auto bitmapLayer = static_cast<LayerBitmap*>(layer);
-                *bitmapLayer->getLastBitmapImageAtFrame(this->frame, 0) = bitmapImage;  // restore the image
+                *bitmapLayer->getLastBitmapImageAtFrame(this->frame) = bitmapImage;  // restore the image
             }
         }
     }
@@ -97,7 +97,7 @@ void BackupLegacyVectorElement::restore(Editor* editor)
             if (layer->type() == Layer::VECTOR)
             {
                 auto pVectorImage = static_cast<LayerVector*>(layer);
-                *pVectorImage->getLastVectorImageAtFrame(this->frame, 0) = this->vectorImage;  // restore the image
+                *pVectorImage->getLastVectorImageAtFrame(this->frame) = this->vectorImage;  // restore the image
             }
         }
     }

--- a/core_lib/src/interface/scribblearea.cpp
+++ b/core_lib/src/interface/scribblearea.cpp
@@ -1052,7 +1052,7 @@ VectorImage* ScribbleArea::currentVectorImage(Layer* layer) const
 {
     Q_ASSERT(layer->type() == Layer::VECTOR);
     auto vectorLayer = static_cast<LayerVector*>(layer);
-    return vectorLayer->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+    return vectorLayer->getLastVectorImageAtFrame(mEditor->currentFrame());
 }
 
 void ScribbleArea::prepCameraPainter(int frame)

--- a/core_lib/src/interface/undoredocommand.cpp
+++ b/core_lib/src/interface/undoredocommand.cpp
@@ -266,7 +266,7 @@ VectorReplaceCommand::VectorReplaceCommand(const VectorImage* undoVector,
     Layer* layer = editor->layers()->currentLayer();
     redoLayerId = layer->id();
     redoVector = *static_cast<LayerVector*>(layer)->
-            getLastVectorImageAtFrame(editor->currentFrame(), 0);
+            getLastVectorImageAtFrame(editor->currentFrame());
 
     setText(description);
 }

--- a/core_lib/src/overlaypainter.cpp
+++ b/core_lib/src/overlaypainter.cpp
@@ -42,7 +42,7 @@ void OverlayPainter::paint(QPainter &painter, const QRect& viewport)
 
     QTransform camTransform = mCameraLayer->getViewAtFrame(mOptions.nFrameIndex);
     QRect cameraRect = mCameraLayer->getViewRect();
-    Camera* camera = mCameraLayer->getLastCameraAtFrame(mOptions.nFrameIndex, 0);
+    Camera* camera = mCameraLayer->getLastCameraAtFrame(mOptions.nFrameIndex);
 
     if (camera == nullptr) { return; }
 

--- a/core_lib/src/structure/layerbitmap.cpp
+++ b/core_lib/src/structure/layerbitmap.cpp
@@ -38,10 +38,10 @@ BitmapImage* LayerBitmap::getBitmapImageAtFrame(int frameNumber)
     return static_cast<BitmapImage*>(getKeyFrameAt(frameNumber));
 }
 
-BitmapImage* LayerBitmap::getLastBitmapImageAtFrame(int frameNumber, int increment)
+BitmapImage* LayerBitmap::getLastBitmapImageAtFrame(int frameNumber)
 {
     Q_ASSERT(frameNumber >= 1);
-    return static_cast<BitmapImage*>(getLastKeyFrameAtPosition(frameNumber + increment));
+    return static_cast<BitmapImage*>(getLastKeyFrameAtPosition(frameNumber));
 }
 
 void LayerBitmap::replaceKeyFrame(const KeyFrame* bitmapImage)

--- a/core_lib/src/structure/layerbitmap.h
+++ b/core_lib/src/structure/layerbitmap.h
@@ -35,7 +35,7 @@ public:
     Status presave(const QString& sDataFolder) override;
 
     BitmapImage* getBitmapImageAtFrame(int frameNumber);
-    BitmapImage* getLastBitmapImageAtFrame(int frameNumber, int increment = 0);
+    BitmapImage* getLastBitmapImageAtFrame(int frameNumber);
     void replaceKeyFrame(const KeyFrame*) override;
 
     void repositionFrame(QPoint point, int frame);

--- a/core_lib/src/structure/layercamera.cpp
+++ b/core_lib/src/structure/layercamera.cpp
@@ -66,9 +66,9 @@ Camera* LayerCamera::getCameraAtFrame(int frameNumber) const
     return static_cast<Camera*>(getKeyFrameAt(frameNumber));
 }
 
-Camera* LayerCamera::getLastCameraAtFrame(int frameNumber, int increment) const
+Camera* LayerCamera::getLastCameraAtFrame(int frameNumber) const
 {
-    return static_cast<Camera*>(getLastKeyFrameAtPosition(frameNumber + increment));
+    return static_cast<Camera*>(getLastKeyFrameAtPosition(frameNumber));
 }
 
 QTransform LayerCamera::getViewAtFrame(int frameNumber) const
@@ -264,7 +264,7 @@ void LayerCamera::splitControlPointIfNeeded(int frame) const
     // if inbetween frames
     if (frame > prev && (frame > 1) && frame < next)
     {
-        Camera* camFrame = getLastCameraAtFrame(frame, 0);
+        Camera* camFrame = getLastCameraAtFrame(frame);
         Camera* camPrev = getCameraAtFrame(prev);
         Camera* camNext = getCameraAtFrame(next);
         Q_ASSERT(camPrev && camFrame && camNext);
@@ -298,7 +298,7 @@ void LayerCamera::mergeControlPointIfNeeded(int frame) const
     if (frame > prev && (frame > 1) && frame < next)
     {
         Camera* camPrev = getCameraAtFrame(prev);
-        Camera* camFrame = getLastCameraAtFrame(frame, 0);
+        Camera* camFrame = getLastCameraAtFrame(frame);
         Camera* camNext = getCameraAtFrame(next);
         Q_ASSERT(camPrev && camFrame && camNext);
 
@@ -346,7 +346,7 @@ void LayerCamera::setViewRect(QRect newViewRect)
 
 void LayerCamera::setCameraEasingAtFrame(CameraEasingType type, int frame) const
 {
-    Camera* camera = getLastCameraAtFrame(frame, 0);
+    Camera* camera = getLastCameraAtFrame(frame);
     camera->setEasingType(type);
     camera->updateViewTransform();
 }
@@ -357,7 +357,7 @@ void LayerCamera::resetCameraAtFrame(CameraFieldOption type, int frame) const
     if (!keyExists(frame)) {
         frameToModify = getPreviousKeyFramePosition(frame);
     }
-    Camera* camera = getLastCameraAtFrame(frameToModify, 0);
+    Camera* camera = getLastCameraAtFrame(frameToModify);
 
     switch (type)
     {
@@ -395,7 +395,7 @@ void LayerCamera::resetCameraAtFrame(CameraFieldOption type, int frame) const
         qreal rotation = camera->rotation();
         qreal scaling = camera->scaling();
         camera->setPathControlPointMoved(false);
-        Camera* nextCamera = getLastCameraAtFrame(getNextKeyFramePosition(frame), 0);
+        Camera* nextCamera = getLastCameraAtFrame(getNextKeyFramePosition(frame));
         nextCamera->translate(translation);
         nextCamera->scale(scaling);
         nextCamera->rotate(rotation);
@@ -439,7 +439,7 @@ void LayerCamera::updateDotColor(DotColorType color)
 
 QString LayerCamera::getInterpolationTextAtFrame(int frame) const
 {
-    Camera* camera = getLastCameraAtFrame(frame, 0);
+    Camera* camera = getLastCameraAtFrame(frame);
     return getInterpolationText(camera->getEasingType());
 }
 
@@ -508,7 +508,7 @@ QPointF LayerCamera::getCenteredPathPoint(int frame) const
 
 void LayerCamera::setPathMovedAtFrame(int frame, bool moved) const
 {
-    Camera* cam = getLastCameraAtFrame(frame, 0);
+    Camera* cam = getLastCameraAtFrame(frame);
     Q_ASSERT(cam);
 
     cam->setPathControlPointMoved(moved);
@@ -516,7 +516,7 @@ void LayerCamera::setPathMovedAtFrame(int frame, bool moved) const
 
 void LayerCamera::updatePathControlPointAtFrame(const QPointF& point, int frame) const
 {
-    Camera* camera = getLastCameraAtFrame(frame, 0);
+    Camera* camera = getLastCameraAtFrame(frame);
     Q_ASSERT(camera);
 
     camera->setPathControlPoint(point);

--- a/core_lib/src/structure/layercamera.h
+++ b/core_lib/src/structure/layercamera.h
@@ -43,7 +43,7 @@ public:
     void replaceKeyFrame(const KeyFrame* camera) override;
 
     Camera* getCameraAtFrame(int frameNumber) const;
-    Camera* getLastCameraAtFrame(int frameNumber, int increment) const;
+    Camera* getLastCameraAtFrame(int frameNumber) const;
     QTransform getViewAtFrame(int frameNumber) const;
 
     QRect getViewRect() const;

--- a/core_lib/src/structure/layervector.cpp
+++ b/core_lib/src/structure/layervector.cpp
@@ -190,9 +190,9 @@ VectorImage* LayerVector::getVectorImageAtFrame(int frameNumber) const
     return static_cast<VectorImage*>(getKeyFrameAt(frameNumber));
 }
 
-VectorImage* LayerVector::getLastVectorImageAtFrame(int frameNumber, int increment) const
+VectorImage* LayerVector::getLastVectorImageAtFrame(int frameNumber) const
 {
-    return static_cast<VectorImage*>(getLastKeyFrameAtPosition(frameNumber + increment));
+    return static_cast<VectorImage*>(getLastKeyFrameAtPosition(frameNumber));
 }
 
 void LayerVector::replaceKeyFrame(const KeyFrame* vectorImage)

--- a/core_lib/src/structure/layervector.h
+++ b/core_lib/src/structure/layervector.h
@@ -37,7 +37,7 @@ public:
     void loadDomElement(const QDomElement& element, QString dataDirPath, ProgressCallback progressStep) override;
 
     VectorImage* getVectorImageAtFrame(int frameNumber) const;
-    VectorImage* getLastVectorImageAtFrame(int frameNumber, int increment) const;
+    VectorImage* getLastVectorImageAtFrame(int frameNumber) const;
     void replaceKeyFrame(const KeyFrame* vectorImage) override;
 
     bool usesColor(int index);

--- a/core_lib/src/structure/object.cpp
+++ b/core_lib/src/structure/object.cpp
@@ -750,7 +750,7 @@ void Object::paintImage(QPainter& painter,int frameNumber,
         if (layer->type() == Layer::VECTOR)
         {
             LayerVector* layerVector = static_cast<LayerVector*>(layer);
-            VectorImage* vec = layerVector->getLastVectorImageAtFrame(frameNumber, 0);
+            VectorImage* vec = layerVector->getLastVectorImageAtFrame(frameNumber);
             if (vec)
             {
                 painter.setOpacity(vec->getOpacity());

--- a/core_lib/src/tool/buckettool.cpp
+++ b/core_lib/src/tool/buckettool.cpp
@@ -173,7 +173,7 @@ void BucketTool::paintVector(Layer* layer)
 {
     mScribbleArea->clearDrawingBuffer();
 
-    VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+    VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame());
     if (vectorImage == nullptr) { return; } // Can happen if the first frame is deleted while drawing
 
     if (!vectorImage->isPathFilled())

--- a/core_lib/src/tool/cameratool.cpp
+++ b/core_lib/src/tool/cameratool.cpp
@@ -92,7 +92,7 @@ void CameraTool::updateUIAssists(const Layer* layer)
     mCameraRect = Transform::mapFromLocalRect(localCamT, cameraRect);
     mCameraPolygon = Transform::mapFromLocalPolygon(localCamT, cameraRect);
 
-    Camera* cam = camLayer->getLastCameraAtFrame(mEditor->currentFrame(), 0);
+    Camera* cam = camLayer->getLastCameraAtFrame(mEditor->currentFrame());
     if (cam) {
         mRotationHandlePoint = localRotationHandlePoint(cameraRect.topLeft(), localCamT, cam->scaling(), mEditor->view()->getScaleInversed());
     }
@@ -415,7 +415,7 @@ CameraMoveType CameraTool::getPathMoveMode(const LayerCamera* layerCamera, int f
     if (layerCamera->hasSameTranslation(prev, next))
         return CameraMoveType::NONE;
 
-    Camera* camera = layerCamera->getLastCameraAtFrame(frameNumber, 0);
+    Camera* camera = layerCamera->getLastCameraAtFrame(frameNumber);
 
     if (camera == nullptr) { return CameraMoveType::NONE; }
 
@@ -500,7 +500,7 @@ void CameraTool::paint(QPainter& painter, const QRect&)
     // Show handles while we're on a camera layer and not doing playback
     if (!isPlaying) {
         int frame = cameraLayerBelow->getPreviousKeyFramePosition(frameIndex);
-        Camera* cam = cameraLayerBelow->getLastCameraAtFrame(qMax(frame, frameIndex), 0);
+        Camera* cam = cameraLayerBelow->getLastCameraAtFrame(qMax(frame, frameIndex));
         Q_ASSERT(cam);
         qreal scale = cam->scaling();
         qreal rotation = cam->rotation();

--- a/core_lib/src/tool/erasertool.cpp
+++ b/core_lib/src/tool/erasertool.cpp
@@ -244,7 +244,7 @@ void EraserTool::removeVectorPaint()
     if (layer->type() == Layer::VECTOR)
     {
         mScribbleArea->clearDrawingBuffer();
-        VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+        VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame());
         if (vectorImage == nullptr) { return; } // Can happen if the first frame is deleted while drawing
         // Clear the area containing the last point
         //vectorImage->removeArea(lastPoint);

--- a/core_lib/src/tool/eyedroppertool.cpp
+++ b/core_lib/src/tool/eyedroppertool.cpp
@@ -143,7 +143,7 @@ void EyedropperTool::updateFrontColor(const QPointF& pos)
 
 QColor EyedropperTool::getBitmapColor(LayerBitmap* layer, const QPointF& pos)
 {
-    BitmapImage* targetImage = layer->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0);
+    BitmapImage* targetImage = layer->getLastBitmapImageAtFrame(mEditor->currentFrame());
     if (targetImage == nullptr || !targetImage->contains(pos)) return QColor();
 
     QColor pickedColour;

--- a/core_lib/src/tool/movetool.cpp
+++ b/core_lib/src/tool/movetool.cpp
@@ -264,7 +264,7 @@ void MoveTool::createVectorSelection(const QPointF& pos, Qt::KeyboardModifiers k
 {
     assert(layer->type() == Layer::VECTOR);
     LayerVector* vecLayer = static_cast<LayerVector*>(layer);
-    VectorImage* vectorImage = vecLayer->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+    VectorImage* vectorImage = vecLayer->getLastVectorImageAtFrame(mEditor->currentFrame());
     if (vectorImage == nullptr) { return; }
 
     if (!mEditor->select()->closestCurves().empty()) // the user clicks near a curve
@@ -313,7 +313,7 @@ void MoveTool::storeClosestVectorCurve(const QPointF& pos, Layer* layer)
 {
     auto selectMan = mEditor->select();
     auto layerVector = static_cast<LayerVector*>(layer);
-    VectorImage* pVecImg = layerVector->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+    VectorImage* pVecImg = layerVector->getLastVectorImageAtFrame(mEditor->currentFrame());
     if (pVecImg == nullptr) { return; }
     selectMan->setCurves(pVecImg->getCurvesCloseTo(pos, selectMan->selectionTolerance()));
 }

--- a/core_lib/src/tool/penciltool.cpp
+++ b/core_lib/src/tool/penciltool.cpp
@@ -251,7 +251,7 @@ void PencilTool::paintVectorStroke(Layer* layer)
     curve.setInvisibility(true);
     curve.setVariableWidth(false);
     curve.setColorNumber(mEditor->color()->frontColorNumber());
-    VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+    VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame());
     if (vectorImage == nullptr) { return; } // Can happen if the first frame is deleted while drawing
     vectorImage->addCurve(curve, qAbs(mEditor->view()->scaling()), false);
 

--- a/core_lib/src/tool/pentool.cpp
+++ b/core_lib/src/tool/pentool.cpp
@@ -240,7 +240,7 @@ void PenTool::paintVectorStroke(Layer* layer)
     curve.setColorNumber(mEditor->color()->frontColorNumber());
 
     auto pLayerVector = static_cast<LayerVector*>(layer);
-    VectorImage* vectorImage = pLayerVector->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+    VectorImage* vectorImage = pLayerVector->getLastVectorImageAtFrame(mEditor->currentFrame());
     if (vectorImage == nullptr) { return; } // Can happen if the first frame is deleted while drawing
     vectorImage->addCurve(curve, mEditor->view()->scaling(), false);
 

--- a/core_lib/src/tool/polylinetool.cpp
+++ b/core_lib/src/tool/polylinetool.cpp
@@ -125,7 +125,7 @@ void PolylineTool::pointerPressEvent(PointerEvent* event)
 
             if (layer->type() == Layer::VECTOR)
             {
-                VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+                VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame());
                 Q_CHECK_PTR(vectorImage);
                 vectorImage->deselectAll();
                 if (mScribbleArea->makeInvisible() && !mEditor->preference()->isOn(SETTING::INVISIBLE_LINES))
@@ -326,7 +326,7 @@ void PolylineTool::endPolyline(QList<QPointF> points)
         curve.setVariableWidth(false);
         curve.setInvisibility(mScribbleArea->makeInvisible());
 
-        VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+        VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame());
         if (vectorImage == nullptr) { return; } // Can happen if the first frame is deleted while drawing
         vectorImage->addCurve(curve, mEditor->view()->scaling());
     }

--- a/core_lib/src/tool/selecttool.cpp
+++ b/core_lib/src/tool/selecttool.cpp
@@ -95,7 +95,7 @@ void SelectTool::beginSelection(Layer* currentLayer, const QPointF& pos)
     {
         if (currentLayer->type() == Layer::VECTOR)
         {
-            VectorImage* vectorImage = static_cast<LayerVector*>(currentLayer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+            VectorImage* vectorImage = static_cast<LayerVector*>(currentLayer)->getLastVectorImageAtFrame(mEditor->currentFrame());
             if (vectorImage != nullptr) {
                 vectorImage->deselectAll();
             }
@@ -157,7 +157,7 @@ void SelectTool::pointerMoveEvent(PointerEvent* event)
 
         if (currentLayer->type() == Layer::VECTOR)
         {
-            VectorImage* vectorImage = static_cast<LayerVector*>(currentLayer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+            VectorImage* vectorImage = static_cast<LayerVector*>(currentLayer)->getLastVectorImageAtFrame(mEditor->currentFrame());
             if (vectorImage != nullptr) {
                 vectorImage->select(selectMan->mapToSelection(QPolygonF(selectMan->mySelectionRect())).boundingRect());
             }
@@ -218,7 +218,7 @@ void SelectTool::keepSelection(Layer* currentLayer)
 {
     if (currentLayer->type() == Layer::VECTOR)
     {
-        VectorImage* vectorImage = static_cast<LayerVector*>(currentLayer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+        VectorImage* vectorImage = static_cast<LayerVector*>(currentLayer)->getLastVectorImageAtFrame(mEditor->currentFrame());
         if (vectorImage == nullptr) { return; }
         auto selectMan = mEditor->select();
         selectMan->setSelection(vectorImage->getSelectionRect(), false);

--- a/core_lib/src/tool/smudgetool.cpp
+++ b/core_lib/src/tool/smudgetool.cpp
@@ -130,7 +130,7 @@ void SmudgeTool::pointerPressEvent(PointerEvent* event)
         {
             const int currentFrame = mEditor->currentFrame();
             const float distanceFrom = selectMan->selectionTolerance();
-            VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(currentFrame, 0);
+            VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(currentFrame);
             if (vectorImage == nullptr) { return; }
             selectMan->setCurves(vectorImage->getCurvesCloseTo(getCurrentPoint(), distanceFrom));
             selectMan->setVertices(vectorImage->getVerticesCloseTo(getCurrentPoint(), distanceFrom));
@@ -194,7 +194,7 @@ void SmudgeTool::pointerMoveEvent(PointerEvent* event)
             {
                 if (event->modifiers() != Qt::ShiftModifier)    // (and the user doesn't press shift)
                 {
-                    VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+                    VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame());
                     if (vectorImage == nullptr) { return; }
                     // transforms the selection
 
@@ -216,7 +216,7 @@ void SmudgeTool::pointerMoveEvent(PointerEvent* event)
         {
             if (layer->type() == Layer::VECTOR)
             {
-                VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+                VectorImage* vectorImage = static_cast<LayerVector*>(layer)->getLastVectorImageAtFrame(mEditor->currentFrame());
                 if (vectorImage == nullptr) { return; }
 
                 selectMan->setVertices(vectorImage->getVerticesCloseTo(getCurrentPoint(), selectMan->selectionTolerance()));
@@ -253,7 +253,7 @@ void SmudgeTool::pointerReleaseEvent(PointerEvent* event)
         }
         else if (layer->type() == Layer::VECTOR)
         {
-            VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame(), 0);
+            VectorImage *vectorImage = ((LayerVector *)layer)->getLastVectorImageAtFrame(mEditor->currentFrame());
             if (vectorImage == nullptr) { return; }
             vectorImage->applySelectionTransformation();
 
@@ -276,7 +276,7 @@ void SmudgeTool::drawStroke()
     Layer* layer = mEditor->layers()->currentLayer();
     if (layer == nullptr || !layer->isPaintable()) { return; }
 
-    BitmapImage *sourceImage = static_cast<LayerBitmap*>(layer)->getLastBitmapImageAtFrame(mEditor->currentFrame(), 0);
+    BitmapImage *sourceImage = static_cast<LayerBitmap*>(layer)->getLastBitmapImageAtFrame(mEditor->currentFrame());
     if (sourceImage == nullptr) { return; } // Can happen if the first frame is deleted while drawing
     BitmapImage targetImage = sourceImage->copy();
     StrokeTool::drawStroke();


### PR DESCRIPTION
Followup from the talk in #1976
This PR removes the increment argument from getLastKeyFrameAtPosition, because it is never used.