### PR TITLE
LayerSound: Compare canonical paths (#2009)

### DIFF
--- a/core_lib/src/structure/layersound.cpp
+++ b/core_lib/src/structure/layersound.cpp
@@ -133,8 +133,11 @@ Status LayerSound::saveKeyFrameFile(KeyFrame* key, QString path)
 
     QFileInfo info(key->fileName());
     QString sDestFileLocation = QDir(path).filePath(info.fileName());
+    QFileInfo projectFileLocation(sDestFileLocation);
 
-    if (sDestFileLocation != key->fileName())
+    // Note(MrStevns): When using PCL format, the file has to be moved from the temporary
+    // folder and into its actual project folder.
+    if (info.canonicalFilePath() != projectFileLocation.canonicalFilePath())
     {
         if (QFile::exists(sDestFileLocation))
             QFile::remove(sDestFileLocation);


### PR DESCRIPTION
Because if the root of the paths differentiate, even though the paths are technically pointing to the correct file, then this will fail and delete the only sound file there is and then fail to copy which will lead to project corruption.

Related to #2009 