### PR TITLE
QMiniz: Get the actual relative file path (#2009)

### DIFF
--- a/core_lib/src/qminiz.cpp
+++ b/core_lib/src/qminiz.cpp
@@ -111,13 +111,27 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
         }
     }
 
-    //qDebug() << "SrcFolder=" << srcFolderPath;
     QString canonicalFolder = QFileInfo(srcFolderPath).canonicalFilePath();
+    if (canonicalFolder.isEmpty())
+    {
+        dd << QString("Error: Source folder does not exist: %1").arg(srcFolderPath);
+        return Status(Status::FAIL, dd);
+    }
     QDir baseDir(canonicalFolder);
     for (const QString& filePath : fileList)
     {
         QString canonicalFilePath = QFileInfo(filePath).canonicalFilePath();
+        if (canonicalFilePath.isEmpty())
+        {
+            dd << QString("Error: File does not exist: %1").arg(filePath);
+            return Status(Status::FAIL, dd);
+        }
         QString sRelativePath = baseDir.relativeFilePath(canonicalFilePath);
+        if (sRelativePath.startsWith("../") || sRelativePath == "..")
+        {
+            dd << QString("Error: File is outside the base folder: %1").arg(filePath);
+            return Status(Status::FAIL, dd);
+        }
         if (sRelativePath == "mimetype") continue;
 
         dd << QString("Add file to zip: ").append(sRelativePath);

--- a/core_lib/src/qminiz.cpp
+++ b/core_lib/src/qminiz.cpp
@@ -112,10 +112,12 @@ Status MiniZ::compressFolder(QString zipFilePath, QString srcFolderPath, const Q
     }
 
     //qDebug() << "SrcFolder=" << srcFolderPath;
+    QString canonicalFolder = QFileInfo(srcFolderPath).canonicalFilePath();
+    QDir baseDir(canonicalFolder);
     for (const QString& filePath : fileList)
     {
-        QString sRelativePath = filePath;
-        sRelativePath.remove(srcFolderPath);
+        QString canonicalFilePath = QFileInfo(filePath).canonicalFilePath();
+        QString sRelativePath = baseDir.relativeFilePath(canonicalFilePath);
         if (sRelativePath == "mimetype") continue;
 
         dd << QString("Add file to zip: ").append(sRelativePath);

--- a/tests/src/test_qminiz.cpp
+++ b/tests/src/test_qminiz.cpp
@@ -26,6 +26,7 @@ TEST_CASE("QMiniZ::CompressFolder")
     SECTION("Verify robustness against paths with different roots")
     {
         QTemporaryDir tempDir;
+        REQUIRE(tempDir.isValid());
 
         QString subFolder = tempDir.path() + "/bar/";
         QDir().mkpath(subFolder);

--- a/tests/src/test_qminiz.cpp
+++ b/tests/src/test_qminiz.cpp
@@ -18,6 +18,10 @@ GNU General Public License for more details.
 #include "catch.hpp"
 #include "qminiz.h"
 
+#include <cstring>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
 #include <QTemporaryDir>
 
 // https://github.com/pencil2d/pencil/issues/2009

--- a/tests/src/test_qminiz.cpp
+++ b/tests/src/test_qminiz.cpp
@@ -1,0 +1,57 @@
+/*
+
+Pencil2D - Traditional Animation Software
+Copyright (C) 2012-2020 Matthew Chiawen Chang
+Copyright (C) 2026-2099 Oliver S. Larsen
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+*/
+
+#include "catch.hpp"
+#include "qminiz.h"
+
+#include <QTemporaryDir>
+
+// https://github.com/pencil2d/pencil/issues/2009
+TEST_CASE("QMiniZ::CompressFolder")
+{
+    SECTION("Verify robustness against paths with different roots")
+    {
+        QTemporaryDir tempDir;
+
+        QString subFolder = tempDir.path() + "/bar/";
+        QDir().mkpath(subFolder);
+        QFile file(subFolder + "biz.mp3");
+        file.open(QIODevice::WriteOnly);
+        file.close();
+
+        QString zipPath = tempDir.path() + "/test.pclx";
+
+        // Simulate root mismatch by using canonical path for file
+        // but non-canonical path for the base
+        QString canonicalFile = QFileInfo(subFolder + "biz.mp3").canonicalFilePath();
+        QString nonCanonicalBase = tempDir.path();
+
+        QList<QString> filesToZip = { canonicalFile };
+
+        Status st = MiniZ::compressFolder(zipPath, nonCanonicalBase, filesToZip, "application/x-pencil2d-pclx");
+        REQUIRE(st.ok());
+
+        mz_zip_archive zip;
+        memset(&zip, 0, sizeof(zip));
+        REQUIRE(mz_zip_reader_init_file(&zip, zipPath.toUtf8().data(), 0));
+
+        int fileIndex = mz_zip_reader_locate_file(&zip, "bar/biz.mp3", nullptr, 0);
+        REQUIRE(fileIndex >= 0);
+
+        mz_zip_reader_end(&zip);
+    }
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -19,6 +19,7 @@ set(TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_filemanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_bitmapimage.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_bitmapbucket.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_qminiz.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_vectorimage.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_viewmanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/src/test_util.cpp

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -43,6 +43,7 @@ SOURCES += \
     src/test_bitmapimage.cpp \
     src/test_bitmapbucket.cpp \
     src/test_propertyinfo.cpp \
+    src/test_qminiz.cpp \
     src/test_toolsettings.cpp \
     src/test_vectorimage.cpp \
     src/test_viewmanager.cpp \


### PR DESCRIPTION
Because doing string manipulation here is prone to fail if the paths have different root.

Fixes #2009 