### PR TITLE
Clarify: isLoaded, loadFile, unloadFile

### DIFF
--- a/core_lib/src/graphics/bitmap/bitmapimage.cpp
+++ b/core_lib/src/graphics/bitmap/bitmapimage.cpp
@@ -139,7 +139,7 @@ void BitmapImage::loadFile()
 
 void BitmapImage::unloadFile()
 {
-    if (isModified() == false)
+    if (isModified() == false && !fileName().isEmpty())
     {
         mImage = QImage();
     }
@@ -147,6 +147,8 @@ void BitmapImage::unloadFile()
 
 bool BitmapImage::isLoaded() const
 {
+    if (mImage.isNull()) { return false; }
+
     return mImage.width() == mBounds.width();
 }
 

--- a/core_lib/src/graphics/bitmap/bitmapimage.h
+++ b/core_lib/src/graphics/bitmap/bitmapimage.h
@@ -43,8 +43,18 @@ public:
     BitmapImage& operator=(const BitmapImage& a);
 
     BitmapImage* clone() const override;
+
+    /** Loads the backing image data from disk and into memory if it exists but hasn't been loaded yet */
     void loadFile() override;
+
+    /** Unloads the image data from memory if there's valid backing data on disk and the latest state has been stored */
     void unloadFile() override;
+
+    /** Checks whether the keyframe holds valid image data.
+     *
+     *  @note This does not verify that the data is loaded from a backing file.
+     *  @return `true` if the keyframe holds a valid image, otherwise returns `false`
+    */
     bool isLoaded() const override;
     quint64 memoryUsage() override;
 

--- a/core_lib/src/structure/keyframe.h
+++ b/core_lib/src/structure/keyframe.h
@@ -52,9 +52,16 @@ public:
     void removeEventListner(KeyFrameEventListener*);
 
     virtual KeyFrame* clone() const { return nullptr; }
+    /** Loads the backing file into memory if it exists, otherwise it does nothing */
     virtual void loadFile() {}
+
+    /** Unloads the data from memory in order to save memory. This will only work if a backing file exists
+     *  and the latest keyframe data has been saved to disk, eg. `isModified` is false */
     virtual void unloadFile() {}
-    virtual bool isLoaded() const { return true; }
+
+    /** A check to ensure that the keyframe holds valid data.
+     *  @return `true` if the keyframe holds valid data, otherwise false. */
+    virtual bool isLoaded() const { return false; }
 
     virtual quint64 memoryUsage() { return 0; }
 


### PR DESCRIPTION
The methods are now documented. In addition I have also tweaked the unloadFile a bit, so it's no longer possible to unload the bitmap image without a valid backing image.

Let me know if you agree with this or not.. Previously i thought isLoaded was about whether the backing file has been loaded or not but looking at how we use it, that can't be. It seems to only be about whether the keyframe holds valid data in memory, which is slightly confusing with the name leaning towards loadFile, unloadFile.