### PR TITLE
Move isFirstRedo state to undo manager

### DIFF
--- a/core_lib/src/interface/undoredocommand.cpp
+++ b/core_lib/src/interface/undoredocommand.cpp
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 
 #include "layermanager.h"
 #include "selectionmanager.h"
+#include "undoredomanager.h"
 
 #include "layersound.h"
 #include "layerbitmap.h"
@@ -33,6 +34,11 @@ UndoRedoCommand::UndoRedoCommand(Editor* editor, QUndoCommand* parent) : QUndoCo
 {
     qDebug() << "backupElement created";
     mEditor = editor;
+}
+
+bool UndoRedoCommand::isFirstRedo() const
+{
+    return mEditor->undoRedo()->isFirstRedoInProgress();
 }
 
 KeyFrameRemoveCommand::KeyFrameRemoveCommand(const KeyFrame* undoKeyFrame,
@@ -84,7 +90,8 @@ void KeyFrameRemoveCommand::redo()
 
     UndoRedoCommand::redo();
 
-    if (isFirstRedo()) { setFirstRedo(false); return; }
+    // Ignore automatic redo when added to undo stack
+    if (isFirstRedo()) { return; }
 
     layer->removeKeyFrame(redoPosition);
 
@@ -136,7 +143,7 @@ void KeyFrameAddCommand::redo()
     UndoRedoCommand::redo();
 
     // Ignore automatic redo when added to undo stack
-    if (isFirstRedo()) { setFirstRedo(false); return; }
+    if (isFirstRedo()) { return; }
 
     layer->addNewKeyFrameAt(redoPosition);
 
@@ -192,7 +199,7 @@ void MoveKeyFramesCommand::redo()
     UndoRedoCommand::redo();
 
     // Ignore automatic redo when added to undo stack
-    if (isFirstRedo()) { setFirstRedo(false); return; }
+    if (isFirstRedo()) { return; }
 
     QList<int> newPositions = positions;
 
@@ -247,7 +254,7 @@ void BitmapReplaceCommand::redo()
     UndoRedoCommand::redo();
 
     // Ignore automatic redo when added to undo stack
-    if (isFirstRedo()) { setFirstRedo(false); return; }
+    if (isFirstRedo()) { return; }
 
     static_cast<LayerBitmap*>(layer)->replaceKeyFrame(&redoBitmap);
 
@@ -295,7 +302,7 @@ void VectorReplaceCommand::redo()
     UndoRedoCommand::redo();
 
     // Ignore automatic redo when added to undo stack
-    if (isFirstRedo()) { setFirstRedo(false); return; }
+    if (isFirstRedo()) { return; }
 
     static_cast<LayerVector*>(layer)->replaceKeyFrame(&redoVector);
 
@@ -350,7 +357,7 @@ void TransformCommand::redo()
     UndoRedoCommand::redo();
 
     // Ignore automatic redo when added to undo stack
-    if (isFirstRedo()) { setFirstRedo(false); return; }
+    if (isFirstRedo()) { return; }
 
     apply(redoSelectionRect,
           redoTranslation,

--- a/core_lib/src/interface/undoredocommand.h
+++ b/core_lib/src/interface/undoredocommand.h
@@ -45,12 +45,10 @@ public:
 protected:
     Editor* editor() const { return mEditor; }
 
-    bool isFirstRedo() const { return mIsFirstRedo; }
-    void setFirstRedo(const bool state) { mIsFirstRedo = state; }
+    bool isFirstRedo() const;
 
 private:
     Editor* mEditor = nullptr;
-    bool mIsFirstRedo = true;
 };
 
 class KeyFrameRemoveCommand : public UndoRedoCommand

--- a/core_lib/src/managers/undoredomanager.cpp
+++ b/core_lib/src/managers/undoredomanager.cpp
@@ -170,7 +170,9 @@ bool UndoRedoManager::hasUnsavedChanges() const
 
 void UndoRedoManager::pushCommand(QUndoCommand* command)
 {
+    mFirstUndoInProgress = true;
     mUndoStack.push(command);
+    mFirstUndoInProgress = false;
 
     emit didUpdateUndoStack();
 }

--- a/core_lib/src/managers/undoredomanager.h
+++ b/core_lib/src/managers/undoredomanager.h
@@ -138,6 +138,7 @@ public:
     /** Checks whether there are unsaved changes.
      *  @return true if there are unsaved changes, otherwise false */
     bool hasUnsavedChanges() const;
+    bool isFirstRedoInProgress() const { return mFirstUndoInProgress; }
 
     /** Prepares and returns an save state with common data
      * @return A UndoSaveState struct with common keyframe data */
@@ -220,6 +221,7 @@ private:
     SAVESTATE_ID mSaveStateId = 1;
 
     bool mNewBackupSystemEnabled = false;
+    bool mFirstUndoInProgress = false;
 };
 
 #endif // UNDOREDOMANAGER_H


### PR DESCRIPTION
Because it causes issues that each undo/redo command owns the isFirstRedo when parent is ignored. The consequence of this is that later when the you perform a redo that triggers a child command, the command will be ignored because it hasn't been called previously.

To recap why we do this:
QUndoCommand works in the way where pushing a command onto the stack, triggers redo immediately and that doesn't work with our current architecture, so to prevent triggering the same action twice, we skip the first redo.